### PR TITLE
Add block.shopify_attributes to blocks

### DIFF
--- a/sections/announcement-bar.liquid
+++ b/sections/announcement-bar.liquid
@@ -1,7 +1,7 @@
 {%- for block in section.blocks -%}
   {%- case block.type -%}
     {%- when 'announcement' -%}
-      <div class="announcement-bar color-{{ block.settings.color_scheme }}" role="region" aria-label="{{ 'sections.header.announcement' | t }}">
+      <div class="announcement-bar color-{{ block.settings.color_scheme }}" role="region" aria-label="{{ 'sections.header.announcement' | t }}" {{ block.shopify_attributes }}>
         {%- if block.settings.text != blank -%}
           {%- if block.settings.link != blank -%}
             <a href="{{ block.settings.link }}" class="announcement-bar__link link link--text focus-inset animate-arrow">

--- a/sections/apps.liquid
+++ b/sections/apps.liquid
@@ -1,8 +1,6 @@
 <div class="{% if section.settings.include_margins %}page-width{% endif %}">
   {%- for block in section.blocks -%}
-    <div {{ block.shopify_attributes }}>
-      {% render block %}
-    </div>
+    {% render block %}
   {%- endfor -%}
 </div>
 

--- a/sections/apps.liquid
+++ b/sections/apps.liquid
@@ -1,6 +1,8 @@
 <div class="{% if section.settings.include_margins %}page-width{% endif %}">
   {%- for block in section.blocks -%}
-    {% render block %}
+    <div {{ block.shopify_attributes }}>
+      {% render block %}
+    </div>
   {%- endfor -%}
 </div>
 

--- a/sections/collage.liquid
+++ b/sections/collage.liquid
@@ -19,305 +19,303 @@
         endif
       %}
       {%- case block.type -%}
-        <div {{ block.shopify_attributes }}>
-          {%- when 'image' -%}
-            <div class="collage-card color-{{ block.settings.color_scheme }}{% if focus_card_left %} collage-card--left{% elsif focus_card_right %} collage-card--right{% endif %}">
-              <div class="collage-content collage-card__image-wrapper media media--transparent{% if block.settings.image_padding %} collage-card-spacing{% endif %}">
-                {%- if block.settings.image != blank -%}
-                  <img srcset="{%- if block.settings.image.width >= 500 -%}{{ block.settings.image | img_url: '500x' }} 500w,{%- endif -%}
-                    {%- if block.settings.image.width >= 730 -%}{{ block.settings.image | img_url: '730x' }} 730w,{%- endif -%}
-                    {%- if block.settings.image.width >= 1440 -%}{{ block.settings.image | img_url: '1440x' }} 1440w,{%- endif -%}
-                    {%- if block.settings.image.width >= 990 -%}{{ block.settings.image | img_url: '990x' }} 990w,{%- endif -%}
-                    {%- if block.settings.image.width >= 2080 -%}{{ block.settings.image | img_url: '2080x' }} 2080w{%- endif -%}"
-                    src="{{ block.settings.image | img_url: '720x' }}"
-                    sizes="(min-width: 990px){% if section.blocks.size == 1 %} 990px{% else %} 730px{% endif %}, (min-width: 750px){% if section.blocks.size == 1 %} calc(100vw - 100px){% else%} 500px{% endif %}, calc(100vw - 30px)"
-                    alt="{{ block.settings.image.alt | escape }}"
-                    loading="lazy"
-                    width="{{ block.settings.image.width }}"
-                    height="{{ block.settings.image.height }}"
-                    class="collage-card__image"
-                  >
-                {%- else -%}
-                  {{ 'image' | placeholder_svg_tag: 'placeholder-svg placeholder collage-card__image' }}
-                {%- endif -%}
-              </div>
+        {%- when 'image' -%}
+          <div class="collage-card color-{{ block.settings.color_scheme }}{% if focus_card_left %} collage-card--left{% elsif focus_card_right %} collage-card--right{% endif %}" {{ block.shopify_attributes }}>
+            <div class="collage-content collage-card__image-wrapper media media--transparent{% if block.settings.image_padding %} collage-card-spacing{% endif %}">
+              {%- if block.settings.image != blank -%}
+                <img srcset="{%- if block.settings.image.width >= 500 -%}{{ block.settings.image | img_url: '500x' }} 500w,{%- endif -%}
+                  {%- if block.settings.image.width >= 730 -%}{{ block.settings.image | img_url: '730x' }} 730w,{%- endif -%}
+                  {%- if block.settings.image.width >= 1440 -%}{{ block.settings.image | img_url: '1440x' }} 1440w,{%- endif -%}
+                  {%- if block.settings.image.width >= 990 -%}{{ block.settings.image | img_url: '990x' }} 990w,{%- endif -%}
+                  {%- if block.settings.image.width >= 2080 -%}{{ block.settings.image | img_url: '2080x' }} 2080w{%- endif -%}"
+                  src="{{ block.settings.image | img_url: '720x' }}"
+                  sizes="(min-width: 990px){% if section.blocks.size == 1 %} 990px{% else %} 730px{% endif %}, (min-width: 750px){% if section.blocks.size == 1 %} calc(100vw - 100px){% else%} 500px{% endif %}, calc(100vw - 30px)"
+                  alt="{{ block.settings.image.alt | escape }}"
+                  loading="lazy"
+                  width="{{ block.settings.image.width }}"
+                  height="{{ block.settings.image.height }}"
+                  class="collage-card__image"
+                >
+              {%- else -%}
+                {{ 'image' | placeholder_svg_tag: 'placeholder-svg placeholder collage-card__image' }}
+              {%- endif -%}
             </div>
+          </div>
 
-          {%- when 'product'-%}
-            <div class="collage-card collage-product card-wrapper{% if focus_card_left %} collage-card--left{% elsif focus_card_right %} collage-card--right{% endif %}">
-              {%- if block.settings.product != blank -%}
-                {%- assign featured_media = block.settings.product.selected_or_first_available_variant.featured_media | default: block.settings.product.featured_media -%}
-                <a href="{{ block.settings.product.url }}" class="collage-content full-unstyled-link card{% if block.settings.secondary_background %} card-colored color-background-1{% endif %}{% if block.settings.image_padding %} collage-card-spacing{% endif %}">
-                  {%- if featured_media != blank -%}
-                    <div class="collage-card__image-wrapper media media--transparent media--hover-effect"
-                      {% if focus_card_left and forloop.first %}
-                        style="padding-bottom: {{ 1 | divided_by: featured_media.aspect_ratio | times: 100 }}%;"
-                      {% elsif focus_card_right and forloop.last %}
-                        style="padding-bottom: {{ 1 | divided_by: featured_media.aspect_ratio | times: 100 }}%;"
-                      {% endif %}
+        {%- when 'product'-%}
+          <div class="collage-card collage-product card-wrapper{% if focus_card_left %} collage-card--left{% elsif focus_card_right %} collage-card--right{% endif %}">
+            {%- if block.settings.product != blank -%}
+              {%- assign featured_media = block.settings.product.selected_or_first_available_variant.featured_media | default: block.settings.product.featured_media -%}
+              <a href="{{ block.settings.product.url }}" class="collage-content full-unstyled-link card{% if block.settings.secondary_background %} card-colored color-background-1{% endif %}{% if block.settings.image_padding %} collage-card-spacing{% endif %}" {{ block.shopify_attributes }}>
+                {%- if featured_media != blank -%}
+                  <div class="collage-card__image-wrapper media media--transparent media--hover-effect"
+                    {% if focus_card_left and forloop.first %}
+                      style="padding-bottom: {{ 1 | divided_by: featured_media.aspect_ratio | times: 100 }}%;"
+                    {% elsif focus_card_right and forloop.last %}
+                      style="padding-bottom: {{ 1 | divided_by: featured_media.aspect_ratio | times: 100 }}%;"
+                    {% endif %}
+                  >
+                    <img srcset="{%- if featured_media.width >= 500 -%}{{ featured_media | img_url: '500x' }} 500w,{%- endif -%}
+                      {%- if featured_media.width >= 730 -%}{{ featured_media | img_url: '730x' }} 730w,{%- endif -%}
+                      {%- if featured_media.width >= 1440 -%}{{ featured_media | img_url: '1440x' }} 1440w,{%- endif -%}
+                      {%- if featured_media.width >= 990 -%}{{ featured_media | img_url: '990x' }} 990w,{%- endif -%}
+                      {%- if featured_media.width >= 2080 -%}{{ featured_media | img_url: '2080x' }} 2080w{%- endif -%}"
+                      src="{{ featured_media | img_url: '533x' }}"
+                      sizes="(min-width: 990px){% if section.blocks.size == 1 %} 990px{% else %} 730px{% endif %}, (min-width: 750px){% if section.blocks.size == 1 %} calc(100vw - 100px){% else %} 500px{% endif %}, calc(100vw - 30px)"
+                      alt="{{ featured_media.alt | escape }}"
+                      loading="lazy"
+                      width="{{ featured_media.width }}"
+                      height="{{ featured_media.height }}"
+                      class="collage-card__image"
                     >
-                      <img srcset="{%- if featured_media.width >= 500 -%}{{ featured_media | img_url: '500x' }} 500w,{%- endif -%}
-                        {%- if featured_media.width >= 730 -%}{{ featured_media | img_url: '730x' }} 730w,{%- endif -%}
-                        {%- if featured_media.width >= 1440 -%}{{ featured_media | img_url: '1440x' }} 1440w,{%- endif -%}
-                        {%- if featured_media.width >= 990 -%}{{ featured_media | img_url: '990x' }} 990w,{%- endif -%}
-                        {%- if featured_media.width >= 2080 -%}{{ featured_media | img_url: '2080x' }} 2080w{%- endif -%}"
-                        src="{{ featured_media | img_url: '533x' }}"
-                        sizes="(min-width: 990px){% if section.blocks.size == 1 %} 990px{% else %} 730px{% endif %}, (min-width: 750px){% if section.blocks.size == 1 %} calc(100vw - 100px){% else %} 500px{% endif %}, calc(100vw - 30px)"
-                        alt="{{ featured_media.alt | escape }}"
-                        loading="lazy"
-                        width="{{ featured_media.width }}"
-                        height="{{ featured_media.height }}"
-                        class="collage-card__image"
-                      >
 
-                      {%- if block.settings.second_image and block.settings.product.media[1] != nil -%}
-                        <img srcset="{%- if block.settings.product.media[1].width >= 500 -%}{{ block.settings.product.media[1] | img_url: '500x' }} 500w,{%- endif -%}
-                          {%- if block.settings.product.media[1].width >= 730 -%}{{ block.settings.product.media[1] | img_url: '730x' }} 730w,{%- endif -%}
-                          {%- if block.settings.product.media[1].width >= 1440 -%}{{ block.settings.product.media[1] | img_url: '1440x' }} 1440w,{%- endif -%}
-                          {%- if block.settings.product.media[1].width >= 990 -%}{{ block.settings.product.media[1] | img_url: '990x' }} 990w,{%- endif -%}
-                          {%- if block.settings.product.media[1].width >= 2080 -%}{{ block.settings.product.media[1] | img_url: '2080x' }} 2080w{%- endif -%}"
-                          src="{{ block.settings.product.media[1] | img_url: '533x' }}"
-                          sizes="(min-width: 990px){% if section.blocks.size == 1 %} 990px{% else %} 730px{% endif %}, (min-width: 750px){% if section.blocks.size == 1 %} calc(100vw - 100px){% else %} 500px{% endif %}, calc(100vw - 30px)"
-                          alt="{{ block.settings.product.media[1].alt | escape }}"
-                          loading="lazy"
-                          width="{{ block.settings.product.media[1].width }}"
-                          height="{{ block.settings.product.media[1].height }}"
-                          class="collage-card__image small-hide medium-hide"
-                        >
+                    {%- if block.settings.second_image and block.settings.product.media[1] != nil -%}
+                      <img srcset="{%- if block.settings.product.media[1].width >= 500 -%}{{ block.settings.product.media[1] | img_url: '500x' }} 500w,{%- endif -%}
+                        {%- if block.settings.product.media[1].width >= 730 -%}{{ block.settings.product.media[1] | img_url: '730x' }} 730w,{%- endif -%}
+                        {%- if block.settings.product.media[1].width >= 1440 -%}{{ block.settings.product.media[1] | img_url: '1440x' }} 1440w,{%- endif -%}
+                        {%- if block.settings.product.media[1].width >= 990 -%}{{ block.settings.product.media[1] | img_url: '990x' }} 990w,{%- endif -%}
+                        {%- if block.settings.product.media[1].width >= 2080 -%}{{ block.settings.product.media[1] | img_url: '2080x' }} 2080w{%- endif -%}"
+                        src="{{ block.settings.product.media[1] | img_url: '533x' }}"
+                        sizes="(min-width: 990px){% if section.blocks.size == 1 %} 990px{% else %} 730px{% endif %}, (min-width: 750px){% if section.blocks.size == 1 %} calc(100vw - 100px){% else %} 500px{% endif %}, calc(100vw - 30px)"
+                        alt="{{ block.settings.product.media[1].alt | escape }}"
+                        loading="lazy"
+                        width="{{ block.settings.product.media[1].width }}"
+                        height="{{ block.settings.product.media[1].height }}"
+                        class="collage-card__image small-hide medium-hide"
+                      >
+                    {%- endif -%}
+                  </div>
+                  <div class="collage-product__badge">
+                    <div class="card__badge">
+                      {%- if block.settings.product.available == false -%}
+                        <span class="badge badge--bottom-left color-{{ settings.sold_out_badge_color_scheme }}" aria-hidden="true">
+                          {{ 'products.product.sold_out' | t }}
+                        </span>
+                      {%- elsif block.settings.product.compare_at_price > block.settings.product.price and block.settings.product.available -%}
+                        <span class="badge badge--bottom-left color-{{ settings.sale_badge_color_scheme }}" aria-hidden="true">
+                          {{ 'products.product.on_sale' | t }}
+                        </span>
                       {%- endif -%}
                     </div>
-                    <div class="collage-product__badge">
-                      <div class="card__badge">
-                        {%- if block.settings.product.available == false -%}
-                          <span class="badge badge--bottom-left color-{{ settings.sold_out_badge_color_scheme }}" aria-hidden="true">
-                            {{ 'products.product.sold_out' | t }}
-                          </span>
-                        {%- elsif block.settings.product.compare_at_price > block.settings.product.price and block.settings.product.available -%}
-                          <span class="badge badge--bottom-left color-{{ settings.sale_badge_color_scheme }}" aria-hidden="true">
-                            {{ 'products.product.on_sale' | t }}
-                          </span>
-                        {%- endif -%}
-                      </div>
-                    </div>
-                    <div class="collage-content__info card-information card-information__wrapper">
-                      <h3 class="card-information__text h4">{{ block.settings.product.title | escape }}</h3>
-                      <span class="price">{% render 'price', product: block.settings.product %}</span>
-                    </div>
-                  {%- else -%}
-                    <div class="collage-card__no-image card-colored color-background-1 card__text-spacing center">
-                      <h3 class="h2">{{ block.settings.product.title | escape }}</h3>
-                    </div>
-                    <div class="collage-product__badge">
-                      <div class="card__badge">
-                        {%- if block.settings.product.available == false -%}
-                          <span class="badge badge--bottom-left color-{{ settings.sold_out_badge_color_scheme }}" aria-hidden="true">
-                            {{ 'products.product.sold_out' | t }}
-                          </span>
-                        {%- elsif block.settings.product.compare_at_price > block.settings.product.price and block.settings.product.available -%}
-                          <span class="badge badge--bottom-left color-{{ settings.sale_badge_color_scheme }}" aria-hidden="true">
-                            {{ 'products.product.on_sale' | t }}
-                          </span>
-                        {%- endif -%}
-                      </div>
-                    </div>
-                    <div class="collage-content__info">
-                      {% render 'price', product: block.settings.product %}
-                    </div>
-                  {%- endif -%}
-                </a>
-              {%- else -%}
-                <div class="collage-content">
+                  </div>
+                  <div class="collage-content__info card-information card-information__wrapper">
+                    <h3 class="card-information__text h4">{{ block.settings.product.title | escape }}</h3>
+                    <span class="price">{% render 'price', product: block.settings.product %}</span>
+                  </div>
+                {%- else -%}
                   <div class="collage-card__no-image card-colored color-background-1 card__text-spacing center">
-                    <h3 class="h2">{{ 'onboarding.product_title' | t }}</h3>
+                    <h3 class="h2">{{ block.settings.product.title | escape }}</h3>
+                  </div>
+                  <div class="collage-product__badge">
+                    <div class="card__badge">
+                      {%- if block.settings.product.available == false -%}
+                        <span class="badge badge--bottom-left color-{{ settings.sold_out_badge_color_scheme }}" aria-hidden="true">
+                          {{ 'products.product.sold_out' | t }}
+                        </span>
+                      {%- elsif block.settings.product.compare_at_price > block.settings.product.price and block.settings.product.available -%}
+                        <span class="badge badge--bottom-left color-{{ settings.sale_badge_color_scheme }}" aria-hidden="true">
+                          {{ 'products.product.on_sale' | t }}
+                        </span>
+                      {%- endif -%}
+                    </div>
                   </div>
                   <div class="collage-content__info">
-                    <span class="price">{% render 'price' %}</span>
+                    {% render 'price', product: block.settings.product %}
+                  </div>
+                {%- endif -%}
+              </a>
+            {%- else -%}
+              <div class="collage-content">
+                <div class="collage-card__no-image card-colored color-background-1 card__text-spacing center">
+                  <h3 class="h2">{{ 'onboarding.product_title' | t }}</h3>
+                </div>
+                <div class="collage-content__info">
+                  <span class="price">{% render 'price' %}</span>
+                </div>
+              </div>
+            {%- endif -%}
+          </div>
+
+        {%- when 'collection'-%}
+          <div class="collage-card color-{{ block.settings.color_scheme }}{% if focus_card_left %} collage-card--left{% elsif focus_card_right %} collage-card--right{% endif %}" {{ block.shopify_attributes }}>
+              {%- if block.settings.collection != blank -%}
+                <a href="{{ block.settings.collection.url }}" class="card animate-arrow">
+                  <div class="collage-content card-colored color-{{ block.settings.color_scheme }}{% if block.settings.image_padding %} collage-card-spacing{% endif %}">
+                    {%- if block.settings.collection.image != blank -%}
+                      <div class="collage-card__image-wrapper media media--transparent media--hover-effect">
+                        <img srcset="{%- if block.settings.collection.image.width >= 500 -%}{{ block.settings.collection.image | img_url: '500x' }} 500w,{%- endif -%}
+                          {%- if block.settings.collection.image.width >= 730 -%}{{ block.settings.collection.image | img_url: '730x' }} 730w,{%- endif -%}
+                          {%- if block.settings.collection.image.width >= 1440 -%}{{ block.settings.collection.image | img_url: '1440x' }} 1440w,{%- endif -%}
+                          {%- if block.settings.collection.image.width >= 990 -%}{{ block.settings.collection.image | img_url: '990x' }} 990w,{%- endif -%}
+                          {%- if block.settings.collection.image.width >= 2080 -%}{{ block.settings.collection.image | img_url: '2080x' }} 2080w{%- endif -%}"
+                          src="{{ block.settings.collection.image | img_url: '533x' }}"
+                          sizes="(min-width: 990px){% if section.blocks.size == 1 %} 990px{% else %} 730px{% endif %}, (min-width: 750px){% if section.blocks.size == 1 %} calc(100vw - 100px){% else%} 500px{% endif %}, calc(100vw - 30px)"
+                          alt="{{ block.settings.collection.image.alt | escape }}"
+                          loading="lazy"
+                          width="{{ block.settings.collection.image.width }}"
+                          height="{{ block.settings.collection.image.height }}"
+                          class="collage-card__image"
+                        >
+                      </div>
+
+                      {% unless section.settings.image_padding %}<div class="overlay-card"></div>{% endunless %}
+                      <div class="collage-content__info">
+                        <h3>{{ block.settings.collection.title | escape }}<span class="icon-wrap">&nbsp;{% render 'icon-arrow' %}</span></h3>
+                      </div>
+                    {%- else -%}
+                      <div class="collage-card__no-image card__text-spacing card__text-hover card-color ">
+                        <div class="overlay-card"></div>
+                        <h3 class="h2">
+                          {{- block.settings.collection.title -}}<span class="icon-wrap{% if block.settings.collection.description != blank %} collage-card__arrow{% endif %}">&nbsp;{% render 'icon-arrow' %}</span>
+                        </h3>
+
+                        {%- if block.settings.collection.description != blank -%}
+                          <p class="collage-card__description card__caption">
+                            {{- block.settings.collection.description | strip_html | truncatewords: 12 -}}<span class="icon-wrap">&nbsp;{% render 'icon-arrow' %}</span>
+                          </p>
+                        {%- endif -%}
+                      </div>
+                    {%- endif -%}
+                  </div>
+                </a>
+              {%- else -%}
+                <div class="collage-content card card-colored color-{{ block.settings.color_scheme }}">
+                  <div class="collage-card__no-image card__text-spacing card__text-hover">
+                    <h3 class="h2">
+                      {{ 'onboarding.collection_title' | t }}<span class="icon-wrap">&nbsp;{% render 'icon-arrow' %}</span>
+                    </h3>
                   </div>
                 </div>
               {%- endif -%}
-            </div>
+          </div>
 
-          {%- when 'collection'-%}
-            <div class="collage-card color-{{ block.settings.color_scheme }}{% if focus_card_left %} collage-card--left{% elsif focus_card_right %} collage-card--right{% endif %}">
-                {%- if block.settings.collection != blank -%}
-                  <a href="{{ block.settings.collection.url }}" class="card animate-arrow">
-                    <div class="collage-content card-colored color-{{ block.settings.color_scheme }}{% if block.settings.image_padding %} collage-card-spacing{% endif %}">
-                      {%- if block.settings.collection.image != blank -%}
-                        <div class="collage-card__image-wrapper media media--transparent media--hover-effect">
-                          <img srcset="{%- if block.settings.collection.image.width >= 500 -%}{{ block.settings.collection.image | img_url: '500x' }} 500w,{%- endif -%}
-                            {%- if block.settings.collection.image.width >= 730 -%}{{ block.settings.collection.image | img_url: '730x' }} 730w,{%- endif -%}
-                            {%- if block.settings.collection.image.width >= 1440 -%}{{ block.settings.collection.image | img_url: '1440x' }} 1440w,{%- endif -%}
-                            {%- if block.settings.collection.image.width >= 990 -%}{{ block.settings.collection.image | img_url: '990x' }} 990w,{%- endif -%}
-                            {%- if block.settings.collection.image.width >= 2080 -%}{{ block.settings.collection.image | img_url: '2080x' }} 2080w{%- endif -%}"
-                            src="{{ block.settings.collection.image | img_url: '533x' }}"
-                            sizes="(min-width: 990px){% if section.blocks.size == 1 %} 990px{% else %} 730px{% endif %}, (min-width: 750px){% if section.blocks.size == 1 %} calc(100vw - 100px){% else%} 500px{% endif %}, calc(100vw - 30px)"
-                            alt="{{ block.settings.collection.image.alt | escape }}"
-                            loading="lazy"
-                            width="{{ block.settings.collection.image.width }}"
-                            height="{{ block.settings.collection.image.height }}"
-                            class="collage-card__image"
-                          >
-                        </div>
-
-                        {% unless section.settings.image_padding %}<div class="overlay-card"></div>{% endunless %}
-                        <div class="collage-content__info">
-                          <h3>{{ block.settings.collection.title | escape }}<span class="icon-wrap">&nbsp;{% render 'icon-arrow' %}</span></h3>
-                        </div>
-                      {%- else -%}
-                        <div class="collage-card__no-image card__text-spacing card__text-hover card-color ">
-                          <div class="overlay-card"></div>
-                          <h3 class="h2">
-                            {{- block.settings.collection.title -}}<span class="icon-wrap{% if block.settings.collection.description != blank %} collage-card__arrow{% endif %}">&nbsp;{% render 'icon-arrow' %}</span>
-                          </h3>
-
-                          {%- if block.settings.collection.description != blank -%}
-                            <p class="collage-card__description card__caption">
-                              {{- block.settings.collection.description | strip_html | truncatewords: 12 -}}<span class="icon-wrap">&nbsp;{% render 'icon-arrow' %}</span>
-                            </p>
-                          {%- endif -%}
-                        </div>
-                      {%- endif -%}
-                    </div>
-                  </a>
-                {%- else -%}
-                  <div class="collage-content card card-colored color-{{ block.settings.color_scheme }}">
-                    <div class="collage-card__no-image card__text-spacing card__text-hover">
-                      <h3 class="h2">
-                        {{ 'onboarding.collection_title' | t }}<span class="icon-wrap">&nbsp;{% render 'icon-arrow' %}</span>
-                      </h3>
-                    </div>
-                  </div>
-                {%- endif -%}
-            </div>
-
-          {%- when 'video' -%}
-            <div class="collage-card collage-video{% if focus_card_left %} collage-card--left{% elsif focus_card_right %} collage-card--right{% endif %}">
-              <noscript>
-                <a href="{{ block.settings.video_url }}" class="card{% if block.settings.cover_image == blank %} collage-video-placeholder{% endif %}"
+        {%- when 'video' -%}
+          <div class="collage-card collage-video{% if focus_card_left %} collage-card--left{% elsif focus_card_right %} collage-card--right{% endif %}" {{ block.shopify_attributes }}>
+            <noscript>
+              <a href="{{ block.settings.video_url }}" class="card{% if block.settings.cover_image == blank %} collage-video-placeholder{% endif %}"
+                {% if block.settings.cover_image != blank and focus_card_left and forloop.first %}
+                  style="padding-bottom: {{ 1 | divided_by: block.settings.cover_image.aspect_ratio | times: 100 }}%;"
+                {% elsif block.settings.cover_image != blank and focus_card_right and forloop.last %}
+                  style="padding-bottom: {{ 1 | divided_by: block.settings.cover_image.aspect_ratio | times: 100 }}%;"
+                {% endif %}
+              >
+                <div class="collage-content collage-card__image-wrapper media media--transparent{% if block.settings.image_padding %} collage-card-spacing{% endif %}">
+                  {%- if block.settings.cover_image != blank -%}
+                    <img
+                      srcset="{%- if block.settings.cover_image.width >= 500 -%}{{ block.settings.cover_image | img_url: '500x' }} 500w,{%- endif -%}
+                      {%- if block.settings.cover_image.width >= 730 -%}{{ block.settings.cover_image | img_url: '730x' }} 730w,{%- endif -%}
+                      {%- if block.settings.cover_image.width >= 1440 -%}{{ block.settings.cover_image | img_url: '1440x' }} 1440w,{%- endif -%}
+                      {%- if block.settings.cover_image.width >= 990 -%}{{ block.settings.cover_image | img_url: '990x' }} 990w,{%- endif -%}
+                      {%- if block.settings.cover_image.width >= 2080 -%}{{ block.settings.cover_image | img_url: '2080x' }} 2080w{%- endif -%}"
+                      src="{{ block.settings.cover_image | img_url: '533x' }}"
+                      sizes="(min-width: 990px){% if section.blocks.size == 1 %} 990px{% else %} 730px{% endif %}, (min-width: 750px){% if section.blocks.size == 1 %} calc(100vw - 100px){% else%} 500px{% endif %}, calc(100vw - 30px)"
+                      alt="{{ block.settings.description | escape }}"
+                      loading="lazy"
+                      width="{{ block.settings.cover_image.width }}"
+                      height="{{ block.settings.cover_image.height }}"
+                      class="collage-card__image"
+                    >
+                  {%- else -%}
+                    {{ 'collection-2' | placeholder_svg_tag: 'placeholder-svg placeholder collage-card__image' }}
+                  {%- endif -%}
+                </div>
+              </a>
+            </noscript>
+            {%- if section.blocks.size == 1 -%}
+              <deferred-media class="deferred-media no-js-hidden{% if block.settings.image_padding %} collage-card-spacing{% endif %}" data-media-id="{{ block.settings.video_url.id }}"
+                {% if block.settings.cover_image != blank %}
+                  style="padding-bottom: {{ 1 | divided_by: block.settings.cover_image.aspect_ratio | times: 100 }}%;"
+                {% else %}
+                  style="padding-bottom: 100%;"
+                {% endif %}
+              >
+                <button
+                  id="Deferred-Poster-Modal-{{ block.settings.video_url.id }}"
+                  class="collage-content collage-card__image-wrapper media deferred-media__poster"
+                  type="button"
+                >
+                  {%- if block.settings.cover_image != blank -%}
+                    <img
+                      srcset="{%- if block.settings.cover_image.width >= 500 -%}{{ block.settings.cover_image | img_url: '500x' }} 500w,{%- endif -%}
+                      {%- if block.settings.cover_image.width >= 730 -%}{{ block.settings.cover_image | img_url: '730x' }} 730w,{%- endif -%}
+                      {%- if block.settings.cover_image.width >= 1440 -%}{{ block.settings.cover_image | img_url: '1440x' }} 1440w,{%- endif -%}
+                      {%- if block.settings.cover_image.width >= 990 -%}{{ block.settings.cover_image | img_url: '990x' }} 990w,{%- endif -%}
+                      {%- if block.settings.cover_image.width >= 2080 -%}{{ block.settings.cover_image | img_url: '2080x' }} 2080w{%- endif -%}"
+                      src="{{ block.settings.cover_image | img_url: '533x' }}"
+                      sizes="(min-width: 990px){% if section.blocks.size == 1 %} 990px{% else %} 730px{% endif %}, (min-width: 750px){% if section.blocks.size == 1 %} calc(100vw - 100px){% else%} 500px{% endif %}, calc(100vw - 30px)"
+                      alt="{{ block.settings.description | escape }}"
+                      loading="lazy"
+                      width="{{ block.settings.cover_image.width }}"
+                      height="{{ block.settings.cover_image.height }}"
+                      class="collage-card__image"
+                    >
+                  {%- else -%}
+                    {{ 'collection-2' | placeholder_svg_tag: 'placeholder-svg placeholder collage-card__image' }}
+                  {%- endif -%}
+                  <span class="deferred-media__poster-button motion-reduce">
+                    {%- render 'icon-play' -%}
+                  </span>
+                </button>
+                <template>
+                  {%- if block.settings.video_url.type == 'youtube' -%}
+                    <iframe src="https://www.youtube.com/embed/{{ block.settings.video_url.id }}?enablejsapi=1" class="js-youtube" allow="autoplay; encrypted-media" allowfullscreen title="{{ block.settings.description | escape }}"></iframe>
+                  {%- else -%}
+                    <iframe src="https://player.vimeo.com/video/{{ block.settings.video_url.id }}" class="js-vimeo" allow="autoplay; encrypted-media" allowfullscreen title="{{ block.settings.description | escape }}"></iframe>
+                  {%- endif -%}
+                </template>
+              </deferred-media>
+            {%- else -%}
+              <modal-opener class="no-js-hidden" data-modal="#PopupModal-{{ block.id }}">
+                <div class="deferred-media{% if block.settings.cover_image == blank %} deferred-media--placeholder{% endif %}"
                   {% if block.settings.cover_image != blank and focus_card_left and forloop.first %}
                     style="padding-bottom: {{ 1 | divided_by: block.settings.cover_image.aspect_ratio | times: 100 }}%;"
                   {% elsif block.settings.cover_image != blank and focus_card_right and forloop.last %}
                     style="padding-bottom: {{ 1 | divided_by: block.settings.cover_image.aspect_ratio | times: 100 }}%;"
-                  {% endif %}
-                >
-                  <div class="collage-content collage-card__image-wrapper media media--transparent{% if block.settings.image_padding %} collage-card-spacing{% endif %}">
-                    {%- if block.settings.cover_image != blank -%}
-                      <img
-                        srcset="{%- if block.settings.cover_image.width >= 500 -%}{{ block.settings.cover_image | img_url: '500x' }} 500w,{%- endif -%}
-                        {%- if block.settings.cover_image.width >= 730 -%}{{ block.settings.cover_image | img_url: '730x' }} 730w,{%- endif -%}
-                        {%- if block.settings.cover_image.width >= 1440 -%}{{ block.settings.cover_image | img_url: '1440x' }} 1440w,{%- endif -%}
-                        {%- if block.settings.cover_image.width >= 990 -%}{{ block.settings.cover_image | img_url: '990x' }} 990w,{%- endif -%}
-                        {%- if block.settings.cover_image.width >= 2080 -%}{{ block.settings.cover_image | img_url: '2080x' }} 2080w{%- endif -%}"
-                        src="{{ block.settings.cover_image | img_url: '533x' }}"
-                        sizes="(min-width: 990px){% if section.blocks.size == 1 %} 990px{% else %} 730px{% endif %}, (min-width: 750px){% if section.blocks.size == 1 %} calc(100vw - 100px){% else%} 500px{% endif %}, calc(100vw - 30px)"
-                        alt="{{ block.settings.description | escape }}"
-                        loading="lazy"
-                        width="{{ block.settings.cover_image.width }}"
-                        height="{{ block.settings.cover_image.height }}"
-                        class="collage-card__image"
-                      >
-                    {%- else -%}
-                      {{ 'collection-2' | placeholder_svg_tag: 'placeholder-svg placeholder collage-card__image' }}
-                    {%- endif -%}
-                  </div>
-                </a>
-              </noscript>
-              {%- if section.blocks.size == 1 -%}
-                <deferred-media class="deferred-media no-js-hidden{% if block.settings.image_padding %} collage-card-spacing{% endif %}" data-media-id="{{ block.settings.video_url.id }}"
-                  {% if block.settings.cover_image != blank %}
-                    style="padding-bottom: {{ 1 | divided_by: block.settings.cover_image.aspect_ratio | times: 100 }}%;"
-                  {% else %}
-                    style="padding-bottom: 100%;"
-                  {% endif %}
-                >
-                  <button
-                    id="Deferred-Poster-Modal-{{ block.settings.video_url.id }}"
-                    class="collage-content collage-card__image-wrapper media deferred-media__poster"
-                    type="button"
-                  >
-                    {%- if block.settings.cover_image != blank -%}
-                      <img
-                        srcset="{%- if block.settings.cover_image.width >= 500 -%}{{ block.settings.cover_image | img_url: '500x' }} 500w,{%- endif -%}
-                        {%- if block.settings.cover_image.width >= 730 -%}{{ block.settings.cover_image | img_url: '730x' }} 730w,{%- endif -%}
-                        {%- if block.settings.cover_image.width >= 1440 -%}{{ block.settings.cover_image | img_url: '1440x' }} 1440w,{%- endif -%}
-                        {%- if block.settings.cover_image.width >= 990 -%}{{ block.settings.cover_image | img_url: '990x' }} 990w,{%- endif -%}
-                        {%- if block.settings.cover_image.width >= 2080 -%}{{ block.settings.cover_image | img_url: '2080x' }} 2080w{%- endif -%}"
-                        src="{{ block.settings.cover_image | img_url: '533x' }}"
-                        sizes="(min-width: 990px){% if section.blocks.size == 1 %} 990px{% else %} 730px{% endif %}, (min-width: 750px){% if section.blocks.size == 1 %} calc(100vw - 100px){% else%} 500px{% endif %}, calc(100vw - 30px)"
-                        alt="{{ block.settings.description | escape }}"
-                        loading="lazy"
-                        width="{{ block.settings.cover_image.width }}"
-                        height="{{ block.settings.cover_image.height }}"
-                        class="collage-card__image"
-                      >
-                    {%- else -%}
-                      {{ 'collection-2' | placeholder_svg_tag: 'placeholder-svg placeholder collage-card__image' }}
-                    {%- endif -%}
+                  {% endif %}>
+                  <button class="collage-content collage-card__image-wrapper media deferred-media__poster full-unstyled-link{% if block.settings.image_padding %} collage-card-spacing{% endif %}" type="button" aria-haspopup="dialog" data-media-id="{{ block.settings.video_url.id }}">
                     <span class="deferred-media__poster-button motion-reduce">
                       {%- render 'icon-play' -%}
                     </span>
-                  </button>
-                  <template>
-                    {%- if block.settings.video_url.type == 'youtube' -%}
-                      <iframe src="https://www.youtube.com/embed/{{ block.settings.video_url.id }}?enablejsapi=1" class="js-youtube" allow="autoplay; encrypted-media" allowfullscreen title="{{ block.settings.description | escape }}"></iframe>
+
+                    {%- if block.settings.cover_image != blank -%}
+                      <img
+                        srcset="{%- if block.settings.cover_image.width >= 500 -%}{{ block.settings.cover_image | img_url: '500x' }} 500w,{%- endif -%}
+                        {%- if block.settings.cover_image.width >= 730 -%}{{ block.settings.cover_image | img_url: '730x' }} 730w,{%- endif -%}
+                        {%- if block.settings.cover_image.width >= 1440 -%}{{ block.settings.cover_image | img_url: '1440x' }} 1440w,{%- endif -%}
+                        {%- if block.settings.cover_image.width >= 990 -%}{{ block.settings.cover_image | img_url: '990x' }} 990w,{%- endif -%}
+                        {%- if block.settings.cover_image.width >= 2080 -%}{{ block.settings.cover_image | img_url: '2080x' }} 2080w{%- endif -%}"
+                        src="{{ block.settings.cover_image | img_url: '533x' }}"
+                        sizes="(min-width: 990px){% if section.blocks.size == 1 %} 990px{% else %} 730px{% endif %}, (min-width: 750px){% if section.blocks.size == 1 %} calc(100vw - 100px){% else%} 500px{% endif %}, calc(100vw - 30px)"
+                        alt="{{ block.settings.description | escape }}"
+                        loading="lazy"
+                        width="{{ block.settings.cover_image.width }}"
+                        height="{{ block.settings.cover_image.height }}"
+                        class="collage-card__image"
+                      >
                     {%- else -%}
-                      <iframe src="https://player.vimeo.com/video/{{ block.settings.video_url.id }}" class="js-vimeo" allow="autoplay; encrypted-media" allowfullscreen title="{{ block.settings.description | escape }}"></iframe>
+                      {{ 'collection-2' | placeholder_svg_tag: 'placeholder-svg placeholder collage-card__image' }}
                     {%- endif -%}
-                  </template>
-                </deferred-media>
-              {%- else -%}
-                <modal-opener class="no-js-hidden" data-modal="#PopupModal-{{ block.id }}">
-                  <div class="deferred-media{% if block.settings.cover_image == blank %} deferred-media--placeholder{% endif %}"
-                    {% if block.settings.cover_image != blank and focus_card_left and forloop.first %}
-                      style="padding-bottom: {{ 1 | divided_by: block.settings.cover_image.aspect_ratio | times: 100 }}%;"
-                    {% elsif block.settings.cover_image != blank and focus_card_right and forloop.last %}
-                      style="padding-bottom: {{ 1 | divided_by: block.settings.cover_image.aspect_ratio | times: 100 }}%;"
-                    {% endif %}>
-                    <button class="collage-content collage-card__image-wrapper media deferred-media__poster full-unstyled-link{% if block.settings.image_padding %} collage-card-spacing{% endif %}" type="button" aria-haspopup="dialog" data-media-id="{{ block.settings.video_url.id }}">
-                      <span class="deferred-media__poster-button motion-reduce">
-                        {%- render 'icon-play' -%}
-                      </span>
+                  </button>
+                </div>
+              </modal-opener>
 
-                      {%- if block.settings.cover_image != blank -%}
-                        <img
-                          srcset="{%- if block.settings.cover_image.width >= 500 -%}{{ block.settings.cover_image | img_url: '500x' }} 500w,{%- endif -%}
-                          {%- if block.settings.cover_image.width >= 730 -%}{{ block.settings.cover_image | img_url: '730x' }} 730w,{%- endif -%}
-                          {%- if block.settings.cover_image.width >= 1440 -%}{{ block.settings.cover_image | img_url: '1440x' }} 1440w,{%- endif -%}
-                          {%- if block.settings.cover_image.width >= 990 -%}{{ block.settings.cover_image | img_url: '990x' }} 990w,{%- endif -%}
-                          {%- if block.settings.cover_image.width >= 2080 -%}{{ block.settings.cover_image | img_url: '2080x' }} 2080w{%- endif -%}"
-                          src="{{ block.settings.cover_image | img_url: '533x' }}"
-                          sizes="(min-width: 990px){% if section.blocks.size == 1 %} 990px{% else %} 730px{% endif %}, (min-width: 750px){% if section.blocks.size == 1 %} calc(100vw - 100px){% else%} 500px{% endif %}, calc(100vw - 30px)"
-                          alt="{{ block.settings.description | escape }}"
-                          loading="lazy"
-                          width="{{ block.settings.cover_image.width }}"
-                          height="{{ block.settings.cover_image.height }}"
-                          class="collage-card__image"
-                        >
+              <modal-dialog id="PopupModal-{{ block.id }}" class="collage-video__modal">
+                <div class="collage-video__modal-content" role="dialog" aria-label="{{ block.settings.description | escape }}" aria-modal="true" tabindex="-1">
+                  <button id="ModalClose-{{ block.id }}" type="button" class="collage-video__modal-toggle" aria-label="{{ 'accessibility.close' | t }}">{% render 'icon-close' %}</button>
+                  <deferred-media class="collage-video__modal-video template-popup">
+                    <template>
+                      {%- if block.settings.video_url.type == 'youtube' -%}
+                        <iframe src="https://www.youtube.com/embed/{{ block.settings.video_url.id }}?enablejsapi=1" class="js-youtube" allow="autoplay; encrypted-media" allowfullscreen title="{{ block.settings.description | escape }}"></iframe>
                       {%- else -%}
-                        {{ 'collection-2' | placeholder_svg_tag: 'placeholder-svg placeholder collage-card__image' }}
+                        <iframe src="https://player.vimeo.com/video/{{ block.settings.video_url.id }}" class="js-vimeo" allow="autoplay; encrypted-media" allowfullscreen title="{{ block.settings.description | escape }}"></iframe>
                       {%- endif -%}
-                    </button>
-                  </div>
-                </modal-opener>
-
-                <modal-dialog id="PopupModal-{{ block.id }}" class="collage-video__modal">
-                  <div class="collage-video__modal-content" role="dialog" aria-label="{{ block.settings.description | escape }}" aria-modal="true" tabindex="-1">
-                    <button id="ModalClose-{{ block.id }}" type="button" class="collage-video__modal-toggle" aria-label="{{ 'accessibility.close' | t }}">{% render 'icon-close' %}</button>
-                    <deferred-media class="collage-video__modal-video template-popup">
-                      <template>
-                        {%- if block.settings.video_url.type == 'youtube' -%}
-                          <iframe src="https://www.youtube.com/embed/{{ block.settings.video_url.id }}?enablejsapi=1" class="js-youtube" allow="autoplay; encrypted-media" allowfullscreen title="{{ block.settings.description | escape }}"></iframe>
-                        {%- else -%}
-                          <iframe src="https://player.vimeo.com/video/{{ block.settings.video_url.id }}" class="js-vimeo" allow="autoplay; encrypted-media" allowfullscreen title="{{ block.settings.description | escape }}"></iframe>
-                        {%- endif -%}
-                      </template>
-                    </deferred-media>
-                  </div>
-                </modal-dialog>
-              {%- endif -%}
-            </div>
-          {%- endcase -%}
-        </div>
+                    </template>
+                  </deferred-media>
+                </div>
+              </modal-dialog>
+            {%- endif -%}
+          </div>
+        {%- endcase -%}
     {%- endfor -%}
   </div>
 </div>

--- a/sections/collage.liquid
+++ b/sections/collage.liquid
@@ -19,264 +19,188 @@
         endif
       %}
       {%- case block.type -%}
-        {%- when 'image' -%}
-          <div class="collage-card color-{{ block.settings.color_scheme }}{% if focus_card_left %} collage-card--left{% elsif focus_card_right %} collage-card--right{% endif %}">
-            <div class="collage-content collage-card__image-wrapper media media--transparent{% if block.settings.image_padding %} collage-card-spacing{% endif %}">
-              {%- if block.settings.image != blank -%}
-                <img srcset="{%- if block.settings.image.width >= 500 -%}{{ block.settings.image | img_url: '500x' }} 500w,{%- endif -%}
-                  {%- if block.settings.image.width >= 730 -%}{{ block.settings.image | img_url: '730x' }} 730w,{%- endif -%}
-                  {%- if block.settings.image.width >= 1440 -%}{{ block.settings.image | img_url: '1440x' }} 1440w,{%- endif -%}
-                  {%- if block.settings.image.width >= 990 -%}{{ block.settings.image | img_url: '990x' }} 990w,{%- endif -%}
-                  {%- if block.settings.image.width >= 2080 -%}{{ block.settings.image | img_url: '2080x' }} 2080w{%- endif -%}"
-                  src="{{ block.settings.image | img_url: '720x' }}"
-                  sizes="(min-width: 990px){% if section.blocks.size == 1 %} 990px{% else %} 730px{% endif %}, (min-width: 750px){% if section.blocks.size == 1 %} calc(100vw - 100px){% else%} 500px{% endif %}, calc(100vw - 30px)"
-                  alt="{{ block.settings.image.alt | escape }}"
-                  loading="lazy"
-                  width="{{ block.settings.image.width }}"
-                  height="{{ block.settings.image.height }}"
-                  class="collage-card__image"
-                >
-              {%- else -%}
-                {{ 'image' | placeholder_svg_tag: 'placeholder-svg placeholder collage-card__image' }}
-              {%- endif -%}
-            </div>
-          </div>
-
-        {%- when 'product'-%}
-          <div class="collage-card collage-product card-wrapper{% if focus_card_left %} collage-card--left{% elsif focus_card_right %} collage-card--right{% endif %}">
-            {%- if block.settings.product != blank -%}
-              {%- assign featured_media = block.settings.product.selected_or_first_available_variant.featured_media | default: block.settings.product.featured_media -%}
-              <a href="{{ block.settings.product.url }}" class="collage-content full-unstyled-link card{% if block.settings.secondary_background %} card-colored color-background-1{% endif %}{% if block.settings.image_padding %} collage-card-spacing{% endif %}">
-                {%- if featured_media != blank -%}
-                  <div class="collage-card__image-wrapper media media--transparent media--hover-effect"
-                    {% if focus_card_left and forloop.first %}
-                      style="padding-bottom: {{ 1 | divided_by: featured_media.aspect_ratio | times: 100 }}%;"
-                    {% elsif focus_card_right and forloop.last %}
-                      style="padding-bottom: {{ 1 | divided_by: featured_media.aspect_ratio | times: 100 }}%;"
-                    {% endif %}
+        <div {{ block.shopify_attributes }}>
+          {%- when 'image' -%}
+            <div class="collage-card color-{{ block.settings.color_scheme }}{% if focus_card_left %} collage-card--left{% elsif focus_card_right %} collage-card--right{% endif %}">
+              <div class="collage-content collage-card__image-wrapper media media--transparent{% if block.settings.image_padding %} collage-card-spacing{% endif %}">
+                {%- if block.settings.image != blank -%}
+                  <img srcset="{%- if block.settings.image.width >= 500 -%}{{ block.settings.image | img_url: '500x' }} 500w,{%- endif -%}
+                    {%- if block.settings.image.width >= 730 -%}{{ block.settings.image | img_url: '730x' }} 730w,{%- endif -%}
+                    {%- if block.settings.image.width >= 1440 -%}{{ block.settings.image | img_url: '1440x' }} 1440w,{%- endif -%}
+                    {%- if block.settings.image.width >= 990 -%}{{ block.settings.image | img_url: '990x' }} 990w,{%- endif -%}
+                    {%- if block.settings.image.width >= 2080 -%}{{ block.settings.image | img_url: '2080x' }} 2080w{%- endif -%}"
+                    src="{{ block.settings.image | img_url: '720x' }}"
+                    sizes="(min-width: 990px){% if section.blocks.size == 1 %} 990px{% else %} 730px{% endif %}, (min-width: 750px){% if section.blocks.size == 1 %} calc(100vw - 100px){% else%} 500px{% endif %}, calc(100vw - 30px)"
+                    alt="{{ block.settings.image.alt | escape }}"
+                    loading="lazy"
+                    width="{{ block.settings.image.width }}"
+                    height="{{ block.settings.image.height }}"
+                    class="collage-card__image"
                   >
-                    <img srcset="{%- if featured_media.width >= 500 -%}{{ featured_media | img_url: '500x' }} 500w,{%- endif -%}
-                      {%- if featured_media.width >= 730 -%}{{ featured_media | img_url: '730x' }} 730w,{%- endif -%}
-                      {%- if featured_media.width >= 1440 -%}{{ featured_media | img_url: '1440x' }} 1440w,{%- endif -%}
-                      {%- if featured_media.width >= 990 -%}{{ featured_media | img_url: '990x' }} 990w,{%- endif -%}
-                      {%- if featured_media.width >= 2080 -%}{{ featured_media | img_url: '2080x' }} 2080w{%- endif -%}"
-                      src="{{ featured_media | img_url: '533x' }}"
-                      sizes="(min-width: 990px){% if section.blocks.size == 1 %} 990px{% else %} 730px{% endif %}, (min-width: 750px){% if section.blocks.size == 1 %} calc(100vw - 100px){% else %} 500px{% endif %}, calc(100vw - 30px)"
-                      alt="{{ featured_media.alt | escape }}"
-                      loading="lazy"
-                      width="{{ featured_media.width }}"
-                      height="{{ featured_media.height }}"
-                      class="collage-card__image"
-                    >
-
-                    {%- if block.settings.second_image and block.settings.product.media[1] != nil -%}
-                      <img srcset="{%- if block.settings.product.media[1].width >= 500 -%}{{ block.settings.product.media[1] | img_url: '500x' }} 500w,{%- endif -%}
-                        {%- if block.settings.product.media[1].width >= 730 -%}{{ block.settings.product.media[1] | img_url: '730x' }} 730w,{%- endif -%}
-                        {%- if block.settings.product.media[1].width >= 1440 -%}{{ block.settings.product.media[1] | img_url: '1440x' }} 1440w,{%- endif -%}
-                        {%- if block.settings.product.media[1].width >= 990 -%}{{ block.settings.product.media[1] | img_url: '990x' }} 990w,{%- endif -%}
-                        {%- if block.settings.product.media[1].width >= 2080 -%}{{ block.settings.product.media[1] | img_url: '2080x' }} 2080w{%- endif -%}"
-                        src="{{ block.settings.product.media[1] | img_url: '533x' }}"
-                        sizes="(min-width: 990px){% if section.blocks.size == 1 %} 990px{% else %} 730px{% endif %}, (min-width: 750px){% if section.blocks.size == 1 %} calc(100vw - 100px){% else %} 500px{% endif %}, calc(100vw - 30px)"
-                        alt="{{ block.settings.product.media[1].alt | escape }}"
-                        loading="lazy"
-                        width="{{ block.settings.product.media[1].width }}"
-                        height="{{ block.settings.product.media[1].height }}"
-                        class="collage-card__image small-hide medium-hide"
-                      >
-                    {%- endif -%}
-                  </div>
-                  <div class="collage-product__badge">
-                    <div class="card__badge">
-                      {%- if block.settings.product.available == false -%}
-                        <span class="badge badge--bottom-left color-{{ settings.sold_out_badge_color_scheme }}" aria-hidden="true">
-                          {{ 'products.product.sold_out' | t }}
-                        </span>
-                      {%- elsif block.settings.product.compare_at_price > block.settings.product.price and block.settings.product.available -%}
-                        <span class="badge badge--bottom-left color-{{ settings.sale_badge_color_scheme }}" aria-hidden="true">
-                          {{ 'products.product.on_sale' | t }}
-                        </span>
-                      {%- endif -%}
-                    </div>
-                  </div>
-                  <div class="collage-content__info card-information card-information__wrapper">
-                    <h3 class="card-information__text h4">{{ block.settings.product.title | escape }}</h3>
-                    <span class="price">{% render 'price', product: block.settings.product %}</span>
-                  </div>
                 {%- else -%}
-                  <div class="collage-card__no-image card-colored color-background-1 card__text-spacing center">
-                    <h3 class="h2">{{ block.settings.product.title | escape }}</h3>
-                  </div>
-                  <div class="collage-product__badge">
-                    <div class="card__badge">
-                      {%- if block.settings.product.available == false -%}
-                        <span class="badge badge--bottom-left color-{{ settings.sold_out_badge_color_scheme }}" aria-hidden="true">
-                          {{ 'products.product.sold_out' | t }}
-                        </span>
-                      {%- elsif block.settings.product.compare_at_price > block.settings.product.price and block.settings.product.available -%}
-                        <span class="badge badge--bottom-left color-{{ settings.sale_badge_color_scheme }}" aria-hidden="true">
-                          {{ 'products.product.on_sale' | t }}
-                        </span>
+                  {{ 'image' | placeholder_svg_tag: 'placeholder-svg placeholder collage-card__image' }}
+                {%- endif -%}
+              </div>
+            </div>
+
+          {%- when 'product'-%}
+            <div class="collage-card collage-product card-wrapper{% if focus_card_left %} collage-card--left{% elsif focus_card_right %} collage-card--right{% endif %}">
+              {%- if block.settings.product != blank -%}
+                {%- assign featured_media = block.settings.product.selected_or_first_available_variant.featured_media | default: block.settings.product.featured_media -%}
+                <a href="{{ block.settings.product.url }}" class="collage-content full-unstyled-link card{% if block.settings.secondary_background %} card-colored color-background-1{% endif %}{% if block.settings.image_padding %} collage-card-spacing{% endif %}">
+                  {%- if featured_media != blank -%}
+                    <div class="collage-card__image-wrapper media media--transparent media--hover-effect"
+                      {% if focus_card_left and forloop.first %}
+                        style="padding-bottom: {{ 1 | divided_by: featured_media.aspect_ratio | times: 100 }}%;"
+                      {% elsif focus_card_right and forloop.last %}
+                        style="padding-bottom: {{ 1 | divided_by: featured_media.aspect_ratio | times: 100 }}%;"
+                      {% endif %}
+                    >
+                      <img srcset="{%- if featured_media.width >= 500 -%}{{ featured_media | img_url: '500x' }} 500w,{%- endif -%}
+                        {%- if featured_media.width >= 730 -%}{{ featured_media | img_url: '730x' }} 730w,{%- endif -%}
+                        {%- if featured_media.width >= 1440 -%}{{ featured_media | img_url: '1440x' }} 1440w,{%- endif -%}
+                        {%- if featured_media.width >= 990 -%}{{ featured_media | img_url: '990x' }} 990w,{%- endif -%}
+                        {%- if featured_media.width >= 2080 -%}{{ featured_media | img_url: '2080x' }} 2080w{%- endif -%}"
+                        src="{{ featured_media | img_url: '533x' }}"
+                        sizes="(min-width: 990px){% if section.blocks.size == 1 %} 990px{% else %} 730px{% endif %}, (min-width: 750px){% if section.blocks.size == 1 %} calc(100vw - 100px){% else %} 500px{% endif %}, calc(100vw - 30px)"
+                        alt="{{ featured_media.alt | escape }}"
+                        loading="lazy"
+                        width="{{ featured_media.width }}"
+                        height="{{ featured_media.height }}"
+                        class="collage-card__image"
+                      >
+
+                      {%- if block.settings.second_image and block.settings.product.media[1] != nil -%}
+                        <img srcset="{%- if block.settings.product.media[1].width >= 500 -%}{{ block.settings.product.media[1] | img_url: '500x' }} 500w,{%- endif -%}
+                          {%- if block.settings.product.media[1].width >= 730 -%}{{ block.settings.product.media[1] | img_url: '730x' }} 730w,{%- endif -%}
+                          {%- if block.settings.product.media[1].width >= 1440 -%}{{ block.settings.product.media[1] | img_url: '1440x' }} 1440w,{%- endif -%}
+                          {%- if block.settings.product.media[1].width >= 990 -%}{{ block.settings.product.media[1] | img_url: '990x' }} 990w,{%- endif -%}
+                          {%- if block.settings.product.media[1].width >= 2080 -%}{{ block.settings.product.media[1] | img_url: '2080x' }} 2080w{%- endif -%}"
+                          src="{{ block.settings.product.media[1] | img_url: '533x' }}"
+                          sizes="(min-width: 990px){% if section.blocks.size == 1 %} 990px{% else %} 730px{% endif %}, (min-width: 750px){% if section.blocks.size == 1 %} calc(100vw - 100px){% else %} 500px{% endif %}, calc(100vw - 30px)"
+                          alt="{{ block.settings.product.media[1].alt | escape }}"
+                          loading="lazy"
+                          width="{{ block.settings.product.media[1].width }}"
+                          height="{{ block.settings.product.media[1].height }}"
+                          class="collage-card__image small-hide medium-hide"
+                        >
                       {%- endif -%}
                     </div>
-                  </div>
-                  <div class="collage-content__info">
-                    {% render 'price', product: block.settings.product %}
-                  </div>
-                {%- endif -%}
-              </a>
-            {%- else -%}
-              <div class="collage-content">
-                <div class="collage-card__no-image card-colored color-background-1 card__text-spacing center">
-                  <h3 class="h2">{{ 'onboarding.product_title' | t }}</h3>
-                </div>
-                <div class="collage-content__info">
-                  <span class="price">{% render 'price' %}</span>
-                </div>
-              </div>
-            {%- endif -%}
-          </div>
-
-        {%- when 'collection'-%}
-          <div class="collage-card color-{{ block.settings.color_scheme }}{% if focus_card_left %} collage-card--left{% elsif focus_card_right %} collage-card--right{% endif %}">
-              {%- if block.settings.collection != blank -%}
-                <a href="{{ block.settings.collection.url }}" class="card animate-arrow">
-                  <div class="collage-content card-colored color-{{ block.settings.color_scheme }}{% if block.settings.image_padding %} collage-card-spacing{% endif %}">
-                    {%- if block.settings.collection.image != blank -%}
-                      <div class="collage-card__image-wrapper media media--transparent media--hover-effect">
-                        <img srcset="{%- if block.settings.collection.image.width >= 500 -%}{{ block.settings.collection.image | img_url: '500x' }} 500w,{%- endif -%}
-                          {%- if block.settings.collection.image.width >= 730 -%}{{ block.settings.collection.image | img_url: '730x' }} 730w,{%- endif -%}
-                          {%- if block.settings.collection.image.width >= 1440 -%}{{ block.settings.collection.image | img_url: '1440x' }} 1440w,{%- endif -%}
-                          {%- if block.settings.collection.image.width >= 990 -%}{{ block.settings.collection.image | img_url: '990x' }} 990w,{%- endif -%}
-                          {%- if block.settings.collection.image.width >= 2080 -%}{{ block.settings.collection.image | img_url: '2080x' }} 2080w{%- endif -%}"
-                          src="{{ block.settings.collection.image | img_url: '533x' }}"
-                          sizes="(min-width: 990px){% if section.blocks.size == 1 %} 990px{% else %} 730px{% endif %}, (min-width: 750px){% if section.blocks.size == 1 %} calc(100vw - 100px){% else%} 500px{% endif %}, calc(100vw - 30px)"
-                          alt="{{ block.settings.collection.image.alt | escape }}"
-                          loading="lazy"
-                          width="{{ block.settings.collection.image.width }}"
-                          height="{{ block.settings.collection.image.height }}"
-                          class="collage-card__image"
-                        >
-                      </div>
-
-                      {% unless section.settings.image_padding %}<div class="overlay-card"></div>{% endunless %}
-                      <div class="collage-content__info">
-                        <h3>{{ block.settings.collection.title | escape }}<span class="icon-wrap">&nbsp;{% render 'icon-arrow' %}</span></h3>
-                      </div>
-                    {%- else -%}
-                      <div class="collage-card__no-image card__text-spacing card__text-hover card-color ">
-                        <div class="overlay-card"></div>
-                        <h3 class="h2">
-                          {{- block.settings.collection.title -}}<span class="icon-wrap{% if block.settings.collection.description != blank %} collage-card__arrow{% endif %}">&nbsp;{% render 'icon-arrow' %}</span>
-                        </h3>
-
-                        {%- if block.settings.collection.description != blank -%}
-                          <p class="collage-card__description card__caption">
-                            {{- block.settings.collection.description | strip_html | truncatewords: 12 -}}<span class="icon-wrap">&nbsp;{% render 'icon-arrow' %}</span>
-                          </p>
+                    <div class="collage-product__badge">
+                      <div class="card__badge">
+                        {%- if block.settings.product.available == false -%}
+                          <span class="badge badge--bottom-left color-{{ settings.sold_out_badge_color_scheme }}" aria-hidden="true">
+                            {{ 'products.product.sold_out' | t }}
+                          </span>
+                        {%- elsif block.settings.product.compare_at_price > block.settings.product.price and block.settings.product.available -%}
+                          <span class="badge badge--bottom-left color-{{ settings.sale_badge_color_scheme }}" aria-hidden="true">
+                            {{ 'products.product.on_sale' | t }}
+                          </span>
                         {%- endif -%}
                       </div>
-                    {%- endif -%}
-                  </div>
+                    </div>
+                    <div class="collage-content__info card-information card-information__wrapper">
+                      <h3 class="card-information__text h4">{{ block.settings.product.title | escape }}</h3>
+                      <span class="price">{% render 'price', product: block.settings.product %}</span>
+                    </div>
+                  {%- else -%}
+                    <div class="collage-card__no-image card-colored color-background-1 card__text-spacing center">
+                      <h3 class="h2">{{ block.settings.product.title | escape }}</h3>
+                    </div>
+                    <div class="collage-product__badge">
+                      <div class="card__badge">
+                        {%- if block.settings.product.available == false -%}
+                          <span class="badge badge--bottom-left color-{{ settings.sold_out_badge_color_scheme }}" aria-hidden="true">
+                            {{ 'products.product.sold_out' | t }}
+                          </span>
+                        {%- elsif block.settings.product.compare_at_price > block.settings.product.price and block.settings.product.available -%}
+                          <span class="badge badge--bottom-left color-{{ settings.sale_badge_color_scheme }}" aria-hidden="true">
+                            {{ 'products.product.on_sale' | t }}
+                          </span>
+                        {%- endif -%}
+                      </div>
+                    </div>
+                    <div class="collage-content__info">
+                      {% render 'price', product: block.settings.product %}
+                    </div>
+                  {%- endif -%}
                 </a>
               {%- else -%}
-                <div class="collage-content card card-colored color-{{ block.settings.color_scheme }}">
-                  <div class="collage-card__no-image card__text-spacing card__text-hover">
-                    <h3 class="h2">
-                      {{ 'onboarding.collection_title' | t }}<span class="icon-wrap">&nbsp;{% render 'icon-arrow' %}</span>
-                    </h3>
+                <div class="collage-content">
+                  <div class="collage-card__no-image card-colored color-background-1 card__text-spacing center">
+                    <h3 class="h2">{{ 'onboarding.product_title' | t }}</h3>
+                  </div>
+                  <div class="collage-content__info">
+                    <span class="price">{% render 'price' %}</span>
                   </div>
                 </div>
               {%- endif -%}
-          </div>
+            </div>
 
-        {%- when 'video' -%}
-          <div class="collage-card collage-video{% if focus_card_left %} collage-card--left{% elsif focus_card_right %} collage-card--right{% endif %}">
-            <noscript>
-              <a href="{{ block.settings.video_url }}" class="card{% if block.settings.cover_image == blank %} collage-video-placeholder{% endif %}"
-                {% if block.settings.cover_image != blank and focus_card_left and forloop.first %}
-                  style="padding-bottom: {{ 1 | divided_by: block.settings.cover_image.aspect_ratio | times: 100 }}%;"
-                {% elsif block.settings.cover_image != blank and focus_card_right and forloop.last %}
-                  style="padding-bottom: {{ 1 | divided_by: block.settings.cover_image.aspect_ratio | times: 100 }}%;"
-                {% endif %}
-              >
-                <div class="collage-content collage-card__image-wrapper media media--transparent{% if block.settings.image_padding %} collage-card-spacing{% endif %}">
-                  {%- if block.settings.cover_image != blank -%}
-                    <img
-                      srcset="{%- if block.settings.cover_image.width >= 500 -%}{{ block.settings.cover_image | img_url: '500x' }} 500w,{%- endif -%}
-                      {%- if block.settings.cover_image.width >= 730 -%}{{ block.settings.cover_image | img_url: '730x' }} 730w,{%- endif -%}
-                      {%- if block.settings.cover_image.width >= 1440 -%}{{ block.settings.cover_image | img_url: '1440x' }} 1440w,{%- endif -%}
-                      {%- if block.settings.cover_image.width >= 990 -%}{{ block.settings.cover_image | img_url: '990x' }} 990w,{%- endif -%}
-                      {%- if block.settings.cover_image.width >= 2080 -%}{{ block.settings.cover_image | img_url: '2080x' }} 2080w{%- endif -%}"
-                      src="{{ block.settings.cover_image | img_url: '533x' }}"
-                      sizes="(min-width: 990px){% if section.blocks.size == 1 %} 990px{% else %} 730px{% endif %}, (min-width: 750px){% if section.blocks.size == 1 %} calc(100vw - 100px){% else%} 500px{% endif %}, calc(100vw - 30px)"
-                      alt="{{ block.settings.description | escape }}"
-                      loading="lazy"
-                      width="{{ block.settings.cover_image.width }}"
-                      height="{{ block.settings.cover_image.height }}"
-                      class="collage-card__image"
-                    >
-                  {%- else -%}
-                    {{ 'collection-2' | placeholder_svg_tag: 'placeholder-svg placeholder collage-card__image' }}
-                  {%- endif -%}
-                </div>
-              </a>
-            </noscript>
-            {%- if section.blocks.size == 1 -%}
-              <deferred-media class="deferred-media no-js-hidden{% if block.settings.image_padding %} collage-card-spacing{% endif %}" data-media-id="{{ block.settings.video_url.id }}"
-                {% if block.settings.cover_image != blank %}
-                  style="padding-bottom: {{ 1 | divided_by: block.settings.cover_image.aspect_ratio | times: 100 }}%;"
-                {% else %}
-                  style="padding-bottom: 100%;"
-                {% endif %}
-              >
-                <button
-                  id="Deferred-Poster-Modal-{{ block.settings.video_url.id }}"
-                  class="collage-content collage-card__image-wrapper media deferred-media__poster"
-                  type="button"
-                >
-                  {%- if block.settings.cover_image != blank -%}
-                    <img
-                      srcset="{%- if block.settings.cover_image.width >= 500 -%}{{ block.settings.cover_image | img_url: '500x' }} 500w,{%- endif -%}
-                      {%- if block.settings.cover_image.width >= 730 -%}{{ block.settings.cover_image | img_url: '730x' }} 730w,{%- endif -%}
-                      {%- if block.settings.cover_image.width >= 1440 -%}{{ block.settings.cover_image | img_url: '1440x' }} 1440w,{%- endif -%}
-                      {%- if block.settings.cover_image.width >= 990 -%}{{ block.settings.cover_image | img_url: '990x' }} 990w,{%- endif -%}
-                      {%- if block.settings.cover_image.width >= 2080 -%}{{ block.settings.cover_image | img_url: '2080x' }} 2080w{%- endif -%}"
-                      src="{{ block.settings.cover_image | img_url: '533x' }}"
-                      sizes="(min-width: 990px){% if section.blocks.size == 1 %} 990px{% else %} 730px{% endif %}, (min-width: 750px){% if section.blocks.size == 1 %} calc(100vw - 100px){% else%} 500px{% endif %}, calc(100vw - 30px)"
-                      alt="{{ block.settings.description | escape }}"
-                      loading="lazy"
-                      width="{{ block.settings.cover_image.width }}"
-                      height="{{ block.settings.cover_image.height }}"
-                      class="collage-card__image"
-                    >
-                  {%- else -%}
-                    {{ 'collection-2' | placeholder_svg_tag: 'placeholder-svg placeholder collage-card__image' }}
-                  {%- endif -%}
-                  <span class="deferred-media__poster-button motion-reduce">
-                    {%- render 'icon-play' -%}
-                  </span>
-                </button>
-                <template>
-                  {%- if block.settings.video_url.type == 'youtube' -%}
-                    <iframe src="https://www.youtube.com/embed/{{ block.settings.video_url.id }}?enablejsapi=1" class="js-youtube" allow="autoplay; encrypted-media" allowfullscreen title="{{ block.settings.description | escape }}"></iframe>
-                  {%- else -%}
-                    <iframe src="https://player.vimeo.com/video/{{ block.settings.video_url.id }}" class="js-vimeo" allow="autoplay; encrypted-media" allowfullscreen title="{{ block.settings.description | escape }}"></iframe>
-                  {%- endif -%}
-                </template>
-              </deferred-media>
-            {%- else -%}
-              <modal-opener class="no-js-hidden" data-modal="#PopupModal-{{ block.id }}">
-                <div class="deferred-media{% if block.settings.cover_image == blank %} deferred-media--placeholder{% endif %}"
+          {%- when 'collection'-%}
+            <div class="collage-card color-{{ block.settings.color_scheme }}{% if focus_card_left %} collage-card--left{% elsif focus_card_right %} collage-card--right{% endif %}">
+                {%- if block.settings.collection != blank -%}
+                  <a href="{{ block.settings.collection.url }}" class="card animate-arrow">
+                    <div class="collage-content card-colored color-{{ block.settings.color_scheme }}{% if block.settings.image_padding %} collage-card-spacing{% endif %}">
+                      {%- if block.settings.collection.image != blank -%}
+                        <div class="collage-card__image-wrapper media media--transparent media--hover-effect">
+                          <img srcset="{%- if block.settings.collection.image.width >= 500 -%}{{ block.settings.collection.image | img_url: '500x' }} 500w,{%- endif -%}
+                            {%- if block.settings.collection.image.width >= 730 -%}{{ block.settings.collection.image | img_url: '730x' }} 730w,{%- endif -%}
+                            {%- if block.settings.collection.image.width >= 1440 -%}{{ block.settings.collection.image | img_url: '1440x' }} 1440w,{%- endif -%}
+                            {%- if block.settings.collection.image.width >= 990 -%}{{ block.settings.collection.image | img_url: '990x' }} 990w,{%- endif -%}
+                            {%- if block.settings.collection.image.width >= 2080 -%}{{ block.settings.collection.image | img_url: '2080x' }} 2080w{%- endif -%}"
+                            src="{{ block.settings.collection.image | img_url: '533x' }}"
+                            sizes="(min-width: 990px){% if section.blocks.size == 1 %} 990px{% else %} 730px{% endif %}, (min-width: 750px){% if section.blocks.size == 1 %} calc(100vw - 100px){% else%} 500px{% endif %}, calc(100vw - 30px)"
+                            alt="{{ block.settings.collection.image.alt | escape }}"
+                            loading="lazy"
+                            width="{{ block.settings.collection.image.width }}"
+                            height="{{ block.settings.collection.image.height }}"
+                            class="collage-card__image"
+                          >
+                        </div>
+
+                        {% unless section.settings.image_padding %}<div class="overlay-card"></div>{% endunless %}
+                        <div class="collage-content__info">
+                          <h3>{{ block.settings.collection.title | escape }}<span class="icon-wrap">&nbsp;{% render 'icon-arrow' %}</span></h3>
+                        </div>
+                      {%- else -%}
+                        <div class="collage-card__no-image card__text-spacing card__text-hover card-color ">
+                          <div class="overlay-card"></div>
+                          <h3 class="h2">
+                            {{- block.settings.collection.title -}}<span class="icon-wrap{% if block.settings.collection.description != blank %} collage-card__arrow{% endif %}">&nbsp;{% render 'icon-arrow' %}</span>
+                          </h3>
+
+                          {%- if block.settings.collection.description != blank -%}
+                            <p class="collage-card__description card__caption">
+                              {{- block.settings.collection.description | strip_html | truncatewords: 12 -}}<span class="icon-wrap">&nbsp;{% render 'icon-arrow' %}</span>
+                            </p>
+                          {%- endif -%}
+                        </div>
+                      {%- endif -%}
+                    </div>
+                  </a>
+                {%- else -%}
+                  <div class="collage-content card card-colored color-{{ block.settings.color_scheme }}">
+                    <div class="collage-card__no-image card__text-spacing card__text-hover">
+                      <h3 class="h2">
+                        {{ 'onboarding.collection_title' | t }}<span class="icon-wrap">&nbsp;{% render 'icon-arrow' %}</span>
+                      </h3>
+                    </div>
+                  </div>
+                {%- endif -%}
+            </div>
+
+          {%- when 'video' -%}
+            <div class="collage-card collage-video{% if focus_card_left %} collage-card--left{% elsif focus_card_right %} collage-card--right{% endif %}">
+              <noscript>
+                <a href="{{ block.settings.video_url }}" class="card{% if block.settings.cover_image == blank %} collage-video-placeholder{% endif %}"
                   {% if block.settings.cover_image != blank and focus_card_left and forloop.first %}
                     style="padding-bottom: {{ 1 | divided_by: block.settings.cover_image.aspect_ratio | times: 100 }}%;"
                   {% elsif block.settings.cover_image != blank and focus_card_right and forloop.last %}
                     style="padding-bottom: {{ 1 | divided_by: block.settings.cover_image.aspect_ratio | times: 100 }}%;"
-                  {% endif %}>
-                  <button class="collage-content collage-card__image-wrapper media deferred-media__poster full-unstyled-link{% if block.settings.image_padding %} collage-card-spacing{% endif %}" type="button" aria-haspopup="dialog" data-media-id="{{ block.settings.video_url.id }}">
-                    <span class="deferred-media__poster-button motion-reduce">
-                      {%- render 'icon-play' -%}
-                    </span>
-
+                  {% endif %}
+                >
+                  <div class="collage-content collage-card__image-wrapper media media--transparent{% if block.settings.image_padding %} collage-card-spacing{% endif %}">
                     {%- if block.settings.cover_image != blank -%}
                       <img
                         srcset="{%- if block.settings.cover_image.width >= 500 -%}{{ block.settings.cover_image | img_url: '500x' }} 500w,{%- endif -%}
@@ -295,27 +219,105 @@
                     {%- else -%}
                       {{ 'collection-2' | placeholder_svg_tag: 'placeholder-svg placeholder collage-card__image' }}
                     {%- endif -%}
+                  </div>
+                </a>
+              </noscript>
+              {%- if section.blocks.size == 1 -%}
+                <deferred-media class="deferred-media no-js-hidden{% if block.settings.image_padding %} collage-card-spacing{% endif %}" data-media-id="{{ block.settings.video_url.id }}"
+                  {% if block.settings.cover_image != blank %}
+                    style="padding-bottom: {{ 1 | divided_by: block.settings.cover_image.aspect_ratio | times: 100 }}%;"
+                  {% else %}
+                    style="padding-bottom: 100%;"
+                  {% endif %}
+                >
+                  <button
+                    id="Deferred-Poster-Modal-{{ block.settings.video_url.id }}"
+                    class="collage-content collage-card__image-wrapper media deferred-media__poster"
+                    type="button"
+                  >
+                    {%- if block.settings.cover_image != blank -%}
+                      <img
+                        srcset="{%- if block.settings.cover_image.width >= 500 -%}{{ block.settings.cover_image | img_url: '500x' }} 500w,{%- endif -%}
+                        {%- if block.settings.cover_image.width >= 730 -%}{{ block.settings.cover_image | img_url: '730x' }} 730w,{%- endif -%}
+                        {%- if block.settings.cover_image.width >= 1440 -%}{{ block.settings.cover_image | img_url: '1440x' }} 1440w,{%- endif -%}
+                        {%- if block.settings.cover_image.width >= 990 -%}{{ block.settings.cover_image | img_url: '990x' }} 990w,{%- endif -%}
+                        {%- if block.settings.cover_image.width >= 2080 -%}{{ block.settings.cover_image | img_url: '2080x' }} 2080w{%- endif -%}"
+                        src="{{ block.settings.cover_image | img_url: '533x' }}"
+                        sizes="(min-width: 990px){% if section.blocks.size == 1 %} 990px{% else %} 730px{% endif %}, (min-width: 750px){% if section.blocks.size == 1 %} calc(100vw - 100px){% else%} 500px{% endif %}, calc(100vw - 30px)"
+                        alt="{{ block.settings.description | escape }}"
+                        loading="lazy"
+                        width="{{ block.settings.cover_image.width }}"
+                        height="{{ block.settings.cover_image.height }}"
+                        class="collage-card__image"
+                      >
+                    {%- else -%}
+                      {{ 'collection-2' | placeholder_svg_tag: 'placeholder-svg placeholder collage-card__image' }}
+                    {%- endif -%}
+                    <span class="deferred-media__poster-button motion-reduce">
+                      {%- render 'icon-play' -%}
+                    </span>
                   </button>
-                </div>
-              </modal-opener>
+                  <template>
+                    {%- if block.settings.video_url.type == 'youtube' -%}
+                      <iframe src="https://www.youtube.com/embed/{{ block.settings.video_url.id }}?enablejsapi=1" class="js-youtube" allow="autoplay; encrypted-media" allowfullscreen title="{{ block.settings.description | escape }}"></iframe>
+                    {%- else -%}
+                      <iframe src="https://player.vimeo.com/video/{{ block.settings.video_url.id }}" class="js-vimeo" allow="autoplay; encrypted-media" allowfullscreen title="{{ block.settings.description | escape }}"></iframe>
+                    {%- endif -%}
+                  </template>
+                </deferred-media>
+              {%- else -%}
+                <modal-opener class="no-js-hidden" data-modal="#PopupModal-{{ block.id }}">
+                  <div class="deferred-media{% if block.settings.cover_image == blank %} deferred-media--placeholder{% endif %}"
+                    {% if block.settings.cover_image != blank and focus_card_left and forloop.first %}
+                      style="padding-bottom: {{ 1 | divided_by: block.settings.cover_image.aspect_ratio | times: 100 }}%;"
+                    {% elsif block.settings.cover_image != blank and focus_card_right and forloop.last %}
+                      style="padding-bottom: {{ 1 | divided_by: block.settings.cover_image.aspect_ratio | times: 100 }}%;"
+                    {% endif %}>
+                    <button class="collage-content collage-card__image-wrapper media deferred-media__poster full-unstyled-link{% if block.settings.image_padding %} collage-card-spacing{% endif %}" type="button" aria-haspopup="dialog" data-media-id="{{ block.settings.video_url.id }}">
+                      <span class="deferred-media__poster-button motion-reduce">
+                        {%- render 'icon-play' -%}
+                      </span>
 
-              <modal-dialog id="PopupModal-{{ block.id }}" class="collage-video__modal">
-                <div class="collage-video__modal-content" role="dialog" aria-label="{{ block.settings.description | escape }}" aria-modal="true" tabindex="-1">
-                  <button id="ModalClose-{{ block.id }}" type="button" class="collage-video__modal-toggle" aria-label="{{ 'accessibility.close' | t }}">{% render 'icon-close' %}</button>
-                  <deferred-media class="collage-video__modal-video template-popup">
-                    <template>
-                      {%- if block.settings.video_url.type == 'youtube' -%}
-                        <iframe src="https://www.youtube.com/embed/{{ block.settings.video_url.id }}?enablejsapi=1" class="js-youtube" allow="autoplay; encrypted-media" allowfullscreen title="{{ block.settings.description | escape }}"></iframe>
+                      {%- if block.settings.cover_image != blank -%}
+                        <img
+                          srcset="{%- if block.settings.cover_image.width >= 500 -%}{{ block.settings.cover_image | img_url: '500x' }} 500w,{%- endif -%}
+                          {%- if block.settings.cover_image.width >= 730 -%}{{ block.settings.cover_image | img_url: '730x' }} 730w,{%- endif -%}
+                          {%- if block.settings.cover_image.width >= 1440 -%}{{ block.settings.cover_image | img_url: '1440x' }} 1440w,{%- endif -%}
+                          {%- if block.settings.cover_image.width >= 990 -%}{{ block.settings.cover_image | img_url: '990x' }} 990w,{%- endif -%}
+                          {%- if block.settings.cover_image.width >= 2080 -%}{{ block.settings.cover_image | img_url: '2080x' }} 2080w{%- endif -%}"
+                          src="{{ block.settings.cover_image | img_url: '533x' }}"
+                          sizes="(min-width: 990px){% if section.blocks.size == 1 %} 990px{% else %} 730px{% endif %}, (min-width: 750px){% if section.blocks.size == 1 %} calc(100vw - 100px){% else%} 500px{% endif %}, calc(100vw - 30px)"
+                          alt="{{ block.settings.description | escape }}"
+                          loading="lazy"
+                          width="{{ block.settings.cover_image.width }}"
+                          height="{{ block.settings.cover_image.height }}"
+                          class="collage-card__image"
+                        >
                       {%- else -%}
-                        <iframe src="https://player.vimeo.com/video/{{ block.settings.video_url.id }}" class="js-vimeo" allow="autoplay; encrypted-media" allowfullscreen title="{{ block.settings.description | escape }}"></iframe>
+                        {{ 'collection-2' | placeholder_svg_tag: 'placeholder-svg placeholder collage-card__image' }}
                       {%- endif -%}
-                    </template>
-                  </deferred-media>
-                </div>
-              </modal-dialog>
-            {%- endif -%}
-          </div>
-        {%- endcase -%}
+                    </button>
+                  </div>
+                </modal-opener>
+
+                <modal-dialog id="PopupModal-{{ block.id }}" class="collage-video__modal">
+                  <div class="collage-video__modal-content" role="dialog" aria-label="{{ block.settings.description | escape }}" aria-modal="true" tabindex="-1">
+                    <button id="ModalClose-{{ block.id }}" type="button" class="collage-video__modal-toggle" aria-label="{{ 'accessibility.close' | t }}">{% render 'icon-close' %}</button>
+                    <deferred-media class="collage-video__modal-video template-popup">
+                      <template>
+                        {%- if block.settings.video_url.type == 'youtube' -%}
+                          <iframe src="https://www.youtube.com/embed/{{ block.settings.video_url.id }}?enablejsapi=1" class="js-youtube" allow="autoplay; encrypted-media" allowfullscreen title="{{ block.settings.description | escape }}"></iframe>
+                        {%- else -%}
+                          <iframe src="https://player.vimeo.com/video/{{ block.settings.video_url.id }}" class="js-vimeo" allow="autoplay; encrypted-media" allowfullscreen title="{{ block.settings.description | escape }}"></iframe>
+                        {%- endif -%}
+                      </template>
+                    </deferred-media>
+                  </div>
+                </modal-dialog>
+              {%- endif -%}
+            </div>
+          {%- endcase -%}
+        </div>
     {%- endfor -%}
   </div>
 </div>

--- a/sections/collection-list.liquid
+++ b/sections/collection-list.liquid
@@ -20,7 +20,7 @@
       role="list"
     >
       {%- for block in section.blocks -%}
-        <li class="collection-list__item grid__item{% if section.settings.swipe_on_mobile %} slider__slide{% endif %}">
+        <li class="collection-list__item grid__item{% if section.settings.swipe_on_mobile %} slider__slide{% endif %}" {{ block.shopify_attributes }}>
           <a{% if block.settings.collection != blank and block.settings.collection.all_products_count > 0 %} href="{{ block.settings.collection.url }}"{% endif %}
             class="card animate-arrow link{% if block.settings.collection.image != blank %} card--media{% else %}{% if section.settings.image_ratio != 'adapt' %} card--stretch{% endif %}{% endif %}{% unless section.settings.image_padding %} card--light-border{% endunless %}"
           >

--- a/sections/footer.liquid
+++ b/sections/footer.liquid
@@ -31,9 +31,8 @@
         -%}
         <div class="footer__blocks-wrapper grid grid--1-col grid--2-col grid--4-col-tablet {{ footer_grid_class }}">
           {%- for block in section.blocks -%}
-
             {%- if block.type == 'link_list' and block.settings.heading != blank -%}
-              <div class="accordion">
+              <div class="accordion" {{ block.shopify_attributes }}>
                 <details>
                   <summary><h2 class="h4 accordion__title">{{ block.settings.heading | escape }}</h2>{% render 'icon-caret' %}</summary>
                   {%- if block.settings.menu != blank -%}
@@ -51,7 +50,7 @@
               </div>
             {%- endif -%}
 
-            <div class="footer-block grid__item{% if block.type == 'link_list' and block.settings.heading != blank %} footer-block--menu small-hide{% endif %}">
+            <div class="footer-block grid__item{% if block.type == 'link_list' and block.settings.heading != blank %} footer-block--menu small-hide{% endif %}" {{ block.shopify_attributes }}>
               {%- if block.settings.heading != blank -%}
                 <h2 class="footer-block__heading">{{- block.settings.heading | escape -}}</h2>
               {%- endif -%}

--- a/sections/image-banner.liquid
+++ b/sections/image-banner.liquid
@@ -56,27 +56,25 @@
   <div class="banner__content page-width" style="align-items: {{ section.settings.desktop_text_box_position }};">
     <div class="banner__box color-{{ section.settings.color_scheme }}">
       {%- for block in section.blocks -%}
-        <div {{ block.shopify_attributes }}>
-          {%- case block.type -%}
-            {%- when 'heading' -%}
-              <h2 class="banner__heading h1">
-                <span>{{ block.settings.heading | escape }}</span>
-              </h2>
-            {%- when 'text' -%}
-              <div class="banner__text">
-                <span>{{ block.settings.text | escape }}</span>
-              </div>
-            {%- when 'buttons' -%}
-              <div class="banner__buttons{% if block.settings.button_label_1 != blank and block.settings.button_link_1 != blank and block.settings.button_label_2 != blank and block.settings.button_link_2 != blank %} banner__buttons--multiple{% endif %}">
-                {%- if block.settings.button_label_1 != blank -%}
-                  <a href="{{ block.settings.button_link_1 }}" class="button{% if block.settings.button_style_secondary_1 %} button--secondary{% else %} button--primary{% endif %}"{% if block.settings.button_link_1 == blank %} aria-disabled="true"{% endif %}>{{ block.settings.button_label_1 | escape }}</a>
-                {%- endif -%}
-                {%- if block.settings.button_label_2 != blank -%}
-                  <a href="{{ block.settings.button_link_2 }}" class="button{% if block.settings.button_style_secondary_2 %} button--secondary{% else %} button--primary{% endif %}"{% if block.settings.button_link_2 == blank %} aria-disabled="true"{% endif %}>{{ block.settings.button_label_2 | escape }}</a>
-                {%- endif -%}
-              </div>
-          {%- endcase -%}
-        </div>
+        {%- case block.type -%}
+          {%- when 'heading' -%}
+            <h2 class="banner__heading h1" {{ block.shopify_attributes }}>
+              <span>{{ block.settings.heading | escape }}</span>
+            </h2>
+          {%- when 'text' -%}
+            <div class="banner__text" {{ block.shopify_attributes }}>
+              <span>{{ block.settings.text | escape }}</span>
+            </div>
+          {%- when 'buttons' -%}
+            <div class="banner__buttons{% if block.settings.button_label_1 != blank and block.settings.button_link_1 != blank and block.settings.button_label_2 != blank and block.settings.button_link_2 != blank %} banner__buttons--multiple{% endif %}" {{ block.shopify_attributes }}>
+              {%- if block.settings.button_label_1 != blank -%}
+                <a href="{{ block.settings.button_link_1 }}" class="button{% if block.settings.button_style_secondary_1 %} button--secondary{% else %} button--primary{% endif %}"{% if block.settings.button_link_1 == blank %} aria-disabled="true"{% endif %}>{{ block.settings.button_label_1 | escape }}</a>
+              {%- endif -%}
+              {%- if block.settings.button_label_2 != blank -%}
+                <a href="{{ block.settings.button_link_2 }}" class="button{% if block.settings.button_style_secondary_2 %} button--secondary{% else %} button--primary{% endif %}"{% if block.settings.button_link_2 == blank %} aria-disabled="true"{% endif %}>{{ block.settings.button_label_2 | escape }}</a>
+              {%- endif -%}
+            </div>
+        {%- endcase -%}
       {%- endfor -%}
     </div>
   </div>

--- a/sections/image-banner.liquid
+++ b/sections/image-banner.liquid
@@ -56,25 +56,27 @@
   <div class="banner__content page-width" style="align-items: {{ section.settings.desktop_text_box_position }};">
     <div class="banner__box color-{{ section.settings.color_scheme }}">
       {%- for block in section.blocks -%}
-        {%- case block.type -%}
-          {%- when 'heading' -%}
-            <h2 class="banner__heading h1">
-              <span>{{ block.settings.heading | escape }}</span>
-            </h2>
-          {%- when 'text' -%}
-            <div class="banner__text">
-              <span>{{ block.settings.text | escape }}</span>
-            </div>
-          {%- when 'buttons' -%}
-            <div class="banner__buttons{% if block.settings.button_label_1 != blank and block.settings.button_link_1 != blank and block.settings.button_label_2 != blank and block.settings.button_link_2 != blank %} banner__buttons--multiple{% endif %}">
-              {%- if block.settings.button_label_1 != blank -%}
-                <a href="{{ block.settings.button_link_1 }}" class="button{% if block.settings.button_style_secondary_1 %} button--secondary{% else %} button--primary{% endif %}"{% if block.settings.button_link_1 == blank %} aria-disabled="true"{% endif %}>{{ block.settings.button_label_1 | escape }}</a>
-              {%- endif -%}
-              {%- if block.settings.button_label_2 != blank -%}
-                <a href="{{ block.settings.button_link_2 }}" class="button{% if block.settings.button_style_secondary_2 %} button--secondary{% else %} button--primary{% endif %}"{% if block.settings.button_link_2 == blank %} aria-disabled="true"{% endif %}>{{ block.settings.button_label_2 | escape }}</a>
-              {%- endif -%}
-            </div>
-        {%- endcase -%}
+        <div {{ block.shopify_attributes }}>
+          {%- case block.type -%}
+            {%- when 'heading' -%}
+              <h2 class="banner__heading h1">
+                <span>{{ block.settings.heading | escape }}</span>
+              </h2>
+            {%- when 'text' -%}
+              <div class="banner__text">
+                <span>{{ block.settings.text | escape }}</span>
+              </div>
+            {%- when 'buttons' -%}
+              <div class="banner__buttons{% if block.settings.button_label_1 != blank and block.settings.button_link_1 != blank and block.settings.button_label_2 != blank and block.settings.button_link_2 != blank %} banner__buttons--multiple{% endif %}">
+                {%- if block.settings.button_label_1 != blank -%}
+                  <a href="{{ block.settings.button_link_1 }}" class="button{% if block.settings.button_style_secondary_1 %} button--secondary{% else %} button--primary{% endif %}"{% if block.settings.button_link_1 == blank %} aria-disabled="true"{% endif %}>{{ block.settings.button_label_1 | escape }}</a>
+                {%- endif -%}
+                {%- if block.settings.button_label_2 != blank -%}
+                  <a href="{{ block.settings.button_link_2 }}" class="button{% if block.settings.button_style_secondary_2 %} button--secondary{% else %} button--primary{% endif %}"{% if block.settings.button_link_2 == blank %} aria-disabled="true"{% endif %}>{{ block.settings.button_label_2 | escape }}</a>
+                {%- endif -%}
+              </div>
+          {%- endcase -%}
+        </div>
       {%- endfor -%}
     </div>
   </div>

--- a/sections/image-with-text.liquid
+++ b/sections/image-with-text.liquid
@@ -28,18 +28,20 @@
     <div class="grid__item">
       <div class="image-with-text__content image-with-text__content--{{ section.settings.height }}">
         {%- for block in section.blocks -%}
-          {% case block.type %}
-            {%- when 'heading' -%}
-              <h2 class="image-with-text__heading h1">
-                {{ block.settings.heading | escape }}
-              </h2>
-            {%- when 'text' -%}
-              <div class="image-with-text__text rte">{{ block.settings.text }}</div>
-            {%- when 'button' -%}
-              {%- if block.settings.button_label != blank -%}
-                <a href="{{ block.settings.button_link }}" class="button{% if block.settings.button_style_secondary %} button--secondary{% else %} button--primary{% endif %}"{% if block.settings.button_link == blank %} aria-disabled="true"{% endif %}>{{ block.settings.button_label | escape }}</a>
-              {%- endif -%}
-          {%- endcase -%}
+          <div {{ block.shopify_attributes }}>
+            {% case block.type %}
+              {%- when 'heading' -%}
+                <h2 class="image-with-text__heading h1">
+                  {{ block.settings.heading | escape }}
+                </h2>
+              {%- when 'text' -%}
+                <div class="image-with-text__text rte">{{ block.settings.text }}</div>
+              {%- when 'button' -%}
+                {%- if block.settings.button_label != blank -%}
+                  <a href="{{ block.settings.button_link }}" class="button{% if block.settings.button_style_secondary %} button--secondary{% else %} button--primary{% endif %}"{% if block.settings.button_link == blank %} aria-disabled="true"{% endif %}>{{ block.settings.button_label | escape }}</a>
+                {%- endif -%}
+            {%- endcase -%}
+          </div>
         {%- endfor -%}
       </div>
     </div>

--- a/sections/image-with-text.liquid
+++ b/sections/image-with-text.liquid
@@ -28,20 +28,20 @@
     <div class="grid__item">
       <div class="image-with-text__content image-with-text__content--{{ section.settings.height }}">
         {%- for block in section.blocks -%}
-          <div {{ block.shopify_attributes }}>
-            {% case block.type %}
-              {%- when 'heading' -%}
-                <h2 class="image-with-text__heading h1">
-                  {{ block.settings.heading | escape }}
-                </h2>
-              {%- when 'text' -%}
-                <div class="image-with-text__text rte">{{ block.settings.text }}</div>
-              {%- when 'button' -%}
-                {%- if block.settings.button_label != blank -%}
-                  <a href="{{ block.settings.button_link }}" class="button{% if block.settings.button_style_secondary %} button--secondary{% else %} button--primary{% endif %}"{% if block.settings.button_link == blank %} aria-disabled="true"{% endif %}>{{ block.settings.button_label | escape }}</a>
-                {%- endif -%}
-            {%- endcase -%}
-          </div>
+          {% case block.type %}
+            {%- when 'heading' -%}
+              <h2 class="image-with-text__heading h1" {{ block.shopify_attributes }}>
+                {{ block.settings.heading | escape }}
+              </h2>
+            {%- when 'text' -%}
+              <div class="image-with-text__text rte" {{ block.shopify_attributes }}>{{ block.settings.text }}</div>
+            {%- when 'button' -%}
+              {%- if block.settings.button_label != blank -%}
+                <a href="{{ block.settings.button_link }}" class="button{% if block.settings.button_style_secondary %} button--secondary{% else %} button--primary{% endif %}"{% if block.settings.button_link == blank %} aria-disabled="true"{% endif %} {{ block.shopify_attributes }}>
+                  {{ block.settings.button_label | escape }}
+                </a>
+              {%- endif -%}
+          {%- endcase -%}
         {%- endfor -%}
       </div>
     </div>

--- a/sections/main-article.liquid
+++ b/sections/main-article.liquid
@@ -2,55 +2,53 @@
 
 <article class="article-template" itemscope itemtype="http://schema.org/BlogPosting">
   {%- for block in section.blocks -%}
-    <div {{ block.shopify_attributes }}>
-      {%- case block.type -%}
-        {%- when 'featured_image'-%}
-          {%- if article.image -%}
-            <div class="article-template__hero-container">
-              <div class="article-template__hero-{{ block.settings.image_height }} media"
-                itemprop="image"
-                {% if block.settings.image_height == 'adapt' and article.image %} style="padding-bottom: {{ 1 | divided_by: article.image.aspect_ratio | times: 100 }}%;"{% endif %}
-              >
-                <img srcset="{% if article.image.width >= 350 %}{{ article.image | img_url: '350x' }} 350w,{% endif %}
-                    {% if article.image.width >= 700 %}{{ article.image | img_url: '700x' }} 700w,{% endif %}
-                    {% if article.image.width >= 749 %}{{ article.image | img_url: '749x' }} 749w,{% endif %}
-                    {% if article.image.width >= 1498 %}{{ article.image | img_url: '1498x' }} 1498w,{% endif %}
-                    {% if article.image.width >= 1100 %}{{ article.image | img_url: '1100x' }} 1100w,{% endif %}
-                    {% if article.image.width >= 2200 %}{{ article.image | img_url: '2200x' }} 2200w,{% endif %}"
-                  sizes="(min-width: 1200px) 1100px, (min-width: 750px) calc(100vw - 10rem), 100vw"
-                  src="{{ article.image | img_url: '1100x' }}"
-                  loading="lazy"
-                  width="{{ article.image.width }}"
-                  height="{{ article.image.height }}"
-                  alt="{{ article.image.alt | escape }}">
-              </div>
+    {%- case block.type -%}
+      {%- when 'featured_image'-%}
+        {%- if article.image -%}
+          <div class="article-template__hero-container" {{ block.shopify_attributes }}>
+            <div class="article-template__hero-{{ block.settings.image_height }} media"
+              itemprop="image"
+              {% if block.settings.image_height == 'adapt' and article.image %} style="padding-bottom: {{ 1 | divided_by: article.image.aspect_ratio | times: 100 }}%;"{% endif %}
+            >
+              <img srcset="{% if article.image.width >= 350 %}{{ article.image | img_url: '350x' }} 350w,{% endif %}
+                  {% if article.image.width >= 700 %}{{ article.image | img_url: '700x' }} 700w,{% endif %}
+                  {% if article.image.width >= 749 %}{{ article.image | img_url: '749x' }} 749w,{% endif %}
+                  {% if article.image.width >= 1498 %}{{ article.image | img_url: '1498x' }} 1498w,{% endif %}
+                  {% if article.image.width >= 1100 %}{{ article.image | img_url: '1100x' }} 1100w,{% endif %}
+                  {% if article.image.width >= 2200 %}{{ article.image | img_url: '2200x' }} 2200w,{% endif %}"
+                sizes="(min-width: 1200px) 1100px, (min-width: 750px) calc(100vw - 10rem), 100vw"
+                src="{{ article.image | img_url: '1100x' }}"
+                loading="lazy"
+                width="{{ article.image.width }}"
+                height="{{ article.image.height }}"
+                alt="{{ article.image.alt | escape }}">
             </div>
-          {%- endif -%}
+          </div>
+        {%- endif -%}
 
-          {%- when 'title'-%}
-            <header class="page-width page-width--narrow">
-              <h1 class="article-template__title" itemprop="headline">{{ article.title | escape }}</h1>
-              {%- if block.settings.blog_show_date -%}
-                <span class="circle-divider caption-with-letter-spacing" itemprop="dateCreated pubdate datePublished">{{ article.published_at | time_tag: format: 'month_year' }}</span>
-              {%- endif -%}
-              {%- if block.settings.blog_show_author -%}
-                <span class="caption-with-letter-spacing" itemprop="author" itemscope itemtype="http://schema.org/Person">
-                  <span itemprop="name">{{ article.author }}</span>
-                </span>
-              {%- endif -%}
-            </header>
+        {%- when 'title'-%}
+          <header class="page-width page-width--narrow" {{ block.shopify_attributes }}>
+            <h1 class="article-template__title" itemprop="headline">{{ article.title | escape }}</h1>
+            {%- if block.settings.blog_show_date -%}
+              <span class="circle-divider caption-with-letter-spacing" itemprop="dateCreated pubdate datePublished">{{ article.published_at | time_tag: format: 'month_year' }}</span>
+            {%- endif -%}
+            {%- if block.settings.blog_show_author -%}
+              <span class="caption-with-letter-spacing" itemprop="author" itemscope itemtype="http://schema.org/Person">
+                <span itemprop="name">{{ article.author }}</span>
+              </span>
+            {%- endif -%}
+          </header>
 
-          {%- when 'content'-%}
-            <div class="article-template__content page-width page-width--narrow rte" itemprop="articleBody">
-                {{ article.content }}
-            </div>
+        {%- when 'content'-%}
+          <div class="article-template__content page-width page-width--narrow rte" itemprop="articleBody" {{ block.shopify_attributes }}>
+              {{ article.content }}
+          </div>
 
-          {%- when 'social_sharing'-%}
-            <div class="article-template__social-sharing page-width page-width--narrow">
-              {% render 'social-sharing', share_title: article.title, share_permalink: article.url, share_image: article.image %}
-            </div>
-      {%- endcase -%}
-    </div>
+        {%- when 'social_sharing'-%}
+          <div class="article-template__social-sharing page-width page-width--narrow" {{ block.shopify_attributes }}>
+            {% render 'social-sharing', share_title: article.title, share_permalink: article.url, share_image: article.image %}
+          </div>
+    {%- endcase -%}
   {%- endfor -%}
 
   <div class="element-margin center">

--- a/sections/main-article.liquid
+++ b/sections/main-article.liquid
@@ -2,53 +2,55 @@
 
 <article class="article-template" itemscope itemtype="http://schema.org/BlogPosting">
   {%- for block in section.blocks -%}
-    {%- case block.type -%}
-      {%- when 'featured_image'-%}
-        {%- if article.image -%}
-          <div class="article-template__hero-container">
-            <div class="article-template__hero-{{ block.settings.image_height }} media"
-              itemprop="image"
-              {% if block.settings.image_height == 'adapt' and article.image %} style="padding-bottom: {{ 1 | divided_by: article.image.aspect_ratio | times: 100 }}%;"{% endif %}
-            >
-              <img srcset="{% if article.image.width >= 350 %}{{ article.image | img_url: '350x' }} 350w,{% endif %}
-                  {% if article.image.width >= 700 %}{{ article.image | img_url: '700x' }} 700w,{% endif %}
-                  {% if article.image.width >= 749 %}{{ article.image | img_url: '749x' }} 749w,{% endif %}
-                  {% if article.image.width >= 1498 %}{{ article.image | img_url: '1498x' }} 1498w,{% endif %}
-                  {% if article.image.width >= 1100 %}{{ article.image | img_url: '1100x' }} 1100w,{% endif %}
-                  {% if article.image.width >= 2200 %}{{ article.image | img_url: '2200x' }} 2200w,{% endif %}"
-                sizes="(min-width: 1200px) 1100px, (min-width: 750px) calc(100vw - 10rem), 100vw"
-                src="{{ article.image | img_url: '1100x' }}"
-                loading="lazy"
-                width="{{ article.image.width }}"
-                height="{{ article.image.height }}"
-                alt="{{ article.image.alt | escape }}">
+    <div {{ block.shopify_attributes }}>
+      {%- case block.type -%}
+        {%- when 'featured_image'-%}
+          {%- if article.image -%}
+            <div class="article-template__hero-container">
+              <div class="article-template__hero-{{ block.settings.image_height }} media"
+                itemprop="image"
+                {% if block.settings.image_height == 'adapt' and article.image %} style="padding-bottom: {{ 1 | divided_by: article.image.aspect_ratio | times: 100 }}%;"{% endif %}
+              >
+                <img srcset="{% if article.image.width >= 350 %}{{ article.image | img_url: '350x' }} 350w,{% endif %}
+                    {% if article.image.width >= 700 %}{{ article.image | img_url: '700x' }} 700w,{% endif %}
+                    {% if article.image.width >= 749 %}{{ article.image | img_url: '749x' }} 749w,{% endif %}
+                    {% if article.image.width >= 1498 %}{{ article.image | img_url: '1498x' }} 1498w,{% endif %}
+                    {% if article.image.width >= 1100 %}{{ article.image | img_url: '1100x' }} 1100w,{% endif %}
+                    {% if article.image.width >= 2200 %}{{ article.image | img_url: '2200x' }} 2200w,{% endif %}"
+                  sizes="(min-width: 1200px) 1100px, (min-width: 750px) calc(100vw - 10rem), 100vw"
+                  src="{{ article.image | img_url: '1100x' }}"
+                  loading="lazy"
+                  width="{{ article.image.width }}"
+                  height="{{ article.image.height }}"
+                  alt="{{ article.image.alt | escape }}">
+              </div>
             </div>
-          </div>
-        {%- endif -%}
+          {%- endif -%}
 
-        {%- when 'title'-%}
-          <header class="page-width page-width--narrow">
-            <h1 class="article-template__title" itemprop="headline">{{ article.title | escape }}</h1>
-            {%- if block.settings.blog_show_date -%}
-              <span class="circle-divider caption-with-letter-spacing" itemprop="dateCreated pubdate datePublished">{{ article.published_at | time_tag: format: 'month_year' }}</span>
-            {%- endif -%}
-            {%- if block.settings.blog_show_author -%}
-              <span class="caption-with-letter-spacing" itemprop="author" itemscope itemtype="http://schema.org/Person">
-                <span itemprop="name">{{ article.author }}</span>
-              </span>
-            {%- endif -%}
-          </header>
+          {%- when 'title'-%}
+            <header class="page-width page-width--narrow">
+              <h1 class="article-template__title" itemprop="headline">{{ article.title | escape }}</h1>
+              {%- if block.settings.blog_show_date -%}
+                <span class="circle-divider caption-with-letter-spacing" itemprop="dateCreated pubdate datePublished">{{ article.published_at | time_tag: format: 'month_year' }}</span>
+              {%- endif -%}
+              {%- if block.settings.blog_show_author -%}
+                <span class="caption-with-letter-spacing" itemprop="author" itemscope itemtype="http://schema.org/Person">
+                  <span itemprop="name">{{ article.author }}</span>
+                </span>
+              {%- endif -%}
+            </header>
 
-        {%- when 'content'-%}
-          <div class="article-template__content page-width page-width--narrow rte" itemprop="articleBody">
-              {{ article.content }}
-          </div>
+          {%- when 'content'-%}
+            <div class="article-template__content page-width page-width--narrow rte" itemprop="articleBody">
+                {{ article.content }}
+            </div>
 
-        {%- when 'social_sharing'-%}
-          <div class="article-template__social-sharing page-width page-width--narrow">
-            {% render 'social-sharing', share_title: article.title, share_permalink: article.url, share_image: article.image %}
-          </div>
-    {%- endcase -%}
+          {%- when 'social_sharing'-%}
+            <div class="article-template__social-sharing page-width page-width--narrow">
+              {% render 'social-sharing', share_title: article.title, share_permalink: article.url, share_image: article.image %}
+            </div>
+      {%- endcase -%}
+    </div>
   {%- endfor -%}
 
   <div class="element-margin center">

--- a/sections/main-cart-footer.liquid
+++ b/sections/main-cart-footer.liquid
@@ -15,61 +15,59 @@
 
       <div>
         {% for block in section.blocks %}
-          <div {{ block.shopify_attributes }}>
-            {%- case block.type -%}
-              {%- when 'subtotal' -%}
-                <div class="js-contents">
-                  <div class="totals">
-                    <h3 class="totals__subtotal">{{ 'sections.cart.subtotal' | t }}</h3>
-                    <p class="totals__subtotal-value">{{ cart.total_price | money_with_currency }}</p>
-                  </div>
-
-                  <div>
-                    {%- if cart.cart_level_discount_applications.size > 0 -%}
-                      <ul class="discounts list-unstyled" role="list" aria-label="{{ 'customer.order.discount' | t }}">
-                        {%- for discount in cart.cart_level_discount_applications -%}
-                          <li class="discounts__discount discounts__discount--end">
-                            {%- render 'icon-discount' -%}
-                            {{ discount.title }}
-                            (-{{ discount.total_allocated_amount | money }})
-                          </li>
-                        {%- endfor -%}
-                      </ul>
-                    {%- endif -%}
-                  </div>
-
-                  <small class="tax-note caption-large rte">
-                    {%- if cart.taxes_included and shop.shipping_policy.body != blank -%}
-                      {{ 'sections.cart.taxes_included_and_shipping_policy_html' | t: link: shop.shipping_policy.url }}
-                    {%- elsif cart.taxes_included -%}
-                      {{ 'sections.cart.taxes_included_but_shipping_at_checkout' | t }}
-                    {%- elsif shop.shipping_policy.body != blank -%}
-                      {{ 'sections.cart.taxes_and_shipping_policy_at_checkout_html' | t: link: shop.shipping_policy.url }}
-                    {%- else -%}
-                      {{ 'sections.cart.taxes_and_shipping_at_checkout' | t }}
-                    {%- endif -%}
-                  </small>
+          {%- case block.type -%}
+            {%- when 'subtotal' -%}
+              <div class="js-contents" {{ block.shopify_attributes }}>
+                <div class="totals">
+                  <h3 class="totals__subtotal">{{ 'sections.cart.subtotal' | t }}</h3>
+                  <p class="totals__subtotal-value">{{ cart.total_price | money_with_currency }}</p>
                 </div>
-              {%- else -%}
-                <div class="cart__ctas">
-                  <noscript>
-                    <button type="submit" class="cart__update-button button button--secondary" form="cart">
-                      {{ 'sections.cart.update' | t }}
-                    </button>
-                  </noscript>
 
-                  <button type="submit" class="cart__checkout-button button" name="checkout"{% if cart == empty %} disabled{% endif %} form="cart">
-                    {{ 'sections.cart.checkout' | t }}
+                <div>
+                  {%- if cart.cart_level_discount_applications.size > 0 -%}
+                    <ul class="discounts list-unstyled" role="list" aria-label="{{ 'customer.order.discount' | t }}">
+                      {%- for discount in cart.cart_level_discount_applications -%}
+                        <li class="discounts__discount discounts__discount--end">
+                          {%- render 'icon-discount' -%}
+                          {{ discount.title }}
+                          (-{{ discount.total_allocated_amount | money }})
+                        </li>
+                      {%- endfor -%}
+                    </ul>
+                  {%- endif -%}
+                </div>
+
+                <small class="tax-note caption-large rte">
+                  {%- if cart.taxes_included and shop.shipping_policy.body != blank -%}
+                    {{ 'sections.cart.taxes_included_and_shipping_policy_html' | t: link: shop.shipping_policy.url }}
+                  {%- elsif cart.taxes_included -%}
+                    {{ 'sections.cart.taxes_included_but_shipping_at_checkout' | t }}
+                  {%- elsif shop.shipping_policy.body != blank -%}
+                    {{ 'sections.cart.taxes_and_shipping_policy_at_checkout_html' | t: link: shop.shipping_policy.url }}
+                  {%- else -%}
+                    {{ 'sections.cart.taxes_and_shipping_at_checkout' | t }}
+                  {%- endif -%}
+                </small>
+              </div>
+            {%- else -%}
+              <div class="cart__ctas" {{ block.shopify_attributes }}>
+                <noscript>
+                  <button type="submit" class="cart__update-button button button--secondary" form="cart">
+                    {{ 'sections.cart.update' | t }}
                   </button>
-                </div>
+                </noscript>
 
-                {%- if additional_checkout_buttons -%}
-                  <div class="cart__dynamic-checkout-buttons additional-checkout-buttons">
-                    {{ content_for_additional_checkout_buttons }}
-                  </div>
-                {%- endif -%}
-            {%- endcase -%}
-          </div>
+                <button type="submit" class="cart__checkout-button button" name="checkout"{% if cart == empty %} disabled{% endif %} form="cart">
+                  {{ 'sections.cart.checkout' | t }}
+                </button>
+              </div>
+
+              {%- if additional_checkout_buttons -%}
+                <div class="cart__dynamic-checkout-buttons additional-checkout-buttons">
+                  {{ content_for_additional_checkout_buttons }}
+                </div>
+              {%- endif -%}
+          {%- endcase -%}
         {% endfor %}
 
         <div id="cart-errors"></div>

--- a/sections/main-cart-footer.liquid
+++ b/sections/main-cart-footer.liquid
@@ -15,59 +15,61 @@
 
       <div>
         {% for block in section.blocks %}
-          {%- case block.type -%}
-            {%- when 'subtotal' -%}
-              <div class="js-contents">
-                <div class="totals">
-                  <h3 class="totals__subtotal">{{ 'sections.cart.subtotal' | t }}</h3>
-                  <p class="totals__subtotal-value">{{ cart.total_price | money_with_currency }}</p>
-                </div>
+          <div {{ block.shopify_attributes }}>
+            {%- case block.type -%}
+              {%- when 'subtotal' -%}
+                <div class="js-contents">
+                  <div class="totals">
+                    <h3 class="totals__subtotal">{{ 'sections.cart.subtotal' | t }}</h3>
+                    <p class="totals__subtotal-value">{{ cart.total_price | money_with_currency }}</p>
+                  </div>
 
-                <div>
-                  {%- if cart.cart_level_discount_applications.size > 0 -%}
-                    <ul class="discounts list-unstyled" role="list" aria-label="{{ 'customer.order.discount' | t }}">
-                      {%- for discount in cart.cart_level_discount_applications -%}
-                        <li class="discounts__discount discounts__discount--end">
-                          {%- render 'icon-discount' -%}
-                          {{ discount.title }}
-                          (-{{ discount.total_allocated_amount | money }})
-                        </li>
-                      {%- endfor -%}
-                    </ul>
-                  {%- endif -%}
-                </div>
+                  <div>
+                    {%- if cart.cart_level_discount_applications.size > 0 -%}
+                      <ul class="discounts list-unstyled" role="list" aria-label="{{ 'customer.order.discount' | t }}">
+                        {%- for discount in cart.cart_level_discount_applications -%}
+                          <li class="discounts__discount discounts__discount--end">
+                            {%- render 'icon-discount' -%}
+                            {{ discount.title }}
+                            (-{{ discount.total_allocated_amount | money }})
+                          </li>
+                        {%- endfor -%}
+                      </ul>
+                    {%- endif -%}
+                  </div>
 
-                <small class="tax-note caption-large rte">
-                  {%- if cart.taxes_included and shop.shipping_policy.body != blank -%}
-                    {{ 'sections.cart.taxes_included_and_shipping_policy_html' | t: link: shop.shipping_policy.url }}
-                  {%- elsif cart.taxes_included -%}
-                    {{ 'sections.cart.taxes_included_but_shipping_at_checkout' | t }}
-                  {%- elsif shop.shipping_policy.body != blank -%}
-                    {{ 'sections.cart.taxes_and_shipping_policy_at_checkout_html' | t: link: shop.shipping_policy.url }}
-                  {%- else -%}
-                    {{ 'sections.cart.taxes_and_shipping_at_checkout' | t }}
-                  {%- endif -%}
-                </small>
-              </div>
-            {%- else -%}
-              <div class="cart__ctas">
-                <noscript>
-                  <button type="submit" class="cart__update-button button button--secondary" form="cart">
-                    {{ 'sections.cart.update' | t }}
+                  <small class="tax-note caption-large rte">
+                    {%- if cart.taxes_included and shop.shipping_policy.body != blank -%}
+                      {{ 'sections.cart.taxes_included_and_shipping_policy_html' | t: link: shop.shipping_policy.url }}
+                    {%- elsif cart.taxes_included -%}
+                      {{ 'sections.cart.taxes_included_but_shipping_at_checkout' | t }}
+                    {%- elsif shop.shipping_policy.body != blank -%}
+                      {{ 'sections.cart.taxes_and_shipping_policy_at_checkout_html' | t: link: shop.shipping_policy.url }}
+                    {%- else -%}
+                      {{ 'sections.cart.taxes_and_shipping_at_checkout' | t }}
+                    {%- endif -%}
+                  </small>
+                </div>
+              {%- else -%}
+                <div class="cart__ctas">
+                  <noscript>
+                    <button type="submit" class="cart__update-button button button--secondary" form="cart">
+                      {{ 'sections.cart.update' | t }}
+                    </button>
+                  </noscript>
+
+                  <button type="submit" class="cart__checkout-button button" name="checkout"{% if cart == empty %} disabled{% endif %} form="cart">
+                    {{ 'sections.cart.checkout' | t }}
                   </button>
-                </noscript>
-
-                <button type="submit" class="cart__checkout-button button" name="checkout"{% if cart == empty %} disabled{% endif %} form="cart">
-                  {{ 'sections.cart.checkout' | t }}
-                </button>
-              </div>
-
-              {%- if additional_checkout_buttons -%}
-                <div class="cart__dynamic-checkout-buttons additional-checkout-buttons">
-                  {{ content_for_additional_checkout_buttons }}
                 </div>
-              {%- endif -%}
-          {%- endcase -%}
+
+                {%- if additional_checkout_buttons -%}
+                  <div class="cart__dynamic-checkout-buttons additional-checkout-buttons">
+                    {{ content_for_additional_checkout_buttons }}
+                  </div>
+                {%- endif -%}
+            {%- endcase -%}
+          </div>
         {% endfor %}
 
         <div id="cart-errors"></div>

--- a/sections/main-product.liquid
+++ b/sections/main-product.liquid
@@ -84,13 +84,15 @@
             <div class="no-js-hidden" id="price-{{ section.id }}" {{ block.shopify_attributes }}>
               {%- render 'price', product: product, use_variant: true, show_badges: true, price_class: 'price--large' -%}
             </div>
-            {%- form 'product', product, id: 'product-form-installment', class: 'installment caption-large' -%}
-              <input type="hidden" name="id" value="{{ product.selected_or_first_available_variant.id }}">
-              {{ form | payment_terms }}
-            {%- endform -%}
+            <div {{ block.shopify_attributes }}>
+              {%- form 'product', product, id: 'product-form-installment', class: 'installment caption-large' -%}
+                <input type="hidden" name="id" value="{{ product.selected_or_first_available_variant.id }}">
+                {{ form | payment_terms }}
+              {%- endform -%}
+            </div>
           {%- when 'description' -%}
             {%- if product.description != blank -%}
-              <div class="product__description rte" {{ block.shopify_attributes }}>
+              <div class="product__description rte">
                 {{ product.description }}
               </div>
             {%- endif -%}
@@ -252,49 +254,51 @@
               </div>
             </noscript>
           {%- when 'buy_buttons' -%}
-            <product-form class="product-form" {{ block.shopify_attributes }}>
-              {%- form 'product', product, id: product_form_id, class: 'form', novalidate: 'novalidate', data-type: 'add-to-cart-form' -%}
-                <input type="hidden" name="id" value="{{ product.selected_or_first_available_variant.id }}">
-                <div class="product-form__buttons">
-                  <button
-                    type="submit"
-                    name="add"
-                    class="product-form__submit button button--full-width {% if block.settings.show_dynamic_checkout and product.selling_plan_groups == empty %}button--secondary{% else %}button--primary{% endif %}"
-                  {% if product.selected_or_first_available_variant.available == false %}disabled{% endif %}
-                  >
-                      {%- if product.selected_or_first_available_variant.available -%}
-                        {{ 'products.product.add_to_cart' | t }}
-                      {%- else -%}
-                        {{ 'products.product.sold_out' | t }}
-                      {%- endif -%}
-                  </button>
-                  {%- if block.settings.show_dynamic_checkout -%}
-                    {{ form | payment_button }}
-                  {%- endif -%}
-                </div>
-              {%- endform -%}
-            </product-form>
-
-            {{ 'component-pickup-availability.css' | asset_url | stylesheet_tag }}
-
-            {%- assign pick_up_availabilities = product.selected_or_first_available_variant.store_availabilities | where: 'pick_up_enabled', true -%}
-
-            <pickup-availability class="product__pickup-availabilities no-js-hidden"
-              {% if product.selected_or_first_available_variant.available and pick_up_availabilities.size > 0 %} available{% endif %}
-              data-base-url="{{ shop.url }}{{ routes.root_url }}"
-              data-variant-id="{{ product.selected_or_first_available_variant.id }}"
-              data-has-only-default-variant="{{ product.has_only_default_variant }}"
-            >
-              <template>
-                <pickup-availability-preview class="pickup-availability-preview">
-                  {% render 'icon-unavailable' %}
-                  <div class="pickup-availability-info">
-                    <p class="caption-large">{{ 'products.product.pickup_availability.unavailable' | t }}</p>
-                    <button class="pickup-availability-button link link--text underlined-link">{{ 'products.product.pickup_availability.refresh' | t }}</button>
+            <div {{ block.shopify_attributes }}>
+              <product-form class="product-form">
+                {%- form 'product', product, id: product_form_id, class: 'form', novalidate: 'novalidate', data-type: 'add-to-cart-form' -%}
+                  <input type="hidden" name="id" value="{{ product.selected_or_first_available_variant.id }}">
+                  <div class="product-form__buttons">
+                    <button
+                      type="submit"
+                      name="add"
+                      class="product-form__submit button button--full-width {% if block.settings.show_dynamic_checkout and product.selling_plan_groups == empty %}button--secondary{% else %}button--primary{% endif %}"
+                    {% if product.selected_or_first_available_variant.available == false %}disabled{% endif %}
+                    >
+                        {%- if product.selected_or_first_available_variant.available -%}
+                          {{ 'products.product.add_to_cart' | t }}
+                        {%- else -%}
+                          {{ 'products.product.sold_out' | t }}
+                        {%- endif -%}
+                    </button>
+                    {%- if block.settings.show_dynamic_checkout -%}
+                      {{ form | payment_button }}
+                    {%- endif -%}
                   </div>
-                </div>
-              </template>
-            </pickup-availability>
+                {%- endform -%}
+              </product-form>
+
+              {{ 'component-pickup-availability.css' | asset_url | stylesheet_tag }}
+
+              {%- assign pick_up_availabilities = product.selected_or_first_available_variant.store_availabilities | where: 'pick_up_enabled', true -%}
+
+              <pickup-availability class="product__pickup-availabilities no-js-hidden"
+                {% if product.selected_or_first_available_variant.available and pick_up_availabilities.size > 0 %} available{% endif %}
+                data-base-url="{{ shop.url }}{{ routes.root_url }}"
+                data-variant-id="{{ product.selected_or_first_available_variant.id }}"
+                data-has-only-default-variant="{{ product.has_only_default_variant }}"
+              >
+                <template>
+                  <pickup-availability-preview class="pickup-availability-preview">
+                    {% render 'icon-unavailable' %}
+                    <div class="pickup-availability-info">
+                      <p class="caption-large">{{ 'products.product.pickup_availability.unavailable' | t }}</p>
+                      <button class="pickup-availability-button link link--text underlined-link">{{ 'products.product.pickup_availability.refresh' | t }}</button>
+                    </div>
+                  </div>
+                </template>
+              </pickup-availability>
+            </div>
 
             <script src="{{ 'pickup-availability.js' | asset_url }}" defer="defer"></script>
           {%- endcase -%}

--- a/sections/main-product.liquid
+++ b/sections/main-product.liquid
@@ -69,235 +69,237 @@
         {%- assign product_form_id = 'product-form-' | append: section.id -%}
 
         {%- for block in section.blocks -%}
-          {%- case block.type -%}
-          {%- when '@app' -%}
-            {% render block %}
-          {%- when 'text' -%}
-            <p class="product__text{% if block.settings.text_style == 'uppercase' %} caption-with-letter-spacing{% elsif block.settings.text_style == 'subtitle' %} subtitle{% endif %}">
-              {{- block.settings.text -}}
-            </p>
-          {%- when 'title' -%}
-            <h1 class="product__title">
-              {{ product.title | escape }}
-            </h1>
-          {%- when 'price' -%}
-            <div class="no-js-hidden" id="price-{{ section.id }}">
-              {%- render 'price', product: product, use_variant: true, show_badges: true, price_class: 'price--large' -%}
-            </div>
-            {%- form 'product', product, id: 'product-form-installment', class: 'installment caption-large' -%}
-              <input type="hidden" name="id" value="{{ product.selected_or_first_available_variant.id }}">
-              {{ form | payment_terms }}
-            {%- endform -%}
-          {%- when 'description' -%}
-            {%- if product.description != blank -%}
-              <div class="product__description rte">
-                {{ product.description }}
+          <div {{ block.shopify_attributes }}>
+            {%- case block.type -%}
+            {%- when '@app' -%}
+              {% render block %}
+            {%- when 'text' -%}
+              <p class="product__text{% if block.settings.text_style == 'uppercase' %} caption-with-letter-spacing{% elsif block.settings.text_style == 'subtitle' %} subtitle{% endif %}">
+                {{- block.settings.text -}}
+              </p>
+            {%- when 'title' -%}
+              <h1 class="product__title">
+                {{ product.title | escape }}
+              </h1>
+            {%- when 'price' -%}
+              <div class="no-js-hidden" id="price-{{ section.id }}">
+                {%- render 'price', product: product, use_variant: true, show_badges: true, price_class: 'price--large' -%}
               </div>
-            {%- endif -%}
-          {%- when 'collapsible_tab' -%}
-            <div class="product__accordion accordion">
-              <details>
-                <summary>
-                  <div class="summary__title">
-                    {% render 'icon-accordion', icon: block.settings.icon %}
-                    <h2 class="h4 accordion__title">
-                      {{ block.settings.heading | default: block.settings.page.title }}
-                    </h2>
-                  </div>
-                  {% render 'icon-caret' %}
-                </summary>
-                <div class="accordion__content rte">
-                  {{ block.settings.content }}
-                  {{ block.settings.page.content }}
+              {%- form 'product', product, id: 'product-form-installment', class: 'installment caption-large' -%}
+                <input type="hidden" name="id" value="{{ product.selected_or_first_available_variant.id }}">
+                {{ form | payment_terms }}
+              {%- endform -%}
+            {%- when 'description' -%}
+              {%- if product.description != blank -%}
+                <div class="product__description rte">
+                  {{ product.description }}
                 </div>
-              </details>
-            </div>
-          {%- when 'quantity_selector' -%}
-            <div class="product-form__input product-form__quantity">
-              <label class="form__label" for="Quantity-{{ section.id }}">
-                {{ 'products.product.quantity.label' | t }}
-              </label>
-              <quantity-input class="quantity">
-                <button class="quantity__button no-js-hidden" name="minus" type="button">
-                  <span class="visually-hidden">{{ 'products.product.quantity.decrease' | t: product: product.title | escape }}</span>
-                  {% render 'icon-minus' %}
-                </button>
-                <input class="quantity__input"
-                    type="number"
-                    name="quantity"
-                    id="Quantity-{{ section.id }}"
-                    min="1"
-                    value="1"
-                    form="product-form-{{ section.id }}"
-                  >
-                <button class="quantity__button no-js-hidden" name="plus" type="button">
-                  <span class="visually-hidden">{{ 'products.product.quantity.increase' | t: product: product.title | escape }}</span>
-                  {% render 'icon-plus' %}
-                </button>
-              </quantity-input>
-            </div>
-          {%- when 'popup' -%}
-              <modal-opener class="product-popup-modal__opener no-js-hidden" data-modal="#PopupModal-{{ block.id }}">
-                <button id="ProductPopup-{{ block.id }}" class="product-popup-modal__button link" type="button" aria-haspopup="dialog">{{ block.settings.link_label | default: block.settings.page.title }}</button>
-              </modal-opener>
-              <a href="{{ block.settings.page.url }}" class="product-popup-modal__button link no-js">{{ block.settings.link_label }}</a>
-          {%- when 'share' -%}
-            <share-button class="share-button">
-              <button class="share-button__button button button--tertiary hidden">
-                {% render 'icon-share' %}
-                {{ 'general.share.share' | t }}
-              </button>
-              <details>
-                <summary class="share-button__button button button--tertiary">
+              {%- endif -%}
+            {%- when 'collapsible_tab' -%}
+              <div class="product__accordion accordion">
+                <details>
+                  <summary>
+                    <div class="summary__title">
+                      {% render 'icon-accordion', icon: block.settings.icon %}
+                      <h2 class="h4 accordion__title">
+                        {{ block.settings.heading | default: block.settings.page.title }}
+                      </h2>
+                    </div>
+                    {% render 'icon-caret' %}
+                  </summary>
+                  <div class="accordion__content rte">
+                    {{ block.settings.content }}
+                    {{ block.settings.page.content }}
+                  </div>
+                </details>
+              </div>
+            {%- when 'quantity_selector' -%}
+              <div class="product-form__input product-form__quantity">
+                <label class="form__label" for="Quantity-{{ section.id }}">
+                  {{ 'products.product.quantity.label' | t }}
+                </label>
+                <quantity-input class="quantity">
+                  <button class="quantity__button no-js-hidden" name="minus" type="button">
+                    <span class="visually-hidden">{{ 'products.product.quantity.decrease' | t: product: product.title | escape }}</span>
+                    {% render 'icon-minus' %}
+                  </button>
+                  <input class="quantity__input"
+                      type="number"
+                      name="quantity"
+                      id="Quantity-{{ section.id }}"
+                      min="1"
+                      value="1"
+                      form="product-form-{{ section.id }}"
+                    >
+                  <button class="quantity__button no-js-hidden" name="plus" type="button">
+                    <span class="visually-hidden">{{ 'products.product.quantity.increase' | t: product: product.title | escape }}</span>
+                    {% render 'icon-plus' %}
+                  </button>
+                </quantity-input>
+              </div>
+            {%- when 'popup' -%}
+                <modal-opener class="product-popup-modal__opener no-js-hidden" data-modal="#PopupModal-{{ block.id }}">
+                  <button id="ProductPopup-{{ block.id }}" class="product-popup-modal__button link" type="button" aria-haspopup="dialog">{{ block.settings.link_label | default: block.settings.page.title }}</button>
+                </modal-opener>
+                <a href="{{ block.settings.page.url }}" class="product-popup-modal__button link no-js">{{ block.settings.link_label }}</a>
+            {%- when 'share' -%}
+              <share-button class="share-button">
+                <button class="share-button__button button button--tertiary hidden">
                   {% render 'icon-share' %}
                   {{ 'general.share.share' | t }}
-                </summary>
-                <div class="share-button__fallback">
-                  <div class="field">
-                    <input type="text"
-                          class="field__input"
-                          id="url"
-                          value="{{ shop.url | append: product.url }}"
-                          placeholder="{{ 'general.share.share_url' | t }}"
-                          onclick="this.select();"
-                          readonly
-                    >
-                    <label class="field__label" for="url">{{ 'general.share.share_url' | t }}</label>
-                  </div>
-                  <button class="button button--tertiary">
-                    {% render 'icon-clipboard' %}
-                    {{ 'general.share.copy_to_clipboard' | t }}
-                  </button>
-                  <span id="ShareMessage-{{ section.id }}" class="share-button__message hidden" role="status" aria-hidden="true">
-                    {{ 'general.share.success_message' | t }}
-                  </span>
-                </div>
-              </details>
-            </share-button>
-            <script src="{{ 'share.js' | asset_url }}" defer="defer"></script>
-          {%- when 'variant_picker' -%}
-            {%- unless product.has_only_default_variant -%}
-              {%- if block.settings.picker_type == 'button' -%}
-                <variant-radios class="no-js-hidden" data-section="{{ section.id }}" data-url="{{ product.url }}">
-                  {%- for option in product.options_with_values -%}
-                      <fieldset class="js product-form__input">
-                        <legend class="form__label">{{ option.name }}</legend>
-                        {%- for value in option.values -%}
-                          <input type="radio" id="{{ section.id }}-{{ option.name }}-{{ forloop.index0 }}"
-                                name="{{ option.name }}"
-                                value="{{ value | escape }}"
-                                form="product-form-{{ section.id }}"
-                                {% if option.selected_value == value %}checked{% endif %}
-                          >
-                          <label for="{{ section.id }}-{{ option.name }}-{{ forloop.index0 }}">
-                            {{ value }}
-                          </label>
-                        {%- endfor -%}
-                      </fieldset>
-                  {%- endfor -%}
-                  <script type="application/json">
-                    {{ product.variants | json }}
-                  </script>
-                </variant-radios>
-              {%- else -%}
-                <variant-selects class="no-js-hidden" data-section="{{ section.id }}" data-url="{{ product.url }}">
-                  {%- for option in product.options_with_values -%}
-                    <div class="product-form__input product-form__input--dropdown">
-                      <label class="form__label" for="Option-{{ section.id }}-{{ forloop.index0 }}">
-                        {{ option.name }}
-                      </label>
-                      <div class="select">
-                        <select id="Option-{{ section.id }}-{{ forloop.index0 }}"
-                          class="select__select"
-                          name="options[{{ option.name | escape }}]"
-                          form="product-form-{{ section.id }}"
-                        >
-                          {%- for value in option.values -%}
-                            <option value="{{ value | escape }}" {% if option.selected_value == value %}selected="selected"{% endif %}>
-                              {{ value }}
-                            </option>
-                          {%- endfor -%}
-                        </select>
-                        {% render 'icon-caret' %}
-                      </div>
-                    </div>
-                  {%- endfor -%}
-
-                  <script type="application/json">
-                    {{ product.variants | json }}
-                  </script>
-                </variant-selects>
-              {%- endif -%}
-            {%- endunless -%}
-
-            <noscript>
-              <div class="product-form__input{% if product.has_only_default_variant %} hidden{% endif %}">
-                <label class="form__label" for="Variants-{{ section.id }}">{{ 'products.product.product_variants' | t }}</label>
-                <div class="select">
-                  <select name="id" id="Variants-{{ section.id }}" class="select__select" form="product-form">
-                    {%- for variant in product.variants -%}
-                      <option
-                        {% if variant == product.selected_or_first_available_variant %}selected="selected"{% endif %}
-                        {% if variant.available == false %}disabled{% endif %}
-                        value="{{ variant.id }}"
+                </button>
+                <details>
+                  <summary class="share-button__button button button--tertiary">
+                    {% render 'icon-share' %}
+                    {{ 'general.share.share' | t }}
+                  </summary>
+                  <div class="share-button__fallback">
+                    <div class="field">
+                      <input type="text"
+                            class="field__input"
+                            id="url"
+                            value="{{ shop.url | append: product.url }}"
+                            placeholder="{{ 'general.share.share_url' | t }}"
+                            onclick="this.select();"
+                            readonly
                       >
-                        {{ variant.title }}
-                        {%- if variant.available == false %} - {{ 'products.product.sold_out' | t }}{% endif %}
-                        - {{ variant.price | money | strip_html }}
-                      </option>
+                      <label class="field__label" for="url">{{ 'general.share.share_url' | t }}</label>
+                    </div>
+                    <button class="button button--tertiary">
+                      {% render 'icon-clipboard' %}
+                      {{ 'general.share.copy_to_clipboard' | t }}
+                    </button>
+                    <span id="ShareMessage-{{ section.id }}" class="share-button__message hidden" role="status" aria-hidden="true">
+                      {{ 'general.share.success_message' | t }}
+                    </span>
+                  </div>
+                </details>
+              </share-button>
+              <script src="{{ 'share.js' | asset_url }}" defer="defer"></script>
+            {%- when 'variant_picker' -%}
+              {%- unless product.has_only_default_variant -%}
+                {%- if block.settings.picker_type == 'button' -%}
+                  <variant-radios class="no-js-hidden" data-section="{{ section.id }}" data-url="{{ product.url }}">
+                    {%- for option in product.options_with_values -%}
+                        <fieldset class="js product-form__input">
+                          <legend class="form__label">{{ option.name }}</legend>
+                          {%- for value in option.values -%}
+                            <input type="radio" id="{{ section.id }}-{{ option.name }}-{{ forloop.index0 }}"
+                                  name="{{ option.name }}"
+                                  value="{{ value | escape }}"
+                                  form="product-form-{{ section.id }}"
+                                  {% if option.selected_value == value %}checked{% endif %}
+                            >
+                            <label for="{{ section.id }}-{{ option.name }}-{{ forloop.index0 }}">
+                              {{ value }}
+                            </label>
+                          {%- endfor -%}
+                        </fieldset>
                     {%- endfor -%}
-                  </select>
-                  {% render 'icon-caret' %}
-                </div>
-              </div>
-            </noscript>
-          {%- when 'buy_buttons' -%}
-            <product-form class="product-form">
-              {%- form 'product', product, id: product_form_id, class: 'form', novalidate: 'novalidate', data-type: 'add-to-cart-form' -%}
-                <input type="hidden" name="id" value="{{ product.selected_or_first_available_variant.id }}">
-                <div class="product-form__buttons">
-                  <button
-                    type="submit"
-                    name="add"
-                    class="product-form__submit button button--full-width {% if block.settings.show_dynamic_checkout and product.selling_plan_groups == empty %}button--secondary{% else %}button--primary{% endif %}"
-                  {% if product.selected_or_first_available_variant.available == false %}disabled{% endif %}
-                  >
-                      {%- if product.selected_or_first_available_variant.available -%}
-                        {{ 'products.product.add_to_cart' | t }}
-                      {%- else -%}
-                        {{ 'products.product.sold_out' | t }}
-                      {%- endif -%}
-                  </button>
-                  {%- if block.settings.show_dynamic_checkout -%}
-                    {{ form | payment_button }}
-                  {%- endif -%}
-                </div>
-              {%- endform -%}
-            </product-form>
+                    <script type="application/json">
+                      {{ product.variants | json }}
+                    </script>
+                  </variant-radios>
+                {%- else -%}
+                  <variant-selects class="no-js-hidden" data-section="{{ section.id }}" data-url="{{ product.url }}">
+                    {%- for option in product.options_with_values -%}
+                      <div class="product-form__input product-form__input--dropdown">
+                        <label class="form__label" for="Option-{{ section.id }}-{{ forloop.index0 }}">
+                          {{ option.name }}
+                        </label>
+                        <div class="select">
+                          <select id="Option-{{ section.id }}-{{ forloop.index0 }}"
+                            class="select__select"
+                            name="options[{{ option.name | escape }}]"
+                            form="product-form-{{ section.id }}"
+                          >
+                            {%- for value in option.values -%}
+                              <option value="{{ value | escape }}" {% if option.selected_value == value %}selected="selected"{% endif %}>
+                                {{ value }}
+                              </option>
+                            {%- endfor -%}
+                          </select>
+                          {% render 'icon-caret' %}
+                        </div>
+                      </div>
+                    {%- endfor -%}
 
-            {{ 'component-pickup-availability.css' | asset_url | stylesheet_tag }}
+                    <script type="application/json">
+                      {{ product.variants | json }}
+                    </script>
+                  </variant-selects>
+                {%- endif -%}
+              {%- endunless -%}
 
-            {%- assign pick_up_availabilities = product.selected_or_first_available_variant.store_availabilities | where: 'pick_up_enabled', true -%}
-
-            <pickup-availability class="product__pickup-availabilities no-js-hidden"
-              {% if product.selected_or_first_available_variant.available and pick_up_availabilities.size > 0 %} available{% endif %}
-              data-base-url="{{ shop.url }}{{ routes.root_url }}"
-              data-variant-id="{{ product.selected_or_first_available_variant.id }}"
-              data-has-only-default-variant="{{ product.has_only_default_variant }}"
-            >
-              <template>
-                <pickup-availability-preview class="pickup-availability-preview">
-                  {% render 'icon-unavailable' %}
-                  <div class="pickup-availability-info">
-                    <p class="caption-large">{{ 'products.product.pickup_availability.unavailable' | t }}</p>
-                    <button class="pickup-availability-button link link--text underlined-link">{{ 'products.product.pickup_availability.refresh' | t }}</button>
+              <noscript>
+                <div class="product-form__input{% if product.has_only_default_variant %} hidden{% endif %}">
+                  <label class="form__label" for="Variants-{{ section.id }}">{{ 'products.product.product_variants' | t }}</label>
+                  <div class="select">
+                    <select name="id" id="Variants-{{ section.id }}" class="select__select" form="product-form">
+                      {%- for variant in product.variants -%}
+                        <option
+                          {% if variant == product.selected_or_first_available_variant %}selected="selected"{% endif %}
+                          {% if variant.available == false %}disabled{% endif %}
+                          value="{{ variant.id }}"
+                        >
+                          {{ variant.title }}
+                          {%- if variant.available == false %} - {{ 'products.product.sold_out' | t }}{% endif %}
+                          - {{ variant.price | money | strip_html }}
+                        </option>
+                      {%- endfor -%}
+                    </select>
+                    {% render 'icon-caret' %}
                   </div>
                 </div>
-              </template>
-            </pickup-availability>
+              </noscript>
+            {%- when 'buy_buttons' -%}
+              <product-form class="product-form">
+                {%- form 'product', product, id: product_form_id, class: 'form', novalidate: 'novalidate', data-type: 'add-to-cart-form' -%}
+                  <input type="hidden" name="id" value="{{ product.selected_or_first_available_variant.id }}">
+                  <div class="product-form__buttons">
+                    <button
+                      type="submit"
+                      name="add"
+                      class="product-form__submit button button--full-width {% if block.settings.show_dynamic_checkout and product.selling_plan_groups == empty %}button--secondary{% else %}button--primary{% endif %}"
+                    {% if product.selected_or_first_available_variant.available == false %}disabled{% endif %}
+                    >
+                        {%- if product.selected_or_first_available_variant.available -%}
+                          {{ 'products.product.add_to_cart' | t }}
+                        {%- else -%}
+                          {{ 'products.product.sold_out' | t }}
+                        {%- endif -%}
+                    </button>
+                    {%- if block.settings.show_dynamic_checkout -%}
+                      {{ form | payment_button }}
+                    {%- endif -%}
+                  </div>
+                {%- endform -%}
+              </product-form>
 
-            <script src="{{ 'pickup-availability.js' | asset_url }}" defer="defer"></script>
-          {%- endcase -%}
+              {{ 'component-pickup-availability.css' | asset_url | stylesheet_tag }}
+
+              {%- assign pick_up_availabilities = product.selected_or_first_available_variant.store_availabilities | where: 'pick_up_enabled', true -%}
+
+              <pickup-availability class="product__pickup-availabilities no-js-hidden"
+                {% if product.selected_or_first_available_variant.available and pick_up_availabilities.size > 0 %} available{% endif %}
+                data-base-url="{{ shop.url }}{{ routes.root_url }}"
+                data-variant-id="{{ product.selected_or_first_available_variant.id }}"
+                data-has-only-default-variant="{{ product.has_only_default_variant }}"
+              >
+                <template>
+                  <pickup-availability-preview class="pickup-availability-preview">
+                    {% render 'icon-unavailable' %}
+                    <div class="pickup-availability-info">
+                      <p class="caption-large">{{ 'products.product.pickup_availability.unavailable' | t }}</p>
+                      <button class="pickup-availability-button link link--text underlined-link">{{ 'products.product.pickup_availability.refresh' | t }}</button>
+                    </div>
+                  </div>
+                </template>
+              </pickup-availability>
+
+              <script src="{{ 'pickup-availability.js' | asset_url }}" defer="defer"></script>
+            {%- endcase -%}
+          </div>
         {%- endfor -%}
       </div>
     </div>
@@ -396,7 +398,7 @@
 
   {% assign popups = section.blocks | where: "type", "popup" %}
   {%- for block in popups -%}
-    <modal-dialog id="PopupModal-{{ block.id }}" class="product-popup-modal">
+    <modal-dialog id="PopupModal-{{ block.id }}" class="product-popup-modal" {{ block.shopify_attributes }}>
       <div role="dialog" aria-label="{{ block.settings.link_label }}" aria-modal="true" class="product-popup-modal__content" tabindex="-1">
         <button id="ModalClose-{{ block.id }}" type="button" class="product-popup-modal__toggle" aria-label="{{ 'accessibility.close' | t }}">{% render 'icon-close' %}</button>
         <div class="product-popup-modal__content-info">

--- a/sections/main-product.liquid
+++ b/sections/main-product.liquid
@@ -69,237 +69,235 @@
         {%- assign product_form_id = 'product-form-' | append: section.id -%}
 
         {%- for block in section.blocks -%}
-          <div {{ block.shopify_attributes }}>
-            {%- case block.type -%}
-            {%- when '@app' -%}
-              {% render block %}
-            {%- when 'text' -%}
-              <p class="product__text{% if block.settings.text_style == 'uppercase' %} caption-with-letter-spacing{% elsif block.settings.text_style == 'subtitle' %} subtitle{% endif %}">
-                {{- block.settings.text -}}
-              </p>
-            {%- when 'title' -%}
-              <h1 class="product__title">
-                {{ product.title | escape }}
-              </h1>
-            {%- when 'price' -%}
-              <div class="no-js-hidden" id="price-{{ section.id }}">
-                {%- render 'price', product: product, use_variant: true, show_badges: true, price_class: 'price--large' -%}
+          {%- case block.type -%}
+          {%- when '@app' -%}
+            {% render block %}
+          {%- when 'text' -%}
+            <p class="product__text{% if block.settings.text_style == 'uppercase' %} caption-with-letter-spacing{% elsif block.settings.text_style == 'subtitle' %} subtitle{% endif %}" {{ block.shopify_attributes }}>
+              {{- block.settings.text -}}
+            </p>
+          {%- when 'title' -%}
+            <h1 class="product__title" {{ block.shopify_attributes }}>
+              {{ product.title | escape }}
+            </h1>
+          {%- when 'price' -%}
+            <div class="no-js-hidden" id="price-{{ section.id }}" {{ block.shopify_attributes }}>
+              {%- render 'price', product: product, use_variant: true, show_badges: true, price_class: 'price--large' -%}
+            </div>
+            {%- form 'product', product, id: 'product-form-installment', class: 'installment caption-large' -%}
+              <input type="hidden" name="id" value="{{ product.selected_or_first_available_variant.id }}">
+              {{ form | payment_terms }}
+            {%- endform -%}
+          {%- when 'description' -%}
+            {%- if product.description != blank -%}
+              <div class="product__description rte" {{ block.shopify_attributes }}>
+                {{ product.description }}
               </div>
-              {%- form 'product', product, id: 'product-form-installment', class: 'installment caption-large' -%}
-                <input type="hidden" name="id" value="{{ product.selected_or_first_available_variant.id }}">
-                {{ form | payment_terms }}
-              {%- endform -%}
-            {%- when 'description' -%}
-              {%- if product.description != blank -%}
-                <div class="product__description rte">
-                  {{ product.description }}
-                </div>
-              {%- endif -%}
-            {%- when 'collapsible_tab' -%}
-              <div class="product__accordion accordion">
-                <details>
-                  <summary>
-                    <div class="summary__title">
-                      {% render 'icon-accordion', icon: block.settings.icon %}
-                      <h2 class="h4 accordion__title">
-                        {{ block.settings.heading | default: block.settings.page.title }}
-                      </h2>
-                    </div>
-                    {% render 'icon-caret' %}
-                  </summary>
-                  <div class="accordion__content rte">
-                    {{ block.settings.content }}
-                    {{ block.settings.page.content }}
+            {%- endif -%}
+          {%- when 'collapsible_tab' -%}
+            <div class="product__accordion accordion" {{ block.shopify_attributes }}>
+              <details>
+                <summary>
+                  <div class="summary__title">
+                    {% render 'icon-accordion', icon: block.settings.icon %}
+                    <h2 class="h4 accordion__title">
+                      {{ block.settings.heading | default: block.settings.page.title }}
+                    </h2>
                   </div>
-                </details>
-              </div>
-            {%- when 'quantity_selector' -%}
-              <div class="product-form__input product-form__quantity">
-                <label class="form__label" for="Quantity-{{ section.id }}">
-                  {{ 'products.product.quantity.label' | t }}
-                </label>
-                <quantity-input class="quantity">
-                  <button class="quantity__button no-js-hidden" name="minus" type="button">
-                    <span class="visually-hidden">{{ 'products.product.quantity.decrease' | t: product: product.title | escape }}</span>
-                    {% render 'icon-minus' %}
-                  </button>
-                  <input class="quantity__input"
-                      type="number"
-                      name="quantity"
-                      id="Quantity-{{ section.id }}"
-                      min="1"
-                      value="1"
-                      form="product-form-{{ section.id }}"
-                    >
-                  <button class="quantity__button no-js-hidden" name="plus" type="button">
-                    <span class="visually-hidden">{{ 'products.product.quantity.increase' | t: product: product.title | escape }}</span>
-                    {% render 'icon-plus' %}
-                  </button>
-                </quantity-input>
-              </div>
-            {%- when 'popup' -%}
-                <modal-opener class="product-popup-modal__opener no-js-hidden" data-modal="#PopupModal-{{ block.id }}">
-                  <button id="ProductPopup-{{ block.id }}" class="product-popup-modal__button link" type="button" aria-haspopup="dialog">{{ block.settings.link_label | default: block.settings.page.title }}</button>
-                </modal-opener>
-                <a href="{{ block.settings.page.url }}" class="product-popup-modal__button link no-js">{{ block.settings.link_label }}</a>
-            {%- when 'share' -%}
-              <share-button class="share-button">
-                <button class="share-button__button button button--tertiary hidden">
+                  {% render 'icon-caret' %}
+                </summary>
+                <div class="accordion__content rte">
+                  {{ block.settings.content }}
+                  {{ block.settings.page.content }}
+                </div>
+              </details>
+            </div>
+          {%- when 'quantity_selector' -%}
+            <div class="product-form__input product-form__quantity" {{ block.shopify_attributes }}>
+              <label class="form__label" for="Quantity-{{ section.id }}">
+                {{ 'products.product.quantity.label' | t }}
+              </label>
+              <quantity-input class="quantity">
+                <button class="quantity__button no-js-hidden" name="minus" type="button">
+                  <span class="visually-hidden">{{ 'products.product.quantity.decrease' | t: product: product.title | escape }}</span>
+                  {% render 'icon-minus' %}
+                </button>
+                <input class="quantity__input"
+                    type="number"
+                    name="quantity"
+                    id="Quantity-{{ section.id }}"
+                    min="1"
+                    value="1"
+                    form="product-form-{{ section.id }}"
+                  >
+                <button class="quantity__button no-js-hidden" name="plus" type="button">
+                  <span class="visually-hidden">{{ 'products.product.quantity.increase' | t: product: product.title | escape }}</span>
+                  {% render 'icon-plus' %}
+                </button>
+              </quantity-input>
+            </div>
+          {%- when 'popup' -%}
+              <modal-opener class="product-popup-modal__opener no-js-hidden" data-modal="#PopupModal-{{ block.id }}" {{ block.shopify_attributes }}>
+                <button id="ProductPopup-{{ block.id }}" class="product-popup-modal__button link" type="button" aria-haspopup="dialog">{{ block.settings.link_label | default: block.settings.page.title }}</button>
+              </modal-opener>
+              <a href="{{ block.settings.page.url }}" class="product-popup-modal__button link no-js">{{ block.settings.link_label }}</a>
+          {%- when 'share' -%}
+            <share-button class="share-button" {{ block.shopify_attributes }}>
+              <button class="share-button__button button button--tertiary hidden">
+                {% render 'icon-share' %}
+                {{ 'general.share.share' | t }}
+              </button>
+              <details>
+                <summary class="share-button__button button button--tertiary">
                   {% render 'icon-share' %}
                   {{ 'general.share.share' | t }}
-                </button>
-                <details>
-                  <summary class="share-button__button button button--tertiary">
-                    {% render 'icon-share' %}
-                    {{ 'general.share.share' | t }}
-                  </summary>
-                  <div class="share-button__fallback">
-                    <div class="field">
-                      <input type="text"
-                            class="field__input"
-                            id="url"
-                            value="{{ shop.url | append: product.url }}"
-                            placeholder="{{ 'general.share.share_url' | t }}"
-                            onclick="this.select();"
-                            readonly
-                      >
-                      <label class="field__label" for="url">{{ 'general.share.share_url' | t }}</label>
-                    </div>
-                    <button class="button button--tertiary">
-                      {% render 'icon-clipboard' %}
-                      {{ 'general.share.copy_to_clipboard' | t }}
-                    </button>
-                    <span id="ShareMessage-{{ section.id }}" class="share-button__message hidden" role="status" aria-hidden="true">
-                      {{ 'general.share.success_message' | t }}
-                    </span>
+                </summary>
+                <div class="share-button__fallback">
+                  <div class="field">
+                    <input type="text"
+                          class="field__input"
+                          id="url"
+                          value="{{ shop.url | append: product.url }}"
+                          placeholder="{{ 'general.share.share_url' | t }}"
+                          onclick="this.select();"
+                          readonly
+                    >
+                    <label class="field__label" for="url">{{ 'general.share.share_url' | t }}</label>
                   </div>
-                </details>
-              </share-button>
-              <script src="{{ 'share.js' | asset_url }}" defer="defer"></script>
-            {%- when 'variant_picker' -%}
-              {%- unless product.has_only_default_variant -%}
-                {%- if block.settings.picker_type == 'button' -%}
-                  <variant-radios class="no-js-hidden" data-section="{{ section.id }}" data-url="{{ product.url }}">
-                    {%- for option in product.options_with_values -%}
-                        <fieldset class="js product-form__input">
-                          <legend class="form__label">{{ option.name }}</legend>
-                          {%- for value in option.values -%}
-                            <input type="radio" id="{{ section.id }}-{{ option.name }}-{{ forloop.index0 }}"
-                                  name="{{ option.name }}"
-                                  value="{{ value | escape }}"
-                                  form="product-form-{{ section.id }}"
-                                  {% if option.selected_value == value %}checked{% endif %}
-                            >
-                            <label for="{{ section.id }}-{{ option.name }}-{{ forloop.index0 }}">
-                              {{ value }}
-                            </label>
-                          {%- endfor -%}
-                        </fieldset>
-                    {%- endfor -%}
-                    <script type="application/json">
-                      {{ product.variants | json }}
-                    </script>
-                  </variant-radios>
-                {%- else -%}
-                  <variant-selects class="no-js-hidden" data-section="{{ section.id }}" data-url="{{ product.url }}">
-                    {%- for option in product.options_with_values -%}
-                      <div class="product-form__input product-form__input--dropdown">
-                        <label class="form__label" for="Option-{{ section.id }}-{{ forloop.index0 }}">
-                          {{ option.name }}
-                        </label>
-                        <div class="select">
-                          <select id="Option-{{ section.id }}-{{ forloop.index0 }}"
-                            class="select__select"
-                            name="options[{{ option.name | escape }}]"
-                            form="product-form-{{ section.id }}"
+                  <button class="button button--tertiary">
+                    {% render 'icon-clipboard' %}
+                    {{ 'general.share.copy_to_clipboard' | t }}
+                  </button>
+                  <span id="ShareMessage-{{ section.id }}" class="share-button__message hidden" role="status" aria-hidden="true">
+                    {{ 'general.share.success_message' | t }}
+                  </span>
+                </div>
+              </details>
+            </share-button>
+            <script src="{{ 'share.js' | asset_url }}" defer="defer"></script>
+          {%- when 'variant_picker' -%}
+            {%- unless product.has_only_default_variant -%}
+              {%- if block.settings.picker_type == 'button' -%}
+                <variant-radios class="no-js-hidden" data-section="{{ section.id }}" data-url="{{ product.url }}" {{ block.shopify_attributes }}>
+                  {%- for option in product.options_with_values -%}
+                      <fieldset class="js product-form__input">
+                        <legend class="form__label">{{ option.name }}</legend>
+                        {%- for value in option.values -%}
+                          <input type="radio" id="{{ section.id }}-{{ option.name }}-{{ forloop.index0 }}"
+                                name="{{ option.name }}"
+                                value="{{ value | escape }}"
+                                form="product-form-{{ section.id }}"
+                                {% if option.selected_value == value %}checked{% endif %}
                           >
-                            {%- for value in option.values -%}
-                              <option value="{{ value | escape }}" {% if option.selected_value == value %}selected="selected"{% endif %}>
-                                {{ value }}
-                              </option>
-                            {%- endfor -%}
-                          </select>
-                          {% render 'icon-caret' %}
-                        </div>
-                      </div>
-                    {%- endfor -%}
-
-                    <script type="application/json">
-                      {{ product.variants | json }}
-                    </script>
-                  </variant-selects>
-                {%- endif -%}
-              {%- endunless -%}
-
-              <noscript>
-                <div class="product-form__input{% if product.has_only_default_variant %} hidden{% endif %}">
-                  <label class="form__label" for="Variants-{{ section.id }}">{{ 'products.product.product_variants' | t }}</label>
-                  <div class="select">
-                    <select name="id" id="Variants-{{ section.id }}" class="select__select" form="product-form">
-                      {%- for variant in product.variants -%}
-                        <option
-                          {% if variant == product.selected_or_first_available_variant %}selected="selected"{% endif %}
-                          {% if variant.available == false %}disabled{% endif %}
-                          value="{{ variant.id }}"
+                          <label for="{{ section.id }}-{{ option.name }}-{{ forloop.index0 }}">
+                            {{ value }}
+                          </label>
+                        {%- endfor -%}
+                      </fieldset>
+                  {%- endfor -%}
+                  <script type="application/json">
+                    {{ product.variants | json }}
+                  </script>
+                </variant-radios>
+              {%- else -%}
+                <variant-selects class="no-js-hidden" data-section="{{ section.id }}" data-url="{{ product.url }}" {{ block.shopify_attributes }}>
+                  {%- for option in product.options_with_values -%}
+                    <div class="product-form__input product-form__input--dropdown">
+                      <label class="form__label" for="Option-{{ section.id }}-{{ forloop.index0 }}">
+                        {{ option.name }}
+                      </label>
+                      <div class="select">
+                        <select id="Option-{{ section.id }}-{{ forloop.index0 }}"
+                          class="select__select"
+                          name="options[{{ option.name | escape }}]"
+                          form="product-form-{{ section.id }}"
                         >
-                          {{ variant.title }}
-                          {%- if variant.available == false %} - {{ 'products.product.sold_out' | t }}{% endif %}
-                          - {{ variant.price | money | strip_html }}
-                        </option>
-                      {%- endfor -%}
-                    </select>
-                    {% render 'icon-caret' %}
+                          {%- for value in option.values -%}
+                            <option value="{{ value | escape }}" {% if option.selected_value == value %}selected="selected"{% endif %}>
+                              {{ value }}
+                            </option>
+                          {%- endfor -%}
+                        </select>
+                        {% render 'icon-caret' %}
+                      </div>
+                    </div>
+                  {%- endfor -%}
+
+                  <script type="application/json">
+                    {{ product.variants | json }}
+                  </script>
+                </variant-selects>
+              {%- endif -%}
+            {%- endunless -%}
+
+            <noscript>
+              <div class="product-form__input{% if product.has_only_default_variant %} hidden{% endif %}">
+                <label class="form__label" for="Variants-{{ section.id }}">{{ 'products.product.product_variants' | t }}</label>
+                <div class="select">
+                  <select name="id" id="Variants-{{ section.id }}" class="select__select" form="product-form">
+                    {%- for variant in product.variants -%}
+                      <option
+                        {% if variant == product.selected_or_first_available_variant %}selected="selected"{% endif %}
+                        {% if variant.available == false %}disabled{% endif %}
+                        value="{{ variant.id }}"
+                      >
+                        {{ variant.title }}
+                        {%- if variant.available == false %} - {{ 'products.product.sold_out' | t }}{% endif %}
+                        - {{ variant.price | money | strip_html }}
+                      </option>
+                    {%- endfor -%}
+                  </select>
+                  {% render 'icon-caret' %}
+                </div>
+              </div>
+            </noscript>
+          {%- when 'buy_buttons' -%}
+            <product-form class="product-form" {{ block.shopify_attributes }}>
+              {%- form 'product', product, id: product_form_id, class: 'form', novalidate: 'novalidate', data-type: 'add-to-cart-form' -%}
+                <input type="hidden" name="id" value="{{ product.selected_or_first_available_variant.id }}">
+                <div class="product-form__buttons">
+                  <button
+                    type="submit"
+                    name="add"
+                    class="product-form__submit button button--full-width {% if block.settings.show_dynamic_checkout and product.selling_plan_groups == empty %}button--secondary{% else %}button--primary{% endif %}"
+                  {% if product.selected_or_first_available_variant.available == false %}disabled{% endif %}
+                  >
+                      {%- if product.selected_or_first_available_variant.available -%}
+                        {{ 'products.product.add_to_cart' | t }}
+                      {%- else -%}
+                        {{ 'products.product.sold_out' | t }}
+                      {%- endif -%}
+                  </button>
+                  {%- if block.settings.show_dynamic_checkout -%}
+                    {{ form | payment_button }}
+                  {%- endif -%}
+                </div>
+              {%- endform -%}
+            </product-form>
+
+            {{ 'component-pickup-availability.css' | asset_url | stylesheet_tag }}
+
+            {%- assign pick_up_availabilities = product.selected_or_first_available_variant.store_availabilities | where: 'pick_up_enabled', true -%}
+
+            <pickup-availability class="product__pickup-availabilities no-js-hidden"
+              {% if product.selected_or_first_available_variant.available and pick_up_availabilities.size > 0 %} available{% endif %}
+              data-base-url="{{ shop.url }}{{ routes.root_url }}"
+              data-variant-id="{{ product.selected_or_first_available_variant.id }}"
+              data-has-only-default-variant="{{ product.has_only_default_variant }}"
+            >
+              <template>
+                <pickup-availability-preview class="pickup-availability-preview">
+                  {% render 'icon-unavailable' %}
+                  <div class="pickup-availability-info">
+                    <p class="caption-large">{{ 'products.product.pickup_availability.unavailable' | t }}</p>
+                    <button class="pickup-availability-button link link--text underlined-link">{{ 'products.product.pickup_availability.refresh' | t }}</button>
                   </div>
                 </div>
-              </noscript>
-            {%- when 'buy_buttons' -%}
-              <product-form class="product-form">
-                {%- form 'product', product, id: product_form_id, class: 'form', novalidate: 'novalidate', data-type: 'add-to-cart-form' -%}
-                  <input type="hidden" name="id" value="{{ product.selected_or_first_available_variant.id }}">
-                  <div class="product-form__buttons">
-                    <button
-                      type="submit"
-                      name="add"
-                      class="product-form__submit button button--full-width {% if block.settings.show_dynamic_checkout and product.selling_plan_groups == empty %}button--secondary{% else %}button--primary{% endif %}"
-                    {% if product.selected_or_first_available_variant.available == false %}disabled{% endif %}
-                    >
-                        {%- if product.selected_or_first_available_variant.available -%}
-                          {{ 'products.product.add_to_cart' | t }}
-                        {%- else -%}
-                          {{ 'products.product.sold_out' | t }}
-                        {%- endif -%}
-                    </button>
-                    {%- if block.settings.show_dynamic_checkout -%}
-                      {{ form | payment_button }}
-                    {%- endif -%}
-                  </div>
-                {%- endform -%}
-              </product-form>
+              </template>
+            </pickup-availability>
 
-              {{ 'component-pickup-availability.css' | asset_url | stylesheet_tag }}
-
-              {%- assign pick_up_availabilities = product.selected_or_first_available_variant.store_availabilities | where: 'pick_up_enabled', true -%}
-
-              <pickup-availability class="product__pickup-availabilities no-js-hidden"
-                {% if product.selected_or_first_available_variant.available and pick_up_availabilities.size > 0 %} available{% endif %}
-                data-base-url="{{ shop.url }}{{ routes.root_url }}"
-                data-variant-id="{{ product.selected_or_first_available_variant.id }}"
-                data-has-only-default-variant="{{ product.has_only_default_variant }}"
-              >
-                <template>
-                  <pickup-availability-preview class="pickup-availability-preview">
-                    {% render 'icon-unavailable' %}
-                    <div class="pickup-availability-info">
-                      <p class="caption-large">{{ 'products.product.pickup_availability.unavailable' | t }}</p>
-                      <button class="pickup-availability-button link link--text underlined-link">{{ 'products.product.pickup_availability.refresh' | t }}</button>
-                    </div>
-                  </div>
-                </template>
-              </pickup-availability>
-
-              <script src="{{ 'pickup-availability.js' | asset_url }}" defer="defer"></script>
-            {%- endcase -%}
-          </div>
+            <script src="{{ 'pickup-availability.js' | asset_url }}" defer="defer"></script>
+          {%- endcase -%}
         {%- endfor -%}
       </div>
     </div>

--- a/sections/multicolumn.liquid
+++ b/sections/multicolumn.liquid
@@ -26,7 +26,7 @@
           endfor
         -%}
         {%- for block in section.blocks -%}
-          <li class="multicolumn-list__item grid__item{% if section.settings.swipe_on_mobile %} slider__slide{% endif %}{% if section.settings.column_alignment == 'center' %} center{% endif %}">
+          <li class="multicolumn-list__item grid__item{% if section.settings.swipe_on_mobile %} slider__slide{% endif %}{% if section.settings.column_alignment == 'center' %} center{% endif %}" {{ block.shopify_attributes }}>
             <div class="multicolumn-card">
               {%- if block.settings.image != blank -%}
                 {% if section.settings.image_ratio == 'adapt' or section.settings.image_ratio == 'circle' %}

--- a/sections/newsletter.liquid
+++ b/sections/newsletter.liquid
@@ -10,45 +10,47 @@
         {%- when 'paragraph' -%}
           <div class="newsletter__subheading rte" {{ block.shopify_attributes }}>{{ block.settings.paragraph }}</div>
         {%- when 'email_form' -%}
-          {% form 'customer', class: 'newsletter-form' %}
-            <input type="hidden" name="contact[tags]" value="newsletter" {{ block.shopify_attributes }}>
-            <div class="newsletter-form__field-wrapper">
-              <div class="field">
-                <input
-                  id="NewsletterForm--{{ section.id }}"
-                  type="email"
-                  name="contact[email]"
-                  class="field__input"
-                  value="{{ form.email }}"
-                  aria-required="true"
-                  autocorrect="off"
-                  autocapitalize="off"
-                  autocomplete="email"
-                  {% if form.errors %}
-                    autofocus
-                    aria-invalid="true"
-                    aria-describedby="Newsletter-error--{{ section.id }}"
-                  {% elsif form.posted_successfully? %}
-                    aria-describedby="Newsletter-success--{{ section.id }}"
-                  {% endif %}
-                  placeholder="{{ 'newsletter.label' | t }}"
-                  required
-                >
-                <label class="field__label" for="NewsletterForm--{{ section.id }}">
-                  {{ 'newsletter.label' | t }}
-                </label>
+          <div {{ block.shopify_attributes }}>
+            {% form 'customer', class: 'newsletter-form' %}
+              <input type="hidden" name="contact[tags]" value="newsletter">
+              <div class="newsletter-form__field-wrapper">
+                <div class="field">
+                  <input
+                    id="NewsletterForm--{{ section.id }}"
+                    type="email"
+                    name="contact[email]"
+                    class="field__input"
+                    value="{{ form.email }}"
+                    aria-required="true"
+                    autocorrect="off"
+                    autocapitalize="off"
+                    autocomplete="email"
+                    {% if form.errors %}
+                      autofocus
+                      aria-invalid="true"
+                      aria-describedby="Newsletter-error--{{ section.id }}"
+                    {% elsif form.posted_successfully? %}
+                      aria-describedby="Newsletter-success--{{ section.id }}"
+                    {% endif %}
+                    placeholder="{{ 'newsletter.label' | t }}"
+                    required
+                  >
+                  <label class="field__label" for="NewsletterForm--{{ section.id }}">
+                    {{ 'newsletter.label' | t }}
+                  </label>
+                </div>
+                {%- if form.errors -%}
+                  <small class="newsletter-form__message form__message" id="Newsletter-error--{{ section.id }}">{% render 'icon-error' %}{{ form.errors.translated_fields['email'] | capitalize }} {{ form.errors.messages['email'] }}</small>
+                {%- endif -%}
               </div>
-              {%- if form.errors -%}
-                <small class="newsletter-form__message form__message" id="Newsletter-error--{{ section.id }}">{% render 'icon-error' %}{{ form.errors.translated_fields['email'] | capitalize }} {{ form.errors.messages['email'] }}</small>
+              <button type="submit" class="newsletter__button button" name="commit">
+                {{ 'newsletter.button_label' | t }}
+              </button>
+              {%- if form.posted_successfully? -%}
+                <h3 class="newsletter-form__message newsletter-form__message--success form__message" id="Newsletter-success--{{ section.id }}" tabindex="-1" autofocus>{% render 'icon-success' %}{{ 'newsletter.success' | t }}</h3>
               {%- endif -%}
-            </div>
-            <button type="submit" class="newsletter__button button" name="commit">
-              {{ 'newsletter.button_label' | t }}
-            </button>
-            {%- if form.posted_successfully? -%}
-              <h3 class="newsletter-form__message newsletter-form__message--success form__message" id="Newsletter-success--{{ section.id }}" tabindex="-1" autofocus>{% render 'icon-success' %}{{ 'newsletter.success' | t }}</h3>
-            {%- endif -%}
-          {% endform %}
+            {% endform %}
+          </div>
       {%- endcase -%}
     {%- endfor -%}
   </div>

--- a/sections/newsletter.liquid
+++ b/sections/newsletter.liquid
@@ -4,52 +4,54 @@
 <div class="newsletter center{% if section.settings.full_width == false %} newsletter--narrow page-width{% endif%}">
   <div class="newsletter__wrapper color-{{ section.settings.color_scheme }}">
     {%- for block in section.blocks -%}
-      {%- case block.type -%}
-        {%- when 'heading' -%}
-          <h2 class="h1">{{ block.settings.heading | escape }}</h2>
-        {%- when 'paragraph' -%}
-          <div class="newsletter__subheading rte">{{ block.settings.paragraph }}</div>
-        {%- when 'email_form' -%}
-          {% form 'customer', class: 'newsletter-form' %}
-            <input type="hidden" name="contact[tags]" value="newsletter">
-            <div class="newsletter-form__field-wrapper">
-              <div class="field">
-                <input
-                  id="NewsletterForm--{{ section.id }}"
-                  type="email"
-                  name="contact[email]"
-                  class="field__input"
-                  value="{{ form.email }}"
-                  aria-required="true"
-                  autocorrect="off"
-                  autocapitalize="off"
-                  autocomplete="email"
-                  {% if form.errors %}
-                    autofocus
-                    aria-invalid="true"
-                    aria-describedby="Newsletter-error--{{ section.id }}"
-                  {% elsif form.posted_successfully? %}
-                    aria-describedby="Newsletter-success--{{ section.id }}"
-                  {% endif %}
-                  placeholder="{{ 'newsletter.label' | t }}"
-                  required
-                >
-                <label class="field__label" for="NewsletterForm--{{ section.id }}">
-                  {{ 'newsletter.label' | t }}
-                </label>
+      <div {{ block.shopify_attributes }}>
+        {%- case block.type -%}
+          {%- when 'heading' -%}
+            <h2 class="h1">{{ block.settings.heading | escape }}</h2>
+          {%- when 'paragraph' -%}
+            <div class="newsletter__subheading rte">{{ block.settings.paragraph }}</div>
+          {%- when 'email_form' -%}
+            {% form 'customer', class: 'newsletter-form' %}
+              <input type="hidden" name="contact[tags]" value="newsletter">
+              <div class="newsletter-form__field-wrapper">
+                <div class="field">
+                  <input
+                    id="NewsletterForm--{{ section.id }}"
+                    type="email"
+                    name="contact[email]"
+                    class="field__input"
+                    value="{{ form.email }}"
+                    aria-required="true"
+                    autocorrect="off"
+                    autocapitalize="off"
+                    autocomplete="email"
+                    {% if form.errors %}
+                      autofocus
+                      aria-invalid="true"
+                      aria-describedby="Newsletter-error--{{ section.id }}"
+                    {% elsif form.posted_successfully? %}
+                      aria-describedby="Newsletter-success--{{ section.id }}"
+                    {% endif %}
+                    placeholder="{{ 'newsletter.label' | t }}"
+                    required
+                  >
+                  <label class="field__label" for="NewsletterForm--{{ section.id }}">
+                    {{ 'newsletter.label' | t }}
+                  </label>
+                </div>
+                {%- if form.errors -%}
+                  <small class="newsletter-form__message form__message" id="Newsletter-error--{{ section.id }}">{% render 'icon-error' %}{{ form.errors.translated_fields['email'] | capitalize }} {{ form.errors.messages['email'] }}</small>
+                {%- endif -%}
               </div>
-              {%- if form.errors -%}
-                <small class="newsletter-form__message form__message" id="Newsletter-error--{{ section.id }}">{% render 'icon-error' %}{{ form.errors.translated_fields['email'] | capitalize }} {{ form.errors.messages['email'] }}</small>
+              <button type="submit" class="newsletter__button button" name="commit">
+                {{ 'newsletter.button_label' | t }}
+              </button>
+              {%- if form.posted_successfully? -%}
+                <h3 class="newsletter-form__message newsletter-form__message--success form__message" id="Newsletter-success--{{ section.id }}" tabindex="-1" autofocus>{% render 'icon-success' %}{{ 'newsletter.success' | t }}</h3>
               {%- endif -%}
-            </div>
-            <button type="submit" class="newsletter__button button" name="commit">
-              {{ 'newsletter.button_label' | t }}
-            </button>
-            {%- if form.posted_successfully? -%}
-              <h3 class="newsletter-form__message newsletter-form__message--success form__message" id="Newsletter-success--{{ section.id }}" tabindex="-1" autofocus>{% render 'icon-success' %}{{ 'newsletter.success' | t }}</h3>
-            {%- endif -%}
-          {% endform %}
-      {%- endcase -%}
+            {% endform %}
+        {%- endcase -%}
+      </div>
     {%- endfor -%}
   </div>
 </div>

--- a/sections/newsletter.liquid
+++ b/sections/newsletter.liquid
@@ -4,54 +4,52 @@
 <div class="newsletter center{% if section.settings.full_width == false %} newsletter--narrow page-width{% endif%}">
   <div class="newsletter__wrapper color-{{ section.settings.color_scheme }}">
     {%- for block in section.blocks -%}
-      <div {{ block.shopify_attributes }}>
-        {%- case block.type -%}
-          {%- when 'heading' -%}
-            <h2 class="h1">{{ block.settings.heading | escape }}</h2>
-          {%- when 'paragraph' -%}
-            <div class="newsletter__subheading rte">{{ block.settings.paragraph }}</div>
-          {%- when 'email_form' -%}
-            {% form 'customer', class: 'newsletter-form' %}
-              <input type="hidden" name="contact[tags]" value="newsletter">
-              <div class="newsletter-form__field-wrapper">
-                <div class="field">
-                  <input
-                    id="NewsletterForm--{{ section.id }}"
-                    type="email"
-                    name="contact[email]"
-                    class="field__input"
-                    value="{{ form.email }}"
-                    aria-required="true"
-                    autocorrect="off"
-                    autocapitalize="off"
-                    autocomplete="email"
-                    {% if form.errors %}
-                      autofocus
-                      aria-invalid="true"
-                      aria-describedby="Newsletter-error--{{ section.id }}"
-                    {% elsif form.posted_successfully? %}
-                      aria-describedby="Newsletter-success--{{ section.id }}"
-                    {% endif %}
-                    placeholder="{{ 'newsletter.label' | t }}"
-                    required
-                  >
-                  <label class="field__label" for="NewsletterForm--{{ section.id }}">
-                    {{ 'newsletter.label' | t }}
-                  </label>
-                </div>
-                {%- if form.errors -%}
-                  <small class="newsletter-form__message form__message" id="Newsletter-error--{{ section.id }}">{% render 'icon-error' %}{{ form.errors.translated_fields['email'] | capitalize }} {{ form.errors.messages['email'] }}</small>
-                {%- endif -%}
+      {%- case block.type -%}
+        {%- when 'heading' -%}
+          <h2 class="h1" {{ block.shopify_attributes }}>{{ block.settings.heading | escape }}</h2>
+        {%- when 'paragraph' -%}
+          <div class="newsletter__subheading rte" {{ block.shopify_attributes }}>{{ block.settings.paragraph }}</div>
+        {%- when 'email_form' -%}
+          {% form 'customer', class: 'newsletter-form' %}
+            <input type="hidden" name="contact[tags]" value="newsletter" {{ block.shopify_attributes }}>
+            <div class="newsletter-form__field-wrapper">
+              <div class="field">
+                <input
+                  id="NewsletterForm--{{ section.id }}"
+                  type="email"
+                  name="contact[email]"
+                  class="field__input"
+                  value="{{ form.email }}"
+                  aria-required="true"
+                  autocorrect="off"
+                  autocapitalize="off"
+                  autocomplete="email"
+                  {% if form.errors %}
+                    autofocus
+                    aria-invalid="true"
+                    aria-describedby="Newsletter-error--{{ section.id }}"
+                  {% elsif form.posted_successfully? %}
+                    aria-describedby="Newsletter-success--{{ section.id }}"
+                  {% endif %}
+                  placeholder="{{ 'newsletter.label' | t }}"
+                  required
+                >
+                <label class="field__label" for="NewsletterForm--{{ section.id }}">
+                  {{ 'newsletter.label' | t }}
+                </label>
               </div>
-              <button type="submit" class="newsletter__button button" name="commit">
-                {{ 'newsletter.button_label' | t }}
-              </button>
-              {%- if form.posted_successfully? -%}
-                <h3 class="newsletter-form__message newsletter-form__message--success form__message" id="Newsletter-success--{{ section.id }}" tabindex="-1" autofocus>{% render 'icon-success' %}{{ 'newsletter.success' | t }}</h3>
+              {%- if form.errors -%}
+                <small class="newsletter-form__message form__message" id="Newsletter-error--{{ section.id }}">{% render 'icon-error' %}{{ form.errors.translated_fields['email'] | capitalize }} {{ form.errors.messages['email'] }}</small>
               {%- endif -%}
-            {% endform %}
-        {%- endcase -%}
-      </div>
+            </div>
+            <button type="submit" class="newsletter__button button" name="commit">
+              {{ 'newsletter.button_label' | t }}
+            </button>
+            {%- if form.posted_successfully? -%}
+              <h3 class="newsletter-form__message newsletter-form__message--success form__message" id="Newsletter-success--{{ section.id }}" tabindex="-1" autofocus>{% render 'icon-success' %}{{ 'newsletter.success' | t }}</h3>
+            {%- endif -%}
+          {% endform %}
+      {%- endcase -%}
     {%- endfor -%}
   </div>
 </div>

--- a/sections/rich-text.liquid
+++ b/sections/rich-text.liquid
@@ -7,14 +7,16 @@
 <div class="rich-text{% if section.settings.full_width %} rich-text--full-width{% endif %} color-{{ section.settings.color_scheme }}">
   <div class="rich-text__blocks">
     {%- for block in section.blocks -%}
-      {%- case block.type -%}
-        {%- when 'heading' -%}
-          <h2 class="{% if block.settings.heading_size == 'small' %}h2{% else %}h1{% endif %}">{{ block.settings.heading | escape }}</h2>
-        {%- when 'text' -%}
-          <div class="rich-text__text rte">{{ block.settings.text }}</div>
-        {%- when 'button' -%}
-          <a{% if block.settings.button_link == blank %} aria-disabled="true"{% else %} href="{{ block.settings.button_link }}"{% endif %} class="button{% if block.settings.button_style_secondary %} button--secondary{% else %} button--primary{% endif %}">{{ block.settings.button_label | escape }}</a>
-      {%- endcase -%}
+      <div {{ block.shopify_attributes }}>
+        {%- case block.type -%}
+          {%- when 'heading' -%}
+            <h2 class="{% if block.settings.heading_size == 'small' %}h2{% else %}h1{% endif %}">{{ block.settings.heading | escape }}</h2>
+          {%- when 'text' -%}
+            <div class="rich-text__text rte">{{ block.settings.text }}</div>
+          {%- when 'button' -%}
+            <a{% if block.settings.button_link == blank %} aria-disabled="true"{% else %} href="{{ block.settings.button_link }}"{% endif %} class="button{% if block.settings.button_style_secondary %} button--secondary{% else %} button--primary{% endif %}">{{ block.settings.button_label | escape }}</a>
+        {%- endcase -%}
+      </div>
     {%- endfor -%}
   </div>
 </div>

--- a/sections/rich-text.liquid
+++ b/sections/rich-text.liquid
@@ -7,16 +7,16 @@
 <div class="rich-text{% if section.settings.full_width %} rich-text--full-width{% endif %} color-{{ section.settings.color_scheme }}">
   <div class="rich-text__blocks">
     {%- for block in section.blocks -%}
-      <div {{ block.shopify_attributes }}>
-        {%- case block.type -%}
-          {%- when 'heading' -%}
-            <h2 class="{% if block.settings.heading_size == 'small' %}h2{% else %}h1{% endif %}">{{ block.settings.heading | escape }}</h2>
-          {%- when 'text' -%}
-            <div class="rich-text__text rte">{{ block.settings.text }}</div>
-          {%- when 'button' -%}
-            <a{% if block.settings.button_link == blank %} aria-disabled="true"{% else %} href="{{ block.settings.button_link }}"{% endif %} class="button{% if block.settings.button_style_secondary %} button--secondary{% else %} button--primary{% endif %}">{{ block.settings.button_label | escape }}</a>
-        {%- endcase -%}
-      </div>
+      {%- case block.type -%}
+        {%- when 'heading' -%}
+          <h2 class="{% if block.settings.heading_size == 'small' %}h2{% else %}h1{% endif %}" {{ block.shopify_attributes }}>{{ block.settings.heading | escape }}</h2>
+        {%- when 'text' -%}
+          <div class="rich-text__text rte" {{ block.shopify_attributes }}>{{ block.settings.text }}</div>
+        {%- when 'button' -%}
+          <a{% if block.settings.button_link == blank %} aria-disabled="true"{% else %} href="{{ block.settings.button_link }}"{% endif %} class="button{% if block.settings.button_style_secondary %} button--secondary{% else %} button--primary{% endif %}" {{ block.shopify_attributes }}>
+            {{ block.settings.button_label | escape }}
+          </a>
+      {%- endcase -%}
     {%- endfor -%}
   </div>
 </div>

--- a/snippets/article-card.liquid
+++ b/snippets/article-card.liquid
@@ -36,46 +36,44 @@
 
     <div class="article-card__info">
       {%- for block in section.blocks -%}
-        <div {{ block.shopify_attributes }}>
-          {%- case block.type -%}
-            {%- when 'title'-%}
-              <header class="article-card__header">
-                <h2 class="article-card__title" id="Article-{{ article.id }}">
-                  {{ article.title | escape }}
-                </h2>
-                {%- if block.settings.show_date -%}
-                  <span class="circle-divider caption-with-letter-spacing">
-                    {{- article.published_at | time_tag: format: 'month_year' -}}
-                  </span>
-                {%- endif -%}
-                {%- if block.settings.show_author -%}
-                  <span class="caption-with-letter-spacing">{{ article.author -}}</span>
-                {%- endif -%}
-              </header>
-
-            {%- when 'summary'-%}
-              {%- if article.excerpt.size > 0 or article.content.size > 0 -%}
-                <p class="article-card__excerpt rte-width">
-                  {%- if article.excerpt.size > 0 -%}
-                    {{ article.excerpt | strip_html | truncatewords: 30 }}
-                  {%- else -%}
-                    {{ article.content | strip_html | truncatewords: 30 }}
-                  {%- endif -%}
-                </p>
-              {%- endif -%}
-
-            {%- when 'link'-%}
-              <div class="article-card__footer">
-                <span class="link article-card__link" aria-label="{{ 'blogs.article.read_more_title' | t: title: article.title | escape }}">
-                  {{ 'blogs.article.read_more' | t }}
+        {%- case block.type -%}
+          {%- when 'title'-%}
+            <header class="article-card__header" {{ block.shopify_attributes }}>
+              <h2 class="article-card__title" id="Article-{{ article.id }}">
+                {{ article.title | escape }}
+              </h2>
+              {%- if block.settings.show_date -%}
+                <span class="circle-divider caption-with-letter-spacing">
+                  {{- article.published_at | time_tag: format: 'month_year' -}}
                 </span>
+              {%- endif -%}
+              {%- if block.settings.show_author -%}
+                <span class="caption-with-letter-spacing">{{ article.author -}}</span>
+              {%- endif -%}
+            </header>
 
-                {%- if article.comments_count > 0 and blog.comments_enabled? -%}
-                  <span>{{ 'blogs.article.comments' | t: count: article.comments_count }}</span>
+          {%- when 'summary'-%}
+            {%- if article.excerpt.size > 0 or article.content.size > 0 -%}
+              <p class="article-card__excerpt rte-width" {{ block.shopify_attributes }}>
+                {%- if article.excerpt.size > 0 -%}
+                  {{ article.excerpt | strip_html | truncatewords: 30 }}
+                {%- else -%}
+                  {{ article.content | strip_html | truncatewords: 30 }}
                 {%- endif -%}
-              </div>
-          {%- endcase -%}
-        </div>
+              </p>
+            {%- endif -%}
+
+          {%- when 'link'-%}
+            <div class="article-card__footer" {{ block.shopify_attributes }}>
+              <span class="link article-card__link" aria-label="{{ 'blogs.article.read_more_title' | t: title: article.title | escape }}">
+                {{ 'blogs.article.read_more' | t }}
+              </span>
+
+              {%- if article.comments_count > 0 and blog.comments_enabled? -%}
+                <span>{{ 'blogs.article.comments' | t: count: article.comments_count }}</span>
+              {%- endif -%}
+            </div>
+        {%- endcase -%}
       {%- endfor -%}
     </div>
   </a>

--- a/snippets/article-card.liquid
+++ b/snippets/article-card.liquid
@@ -36,44 +36,46 @@
 
     <div class="article-card__info">
       {%- for block in section.blocks -%}
-        {%- case block.type -%}
-          {%- when 'title'-%}
-            <header class="article-card__header">
-              <h2 class="article-card__title" id="Article-{{ article.id }}">
-                {{ article.title | escape }}
-              </h2>
-              {%- if block.settings.show_date -%}
-                <span class="circle-divider caption-with-letter-spacing">
-                  {{- article.published_at | time_tag: format: 'month_year' -}}
-                </span>
-              {%- endif -%}
-              {%- if block.settings.show_author -%}
-                <span class="caption-with-letter-spacing">{{ article.author -}}</span>
-              {%- endif -%}
-            </header>
-
-          {%- when 'summary'-%}
-            {%- if article.excerpt.size > 0 or article.content.size > 0 -%}
-              <p class="article-card__excerpt rte-width">
-                {%- if article.excerpt.size > 0 -%}
-                  {{ article.excerpt | strip_html | truncatewords: 30 }}
-                {%- else -%}
-                  {{ article.content | strip_html | truncatewords: 30 }}
+        <div {{ block.shopify_attributes }}>
+          {%- case block.type -%}
+            {%- when 'title'-%}
+              <header class="article-card__header">
+                <h2 class="article-card__title" id="Article-{{ article.id }}">
+                  {{ article.title | escape }}
+                </h2>
+                {%- if block.settings.show_date -%}
+                  <span class="circle-divider caption-with-letter-spacing">
+                    {{- article.published_at | time_tag: format: 'month_year' -}}
+                  </span>
                 {%- endif -%}
-              </p>
-            {%- endif -%}
+                {%- if block.settings.show_author -%}
+                  <span class="caption-with-letter-spacing">{{ article.author -}}</span>
+                {%- endif -%}
+              </header>
 
-          {%- when 'link'-%}
-            <div class="article-card__footer">
-              <span class="link article-card__link" aria-label="{{ 'blogs.article.read_more_title' | t: title: article.title | escape }}">
-                {{ 'blogs.article.read_more' | t }}
-              </span>
-
-              {%- if article.comments_count > 0 and blog.comments_enabled? -%}
-                <span>{{ 'blogs.article.comments' | t: count: article.comments_count }}</span>
+            {%- when 'summary'-%}
+              {%- if article.excerpt.size > 0 or article.content.size > 0 -%}
+                <p class="article-card__excerpt rte-width">
+                  {%- if article.excerpt.size > 0 -%}
+                    {{ article.excerpt | strip_html | truncatewords: 30 }}
+                  {%- else -%}
+                    {{ article.content | strip_html | truncatewords: 30 }}
+                  {%- endif -%}
+                </p>
               {%- endif -%}
-            </div>
-        {%- endcase -%}
+
+            {%- when 'link'-%}
+              <div class="article-card__footer">
+                <span class="link article-card__link" aria-label="{{ 'blogs.article.read_more_title' | t: title: article.title | escape }}">
+                  {{ 'blogs.article.read_more' | t }}
+                </span>
+
+                {%- if article.comments_count > 0 and blog.comments_enabled? -%}
+                  <span>{{ 'blogs.article.comments' | t: count: article.comments_count }}</span>
+                {%- endif -%}
+              </div>
+          {%- endcase -%}
+        </div>
       {%- endfor -%}
     </div>
   </a>


### PR DESCRIPTION
**Why are these changes introduced?**

Fixes #51.

**What approach did you take?**

Added `block.shopify_attributes` to each block inside of `section.blocks`. More information: https://shopify.dev/api/liquid/objects/block#block-shopify_attributes.

**Demo links**

- [Store](https://os2-demo.myshopify.com/?preview_theme_id=120813486102)
- [Editor](https://os2-demo.myshopify.com/admin/themes/120813486102/editor)

**Checklist**
- [x] Followed [theme code principles](https://github.com/Shopify/dawn/blob/main/.github/CONTRIBUTING.md#theme-code-principles)
- [x] Linted with [Theme Check](https://github.com/Shopify/theme-check)
- [x] Tested on [mobile](https://shopify.dev/themes/store/requirements#mobile-browser-requirements)
- [x] Tested on [multiple browsers](https://shopify.dev/themes/store/requirements#desktop-browser-requirements)
- [x] Tested for [accessibility](https://shopify.dev/themes/best-practices/accessibility)
