### PR TITLE
[Password page] Add default blocks

### DIFF
--- a/templates/password.json
+++ b/templates/password.json
@@ -19,12 +19,18 @@
             "paragraph": "<p>Be the first to know when we launch.</p>"
           }
         },
-        "email": {
+        "email_form": {
           "type": "email_form"
         }
       },
-      "block_order": ["heading", "subheading", "email"]
+      "block_order": [
+        "heading",
+        "subheading",
+        "email_form"
+      ]
     }
   },
-  "order": ["main"]
+  "order": [
+    "main"
+  ]
 }

--- a/templates/password.json
+++ b/templates/password.json
@@ -4,13 +4,27 @@
     "main": {
       "type": "newsletter",
       "settings": {
-        "heading": "Opening soon",
-        "subheading": "<p>Be the first to know when we launch.</p>",
         "full_width": false
-      }
+      },
+      "blocks": {
+        "heading": {
+          "type": "heading",
+          "settings": {
+            "heading": "Opening soon"
+          }
+        },
+        "subheading": {
+          "type": "paragraph",
+          "settings": {
+            "paragraph": "<p>Be the first to know when we launch.</p>"
+          }
+        },
+        "email": {
+          "type": "email_form"
+        }
+      },
+      "block_order": ["heading", "subheading", "email"]
     }
   },
-  "order": [
-    "main"
-  ]
+  "order": ["main"]
 }

--- a/templates/password.json
+++ b/templates/password.json
@@ -13,7 +13,7 @@
             "heading": "Opening soon"
           }
         },
-        "subheading": {
+        "paragraph": {
           "type": "paragraph",
           "settings": {
             "paragraph": "<p>Be the first to know when we launch.</p>"
@@ -25,7 +25,7 @@
       },
       "block_order": [
         "heading",
-        "subheading",
+        "paragraph",
         "email_form"
       ]
     }


### PR DESCRIPTION
**Why are these changes introduced?**

Fixes #3 .

**What approach did you take?**

Added the block settings to the `.json` template. It was using some settings as if the section didn't have blocks. 

**Demo links**

- [Editor](https://os2-demo.myshopify.com/admin/themes/120822071318/editor)

**Checklist**
- [x] Followed [theme code principles](https://github.com/Shopify/dawn/blob/main/.github/CONTRIBUTING.md#theme-code-principles)
- [x] Linted with [Theme Check](https://github.com/Shopify/theme-check)
- [x] Tested on [mobile](https://shopify.dev/themes/store/requirements#mobile-browser-requirements)
- [x] Tested on [multiple browsers](https://shopify.dev/themes/store/requirements#desktop-browser-requirements)
- [x] Tested for [accessibility](https://shopify.dev/themes/best-practices/accessibility)
