### PR TITLE
Update color variables for rgb. Remove unused color variables

### DIFF
--- a/assets/template-collection.css
+++ b/assets/template-collection.css
@@ -112,7 +112,7 @@
 
 .collection-filters__label {
   display: block;
-  color: var(--color-base-text-opacity-85-percent);
+  color: var(--color-foreground-85);
   font-size: 1.4rem;
   line-height: 1;
   margin: 0 0 1rem;
@@ -129,7 +129,7 @@
   padding: 0 1.5rem;
   min-width: 25rem;
   margin-top: 2.4rem;
-  border: 0.1rem solid var(--color-base-text-opacity-55-percent);
+  border: 0.1rem solid var(--color-foreground-55);
 }
 
 .collection-filters__summary::after {

--- a/layout/theme.liquid
+++ b/layout/theme.liquid
@@ -46,26 +46,19 @@
         --font-heading-weight: {{ settings.type_header_font.weight }};
 
         --color-base-text: {{ settings.colors_text }};
-        --color-base-text-rgb: {{ settings.colors_text | color_to_rgb | remove: 'rgb(' | remove: ')' }};
+        --color-base-text-rgb: {{ settings.colors_text.red }}, {{ settings.colors_text.green }}, {{ settings.colors_text.blue }};
         --color-base-background-1: {{ settings.colors_background_1 }};
-        --color-base-background-1-rgb: {{ settings.colors_background_1 | color_to_rgb | remove: 'rgb(' | remove: ')' }};
+        --color-base-background-1-rgb: {{ settings.colors_background_1.red }}, {{ settings.colors_background_1.green }}, {{ settings.colors_background_1.blue }};
         --color-base-background-2: {{ settings.colors_background_2 }};
-        --color-base-background-2-rgb: {{ settings.colors_background_2 | color_to_rgb | remove: 'rgb(' | remove: ')' }};
+        --color-base-background-2-rgb: {{ settings.colors_background_2.red }}, {{ settings.colors_background_2.green }}, {{ settings.colors_background_2.blue }};
         --color-base-solid-button-labels: {{ settings.colors_solid_button_labels }};
-        --color-base-solid-button-labels-rgb: {{ settings.colors_solid_button_labels | color_to_rgb | remove: 'rgb(' | remove: ')' }};
+        --color-base-solid-button-labels-rgb: {{ settings.colors_solid_button_labels.red }}, {{ settings.colors_solid_button_labels.green }}, {{ settings.colors_solid_button_labels.blue }};
         --color-base-outline-button-labels: {{ settings.colors_outline_button_labels }};
-        --color-base-outline-button-labels-rgb: {{ settings.colors_outline_button_labels | color_to_rgb | remove: 'rgb(' | remove: ')' }};
+        --color-base-outline-button-labels-rgb: {{ settings.colors_outline_button_labels.red }}, {{ settings.colors_outline_button_labels.green }}, {{ settings.colors_outline_button_labels.blue }};
         --color-base-accent-1: {{ settings.colors_accent_1 }};
-        --color-base-accent-1-rgb: {{ settings.colors_accent_1 | color_to_rgb | remove: 'rgb(' | remove: ')' }};
+        --color-base-accent-1-rgb: {{ settings.colors_accent_1.red }}, {{ settings.colors_accent_1.green }}, {{ settings.colors_accent_1.blue }};
         --color-base-accent-2: {{ settings.colors_accent_2 }};
-        --color-base-accent-2-rgb: {{ settings.colors_accent_2 | color_to_rgb | remove: 'rgb(' | remove: ')' }};
-
-        --color-base-text-opacity-10-percent: {{ settings.colors_text | color_mix: settings.colors_background_1, 10 }};
-        --color-base-text-opacity-20-percent: {{ settings.colors_text | color_mix: settings.colors_background_1, 20 }};
-        --color-base-text-opacity-55-percent: {{ settings.colors_text | color_mix: settings.colors_background_1, 55 }};
-        --color-base-text-opacity-85-percent: {{ settings.colors_text | color_mix: settings.colors_background_1, 85 }};
-        --color-base-accent-1-opacity-10-percent: {{ settings.colors_accent_1 | color_mix: settings.colors_background_1, 10 }};
-        --color-base-accent-2-opacity-10-percent: {{ settings.colors_accent_2 | color_mix: settings.colors_background_1, 10 }};
+        --color-base-accent-2-rgb: {{ settings.colors_accent_2.red }}, {{ settings.colors_accent_2.green }}, {{ settings.colors_accent_2.blue }};
       }
 
       *,


### PR DESCRIPTION
**Why are these changes introduced?**
- Update definition of CSS RGB color variables in `Liquid` to leverage updated `ColorDrop`
- Fix issue with invalidated CSS when setting a theme color setting to `none`

Fixes https://github.com/Shopify/dawn/issues/52

**What approach did you take?**
- Define RGB colors using `ColorDrop` `red`, `green` and `blue` properties: 
```
--color-base-text-rgb: {{ settings.colors_text.red }}, {{ settings.colors_text.green }}, {{ settings.colors_text.blue }};
```
- Remove any unreferenced CSS color variables (clean up)

**Other considerations**

**Demo links**

- [Store](https://os2-demo.myshopify.com/?preview_theme_id=120822431766)
- [Editor](https://os2-demo.myshopify.com/admin/themes/120822431766/editor)

**Checklist**
- [x] Followed [theme code principles](https://github.com/Shopify/dawn/blob/main/.github/CONTRIBUTING.md#theme-code-principles)
- [x] Linted with [Theme Check](https://github.com/Shopify/theme-check)
- [x] Tested on [mobile](https://shopify.dev/themes/store/requirements#mobile-browser-requirements)
- [x] Tested on [multiple browsers](https://shopify.dev/themes/store/requirements#desktop-browser-requirements)
- [x] Tested for [accessibility](https://shopify.dev/themes/best-practices/accessibility)
