### PR TITLE
Fix hidden unit price on sold out variant

### DIFF
--- a/snippets/price.liquid
+++ b/snippets/price.liquid
@@ -67,7 +67,7 @@
         </span>
       </dd>
     </div>
-    <small class="unit-price caption{% if available == false or product.selected_or_first_available_variant.unit_price_measurement == nil %} hidden{% endif %}">
+    <small class="unit-price caption{% if product.selected_or_first_available_variant.unit_price_measurement == nil %} hidden{% endif %}">
       <dt class="visually-hidden">{{ 'products.product.price.unit_price' | t }}</dt>
       <dd {% if show_badges == false %}class="price__last"{% endif %}>
         <span>{{- product.selected_or_first_available_variant.unit_price | money -}}</span>


### PR DESCRIPTION
**Why are these changes introduced?**

Related issue: https://github.com/Shopify/dawn/issues/4

Resolved one of the items in #4 

> - [ ] Unit price disappears for sold out variants. [Screen recording](https://screenshot.click/21-06-t5c25-pzcxa.mp4) 

<details>

<summary>Image</summary>

[![alt](https://screenshot.click/30-50-y98wm-smz1d.png)](https://screenshot.click/30-50-y98wm-smz1d.png)

</details>

However, I can't fix the first point as I get [Liquid error](https://github.com/Shopify/dawn/issues/4#issuecomment-871476564)

**What approach did you take?**

- Remove liquid logic that adds `hidden` class so Sold out product can still show unit price.

**Demo links**

- [Store - Variant Color "Gummy" + Size "38"](https://os2-demo.myshopify.com/products/louise-slide-sandal?variant=39322646216726&preview_theme_id=120823087126)
- [Editor](https://os2-demo.myshopify.com/admin/themes/120823087126/editor)

**Checklist**
- [x] Followed [theme code principles](https://github.com/Shopify/dawn/blob/main/.github/CONTRIBUTING.md#theme-code-principles)
- [x] Linted with [Theme Check](https://github.com/Shopify/theme-check)
- [x] Tested on [mobile](https://shopify.dev/themes/store/requirements#mobile-browser-requirements)
- [x] Tested on [multiple browsers](https://shopify.dev/themes/store/requirements#desktop-browser-requirements)
- [x] Tested for [accessibility](https://shopify.dev/themes/best-practices/accessibility)
