### PR TITLE
Add favicon to theme settings

### DIFF
--- a/config/settings_schema.json
+++ b/config/settings_schema.json
@@ -250,5 +250,16 @@
         "info": "t:settings_schema.social-media.settings.social_vimeo_link.info"
       }
     ]
+  },
+  {
+    "name": "Favicon",
+    "settings": [
+      {
+        "type": "image_picker",
+        "id": "favicon",
+        "label": "Favicon image",
+        "info": "Will be scaled down to 32 x 32px"
+      }
+    ]
   }
 ]

--- a/config/settings_schema.json
+++ b/config/settings_schema.json
@@ -252,13 +252,13 @@
     ]
   },
   {
-    "name": "Favicon",
+    "name": "t:settings_schema.favicon.name",
     "settings": [
       {
         "type": "image_picker",
         "id": "favicon",
-        "label": "Favicon image",
-        "info": "Will be scaled down to 32 x 32px"
+        "label": "t:settings_schema.favicon.settings.favicon.label",
+        "info": "t:settings_schema.favicon.settings.favicon.info"
       }
     ]
   }

--- a/layout/password.liquid
+++ b/layout/password.liquid
@@ -8,6 +8,10 @@
     <link rel="canonical" href="{{ canonical_url }}">
     <link rel="preconnect" href="https://cdn.shopify.com" crossorigin>
 
+    {%- if settings.favicon != blank -%}
+      <link rel="icon" type="image/png" href="{{ settings.favicon | img_url: '32x32' }}">
+    {%- endif -%}
+
     {%- unless settings.type_header_font.system? -%}
       <link rel="preconnect" href="https://fonts.shopifycdn.com" crossorigin>
     {%- endunless -%}

--- a/layout/theme.liquid
+++ b/layout/theme.liquid
@@ -8,6 +8,10 @@
     <link rel="canonical" href="{{ canonical_url }}">
     <link rel="preconnect" href="https://cdn.shopify.com" crossorigin>
 
+    {%- if settings.favicon != blank -%}
+      <link rel="icon" type="image/png" href="{{ settings.favicon | img_url: '32x32' }}">
+    {%- endif -%}
+
     {%- unless settings.type_header_font.system? -%}
       <link rel="preconnect" href="https://fonts.shopifycdn.com" crossorigin>
     {%- endunless -%}

--- a/locales/en.default.schema.json
+++ b/locales/en.default.schema.json
@@ -157,6 +157,15 @@
           "info": "https://vimeo.com/shopify"
         }
       }
+    },
+    "favicon": {
+      "name": "Favicon",
+      "settings": {
+        "favicon": {
+          "label": "Favicon image",
+          "info": "Will be scaled down to 32 x 32px"
+        }
+      }
     }
   },
   "sections": {

--- a/templates/gift_card.liquid
+++ b/templates/gift_card.liquid
@@ -11,6 +11,10 @@
     <link rel="canonical" href="{{ canonical_url }}">
     <link rel="preconnect" href="https://cdn.shopify.com" crossorigin>
 
+    {%- if settings.favicon != blank -%}
+      <link rel="icon" type="image/png" href="{{ settings.favicon | img_url: '32x32' }}">
+    {%- endif -%}
+
     {%- unless settings.type_header_font.system? -%}
       <link rel="preconnect" href="https://fonts.shopifycdn.com" crossorigin>
     {%- endunless -%}


### PR DESCRIPTION
**Why are these changes introduced?**

Fixes #37.

**What approach did you take?**

Added a new `image_picker` setting type to the theme settings and referenced it the layout files.

**Other considerations**

In our previous themes, we would reference `rel="shortcut icon"` but according to [MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Link_types):
>The shortcut link type is often seen before icon, but this link type is non-conforming, ignored and web authors must not use it anymore.

There's most likely a number of things we can do on the platform side to optimize favicons for a number of devices, including ones that have retina/high DPI displays.

**Demo links**

- [Store](https://os2-demo.myshopify.com/?preview_theme_id=120823545878)
- [Editor](https://os2-demo.myshopify.com/admin/themes/120823545878/editor)

**Checklist**
- [ ] Followed [theme code principles](https://github.com/Shopify/dawn/blob/main/.github/CONTRIBUTING.md#theme-code-principles)
- [ ] Linted with [Theme Check](https://github.com/Shopify/theme-check)
- [ ] Tested on [mobile](https://shopify.dev/themes/store/requirements#mobile-browser-requirements)
- [ ] Tested on [multiple browsers](https://shopify.dev/themes/store/requirements#desktop-browser-requirements)
- [ ] Tested for [accessibility](https://shopify.dev/themes/best-practices/accessibility)
