### PR TITLE
Page Title defaults to product, blog, article etc. title

### DIFF
--- a/layout/theme.liquid
+++ b/layout/theme.liquid
@@ -12,7 +12,7 @@
       <link rel="preconnect" href="https://fonts.shopifycdn.com" crossorigin>
     {%- endunless -%}
 
-    <title>{{ shop.name }}</title>
+    <title>{{ page_title }}</title>
 
     {% if page_description %}
       <meta name="description" content="{{ page_description | escape }}">


### PR DESCRIPTION
**Why are these changes introduced?**

Currently the title on any page is just the shop name. It should default to the title of the product, blog, article, page etc.

**What approach did you take?**

Use `page_title` liquid attribute. 
https://shopify.dev/api/liquid/objects#page_title

**Other considerations**

**Demo links**

- [Store](url)
- [Editor](url)

**Checklist**
- [ ] Followed [theme code principles](https://github.com/Shopify/dawn/blob/main/.github/CONTRIBUTING.md#theme-code-principles)
- [ ] Linted with [Theme Check](https://github.com/Shopify/theme-check)
- [ ] Tested on [mobile](https://shopify.dev/themes/store/requirements#mobile-browser-requirements)
- [ ] Tested on [multiple browsers](https://shopify.dev/themes/store/requirements#desktop-browser-requirements)
- [ ] Tested for [accessibility](https://shopify.dev/themes/best-practices/accessibility)
