### PR TITLE
Added app blocks to some sections

### DIFF
--- a/assets/component-cart.css
+++ b/assets/component-cart.css
@@ -139,7 +139,12 @@ cart-items {
 }
 
 .cart__dynamic-checkout-buttons {
-  margin-top: 0;
+  max-width: 36rem;
+  margin: 0 auto;
+}
+
+.cart__blocks > * + * {
+  margin-top: 1rem;
 }
 
 .cart__dynamic-checkout-buttons div[role='button'] {
@@ -174,10 +179,6 @@ cart-items {
   .cart__update-button {
     margin-bottom: 0;
     margin-right: 0.8rem;
-  }
-
-  .cart__dynamic-checkout-buttons {
-    margin-top: 1rem;
   }
 
   .tax-note {

--- a/sections/main-article.liquid
+++ b/sections/main-article.liquid
@@ -3,6 +3,10 @@
 <article class="article-template" itemscope itemtype="http://schema.org/BlogPosting">
   {%- for block in section.blocks -%}
     {%- case block.type -%}
+      {%- when '@app' -%}
+        <div class="page-width page-width--narrow">
+          {% render block %}
+        </div>
       {%- when 'featured_image'-%}
         {%- if article.image -%}
           <div class="article-template__hero-container" {{ block.shopify_attributes }}>
@@ -209,6 +213,9 @@
   "name": "t:sections.main-article.name",
   "tag": "section",
   "blocks": [
+    {
+      "type": "@app"
+    },
     {
       "type": "featured_image",
       "name": "t:sections.main-article.blocks.featured_image.name",

--- a/sections/main-cart-footer.liquid
+++ b/sections/main-cart-footer.liquid
@@ -13,9 +13,11 @@
         </cart-note>
       {%- endif -%}
 
-      <div>
+      <div class="cart__blocks">
         {% for block in section.blocks %}
           {%- case block.type -%}
+            {%- when '@app' -%}
+              {% render block %}
             {%- when 'subtotal' -%}
               <div class="js-contents" {{ block.shopify_attributes }}>
                 <div class="totals">
@@ -113,6 +115,9 @@
       "type": "buttons",
       "name": "t:sections.main-cart-footer.blocks.buttons.name",
       "limit": 1
+    },
+    {
+      "type": "@app"
     }
   ]
 }

--- a/sections/newsletter.liquid
+++ b/sections/newsletter.liquid
@@ -5,6 +5,8 @@
   <div class="newsletter__wrapper color-{{ section.settings.color_scheme }}">
     {%- for block in section.blocks -%}
       {%- case block.type -%}
+        {%- when '@app' -%}
+          {% render block %}
         {%- when 'heading' -%}
           <h2 class="h1" {{ block.shopify_attributes }}>{{ block.settings.heading | escape }}</h2>
         {%- when 'paragraph' -%}
@@ -132,6 +134,9 @@
       "type": "email_form",
       "name": "t:sections.newsletter.blocks.email_form.name",
       "limit": 1
+    },
+    {
+      "type": "@app"
     }
   ],
   "presets": [


### PR DESCRIPTION
**Why are these changes introduced?**

Fixes #38.

**What approach did you take?**

I added the app blocks to the following sections:

* Cart template - Subtotal section
* Blog Post template
* Password template - Newsletter section

**Other considerations**

We wanted to add app blocks to the announcement bar, but static sections do not support app blocks.

**Demo links**

- [Store](https://os2-demo.myshopify.com/?_ab=0&_fd=0&_sc=1&preview_theme_id=120838848534)
- [Editor](https://os2-demo.myshopify.com/admin/themes/120838750230/editor)

**Checklist**
- [x] Followed [theme code principles](https://github.com/Shopify/dawn/blob/main/.github/CONTRIBUTING.md#theme-code-principles)
- [x] Linted with [Theme Check](https://github.com/Shopify/theme-check)
- [x] Tested on [mobile](https://shopify.dev/themes/store/requirements#mobile-browser-requirements)
- [x] Tested on [multiple browsers](https://shopify.dev/themes/store/requirements#desktop-browser-requirements)
- [x] Tested for [accessibility](https://shopify.dev/themes/best-practices/accessibility)
