### PR TITLE
Fix unit price styling on order detail page

### DIFF
--- a/assets/customer.css
+++ b/assets/customer.css
@@ -481,7 +481,12 @@
 }
 
 .order tbody td:nth-of-type(3) dd:nth-of-type(2) {
-  font-size: 1.2rem;
+  font-size: 1.1rem;
+  letter-spacing: 0.07rem;
+  line-height: 1.2;
+  margin-top: 0.2rem;
+  text-transform: uppercase;
+  color: var(--color-foreground-70);
 }
 
 .order tfoot tr:last-of-type td,

--- a/assets/customer.css
+++ b/assets/customer.css
@@ -72,7 +72,7 @@
 }
 
 .customer tbody {
-  color: var(--color-foreground)
+  color: var(--color-foreground);
 }
 
 .customer th,
@@ -198,7 +198,7 @@
 /* works around colspan phantom border issues */
 .customer thead::after,
 .customer tfoot::before {
-  content: " ";
+  content: ' ';
   height: 0.1rem;
   width: 100%;
   display: block;
@@ -355,7 +355,7 @@
   display: none;
 }
 
-.activate button[name="decline"],
+.activate button[name='decline'],
 .addresses li > button,
 .addresses form button[type] {
   background-color: transparent;
@@ -363,14 +363,14 @@
   color: var(--color-base-outline-button-labels);
 }
 
-.activate button[name="decline"]:hover,
+.activate button[name='decline']:hover,
 .addresses li > button:hover,
 .addresses form button[type]:hover {
   box-shadow: 0 0 0 0.2rem var(--color-base-outline-button-labels);
 }
 
 @media only screen and (min-width: 750px) {
-  .activate button[name="decline"] {
+  .activate button[name='decline'] {
     margin-top: inherit;
     margin-left: 1rem;
   }
@@ -458,12 +458,14 @@
 .account table td:first-of-type a {
   padding: 1.1rem 1.5rem;
   text-decoration: none;
-  box-shadow: 0 0 0 0.1rem rgba(var(--color-base-outline-button-labels-rgb), 0.2);
+  box-shadow: 0 0 0 0.1rem
+    rgba(var(--color-base-outline-button-labels-rgb), 0.2);
   font-size: 1.2rem;
 }
 
 .account table td:first-of-type a:hover {
-  box-shadow: 0 0 0 0.2rem rgba(var(--color-base-outline-button-labels-rgb), 0.2);
+  box-shadow: 0 0 0 0.2rem
+    rgba(var(--color-base-outline-button-labels-rgb), 0.2);
   color: var(--color-base-outline-button-labels);
 }
 
@@ -472,10 +474,14 @@
 }
 
 @media screen and (min-width: 750px) {
-  .order thead th:nth-last-child(-n+3),
-  .order td:nth-last-child(-n+3) {
+  .order thead th:nth-last-child(-n + 3),
+  .order td:nth-last-child(-n + 3) {
     text-align: right;
   }
+}
+
+.order tbody td:nth-of-type(3) dd:nth-of-type(2) {
+  font-size: 1.2rem;
 }
 
 .order tfoot tr:last-of-type td,
@@ -639,8 +645,8 @@
   margin-right: 1rem;
 }
 
-label[for="AddressCountryNew"],
-label[for="AddressProvinceNew"] {
+label[for='AddressCountryNew'],
+label[for='AddressProvinceNew'] {
   display: block;
   font-size: 1.4rem;
   margin-bottom: 0.6rem;
@@ -666,11 +672,11 @@ li[data-address] {
   margin-top: 5rem;
 }
 
-.addresses [aria-expanded="false"] ~ div[id] {
+.addresses [aria-expanded='false'] ~ div[id] {
   display: none;
 }
 
-.addresses [aria-expanded="true"] ~ div[id] {
+.addresses [aria-expanded='true'] ~ div[id] {
   display: block;
 }
 
@@ -694,7 +700,7 @@ li[data-address] > h2 {
   margin-bottom: 0;
 }
 
-.addresses input[type="checkbox"] {
+.addresses input[type='checkbox'] {
   margin-top: 2rem;
   margin-left: 0;
 }


### PR DESCRIPTION
**Why are these changes introduced?**

Fixes https://github.com/Shopify/dawn/issues/4

The goal of this PR is to fix the unit price styling on the order page:

> Font size on customer order details page is inconsistent with the font size used for unit pricing throughout the rest of the theme. [Screenshot](https://screenshot.click/21-06-wma1t-itru4.png) 

![image](https://user-images.githubusercontent.com/658169/124643767-77512c80-de5f-11eb-91fb-cfafbeb5fb63.png)

![image](https://user-images.githubusercontent.com/658169/124644271-14ac6080-de60-11eb-87a8-c9298e1c8ed6.png)

**What approach did you take?**

- Followed similar approach as other styling on order page: use native CSS pseudo element and target HTML elements directly. In this case, I'm targeting the 3rd column of the table body, and target the 2nd `dd` element (which is the unit price)

**Demo links**

- [Store](https://os2-demo.myshopify.com/?preview_theme_id=120839897110)
- [Editor](https://os2-demo.myshopify.com/admin/themes/120839897110/editor)

**Checklist**
- [x] Followed [theme code principles](https://github.com/Shopify/dawn/blob/main/.github/CONTRIBUTING.md#theme-code-principles)
- [x] Linted with [Theme Check](https://github.com/Shopify/theme-check)
- [x] Tested on [mobile](https://shopify.dev/themes/store/requirements#mobile-browser-requirements)
- [x] Tested on [multiple browsers](https://shopify.dev/themes/store/requirements#desktop-browser-requirements)
- [x] Tested for [accessibility](https://shopify.dev/themes/best-practices/accessibility)
