### PR TITLE
Clear rte page content

### DIFF
--- a/assets/component-rte.css
+++ b/assets/component-rte.css
@@ -1,3 +1,9 @@
+.rte:after {
+  clear: both;
+  content: "";
+  display: block;
+}
+
 .rte > p:first-child {
   margin-top: 0;
 }

--- a/assets/component-rte.css
+++ b/assets/component-rte.css
@@ -1,6 +1,6 @@
 .rte:after {
   clear: both;
-  content: "";
+  content: '';
   display: block;
 }
 

--- a/assets/section-main-product.css
+++ b/assets/section-main-product.css
@@ -248,6 +248,12 @@ a.product__text {
   padding: 0 1rem;
 }
 
+.product__accordion .accordion__content:after {
+  clear: both;
+  content: "";
+  display: block;
+}
+
 .product .price {
   align-items: flex-start;
 }

--- a/assets/section-main-product.css
+++ b/assets/section-main-product.css
@@ -248,12 +248,6 @@ a.product__text {
   padding: 0 1rem;
 }
 
-.product__accordion .accordion__content:after {
-  clear: both;
-  content: "";
-  display: block;
-}
-
 .product .price {
   align-items: flex-start;
 }


### PR DESCRIPTION
**Why are these changes introduced?**

Fixes #2 

**What approach did you take?**

Added a clearfix (via `:after`) to the rte class. Right aligned media in the page content rte gets `float: right`. If that content isn't cleared by something else in that page, the content can bleed out of its container and/or cause other layout issues (i.e. collapsible tabs on the product page).

**Other considerations**

The original issue was scoped for page content within collapsible tabs on product pages, but really this same sort of issue could apply anywhere RTE page content can be displayed.

**Demo links**

- [Editor](https://os2-demo.myshopify.com/admin/themes/120841142294/editor)

**Checklist**
- [ ] Followed [theme code principles](https://github.com/Shopify/dawn/blob/main/.github/CONTRIBUTING.md#theme-code-principles)
- [ ] Linted with [Theme Check](https://github.com/Shopify/theme-check)
- [ ] Tested on [mobile](https://shopify.dev/themes/store/requirements#mobile-browser-requirements)
- [ ] Tested on [multiple browsers](https://shopify.dev/themes/store/requirements#desktop-browser-requirements)
- [ ] Tested for [accessibility](https://shopify.dev/themes/best-practices/accessibility)
