### PR TITLE
Fix stretched product modal images on Safari

### DIFF
--- a/assets/section-main-product.css
+++ b/assets/section-main-product.css
@@ -488,16 +488,11 @@ a.product__text {
 
 @media screen and (min-width: 750px) {
   .product-media-modal__content {
-    height: 100vh;
+    padding-bottom: 2rem;
   }
 
   .product-media-modal__content > *:not(.active) {
     display: block;
-  }
-
-  .product-media-modal__content {
-    justify-content: flex-start;
-    padding-bottom: 2rem;
   }
 
   .product-media-modal__content > *:first-child {
@@ -595,60 +590,6 @@ a.product__text {
   height: auto;
   margin: 0;
   width: 2.2rem;
-}
-
-/* Product thumbnail */
-.thumbnails {
-  display: grid;
-  flex-wrap: wrap;
-  margin-top: 1.5rem;
-  grid-template-columns: repeat(5, 1fr);
-  grid-gap: 1rem;
-}
-
-@media screen and (min-width: 750px) {
-  .thumbnails {
-    grid-template-columns: repeat(4, 1fr);
-  }
-}
-
-@media screen and (min-width: 990px) {
-  .thumbnails {
-    grid-template-columns: repeat(6, 1fr);
-  }
-}
-
-.thumbnail {
-  position: relative;
-  display: block;
-  width: 100%;
-  color: var(--color-foreground);
-  cursor: pointer;
-  border: 0.2rem inset var(--color-background);
-  border-style: solid;
-}
-
-.thumbnail:hover {
-  opacity: 0.7;
-}
-
-.thumbnail.is-active {
-  border: 0.2rem solid var(--color-foreground);
-}
-
-.thumbnail img {
-  pointer-events: none;
-}
-
-.thumbnail .icon {
-  position: absolute;
-  top: 0.3rem;
-  right: 0.3rem;
-  width: 2.4rem;
-  height: 2.4rem;
-  z-index: 2;
-  pointer-events: none;
-  fill: var(--color-background);
 }
 
 /* Product share */

--- a/assets/section-main-product.css
+++ b/assets/section-main-product.css
@@ -470,10 +470,13 @@ a.product__text {
   z-index: 101;
 }
 
-.product-media-modal__content {
+.product-media-modal__dialog {
   display: flex;
-  flex-direction: column;
-  height: 100vh;
+  align-items: center;
+}
+
+.product-media-modal__content {
+  max-height: 100vh;
   overflow: auto;
   width: 100%;
 }
@@ -511,6 +514,7 @@ a.product__text {
 }
 
 .product-media-modal__content > * {
+  display: block;
   height: auto;
   margin: auto;
 }

--- a/assets/section-main-product.css
+++ b/assets/section-main-product.css
@@ -447,38 +447,32 @@ a.product__text {
 
 .product-media-modal {
   background-color: var(--color-base-background-1);
-  box-sizing: border-box;
   height: 100%;
-  left: 0;
-  opacity: 0;
   position: fixed;
   top: 0;
+  left: 0;
   width: 100%;
   visibility: hidden;
+  opacity: 0;
   z-index: -1;
 }
 
-@media screen and (min-width: 750px) {
-  .product-media-modal {
-    padding: 0;
-  }
-}
-
 .product-media-modal[open] {
-  opacity: 1;
   visibility: visible;
+  opacity: 1;
   z-index: 101;
 }
 
 .product-media-modal__dialog {
   display: flex;
   align-items: center;
+  height: 100vh;
 }
 
 .product-media-modal__content {
   max-height: 100vh;
-  overflow: auto;
   width: 100%;
+  overflow: auto;
 }
 
 .product-media-modal__content > *:not(.active),

--- a/sections/main-product.liquid
+++ b/sections/main-product.liquid
@@ -309,7 +309,7 @@
   {%- render 'cart-notification' -%}
 
   <product-modal id="ProductModal-{{ section.id }}" class="product-media-modal">
-    <div role="dialog" aria-label="{{ 'products.modal.label' | t }}" aria-modal="true" tabindex="-1">
+    <div class="product-media-modal__dialog" role="dialog" aria-label="{{ 'products.modal.label' | t }}" aria-modal="true" tabindex="-1">
       <button id="ModalClose-{{ section.id }}" type="button" class="product-media-modal__toggle" aria-label="{{ 'accessibility.close' | t }}">{% render 'icon-close' %}</button>
 
       <div class="product-media-modal__content" role="document" aria-label="{{ 'products.modal.label' | t }}" tabindex="0">


### PR DESCRIPTION
**Why are these changes introduced?**

When viewing large images in the product modal on Safari, the images would get vertically distorted. 
Fixes #65.

This PR also removes leftover code for `thumbnails` component - this is no longer used in the context of the product page.

**Before & After**

<details>
<summary>Before</summary>
<img src="https://user-images.githubusercontent.com/37168033/124656806-abcce480-de6f-11eb-99dd-40ef581e024c.png"/>
</details>

<details>
<summary>After</summary>
<img src="https://user-images.githubusercontent.com/37168033/124656739-935cca00-de6f-11eb-8f61-9ab9ddba81fa.png"/>
</details>

**What approach did you take?**
Unlike other modern browsers, Safari will stretch images to its natural height when they're contained in a `flex` wrapper.  This [StackOverflow thread](https://stackoverflow.com/questions/57516373/image-stretching-in-flexbox-in-safari) provides more details on the issue. Unfortunately, the suggested fix in this thread will not completely solve our issues because we need to account for the multiple types of media inside the modal.

- Removed `display: flex` and `flex-direction` from `product-modal__content`, responsible for causing this issue.
- Added `display:flex` to the parent element and limited it's height to `100vh`.

**Demo links**
- [Store](https://os2-demo.myshopify.com/products/small-convertible-flex-bag-multicolor?preview_theme_id=120841043990)
- [Editor](https://os2-demo.myshopify.com/admin/themes/120841043990/editor)

**Checklist**
- [x] Followed [theme code principles](https://github.com/Shopify/dawn/blob/main/.github/CONTRIBUTING.md#theme-code-principles)
- [x] Linted with [Theme Check](https://github.com/Shopify/theme-check)
- [x] Tested on [mobile](https://shopify.dev/themes/store/requirements#mobile-browser-requirements)
- [x] Tested on [multiple browsers](https://shopify.dev/themes/store/requirements#desktop-browser-requirements)
- [x] Tested for [accessibility](https://shopify.dev/themes/best-practices/accessibility)

**Testing instructions**
- [x] Do images look stretched on Safari (desktop and mobile)?
- [x] Are 3D models and videos still center-aligned on mobile?