### PR TITLE
Add escape key function on footer language/country selectors

### DIFF
--- a/sections/footer.liquid
+++ b/sections/footer.liquid
@@ -345,7 +345,21 @@
       };
       this.elements.button.addEventListener('click', this.openSelector.bind(this));
       this.elements.button.addEventListener('focusout', this.closeSelector.bind(this));
+      this.addEventListener('keyup', this.onContainerKeyUp.bind(this));
+
       this.querySelectorAll('a').forEach(item => item.addEventListener('click', this.onItemClick.bind(this)));
+    }
+
+    hidePanel() {
+      this.elements.button.setAttribute('aria-expanded', 'false');
+      this.elements.panel.setAttribute('hidden', true);
+    }
+
+    onContainerKeyUp(event) {
+      if (event.code.toUpperCase() !== 'ESCAPE') return;
+      
+      this.hidePanel();
+      this.elements.button.focus();
     }
 
     onItemClick(event) {
@@ -363,8 +377,7 @@
     closeSelector(event) {
       const shouldClose = event.relatedTarget && event.relatedTarget.nodeName === 'BUTTON';
       if (event.relatedTarget === null || shouldClose) {
-        this.elements.button.setAttribute('aria-expanded', 'false');
-        this.elements.panel.setAttribute('hidden', true);
+        this.hidePanel();
       }
     }
   }


### PR DESCRIPTION
**Why are these changes introduced?**

Fixes https://github.com/Shopify/dawn/issues/73

The goal of this PR is to hide the footer country/language selectors when using "Escape" key.

**What approach did you take?**

- Add key event to hide the country/language panel when we receive Escape key.

**Demo links**

- [Store](https://os2-demo.myshopify.com/?preview_theme_id=120849530902)
- [Editor](https://os2-demo.myshopify.com/admin/themes/120849530902/editor)

**Checklist**
- [x] Followed [theme code principles](https://github.com/Shopify/dawn/blob/main/.github/CONTRIBUTING.md#theme-code-principles)
- [x] Linted with [Theme Check](https://github.com/Shopify/theme-check)
- [x] Tested on [mobile](https://shopify.dev/themes/store/requirements#mobile-browser-requirements)
- [x] Tested on [multiple browsers](https://shopify.dev/themes/store/requirements#desktop-browser-requirements)
- [x] Tested for [accessibility](https://shopify.dev/themes/best-practices/accessibility)
