### PR TITLE
Adjust card badge visual tweaks

### DIFF
--- a/assets/component-badge.css
+++ b/assets/component-badge.css
@@ -5,7 +5,7 @@
   font-size: 1.2rem;
   letter-spacing: 0.1rem;
   line-height: 1;
-  padding: 0.6rem 1.6rem;
+  padding: 0.6rem 1.3rem;
   text-align: center;
   background-color: rgb(var(--color-badge-background));
   border-color: rgba(var(--color-badge-border), var(--alpha-badge-border));

--- a/assets/template-giftcard.css
+++ b/assets/template-giftcard.css
@@ -263,7 +263,7 @@ h2,
   font-size: 1.2rem;
   letter-spacing: 0.1rem;
   line-height: 1;
-  padding: 0.6rem 1.6rem;
+  padding: 0.6rem 1.3rem;
   text-align: center;
   background-color: rgb(var(--color-base-background-1));
   border-color: rgba(var(--color-base-text), 0.04);

--- a/sections/collage.liquid
+++ b/sections/collage.liquid
@@ -88,13 +88,9 @@
                   <div class="collage-product__badge">
                     <div class="card__badge">
                       {%- if block.settings.product.available == false -%}
-                        <span class="badge badge--bottom-left color-{{ settings.sold_out_badge_color_scheme }}" aria-hidden="true">
-                          {{ 'products.product.sold_out' | t }}
-                        </span>
+                        <span class="badge badge--bottom-left color-{{ settings.sold_out_badge_color_scheme }}" aria-hidden="true">{{ 'products.product.sold_out' | t }}</span>
                       {%- elsif block.settings.product.compare_at_price > block.settings.product.price and block.settings.product.available -%}
-                        <span class="badge badge--bottom-left color-{{ settings.sale_badge_color_scheme }}" aria-hidden="true">
-                          {{ 'products.product.on_sale' | t }}
-                        </span>
+                        <span class="badge badge--bottom-left color-{{ settings.sale_badge_color_scheme }}" aria-hidden="true">{{ 'products.product.on_sale' | t }}</span>
                       {%- endif -%}
                     </div>
                   </div>

--- a/snippets/product-card.liquid
+++ b/snippets/product-card.liquid
@@ -70,13 +70,9 @@
 
         <div class="card__badge">
           {%- if product_card_product.available == false -%}
-            <span class="badge badge--bottom-left color-{{ settings.sold_out_badge_color_scheme }}" aria-hidden="true">
-              {{ 'products.product.sold_out' | t }}
-            </span>
+            <span class="badge badge--bottom-left color-{{ settings.sold_out_badge_color_scheme }}" aria-hidden="true">{{ 'products.product.sold_out' | t }}</span>
           {%- elsif product_card_product.compare_at_price > product_card_product.price and product_card_product.available -%}
-            <span class="badge badge--bottom-left color-{{ settings.sale_badge_color_scheme }}" aria-hidden="true">
-              {{ 'products.product.on_sale' | t }}
-            </span>
+            <span class="badge badge--bottom-left color-{{ settings.sale_badge_color_scheme }}" aria-hidden="true">{{ 'products.product.on_sale' | t }}</span>
           {%- endif -%}
         </div>
       </div>


### PR DESCRIPTION
**Why are these changes introduced?**

Fixes https://github.com/Shopify/dawn/issues/25

The goal of this PR is to adjust the padding of the card badge

![image](https://user-images.githubusercontent.com/658169/124970775-58d16980-dff6-11eb-8c4c-0d85471b1754.png)

**What approach did you take?**

- Adjust padding
- Remove whitespacing on the card badge since it's using `display: inline-block` to fix this point:
> - [x] remove the space characters that are added to the sale badge (it increases the padding left and right). [Screenshot](https://screenshot.click/2021-06-17_13-1ylcr-h7p39.png)

**Demo links**

- [Store](https://os2-demo.myshopify.com/?preview_theme_id=120850939926)
- [Editor](https://os2-demo.myshopify.com/admin/themes/120850939926/editor?previewPath=%2Fcollections%2Fall)

**Checklist**
- [x] Followed [theme code principles](https://github.com/Shopify/dawn/blob/main/.github/CONTRIBUTING.md#theme-code-principles)
- [x] Linted with [Theme Check](https://github.com/Shopify/theme-check)
- [x] Tested on [mobile](https://shopify.dev/themes/store/requirements#mobile-browser-requirements)
- [x] Tested on [multiple browsers](https://shopify.dev/themes/store/requirements#desktop-browser-requirements)
- [x] Tested for [accessibility](https://shopify.dev/themes/best-practices/accessibility)
