### PR TITLE
Footer typo

### DIFF
--- a/sections/footer.liquid
+++ b/sections/footer.liquid
@@ -24,7 +24,7 @@
           if section.blocks.size == 9
             assign footer_grid_class = 'grid--3-col-tablet'
           elsif section.blocks.size > 6
-            assign footer_grid_class = 'grid--4col-desktop'
+            assign footer_grid_class = 'grid--4-col-desktop'
           elsif section.blocks.size > 4
             assign footer_grid_class = 'grid--3-col-tablet'
           endif

--- a/sections/footer.liquid
+++ b/sections/footer.liquid
@@ -24,7 +24,7 @@
           if section.blocks.size == 9
             assign footer_grid_class = 'grid--3-col-tablet'
           elsif section.blocks.size > 6
-            assign footer_grid_class = 'grid--4-col-desktop'
+            assign footer_grid_class = 'grid--4col-desktop'
           elsif section.blocks.size > 4
             assign footer_grid_class = 'grid--3-col-tablet'
           endif


### PR DESCRIPTION
**Why are these changes introduced?**
Incorrect grid class name on line 27 in footer.liquid.

**What approach did you take?**
Compared incorrect grid class name to correct class name across the theme.

**Demo links**
None

**Checklist**
- [ x ] Followed [theme code principles](https://github.com/Shopify/dawn/blob/main/.github/CONTRIBUTING.md#theme-code-principles)
- [ x ] Linted with [Theme Check](https://github.com/Shopify/theme-check)
- [ x ] Tested on [mobile](https://shopify.dev/themes/store/requirements#mobile-browser-requirements)
- [ x ] Tested on [multiple browsers](https://shopify.dev/themes/store/requirements#desktop-browser-requirements)
- [ x ] Tested for [accessibility](https://shopify.dev/themes/best-practices/accessibility)
