### PR TITLE
Updating headings to use the proper font weight

### DIFF
--- a/assets/base.css
+++ b/assets/base.css
@@ -308,7 +308,7 @@ h5,
 .h5 {
   font-family: var(--font-heading-family);
   font-style: var(--font-heading-style);
-  font-weight: normal;
+  font-weight: var(--font-heading-weight);
   letter-spacing: 0.06rem;
   color: rgb(var(--color-foreground));
   line-height: 1.3;

--- a/assets/template-giftcard.css
+++ b/assets/template-giftcard.css
@@ -56,6 +56,7 @@ h2,
 .h2 {
   font-family: var(--font-heading-family);
   font-style: var(--font-heading-style);
+  font-weight: var(--font-heading-weight);
   letter-spacing: 0.06rem;
   line-height: 1.3;
 }


### PR DESCRIPTION
**Why are these changes introduced?**

Font weight for headings was set to `normal` which meant that changing font settings in the theme's Typography settings didn't change the heading weight as expected.

To test, change around some body/heading fonts and weights and make sure they change appropriately.

To see the bug that was manifesting before, go to the `main` branch and try setting the same font for both the Body and Headings and then change the Heading font to a non-normal font i.e. Extra Light and the Body font to Normal.  Note that the heading font will then render as Normal.

**Demo links**

- [Store](https://os2-demo.myshopify.com/?_ab=0&_fd=0&_sc=1&preview_theme_id=120878858262)
- [Editor](https://os2-demo.myshopify.com/admin/themes/120878858262/editor)

**Checklist**
- [x] Followed [theme code principles](https://github.com/Shopify/dawn/blob/main/.github/CONTRIBUTING.md#theme-code-principles)
- [x] Linted with [Theme Check](https://github.com/Shopify/theme-check)
- [x] Tested on [mobile](https://shopify.dev/themes/store/requirements#mobile-browser-requirements)
- [x] Tested on [multiple browsers](https://shopify.dev/themes/store/requirements#desktop-browser-requirements)
- [x] Tested for [accessibility](https://shopify.dev/themes/best-practices/accessibility)
