### PR TITLE
Add heading font size setting in Rich text section

### DIFF
--- a/locales/en.default.schema.json
+++ b/locales/en.default.schema.json
@@ -1508,6 +1508,9 @@
               "options__2": {
                 "label": "Medium"
               },
+              "options__3": {
+                "label": "Large"
+              },
               "label": "Heading font size"
             }
           }

--- a/sections/rich-text.liquid
+++ b/sections/rich-text.liquid
@@ -9,7 +9,7 @@
     {%- for block in section.blocks -%}
       {%- case block.type -%}
         {%- when 'heading' -%}
-          <h2 class="{% if block.settings.heading_size == 'small' %}h2{% else %}h1{% endif %}" {{ block.shopify_attributes }}>{{ block.settings.heading | escape }}</h2>
+          <h2 class="{% if block.settings.heading_size == 'large' %}h1{% elsif block.settings.heading_size == 'medium' %}h2{% else %}h3{% endif %}" {{ block.shopify_attributes }}>{{ block.settings.heading | escape }}</h2>
         {%- when 'text' -%}
           <div class="rich-text__text rte" {{ block.shopify_attributes }}>{{ block.settings.text }}</div>
         {%- when 'button' -%}
@@ -85,6 +85,10 @@
             {
               "value": "medium",
               "label": "t:sections.rich-text.blocks.heading.settings.heading_size.options__2.label"
+            },
+            {
+              "value": "large",
+              "label": "t:sections.rich-text.blocks.heading.settings.heading_size.options__3.label"
             }
           ],
           "default": "medium",

--- a/sections/rich-text.liquid
+++ b/sections/rich-text.liquid
@@ -9,7 +9,7 @@
     {%- for block in section.blocks -%}
       {%- case block.type -%}
         {%- when 'heading' -%}
-          <h2 class="{% if block.settings.heading_size == 'large' %}h1{% elsif block.settings.heading_size == 'medium' %}h2{% else %}h3{% endif %}" {{ block.shopify_attributes }}>{{ block.settings.heading | escape }}</h2>
+          <h2 class="{% if block.settings.heading_size == 'large' %}h0{% elsif block.settings.heading_size == 'medium' %}h1{% endif %}" {{ block.shopify_attributes }}>{{ block.settings.heading | escape }}</h2>
         {%- when 'text' -%}
           <div class="rich-text__text rte" {{ block.shopify_attributes }}>{{ block.settings.text }}</div>
         {%- when 'button' -%}

--- a/sections/rich-text.liquid
+++ b/sections/rich-text.liquid
@@ -9,7 +9,7 @@
     {%- for block in section.blocks -%}
       {%- case block.type -%}
         {%- when 'heading' -%}
-          <h2 class="{% if block.settings.heading_size == 'large' %}h0{% elsif block.settings.heading_size == 'medium' %}h1{% endif %}" {{ block.shopify_attributes }}>{{ block.settings.heading | escape }}</h2>
+          <h2 class="{{ block.settings.heading_size }}" {{ block.shopify_attributes }}>{{ block.settings.heading | escape }}</h2>
         {%- when 'text' -%}
           <div class="rich-text__text rte" {{ block.shopify_attributes }}>{{ block.settings.text }}</div>
         {%- when 'button' -%}
@@ -79,19 +79,19 @@
           "id": "heading_size",
           "options": [
             {
-              "value": "small",
+              "value": "h2",
               "label": "t:sections.rich-text.blocks.heading.settings.heading_size.options__1.label"
             },
             {
-              "value": "medium",
+              "value": "h1",
               "label": "t:sections.rich-text.blocks.heading.settings.heading_size.options__2.label"
             },
             {
-              "value": "large",
+              "value": "h0",
               "label": "t:sections.rich-text.blocks.heading.settings.heading_size.options__3.label"
             }
           ],
-          "default": "medium",
+          "default": "h1",
           "label": "t:sections.rich-text.blocks.heading.settings.heading_size.label"
         }
       ]


### PR DESCRIPTION
**Why are these changes introduced?**

Fixes https://github.com/Shopify/dawn/issues/186

The goal of this PR is to add an additional heading setting in the Rich text section.

![image](https://user-images.githubusercontent.com/658169/125812592-9e46fa04-316c-4b02-a691-49907ae213d1.png)

**What approach did you take?**

- Add extra setting and Liquid logic.

**Design notes**
Small: `h3` (did not see in the issue which style it was using, so I assume it's `h3`)
Medium: `h2`
Large: `h3`

**Demo links**

- [Store](https://os2-demo.myshopify.com/?preview_theme_id=120881741846)
- [Editor](https://os2-demo.myshopify.com/admin/themes/120881741846/editor)

**Checklist**
- [ ] Followed [theme code principles](https://github.com/Shopify/dawn/blob/main/.github/CONTRIBUTING.md#theme-code-principles)
- [ ] Linted with [Theme Check](https://github.com/Shopify/theme-check)
- [ ] Tested on [mobile](https://shopify.dev/themes/store/requirements#mobile-browser-requirements)
- [ ] Tested on [multiple browsers](https://shopify.dev/themes/store/requirements#desktop-browser-requirements)
- [ ] Tested for [accessibility](https://shopify.dev/themes/best-practices/accessibility)
