### PR TITLE
Updated to relative link

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ You can follow this [quick start guide for theme developers](https://github.com/
 
 We recommend using [Theme Check](https://github.com/shopify/theme-check) as a way to validate and lint your Shopify themes.
 
-We've added Theme Check to Dawn's [list of VS Code extensions](https://github.com/Shopify/dawn/blob/update-README/.vscode/extensions.json) so if you're using Visual Studio Code as your code editor of choice, you'll be prompted to install the [Theme Check VS Code](https://marketplace.visualstudio.com/items?itemName=Shopify.theme-check-vscode) extension upon opening VS Code after you've forked and cloned Dawn.
+We've added Theme Check to Dawn's [list of VS Code extensions](/.vscode/extensions.json) so if you're using Visual Studio Code as your code editor of choice, you'll be prompted to install the [Theme Check VS Code](https://marketplace.visualstudio.com/items?itemName=Shopify.theme-check-vscode) extension upon opening VS Code after you've forked and cloned Dawn.
 
 You can also run it from a terminal with the following Shopify CLI command:
 


### PR DESCRIPTION
**Why are these changes introduced?**
The current link to recommended VS Code extensions in the README links to a specific branch (which is not available). This is now updated to a relative link which leads to the list in the current branch. 

Fixes #0.

**What approach did you take?**
I used the standard relative link format for markdown within GitHub 

**Other considerations**
Another solution could be to use an absolute link to the main branch which would be: https://github.com/Shopify/dawn/blob/main/.vscode/extensions.json

**Checklist**
- [*] Followed [theme code principles](https://github.com/Shopify/dawn/blob/main/.github/CONTRIBUTING.md#theme-code-principles)
- [*] Linted with [Theme Check](https://github.com/Shopify/theme-check)
- [*] Tested on [mobile](https://shopify.dev/themes/store/requirements#mobile-browser-requirements)
- [*] Tested on [multiple browsers](https://shopify.dev/themes/store/requirements#desktop-browser-requirements)
- [*] Tested for [accessibility](https://shopify.dev/themes/best-practices/accessibility)
