### PR TITLE
Currency code theme setting

### DIFF
--- a/config/settings_schema.json
+++ b/config/settings_schema.json
@@ -239,5 +239,24 @@
         "info": "t:settings_schema.favicon.settings.favicon.info"
       }
     ]
+  },
+  {
+    "name": "t:settings_schema.currency_format.name",
+    "settings": [
+      {
+        "type": "header",
+        "content": "t:settings_schema.currency_format.settings.content"
+      },
+      {
+        "type": "paragraph",
+        "content": "t:settings_schema.currency_format.settings.paragraph"
+      },
+      {
+        "type": "checkbox",
+        "id": "currency_code_enabled",
+        "label": "t:settings_schema.currency_format.settings.currency_code_enabled.label",
+        "default": true
+      }
+    ]
   }
 ]

--- a/locales/cs.schema.json
+++ b/locales/cs.schema.json
@@ -157,6 +157,16 @@
           "info": "https://vimeo.com/shopify"
         }
       }
+    },
+    "currency_format": {
+      "name": "Formát měny",
+      "settings": {
+        "content": "Kódy měn",
+        "currency_code_enabled": {
+          "label": "Zobrazit kódy měn"
+        },
+        "paragraph": "Košík a ceny na pokladně vždy zahrnují kódy měn. Příklad: 1,00 USD ($)"
+      }
     }
   },
   "sections": {

--- a/locales/da.schema.json
+++ b/locales/da.schema.json
@@ -157,6 +157,16 @@
           "info": "https://vimeo.com/shopify"
         }
       }
+    },
+    "currency_format": {
+      "name": "Valutaformat",
+      "settings": {
+        "content": "Valutakoder",
+        "currency_code_enabled": {
+          "label": "Vis valutakoder"
+        },
+        "paragraph": "Priser i indkøbskurv og betalingsproces viser altid valutakoder. Eksempel: 1,00 USD."
+      }
     }
   },
   "sections": {

--- a/locales/de.schema.json
+++ b/locales/de.schema.json
@@ -157,6 +157,16 @@
           "info": "https://vimeo.com/shopify"
         }
       }
+    },
+    "currency_format": {
+      "name": "Währungsformat",
+      "settings": {
+        "content": "Währungscodes",
+        "currency_code_enabled": {
+          "label": "Währungscodes anzeigen"
+        },
+        "paragraph": "Warenkorb- und Checkout-Preise zeigen immer Währungscodes an. Beispiel: 1,00 USD."
+      }
     }
   },
   "sections": {

--- a/locales/en.default.schema.json
+++ b/locales/en.default.schema.json
@@ -154,6 +154,16 @@
           "info": "Will be scaled down to 32 x 32px"
         }
       }
+    },
+    "currency_format": {
+      "name":"Currency format",
+      "settings": {
+        "content": "Currency codes",
+        "paragraph": "Cart and checkout prices always show currency codes. Example: $1.00 USD.",
+        "currency_code_enabled": {
+          "label": "Show currency codes"
+        }
+      }
     }
   },
   "sections": {

--- a/locales/es.schema.json
+++ b/locales/es.schema.json
@@ -157,6 +157,16 @@
           "info": "https://vimeo.com/shopify"
         }
       }
+    },
+    "currency_format": {
+      "name": "Formato de moneda",
+      "settings": {
+        "content": "Códigos de moneda",
+        "currency_code_enabled": {
+          "label": "Mostrar códigos de moneda"
+        },
+        "paragraph": "Los precios en el carrito y la pantalla de pago siempre muestran códigos de moneda. Ejemplo: USD 1,00."
+      }
     }
   },
   "sections": {

--- a/locales/fi.schema.json
+++ b/locales/fi.schema.json
@@ -157,6 +157,16 @@
           "info": "https://vimeo.com/shopify"
         }
       }
+    },
+    "currency_format": {
+      "name": "Valuutan muoto",
+      "settings": {
+        "content": "Valuuttakoodit",
+        "currency_code_enabled": {
+          "label": "Näytä valuuttakoodit"
+        },
+        "paragraph": "Ostoskorin ja kassan hinnat näyttävät aina valuuttakoodit. Esimerkki: $1.00 USD."
+      }
     }
   },
   "sections": {

--- a/locales/fr.schema.json
+++ b/locales/fr.schema.json
@@ -157,6 +157,16 @@
           "info": "https://vimeo.com/shopify"
         }
       }
+    },
+    "currency_format": {
+      "name": "Format de devise",
+      "settings": {
+        "content": "Codes de devise",
+        "currency_code_enabled": {
+          "label": "Afficher les codes de devise"
+        },
+        "paragraph": "Le panier et les prix au moment du paiement indiquent toujours les codes de devise. Exemple : 1 EUR."
+      }
     }
   },
   "sections": {

--- a/locales/it.schema.json
+++ b/locales/it.schema.json
@@ -157,6 +157,16 @@
           "info": "https://vimeo.com/shopify"
         }
       }
+    },
+    "currency_format": {
+      "name": "Formato valuta",
+      "settings": {
+        "content": "Codici valuta",
+        "currency_code_enabled": {
+          "label": "Mostra i codici valuta"
+        },
+        "paragraph": "I prezzi del carrello e del check-out mostrano sempre i codici valuta. Esempio: 1,00 EUR."
+      }
     }
   },
   "sections": {

--- a/locales/ja.schema.json
+++ b/locales/ja.schema.json
@@ -157,6 +157,16 @@
           "info": "https://vimeo.com/shopify"
         }
       }
+    },
+    "currency_format": {
+      "name": "通貨形式",
+      "settings": {
+        "content": "通貨コード",
+        "paragraph": "カート価格とチェックアウト価格にはいつも通貨コードが表示されます。例: $1.00 USD。",
+        "currency_code_enabled": {
+          "label": "通貨コードを表示する"
+        }
+      }
     }
   },
   "sections": {

--- a/locales/ko.schema.json
+++ b/locales/ko.schema.json
@@ -157,6 +157,16 @@
           "info": "https://vimeo.com/shopify"
         }
       }
+    },
+    "currency_format": {
+      "name": "통화 형식",
+      "settings": {
+        "content": "통화 코드",
+        "paragraph": "카트 및 결제 가격에는 항상 통화 코드가 표시됩니다. 예: $1.00(USD)",
+        "currency_code_enabled": {
+          "label": "통화 코드 표시"
+        }
+      }
     }
   },
   "sections": {

--- a/locales/nb.schema.json
+++ b/locales/nb.schema.json
@@ -157,6 +157,16 @@
           "info": "https://vimeo.com/shopify"
         }
       }
+    },
+    "currency_format": {
+      "name": "Valutaformat",
+      "settings": {
+        "content": "Valutakoder",
+        "currency_code_enabled": {
+          "label": "Vis valutakoder"
+        },
+        "paragraph": "Handlekurv- og kassepriser viser alltid valutakoder. Eksempel: 1,00 USD."
+      }
     }
   },
   "sections": {

--- a/locales/nl.schema.json
+++ b/locales/nl.schema.json
@@ -157,6 +157,16 @@
           "info": "https://vimeo.com/shopify"
         }
       }
+    },
+    "currency_format": {
+      "name": "Valuta-indeling",
+      "settings": {
+        "content": "Valutacodes",
+        "currency_code_enabled": {
+          "label": "Valutacodes tonen"
+        },
+        "paragraph": "Prijzen in winkelwagen en bij checkout tonen altijd de valutacodes. Voorbeeld: $1,00 USD."
+      }
     }
   },
   "sections": {

--- a/locales/pl.schema.json
+++ b/locales/pl.schema.json
@@ -157,6 +157,16 @@
           "info": "https://vimeo.com/shopify"
         }
       }
+    },
+    "currency_format": {
+      "name": "Format waluty",
+      "settings": {
+        "content": "Kody walut",
+        "currency_code_enabled": {
+          "label": "Pokaż kody walut"
+        },
+        "paragraph": "Ceny w koszyku i kasie zawsze zawierają kody walut. Przykład: 1,00 USD."
+      }
     }
   },
   "sections": {

--- a/locales/pt-BR.schema.json
+++ b/locales/pt-BR.schema.json
@@ -157,6 +157,16 @@
           "info": "https://vimeo.com/shopify"
         }
       }
+    },
+    "currency_format": {
+      "name": "Formato de moeda",
+      "settings": {
+        "content": "Códigos de moeda",
+        "currency_code_enabled": {
+          "label": "Exibir códigos de moeda"
+        },
+        "paragraph": "Os preços do carrinho e do checkout sempre mostram os códigos de moeda. Exemplo: 1,00 USD."
+      }
     }
   },
   "sections": {

--- a/locales/pt-PT.schema.json
+++ b/locales/pt-PT.schema.json
@@ -157,6 +157,16 @@
           "info": "https://vimeo.com/shopify"
         }
       }
+    },
+    "currency_format": {
+      "name": "Formato de moeda",
+      "settings": {
+        "content": "Códigos de moeda",
+        "currency_code_enabled": {
+          "label": "Mostrar códigos de moeda"
+        },
+        "paragraph": "Os preços de finalização da compra e carrinho mostram sempre os códigos de moeda. Exemplo: 1,00 USD."
+      }
     }
   },
   "sections": {

--- a/locales/sv.schema.json
+++ b/locales/sv.schema.json
@@ -157,6 +157,16 @@
           "info": "https://vimeo.com/shopify"
         }
       }
+    },
+    "currency_format": {
+      "name": "Valutaformat",
+      "settings": {
+        "content": "Valutakoder",
+        "currency_code_enabled": {
+          "label": "Visa valutakoder"
+        },
+        "paragraph": "Priser i varukorgen och kassan visar alltid valutakoder. T.ex. 1,00 USD."
+      }
     }
   },
   "sections": {

--- a/locales/th.schema.json
+++ b/locales/th.schema.json
@@ -157,6 +157,16 @@
           "info": "https://vimeo.com/shopify"
         }
       }
+    },
+    "currency_format": {
+      "name": "รูปแบบสกุลเงิน",
+      "settings": {
+        "content": "รหัสสกุลเงิน",
+        "paragraph": "ราคาในตะกร้าสินค้าและการชำระเงินจะแสดงรหัสสกุลเงินเสมอ ตัวอย่าง: $1.00 USD",
+        "currency_code_enabled": {
+          "label": "แสดงรหัสสกุลเงิน"
+        }
+      }
     }
   },
   "sections": {

--- a/locales/tr.schema.json
+++ b/locales/tr.schema.json
@@ -157,6 +157,16 @@
           "info": "https://vimeo.com/shopify"
         }
       }
+    },
+    "currency_format": {
+      "name": "Para birimi biçimi",
+      "settings": {
+        "content": "Para birimi kodları",
+        "currency_code_enabled": {
+          "label": "Para birimi kodlarını göster"
+        },
+        "paragraph": "Sepet ve ödeme ücretleri her zaman para birimi kodlarını gösterir. Örnek: 1,00 USD."
+      }
     }
   },
   "sections": {

--- a/locales/vi.schema.json
+++ b/locales/vi.schema.json
@@ -157,6 +157,16 @@
           "info": "https://vimeo.com/shopify"
         }
       }
+    },
+    "currency_format": {
+      "name": "Định dạng đơn vị tiền tệ",
+      "settings": {
+        "content": "Mã đơn vị tiền tệ",
+        "currency_code_enabled": {
+          "label": "Hiển thị mã đơn vị tiền tệ"
+        },
+        "paragraph": "Giá giỏ hàng và giá thanh toán luôn hiển thị mã đơn vị tiền tệ. Ví dụ: 1,00 USD."
+      }
     }
   },
   "sections": {

--- a/locales/zh-CN.schema.json
+++ b/locales/zh-CN.schema.json
@@ -157,6 +157,16 @@
           "info": "https://vimeo.com/shopify"
         }
       }
+    },
+    "currency_format": {
+      "name": "货币格式",
+      "settings": {
+        "content": "货币代码",
+        "currency_code_enabled": {
+          "label": "显示货币代码"
+        },
+        "paragraph": "购物车和结账价格将始终显示货币代码。示例：1.00 USD。"
+      }
     }
   },
   "sections": {

--- a/locales/zh-TW.schema.json
+++ b/locales/zh-TW.schema.json
@@ -157,6 +157,16 @@
           "info": "https://vimeo.com/shopify"
         }
       }
+    },
+    "currency_format": {
+      "name": "幣別格式",
+      "settings": {
+        "content": "幣別代碼",
+        "paragraph": "購物車和結帳價格一律顯示幣別代碼。例如：$1.00 美元。",
+        "currency_code_enabled": {
+          "label": "顯示幣別代碼"
+        }
+      }
     }
   },
   "sections": {

--- a/snippets/price.liquid
+++ b/snippets/price.liquid
@@ -20,7 +20,11 @@
   assign compare_at_price = target.compare_at_price
   assign price = target.price | default: 1999
   assign available = target.available | default: false
-  assign money_price = price | money
+  if settings.currency_code_enabled
+    assign money_price = price | money_with_currency
+  else
+    assign money_price = price | money
+  endif
 
   if target == product and product.price_varies
     assign money_price = 'products.product.price.from_price_html' | t: price: money_price
@@ -55,7 +59,11 @@
       </dt>
       <dd class="price__compare">
         <s class="price-item price-item--regular">
-          {{ compare_at_price | money }}
+          {% if settings.currency_code_enabled %}
+            {{ compare_at_price | money_with_currency }}
+          {% else %}
+            {{ compare_at_price | money }}
+          {% endif %}
         </s>
       </dd>
       <dt>

--- a/snippets/price.liquid
+++ b/snippets/price.liquid
@@ -20,10 +20,9 @@
   assign compare_at_price = target.compare_at_price
   assign price = target.price | default: 1999
   assign available = target.available | default: false
+  assign money_price = price | money
   if settings.currency_code_enabled
     assign money_price = price | money_with_currency
-  else
-    assign money_price = price | money
   endif
 
   if target == product and product.price_varies

--- a/templates/gift_card.liquid
+++ b/templates/gift_card.liquid
@@ -19,11 +19,7 @@
       <link rel="preconnect" href="https://fonts.shopifycdn.com" crossorigin>
     {%- endunless -%}
 
-    {% if settings.currency_code_enabled %}
-      {%- assign formatted_initial_value = gift_card.initial_value | money_with_currency -%}
-    {% else %}
-      {%- assign formatted_initial_value = gift_card.initial_value | money -%}
-    {% endif %}
+    {%- assign formatted_initial_value = gift_card.initial_value | money_without_trailing_zeros | strip_html -%}
 
     <title>{{ 'gift_cards.issued.title' | t: value: formatted_initial_value, shop: shop.name }}</title>
 
@@ -78,13 +74,23 @@
       <span class="h2">{{ shop.name }}</span>
       <h1 class="gift-card__heading">{{ 'gift_cards.issued.subtext' | t }}</h1>
       <div class="gift-card__price">
-        <p>{{ gift_card.initial_value | money }}</p>
+        <p>
+          {% if settings.currency_code_enabled %}
+            {{ gift_card.initial_value | money_with_currency }}
+          {% else %}
+            {{ gift_card.initial_value | money }}
+          {% endif %}
+        </p>
         {%- if gift_card.enabled == false or gift_card.expired -%}
           <p class="gift-card__label badge badge--{{ settings.sold_out_badge_color_scheme }}">{{ 'gift_cards.issued.expired' | t }}</p>
         {%- endif -%}
       </div>
 
-      {%- assign gift_card_balance = gift_card.balance | money -%}
+      {% if settings.currency_code_enabled %}
+        {%- assign gift_card_balance = gift_card.balance | money_with_currency -%}
+      {% else %}
+        {%- assign gift_card_balance = gift_card.balance | money -%}
+      {% endif %}
       {%- if gift_card.balance != gift_card.initial_value -%}
         <p class="gift-card__label caption-large">{{ 'gift_cards.issued.remaining_html' | t: balance: gift_card_balance }}</p>
       {%- endif -%}

--- a/templates/gift_card.liquid
+++ b/templates/gift_card.liquid
@@ -19,7 +19,12 @@
       <link rel="preconnect" href="https://fonts.shopifycdn.com" crossorigin>
     {%- endunless -%}
 
-    {%- assign formatted_initial_value = gift_card.initial_value | money_without_trailing_zeros: gift_card.currency | strip_html -%}
+    {% if settings.currency_code_enabled %}
+      {%- assign formatted_initial_value = gift_card.initial_value | money_with_currency -%}
+    {% else %}
+      {%- assign formatted_initial_value = gift_card.initial_value | money -%}
+    {% endif %}
+
     <title>{{ 'gift_cards.issued.title' | t: value: formatted_initial_value, shop: shop.name }}</title>
 
     <meta name="description" content="{{ 'gift_cards.issued.subtext' | t }}">


### PR DESCRIPTION
**Why are these changes introduced?**

Adds theme setting level checkbox that controls whether currency code shows up in places like product prices.
![image](https://user-images.githubusercontent.com/13230168/126355924-0bcc5d16-faa0-48e9-8ad3-91c5bf1bd2ec.png)

![image](https://user-images.githubusercontent.com/13230168/126361731-c61995e4-8fac-4d32-8003-ef7329c3c314.png)

**What approach did you take?**

Similar approach to Debut

**Other considerations**

**Demo links**

- [Store](https://jgheg4wsdpdvdos5-20495958038.shopifypreview.com)
- [Editor](https://lucaskim.myshopify.com/admin/themes/120895995926/editor)

**Checklist**
- [ ] Followed [theme code principles](https://github.com/Shopify/dawn/blob/main/.github/CONTRIBUTING.md#theme-code-principles)
- [ ] Linted with [Theme Check](https://github.com/Shopify/theme-check)
- [ ] Tested on [mobile](https://shopify.dev/themes/store/requirements#mobile-browser-requirements)
- [ ] Tested on [multiple browsers](https://shopify.dev/themes/store/requirements#desktop-browser-requirements)
- [ ] Tested for [accessibility](https://shopify.dev/themes/best-practices/accessibility)
