### PR TITLE
Create SUPPORT.md to surface external support resources to new contributors in new issue tooltips.

### DIFF
--- a/.github/SUPPORT.md
+++ b/.github/SUPPORT.md
@@ -1,0 +1,13 @@
+For help with **general** theme problems , please use the following theme resources for non-dawn related problems instead:
+* [Shopify Forum](https://ecommerce.shopify.com/forums), or the [Design Subforum](https://community.shopify.com/c/Shopify-Design/bd-p/ecommerce-design)
+* [Shopify Help Center - Themes](https://help.shopify.com/themes)
+* [Shopify Developer Documentation](https://shopify.dev/themes)
+* Read [Shopify Support for Themes and Design Policy](https://help.shopify.com/en/manual/online-store/themes/theme-support)
+* [Hire Shopify Experts](https://experts.shopify.com/)
+* [Shopify Forum - Jobs Board](https://community.shopify.com/c/Shopify-Ecommerce-Jobs/bd-p/shopify-job-board)
+
+For third party theme support check the support documentation for your theme,  or by finding your theme on the [Shopify Theme Store](https://themes.shopify.com/) then viewing "Support and documentation".
+
+For information on what is a proper issue to create for the Dawn Project please see the [Contributing Scope](https://github.com/Shopify/dawn/blob/main/.github/CONTRIBUTING.md#scope).
+
+Shopify Partners looking for **peer to peer** support should join the Shopify Partner's Slack channel `#online-store-2-0` for extended discussion around the Dawn theme project.


### PR DESCRIPTION
**Why are these changes introduced?**
Adds SUPPORT.MD that is linked too in a helpful tooltip presented to first time issue creators on new issue pages to direct people to better support and and preempt frivolous support requests.
https://docs.github.com/en/communities/setting-up-your-project-for-healthy-contributions/adding-support-resources-to-your-project

Differs from basic links found in [CONTRIBUTING.md](https://github.com/Shopify/dawn/blob/main/.github/CONTRIBUTING.md):
* More link resources( design forum, support policy, forum job board)
* Link titles are more verbose
* Includes a general note on finding third party support as I didn't want to list out EVERY theme w/ a developer website since the theme store is open submissions that could could become a burden or accidently seem like a preference by omission as time goes on. 
* Includes a blurb for partners

**Other considerations**
Decided against a full list of themes & their related contact information.

Note: This does not change the githubs default tooltip text it merely fills in the underlying link,  to this document.
   "Looking for help? Check out the project’s [instructions for getting support](https://github.com/Shopify/dawn/tree/main/.github/support.md)."
So currently cannot customize that tooltip to more direct text
   "Looking for help with general theme problems? Please try the [shopify community design forum](https://community.shopify.com/c/Shopify-Design/bd-p/ecommerce-design)!"

**Demo links**
https://docs.github.com/assets/images/help/issues/support_guidelines_in_issue.png

