### PR TITLE
Adjust spacing of elements around pickup availability on product page

### DIFF
--- a/assets/component-pickup-availability.css
+++ b/assets/component-pickup-availability.css
@@ -3,19 +3,14 @@ pickup-availability {
 }
 
 pickup-availability[available] {
-  min-height: 12rem;
+  min-height: 8rem;
 }
 
 .pickup-availability-preview {
   align-items: flex-start;
   display: flex;
   gap: 0.2rem;
-}
-
-@media screen and (min-width: 750px) {
-  .pickup-availability-preview {
-    padding: 0 2rem 0 0;
-  }
+  padding: 1rem 2rem 0 0;
 }
 
 .pickup-availability-preview .icon {

--- a/assets/section-main-product.css
+++ b/assets/section-main-product.css
@@ -96,6 +96,10 @@
   text-underline-offset: 0.3rem;
 }
 
+.shopify-payment-button__button--hidden {
+  display: none;
+}
+
 /* Product form */
 
 .product-form {


### PR DESCRIPTION
**Why are these changes introduced?**

Fixes #232

**What approach did you take?**

- Reduce `min-height` (used to avoid layout shift) of pickup-availability component 
- Adjust padding
- Ensure hidden Shopify pay button does not take up space by adding `display: none`

**Other considerations**

**Demo links**

- [Store](https://os2-demo.myshopify.com/?preview_theme_id=120904646678)
- [Editor](https://os2-demo.myshopify.com/admin/themes/120904646678/editor)

**Checklist**
- [x] Followed [theme code principles](https://github.com/Shopify/dawn/blob/main/.github/CONTRIBUTING.md#theme-code-principles)
- [x] Linted with [Theme Check](https://github.com/Shopify/theme-check)
- [x] Tested on [mobile](https://shopify.dev/themes/store/requirements#mobile-browser-requirements)
- [x] Tested on [multiple browsers](https://shopify.dev/themes/store/requirements#desktop-browser-requirements)
- [x] Tested for [accessibility](https://shopify.dev/themes/best-practices/accessibility)
