### PR TITLE
Adjust conditional rendering of view all link in featured collection

### DIFF
--- a/sections/featured-collection.liquid
+++ b/sections/featured-collection.liquid
@@ -10,22 +10,22 @@
 <noscript>{{ 'component-badge.css' | asset_url | stylesheet_tag }}</noscript>
 <noscript>{{ 'template-collection.css' | asset_url | stylesheet_tag }}</noscript>
 
+{%- liquid
+  assign products_to_display = section.settings.collection.all_products_count
+
+  if section.settings.collection.all_products_count > section.settings.products_to_show
+    assign products_to_display = section.settings.products_to_show
+    assign more_in_collection = true
+  endif
+-%}
 <div class="collection page-width{% if section.settings.swipe_on_mobile == true and section.settings.collection.all_products_count > 2 and section.settings.products_to_show > 2 %} page-width-desktop{% endif %}">
   <div class="{% if section.settings.show_view_all and section.settings.swipe_on_mobile %}title-wrapper-with-link{% endif %}{% if section.settings.title == blank %} title-wrapper-with-link--no-heading{% endif %}{% if section.settings.collection.all_products_count > 2 and section.settings.swipe_on_mobile and section.settings.products_to_show > 2 %} title-wrapper--self-padded-tablet-down{% endif %}">
     <h2 class="title{% if section.settings.title == blank %} title--no-heading{% endif %}">{{ section.settings.title | escape }}</h2>
 
-    {%- if section.settings.show_view_all and section.settings.swipe_on_mobile -%}
+    {%- if section.settings.show_view_all and section.settings.swipe_on_mobile and more_in_collection -%}
       <a href="{{ section.settings.collection.url }}" class="link underlined-link large-up-hide">{{ 'sections.featured_collection.view_all' | t }}</a>
     {%- endif -%}
   </div>
-
-  {%- liquid
-    assign products_to_display = section.settings.collection.all_products_count
-
-    if section.settings.collection.all_products_count > section.settings.products_to_show
-      assign products_to_display = section.settings.products_to_show
-    endif
-  %}
 
   <slider-component class="slider-mobile-gutter">
     <ul class="grid grid--2-col product-grid{% if products_to_display == 4 or section.settings.collection == blank %} grid--2-col-tablet grid--4-col-desktop{% else %} grid--3-col-tablet{% endif %}{% if products_to_display > 5 %} grid--one-third-max grid--4-col-desktop grid--quarter-max{% endif %}{% if section.settings.collection.all_products_count > 2 and section.settings.swipe_on_mobile and section.settings.products_to_show > 2 %} slider slider--tablet grid--peek{% endif %}{% if section.settings.show_view_all == false or section.settings.collection.products.size < section.settings.products_to_show %} negative-margin{% endif %}{% if section.settings.show_view_all and section.settings.collection.products.size > section.settings.products_to_show %} negative-margin--small{% endif %}" role="list">
@@ -61,7 +61,7 @@
     {%- endif -%}
   </slider-component>
 
-  {%- if section.settings.show_view_all and section.settings.collection.all_products_count > section.settings.products_to_show -%}
+  {%- if section.settings.show_view_all and more_in_collection -%}
     <div class="center{% if section.settings.swipe_on_mobile %} small-hide medium-hide{% endif %}">
       <a href="{{ section.settings.collection.url }}"
         class="button"


### PR DESCRIPTION
**Why are these changes introduced?**

Fixes #233 

**What approach did you take?**

This issue only applies to the view all button that displays alongside the title when the mobile slider setting enabled. This element just needed the same conditional logic the other view all button was using (if the number of products visible was less than the number of products in the collection)

**Demo links**

- [Editor](https://os2-demo.myshopify.com/admin/themes/120906350614/editor)

**Checklist**
- [ ] Followed [theme code principles](https://github.com/Shopify/dawn/blob/main/.github/CONTRIBUTING.md#theme-code-principles)
- [ ] Linted with [Theme Check](https://github.com/Shopify/theme-check)
- [ ] Tested on [mobile](https://shopify.dev/themes/store/requirements#mobile-browser-requirements)
- [ ] Tested on [multiple browsers](https://shopify.dev/themes/store/requirements#desktop-browser-requirements)
- [ ] Tested for [accessibility](https://shopify.dev/themes/best-practices/accessibility)
