### PR TITLE
Fix null cart properties and line items

### DIFF
--- a/assets/product-form.js
+++ b/assets/product-form.js
@@ -1,28 +1,43 @@
 class ProductForm extends HTMLElement {
   constructor() {
-    super();   
+    super();
 
-    this.form = this.querySelector('form');
-    this.form.addEventListener('submit', this.onSubmitHandler.bind(this));
-    this.cartNotification = document.querySelector('cart-notification');
+    this.form = this.querySelector("form");
+    this.form.addEventListener("submit", this.onSubmitHandler.bind(this));
+    this.cartNotification = document.querySelector("cart-notification");
   }
 
   onSubmitHandler(evt) {
     evt.preventDefault();
     this.cartNotification.setActiveElement(document.activeElement);
-    
+
     const submitButton = this.querySelector('[type="submit"]');
 
-    submitButton.setAttribute('disabled', true);
-    submitButton.classList.add('loading');
+    submitButton.setAttribute("disabled", true);
+    submitButton.classList.add("loading");
+    let parsedForm = JSON.parse(serializeForm(this.form));
+    let properties = {};
+    for (const key in parsedForm) {
+      const propertiesKeyMatch = key.substring(0, 11);
+      if (propertiesKeyMatch === "properties[") {
+        const startIndex = key.indexOf("[") + 1;
+        const endIndex = key.indexOf("]");
+        const propertyKey = key.substring(startIndex, endIndex);
+        const propertyValue = parsedForm[key];
+        properties[propertyKey] = propertyValue;
+      }
+    }
+    parsedForm.properties = properties;
 
     const body = JSON.stringify({
-      ...JSON.parse(serializeForm(this.form)),
-      sections: this.cartNotification.getSectionsToRender().map((section) => section.id),
-      sections_url: window.location.pathname
+      ...parsedForm,
+      sections: this.cartNotification
+        .getSectionsToRender()
+        .map((section) => section.id),
+      sections_url: window.location.pathname,
     });
 
-    fetch(`${routes.cart_add_url}`, { ...fetchConfig('javascript'), body })
+    fetch(`${routes.cart_add_url}`, { ...fetchConfig("javascript"), body })
       .then((response) => response.json())
       .then((parsedState) => {
         this.cartNotification.renderContents(parsedState);
@@ -31,10 +46,10 @@ class ProductForm extends HTMLElement {
         console.error(e);
       })
       .finally(() => {
-        submitButton.classList.remove('loading');
-        submitButton.removeAttribute('disabled');
+        submitButton.classList.remove("loading");
+        submitButton.removeAttribute("disabled");
       });
   }
 }
 
-customElements.define('product-form', ProductForm);
+customElements.define("product-form", ProductForm);

--- a/assets/product-form.js
+++ b/assets/product-form.js
@@ -2,9 +2,9 @@ class ProductForm extends HTMLElement {
   constructor() {
     super();
 
-    this.form = this.querySelector("form");
-    this.form.addEventListener("submit", this.onSubmitHandler.bind(this));
-    this.cartNotification = document.querySelector("cart-notification");
+    this.form = this.querySelector('form');
+    this.form.addEventListener('submit', this.onSubmitHandler.bind(this));
+    this.cartNotification = document.querySelector('cart-notification');
   }
 
   onSubmitHandler(evt) {
@@ -13,15 +13,15 @@ class ProductForm extends HTMLElement {
 
     const submitButton = this.querySelector('[type="submit"]');
 
-    submitButton.setAttribute("disabled", true);
-    submitButton.classList.add("loading");
+    submitButton.setAttribute('disabled', true);
+    submitButton.classList.add('loading');
     let parsedForm = JSON.parse(serializeForm(this.form));
     let properties = {};
     for (const key in parsedForm) {
       const propertiesKeyMatch = key.substring(0, 11);
-      if (propertiesKeyMatch === "properties[") {
-        const startIndex = key.indexOf("[") + 1;
-        const endIndex = key.indexOf("]");
+      if (propertiesKeyMatch === 'properties[') {
+        const startIndex = key.indexOf('[') + 1;
+        const endIndex = key.indexOf(']');
         const propertyKey = key.substring(startIndex, endIndex);
         const propertyValue = parsedForm[key];
         properties[propertyKey] = propertyValue;
@@ -37,7 +37,7 @@ class ProductForm extends HTMLElement {
       sections_url: window.location.pathname,
     });
 
-    fetch(`${routes.cart_add_url}`, { ...fetchConfig("javascript"), body })
+    fetch(`${routes.cart_add_url}`, { ...fetchConfig('javascript'), body })
       .then((response) => response.json())
       .then((parsedState) => {
         this.cartNotification.renderContents(parsedState);
@@ -46,10 +46,10 @@ class ProductForm extends HTMLElement {
         console.error(e);
       })
       .finally(() => {
-        submitButton.classList.remove("loading");
-        submitButton.removeAttribute("disabled");
+        submitButton.classList.remove('loading');
+        submitButton.removeAttribute('disabled');
       });
   }
 }
 
-customElements.define("product-form", ProductForm);
+customElements.define('product-form', ProductForm);


### PR DESCRIPTION
**Why are these changes introduced?**

Fixes #243.

I noticed that the `/cart/add` API endpoint requires a `properties` object to be passed into the `body`. This was not being generated from the line-item HTML inputs by the theme. The theme was only parsing the product form, resulting in key/value pairs such as the following:

```
"properties[Contains]":"1x Item 0",
"properties[_item_0]":"item0-data-here"
```

Instead, we need something like this:

```
"properties": {
   "Contains": "1x Item 0",
   "_item_0": "item0-data-here"
}
```

**What approach did you take?**

To resolve this, I implemented some logic that loops through the keys of the parsed form object in search of keys that begin with `properties[`. From there, I am generating a `properties` object and appending it to the final `body` JSON string, which is later passed to the `/cart/add` API endpoint.

**Other considerations:**

The other option here is to update the docs for Liquid to describe a different way it should be done in the Dawn theme. [As of now it says](https://shopify.dev/api/liquid/objects/line_item#line_item-properties) to add line items in this format:

```
<input id="engraving" type="text" name="properties[Engraving]">
```

If there is a known method of doing so properly in Dawn, please update the docs to let us know! Otherwise, this minor update to the code is a great workaround.

I did however try the following line item input:

```
<input type="text" name="properties" value='{"Contains": "1x Item 0", "_item_0": "item0-data-here"}'>
```

which was unsuccessful, as the API returned a `bad_request` error due to the `properties` field not being formatted properly.

**Checklist**
- [x] Followed [theme code principles](https://github.com/Shopify/dawn/blob/main/.github/CONTRIBUTING.md#theme-code-principles)
- [x] Linted with [Theme Check](https://github.com/Shopify/theme-check)
- [x] Tested on [mobile](https://shopify.dev/themes/store/requirements#mobile-browser-requirements)
- [x] Tested on [multiple browsers](https://shopify.dev/themes/store/requirements#desktop-browser-requirements)
- [x] Tested for [accessibility](https://shopify.dev/themes/best-practices/accessibility)
