### PR TITLE
Add `owners` to Translation Platform config

### DIFF
--- a/translation.yml
+++ b/translation.yml
@@ -4,11 +4,13 @@ components:
   - name: buyer
     audience: buyer
     scheme: 'online-store-theme'
+    owners: ['@Shopify/themes-translations']
     paths:
       - locales/{{language}}.json
   - name: merchant
     target_languages: [cs, da, de, es, fi, fr, it, ja, ko, nb, nl, pl, pt-BR, pt-PT, sv, th, tr, vi, zh-CN, zh-TW]
     audience: merchant
     scheme: 'online-store-theme'
+    owners: ['@Shopify/themes-translations']
     paths:
       - locales/{{language}}.schema.json


### PR DESCRIPTION
**Why are these changes introduced?**

The `owners` attribute is used by the Translation Platform to know who to ping when it opens PRs.

**What approach did you take?**

The ideal approach is to add the ownership details to ServicesDB, but until then this will do.