### PR TITLE
Added custom liquid block to product page

### DIFF
--- a/locales/en.default.schema.json
+++ b/locales/en.default.schema.json
@@ -1143,6 +1143,12 @@
             }
           }
         },
+        "custom_liquid": {
+          "name": "Custom liquid",
+          "settings": {
+            "custom_liquid": "Custom liquid"
+          }
+        },
         "collapsible_tab": {
           "name": "Collapsible tab",
           "settings": {

--- a/locales/en.default.schema.json
+++ b/locales/en.default.schema.json
@@ -1146,7 +1146,9 @@
         "custom_liquid": {
           "name": "Custom liquid",
           "settings": {
-            "custom_liquid": "Custom liquid"
+            "custom_liquid": {
+              "label": "Custom liquid"
+            }
           }
         },
         "collapsible_tab": {

--- a/sections/main-product.liquid
+++ b/sections/main-product.liquid
@@ -98,6 +98,8 @@
                 {{ product.description }}
               </div>
             {%- endif -%}
+          {%- when 'custom_liquid' -%}
+            {{ block.settings.custom_liquid }}
           {%- when 'collapsible_tab' -%}
             <div class="product__accordion accordion" {{ block.shopify_attributes }}>
               <details>
@@ -565,6 +567,17 @@
         {
           "type": "paragraph",
           "content": "t:sections.main-product.blocks.share.settings.title_info.content"
+        }
+      ]
+    },
+    {
+      "type": "custom_liquid",
+      "name": "t:sections.main-product.blocks.custom_liquid.name",
+      "settings": [
+        {
+          "type": "liquid",
+          "id": "custom_liquid",
+          "label": "t:sections.main-product.blocks.custom_liquid.settings.custom_liquid"
         }
       ]
     },

--- a/sections/main-product.liquid
+++ b/sections/main-product.liquid
@@ -577,7 +577,7 @@
         {
           "type": "liquid",
           "id": "custom_liquid",
-          "label": "t:sections.main-product.blocks.custom_liquid.settings.custom_liquid"
+          "label": "t:sections.main-product.blocks.custom_liquid.settings.custom_liquid.label"
         }
       ]
     },


### PR DESCRIPTION
**Why are these changes introduced?**

Fixes #42 

**What approach did you take?**

Pretty straight-forward. I just added a block with a Liquid setting with no limit to how many can be added to the main product section.  I decided against wrapping it in any sort of container, to give the merchant full control over how they want it to output.  If they want it to be block, they can wrap the Liquid in a `<div>` themselves, for example.

**Demo links**

- [Store](https://os2-demo.myshopify.com/?_ab=0&_fd=0&_sc=1&preview_theme_id=120917491734)
- [Editor](https://os2-demo.myshopify.com/admin/themes/120917491734/editor)

**Checklist**
- [x] Followed [theme code principles](https://github.com/Shopify/dawn/blob/main/.github/CONTRIBUTING.md#theme-code-principles)
- [x] Linted with [Theme Check](https://github.com/Shopify/theme-check)
- [x] Tested on [mobile](https://shopify.dev/themes/store/requirements#mobile-browser-requirements)
- [x] Tested on [multiple browsers](https://shopify.dev/themes/store/requirements#desktop-browser-requirements)
- [x] Tested for [accessibility](https://shopify.dev/themes/best-practices/accessibility)
