### PR TITLE
Fixed filtering number inputs

### DIFF
--- a/sections/main-collection-product-grid.liquid
+++ b/sections/main-collection-product-grid.liquid
@@ -118,20 +118,12 @@
                           name="{{ filter.min_value.param_name }}"
                           id="Filter-{{ filter.label | escape }}-GTE"
                           {%- if filter.min_value.value -%}
-                            {%- if uses_comma_decimals -%}
-                              value="{{ filter.min_value.value | money_without_currency | replace: '.', '' | replace: ',', '.' }}"
-                            {%- else -%}
-                              value="{{ filter.min_value.value | money_without_currency | replace: ',', '' }}"
-                            {% endif %}
+                            {%- if uses_comma_decimals -%}value="{{ filter.min_value.value | money_without_currency | replace: '.', '' | replace: ',', '.' }}"{%- else -%}value="{{ filter.min_value.value | money_without_currency | replace: ',', '' }}"{% endif %}
                           {%- endif -%}
                           type="number"
                           placeholder="0"
                           min="0"
-                          {%- if uses_comma_decimals -%}
-                            max="{{ filter.range_max | money_without_currency | replace: '.', '' | replace: ',', '.' }}"
-                          {%- else -%}
-                            max="{{ filter.range_max | money_without_currency | replace: ',', '' }}"
-                          {% endif %}
+                          {%- if uses_comma_decimals -%}max="{{ filter.range_max | money_without_currency | replace: '.', '' | replace: ',', '.' }}"{%- else -%}max="{{ filter.range_max | money_without_currency | replace: ',', '' }}"{% endif %}
                         >
                         </input>
                         <label class="field__label" for="Filter-{{ filter.label | escape }}-GTE">{{ 'sections.collection_template.from' | t }}</label>
@@ -141,12 +133,7 @@
                         <input class="field__input"
                           name="{{ filter.max_value.param_name }}"
                           id="Filter-{{ filter.label | escape }}-LTE"
-                          {%- if filter.max_value.value -%}
-                            {%- if uses_comma_decimals -%}
-                              value="{{ filter.max_value.value | money_without_currency | replace: '.', '' | replace: ',', '.' }}"
-                            {%- else -%}
-                              value="{{ filter.max_value.value | money_without_currency | replace: ',', '' }}"
-                            {% endif %}
+                          {%- if filter.max_value.value -%}{%- if uses_comma_decimals -%}value="{{ filter.max_value.value | money_without_currency | replace: '.', '' | replace: ',', '.' }}"{%- else -%}value="{{ filter.max_value.value | money_without_currency | replace: ',', '' }}"{% endif %}
                           {%- endif -%}
                           type="number"
                           min="0"
@@ -330,20 +317,12 @@
                               name="{{ filter.min_value.param_name }}"
                               id="Mobile-Filter-{{ filter.label | escape }}-GTE"
                               {%- if filter.min_value.value -%}
-                                {%- if uses_comma_decimals -%}
-                                  value="{{ filter.min_value.value | money_without_currency | replace: '.', '' | replace: ',', '.' }}"
-                                {%- else -%}
-                                  value="{{ filter.min_value.value | money_without_currency | replace: ',', '' }}"
-                                {% endif %}
+                                {%- if uses_comma_decimals -%}value="{{ filter.min_value.value | money_without_currency | replace: '.', '' | replace: ',', '.' }}"{%- else -%}value="{{ filter.min_value.value | money_without_currency | replace: ',', '' }}"{% endif %}
                               {%- endif -%}
                               type="number"
                               placeholder="0"
                               min="0"
-                              {%- if uses_comma_decimals -%}
-                                max="{{ filter.range_max | money_without_currency | replace: '.', '' | replace: ',', '.' }}"
-                              {%- else -%}
-                                max="{{ filter.range_max | money_without_currency | replace: ',', '' }}"
-                              {% endif %}
+                              {%- if uses_comma_decimals -%}max="{{ filter.range_max | money_without_currency | replace: '.', '' | replace: ',', '.' }}"{%- else -%}max="{{ filter.range_max | money_without_currency | replace: ',', '' }}"{% endif %}
                             >
                             </input>
                             <label class="field__label" for="Mobile-Filter-{{ filter.label | escape }}-GTE">{{ 'sections.collection_template.from' | t }}</label>
@@ -354,11 +333,7 @@
                               name="{{ filter.max_value.param_name }}"
                               id="Mobile-Filter-{{ filter.label | escape }}-LTE"
                               {%- if filter.max_value.value -%}
-                                {%- if uses_comma_decimals -%}
-                                  value="{{ filter.max_value.value | money_without_currency | replace: '.', '' | replace: ',', '.' }}"
-                                {%- else -%}
-                                  value="{{ filter.max_value.value | money_without_currency | replace: ',', '' }}"
-                                {% endif %}
+                                {%- if uses_comma_decimals -%}value="{{ filter.max_value.value | money_without_currency | replace: '.', '' | replace: ',', '.' }}"{%- else -%}value="{{ filter.max_value.value | money_without_currency | replace: ',', '' }}"{% endif %}
                               {%- endif -%}
                               type="number"
                               min="0"
@@ -496,13 +471,7 @@
           {% endif %}">
           {%- for product in collection.products -%}
             <li class="grid__item">
-              {% render 'product-card',
-                product_card_product: product,
-                media_size: section.settings.image_ratio,
-                show_secondary_image: section.settings.show_secondary_image,
-                add_image_padding: section.settings.add_image_padding,
-                show_vendor: section.settings.show_vendor
-              %}
+              {% render 'product-card', product_card_product: product, media_size: section.settings.image_ratio, show_secondary_image: section.settings.show_secondary_image, add_image_padding: section.settings.add_image_padding, show_vendor: section.settings.show_vendor %}
             </li>
           {%- endfor -%}
         </ul>


### PR DESCRIPTION
**Why are these changes introduced?**

Fixed the bug described in https://github.com/Shopify/dawn/issues/255

However, it doesn't fix the underlying platform feature that could be added to remove all of this complexity.

**What approach did you take?**

Just added the check for the type of separators to the places that I'd originally missed.

**Other considerations**

There is some good discussion in the issue around a potential Liquid filter that could get rid of all of the nasty, fragile logic in here.

**Demo links**

- [Store](https://os2-demo.myshopify.com/?_ab=0&_fd=0&_sc=1&preview_theme_id=120921620502)
- [Editor](https://os2-demo.myshopify.com/admin/themes/120921620502/editort)

**Checklist**
- [x] Followed [theme code principles](https://github.com/Shopify/dawn/blob/main/.github/CONTRIBUTING.md#theme-code-principles)
- [x] Linted with [Theme Check](https://github.com/Shopify/theme-check)
- [x] Tested on [mobile](https://shopify.dev/themes/store/requirements#mobile-browser-requirements)
- [x] Tested on [multiple browsers](https://shopify.dev/themes/store/requirements#desktop-browser-requirements)
- [x] Tested for [accessibility](https://shopify.dev/themes/best-practices/accessibility)
