### PR TITLE
Fix facet price filter label spacing

### DIFF
--- a/assets/template-collection.css
+++ b/assets/template-collection.css
@@ -280,7 +280,7 @@
   padding: 2rem;
 }
 
-.facets__price > * + * {
+.facets__price .field + .field-currency {
   margin-left: 2rem;
 }
 
@@ -288,12 +288,13 @@
   align-items: center;
 }
 
-.facets__price .field .field__currency {
+.facets__price .field-currency {
+  align-self: center;
   margin-right: 0.6rem;
 }
 
 .facets__price .field__label {
-  left: 3rem;
+  left: 1.5rem;
 }
 
 button.facets__button {

--- a/assets/template-collection.css
+++ b/assets/template-collection.css
@@ -293,7 +293,7 @@
 }
 
 .facets__price .field__label {
-  left: 2.1rem;
+  left: 3rem;
 }
 
 button.facets__button {

--- a/sections/main-collection-product-grid.liquid
+++ b/sections/main-collection-product-grid.liquid
@@ -112,8 +112,8 @@
                       </facet-remove>
                     </div>
                     <price-range class="facets__price">
+                      <span class="field-currency">{{ cart.currency.symbol }}</span>
                       <div class="field">
-                        <span class="field__currency">{{ cart.currency.symbol }}</span>
                         <input class="field__input"
                           name="{{ filter.min_value.param_name }}"
                           id="Filter-{{ filter.label | escape }}-GTE"
@@ -131,8 +131,9 @@
                         </input>
                         <label class="field__label" for="Filter-{{ filter.label | escape }}-GTE">{{ 'sections.collection_template.from' | t }}</label>
                       </div>
+
+                      <span class="field-currency">{{ cart.currency.symbol }}</span>
                       <div class="field">
-                        <span class="field__currency">{{ cart.currency.symbol }}</span>
                         <input class="field__input"
                           name="{{ filter.max_value.param_name }}"
                           id="Filter-{{ filter.label | escape }}-LTE"
@@ -313,8 +314,8 @@
                         <p class="mobile-facets__info">{{ "sections.collection_template.max_price" | t: price: max_price_amount }}</p>
 
                         <price-range class="facets__price">
+                          <span class="field-currency">{{ cart.currency.symbol }}</span>
                           <div class="field">
-                            <span class="field__currency">{{ cart.currency.symbol }}</span>
                             <input class="field__input"
                               name="{{ filter.min_value.param_name }}"
                               id="Mobile-Filter-{{ filter.label | escape }}-GTE"
@@ -332,8 +333,9 @@
                             </input>
                             <label class="field__label" for="Mobile-Filter-{{ filter.label | escape }}-GTE">{{ 'sections.collection_template.from' | t }}</label>
                           </div>
+
+                          <span class="field-currency">{{ cart.currency.symbol }}</span>
                           <div class="field">
-                            <span class="field__currency">{{ cart.currency.symbol }}</span>
                             <input class="field__input"
                               name="{{ filter.max_value.param_name }}"
                               id="Mobile-Filter-{{ filter.label | escape }}-LTE"

--- a/sections/main-collection-product-grid.liquid
+++ b/sections/main-collection-product-grid.liquid
@@ -104,7 +104,7 @@
                   <div class="facets__display">
                     <div class="facets__header">
                       {%- assign max_price_amount = filter.range_max | money | escape -%}
-                      <span class="facets__selected">{{ "sections.collection_template.max_price" | t: price: max_price_amount }}</span>
+                      <span class="facets__selected">{{ "sections.collection_template.max_price" | t: price: max_price_amount | strip_html }}</span>
                       <facet-remove>
                         <a href="{{ filter.url_to_remove }}" class="facets__reset link underlined-link" >
                           {{ 'sections.collection_template.reset' | t }}

--- a/sections/main-collection-product-grid.liquid
+++ b/sections/main-collection-product-grid.liquid
@@ -103,8 +103,8 @@
                   </summary>
                   <div class="facets__display">
                     <div class="facets__header">
-                      {%- assign max_price_amount = filter.range_max | money | escape -%}
-                      <span class="facets__selected">{{ "sections.collection_template.max_price" | t: price: max_price_amount | strip_html }}</span>
+                      {%- assign max_price_amount = filter.range_max | money | strip_html | escape -%}
+                      <span class="facets__selected">{{ "sections.collection_template.max_price" | t: price: max_price_amount }}</span>
                       <facet-remove>
                         <a href="{{ filter.url_to_remove }}" class="facets__reset link underlined-link" >
                           {{ 'sections.collection_template.reset' | t }}


### PR DESCRIPTION
**Why are these changes introduced?**

Fixes https://github.com/Shopify/dawn/issues/241

The goal of this PR is to fix the spacing on the "facet price" label on the collection filters.

<details>

<summary>Before</summary>

[![alt](https://screenshot.click/21-20-5f3ny-eodtw.png)](https://screenshot.click/21-20-5f3ny-eodtw.png)
</details>

<details>

<summary>After</summary>

![image](https://user-images.githubusercontent.com/658169/127917648-36006b8e-9612-428e-8969-aca130cdd50f.png)

</details>

**What approach did you take?**

- Adjust CSS spacing

**Demo links**

- [Store](https://os2-demo.myshopify.com/collections/all?preview_theme_id=120947015702)
- [Editor](https://os2-demo.myshopify.com/admin/themes/120947015702/editor)

**Checklist**
- [x] Followed [theme code principles](https://github.com/Shopify/dawn/blob/main/.github/CONTRIBUTING.md#theme-code-principles)
- [x] Linted with [Theme Check](https://github.com/Shopify/theme-check)
- [x] Tested on [mobile](https://shopify.dev/themes/store/requirements#mobile-browser-requirements)
- [x] Tested on [multiple browsers](https://shopify.dev/themes/store/requirements#desktop-browser-requirements)
- [x] Tested for [accessibility](https://shopify.dev/themes/best-practices/accessibility)
