### PR TITLE
Prevent undesired button focus shadow

### DIFF
--- a/assets/base.css
+++ b/assets/base.css
@@ -1107,6 +1107,10 @@ deferred-media {
     0 0 0.5rem 0.4rem rgba(var(--color-foreground), 0.3);
 }
 
+.button:focus:not(:focus-visible) {
+  box-shadow: 0 0 0 0.1rem rgba(var(--color-button), var(--alpha-button-border));
+}
+
 .button,
 .button-label,
 .shopify-challenge__button,


### PR DESCRIPTION
**Why are these changes introduced?**

Fixes #279

**What approach did you take?**

This issue occurs when a button has `:focus` but not `:focus-visible`. base.css already includes a generic `*:focus:not(:focus-visible)` style that resets `box-shadow` but it's not specific enough to override `.button`'s existing shadow styles. Additionally, button's non-focused styles are already using box-shadow so we need to reset this style back to that default, rather than `box-shadow: none` anyway.

**Demo links**

- [Store](https://os2-demo.myshopify.com/?preview_theme_id=120946622486)
- [Editor](https://os2-demo.myshopify.com/admin/themes/120947114006/editor)

**Checklist**
- [x] Followed [theme code principles](https://github.com/Shopify/dawn/blob/main/.github/CONTRIBUTING.md#theme-code-principles)
- [x] Linted with [Theme Check](https://github.com/Shopify/theme-check)
- [x] Tested on [mobile](https://shopify.dev/themes/store/requirements#mobile-browser-requirements)
- [x] Tested on [multiple browsers](https://shopify.dev/themes/store/requirements#desktop-browser-requirements)
- [x] Tested for [accessibility](https://shopify.dev/themes/best-practices/accessibility)
