### PR TITLE
Add top border on cart notification when "show separator line" setting is deactivated

### DIFF
--- a/assets/component-cart-notification.css
+++ b/assets/component-cart-notification.css
@@ -21,6 +21,12 @@
 }
 
 @media screen and (min-width: 750px) {
+  .header-wrapper:not(.header-wrapper--border-bottom)
+    + cart-notification
+    .cart-notification {
+    border-top-width: 0.1rem;
+  }
+
   .cart-notification {
     border-width: 0 0.1rem 0.1rem;
     max-width: 36.8rem;


### PR DESCRIPTION
**Why are these changes introduced?**

Fixes https://github.com/Shopify/dawn/issues/278

The goal of this PR is to add a border top on the cart notification even when the header `Show separator line` setting is deactivated.

<details>

<summary>Show separator line - Deactivated</summary>

[![alt](https://screenshot.click/03-01-z0dpm-6g8bt.png)](https://screenshot.click/03-01-z0dpm-6g8bt.png)
</details>

<details>

<summary>Show separator line - Activated</summary>

[![alt](https://screenshot.click/03-05-lk01m-nq1hp.png)](https://screenshot.click/03-05-lk01m-nq1hp.png)
</details>

**What approach did you take?**

- Add CSS when the header `.header-wrapper--border-bottom` class exist.

**Other considerations**

- We could add the "show seperator line" setting as a parameter when referencing the `{% render cart-notification %}` snippet, but I thought it would be better to leverage native CSS, even though the selector looks more complicated.

**Demo links**

- [Store](https://os2-demo.myshopify.com/?preview_theme_id=120949669910)
- [Editor](https://os2-demo.myshopify.com/admin/themes/120949669910/editor)

**Checklist**
- [x] Followed [theme code principles](https://github.com/Shopify/dawn/blob/main/.github/CONTRIBUTING.md#theme-code-principles)
- [x] Linted with [Theme Check](https://github.com/Shopify/theme-check)
- [x] Tested on [mobile](https://shopify.dev/themes/store/requirements#mobile-browser-requirements)
- [x] Tested on [multiple browsers](https://shopify.dev/themes/store/requirements#desktop-browser-requirements)
- [x] Tested for [accessibility](https://shopify.dev/themes/best-practices/accessibility)
