### PR TITLE
swap :not(list) with :not():not()

### DIFF
--- a/assets/base.css
+++ b/assets/base.css
@@ -1013,7 +1013,7 @@ summary::-webkit-details-marker {
   background-color: transparent;
 }
 
-.media > *:not(.zoom, .deferred-media__poster-button),
+.media > *:not(.zoom):not(.deferred-media__poster-button),
 .media model-viewer {
   display: block;
   max-width: 100%;

--- a/assets/collage.css
+++ b/assets/collage.css
@@ -88,7 +88,7 @@
     max-width: 100%;
   }
 
-  .collage-card:not(.collage-card--left, .collage-card--right) > * {
+  .collage-card:not(.collage-card--left):not(.collage-card--right) > * {
     position: absolute;
     width: 100%;
     height: 100%;
@@ -197,12 +197,12 @@
     font-size: 3rem;
   }
 
-  .collage-card:not(.collage-card--left, .collage-card--right)
+  .collage-card:not(.collage-card--left):not(.collage-card--right)
     .collage-card__description {
     display: none;
   }
 
-  .collage-card:not(.collage-card--left, .collage-card--right)
+  .collage-card:not(.collage-card--left):not(.collage-card--right)
     .collage-card__arrow {
     display: inline-block;
   }
@@ -243,7 +243,7 @@
 
 @media screen and (max-width: 749px) {
   .collage--mobile
-    .collage-card:not(.collage-card--left, .collage-card--right)
+    .collage-card:not(.collage-card--left):not(.collage-card--right)
     .collage-card__image-wrapper {
     padding-bottom: 100%;
   }
@@ -261,10 +261,10 @@
     position: absolute;
   }
 
-  .collage-card:not(.collage-card--left, .collage-card--right)
+  .collage-card:not(.collage-card--left):not(.collage-card--right)
     .collage-card-spacing
     .collage-card__image-wrapper,
-  .collage-card:not(.collage-card--left, .collage-card--right)
+  .collage-card:not(.collage-card--left):not(.collage-card--right)
     .collage-card-spacing.collage-card__image-wrapper {
     padding-bottom: 0;
     flex: 0 auto;
@@ -295,7 +295,7 @@
     height: 100%;
   }
 
-  .collage-card:not(.collage-card--left, .collage-card--right)
+  .collage-card:not(.collage-card--left):not(.collage-card--right)
     .collage-card-spacing
     .collage-card__image {
     position: inherit;
@@ -354,7 +354,7 @@
     margin: 1.8rem 0 0;
   }
 
-  .collage-card:not(.collage-card--left, .collage-card--right)
+  .collage-card:not(.collage-card--left):not(.collage-card--right)
     .collage-card-spacing
     img {
     object-fit: contain;

--- a/assets/customer.css
+++ b/assets/customer.css
@@ -1,4 +1,4 @@
-.customer:not(.account, .order) {
+.customer:not(.account):not(.order) {
   margin: 6rem auto 9rem;
   max-width: 33.4rem;
   padding: 0 1.5rem;
@@ -6,7 +6,7 @@
 }
 
 @media screen and (min-width: 750px) {
-  .customer:not(.account, .order) {
+  .customer:not(.account):not(.order) {
     max-width: 47.8rem;
   }
 }


### PR DESCRIPTION
Lists inside of :not() selectors are not supported in Samsung Browser, but chaining :not():not() is support in all major browsers

**Why are these changes introduced?**

Fixes #303

**What approach did you take?**

Extracted multiple classes inside list based :not() into separate chained :not() selector.

**Checklist**
- [x] Followed [theme code principles](https://github.com/Shopify/dawn/blob/main/.github/CONTRIBUTING.md#theme-code-principles)
- [x] Linted with [Theme Check](https://github.com/Shopify/theme-check)
- [x] Tested on [mobile](https://shopify.dev/themes/store/requirements#mobile-browser-requirements)
- [x] Tested on [multiple browsers](https://shopify.dev/themes/store/requirements#desktop-browser-requirements)
- [x] Tested for [accessibility](https://shopify.dev/themes/best-practices/accessibility)
