### PR TITLE
Adjust id for displaying dynamic names

### DIFF
--- a/sections/announcement-bar.liquid
+++ b/sections/announcement-bar.liquid
@@ -31,9 +31,9 @@
       "settings": [
         {
           "type": "text",
-          "id": "text",
+          "id": "heading",
           "default": "Welcome to our store",
-          "label": "t:sections.announcement-bar.blocks.announcement.settings.text.label"
+          "label": "t:sections.announcement-bar.blocks.announcement.settings.heading.label"
         },
         {
           "type": "select",


### PR DESCRIPTION
**Why are these changes introduced?**

Currently Announcement bar [have static names](https://screenshot.click/21-08-xtxfy-kzk48.png) and the experience for merchants isn't great.

Related to this the recent update https://github.com/Shopify/online-store-web/issues/10953#issuecomment-879094000 we need to change the id  for `heading` rather than `text`

- [Store](url)
- [Editor](url)

**Checklist**
- [ ] Followed [theme code principles](https://github.com/Shopify/dawn/blob/main/.github/CONTRIBUTING.md#theme-code-principles)
- [ ] Linted with [Theme Check](https://github.com/Shopify/theme-check)
- [ ] Tested on [mobile](https://shopify.dev/themes/store/requirements#mobile-browser-requirements)
- [ ] Tested on [multiple browsers](https://shopify.dev/themes/store/requirements#desktop-browser-requirements)
- [ ] Tested for [accessibility](https://shopify.dev/themes/best-practices/accessibility)
