### PR TITLE
Fixed invalid date format month_year in ja locale file

### DIFF
--- a/locales/ja.json
+++ b/locales/ja.json
@@ -51,7 +51,7 @@
     }
   },
   "date_formats": {
-    "month_year": "%Y年%-m月%"
+    "month_year": "%Y年%-m月"
   },
   "newsletter": {
     "label": "メールアドレス",


### PR DESCRIPTION
**Why are these changes introduced?**

In Japanese environment, I have faced a liquid error such as `LIQUID ERROR (ARTICLE-CARD LINE 46): INVALID FORMAT: %Y年%-M月%`.
It seems `%` placed at the end of `month_year` format causes it.

```
  "date_formats": {
    "month_year": "%Y年%-m月%"
  },
```

**What approach did you take?**

I have removed a trailing `%` from `month_year` in `ja.json` locale file.

**Other considerations**

**Demo links**

- [Store](url)
- [Editor](url)

**Checklist**
- [ ] Followed [theme code principles](https://github.com/Shopify/dawn/blob/main/.github/CONTRIBUTING.md#theme-code-principles)
- [ ] Linted with [Theme Check](https://github.com/Shopify/theme-check)
- [ ] Tested on [mobile](https://shopify.dev/themes/store/requirements#mobile-browser-requirements)
- [ ] Tested on [multiple browsers](https://shopify.dev/themes/store/requirements#desktop-browser-requirements)
- [ ] Tested for [accessibility](https://shopify.dev/themes/best-practices/accessibility)
