### PR TITLE
Footer UI updates follow up

### DIFF
--- a/assets/component-newsletter.css
+++ b/assets/component-newsletter.css
@@ -12,7 +12,7 @@
     flex-direction: row;
     align-items: flex-start;
     margin: 0 auto;
-    max-width: 50rem;
+    max-width: 36rem;
   }
 }
 

--- a/assets/section-footer.css
+++ b/assets/section-footer.css
@@ -1,12 +1,15 @@
+.footer {
+  border-top: 0.1rem solid rgba(var(--color-foreground), 0.2);
+}
 
-@media screen and (min-width: 750px) {
-  .footer {
-    border-top: 0.1rem solid rgba(var(--color-foreground), 0.2);
-  }
+.footer:not(.color-background-1) {
+  border-top: none;
+}
 
-  .footer:not(.color-background-1) {
-    border-top: none;
-  }
+.footer__content-top {
+  padding-bottom: 5rem;
+  padding-top: 5rem;
+  display: block;
 }
 
 @media screen and (max-width: 749px) {
@@ -26,15 +29,10 @@
   }
 
   .footer__content-top {
+    padding-bottom: 3rem;
     padding-left: 4rem;
     padding-right: 4rem;
   }
-}
-
-.footer__content-top {
-  padding-bottom: 5rem;
-  padding-top: 5rem;
-  display: block;
 }
 
 @media screen and (min-width: 750px) {
@@ -194,6 +192,10 @@
     justify-content: flex-start;
     margin: 0;
   }
+
+  .footer-block__newsletter:not(:only-child) .newsletter-form__message--success {
+    left: auto;
+  }
 }
 
 .footer-block__newsletter + .footer__list-social {
@@ -224,7 +226,7 @@
   justify-content: center;
   align-content: center;
   flex-wrap: wrap;
-  padding: 1rem;
+  padding: 1rem 1rem 0;
 }
 
 .footer__localization:empty {
@@ -362,12 +364,16 @@ noscript .localization-selector.link {
   animation: animateLocalization var(--duration-default) ease;
 }
 
-.footer__payment {
-  margin-top: 1.5rem;
+
+@media screen and (min-width: 750px) {
+  .footer__payment {
+    margin-top: 1.5rem;
+  }
 }
 
 .footer__copyright {
   text-align: center;
+  margin-top: 1.5rem;
 }
 
 @media screen and (min-width: 750px) {

--- a/sections/footer.liquid
+++ b/sections/footer.liquid
@@ -291,10 +291,6 @@
         {%- endif -%}
       </div>
       <div class="footer__column footer__column--info">
-        <div class="footer__copyright">
-          <small class="copyright__content">&copy; {{ 'now' | date: "%Y" }}, {{ shop.name | link_to: routes.root_url }}</small>
-          <small class="copyright__content">{{ powered_by_link }}</small>
-        </div>
         {%- if section.settings.payment_enable -%}
           <div class="footer__payment">
             <span class="visually-hidden">{{ 'sections.footer.payment' | t }}</span>
@@ -307,6 +303,10 @@
             </ul>
           </div>
         {%- endif -%}
+        <div class="footer__copyright caption">
+          <small class="copyright__content">&copy; {{ 'now' | date: "%Y" }}, {{ shop.name | link_to: routes.root_url }}</small>
+          <small class="copyright__content">{{ powered_by_link }}</small>
+        </div>
       </div>
     </div>
   </div>


### PR DESCRIPTION
**Why are these changes introduced?**

Fixes #361 

This is a follow up to #318 

- Revert mobile footer top border change
- "Powered by shopify" should be below the payment icons
- Once "Powered by Shopify" text is moved below payment icons on mobile, the space between the selectors and the payment icons should reduce to 40px
- The "Powered by Shopify" text should use caption font sizes
- Reduce space between social icon and separator line on mobile (40px)
- Fix success message alignment

**Demo links**

- [Store](https://os2-demo.myshopify.com/?_ab=0&_fd=0&_sc=1&preview_theme_id=124592554006)
- [Editor](https://os2-demo.myshopify.com/admin/themes/124592554006/editor)

**Checklist**
- [X] Followed [theme code principles](https://github.com/Shopify/dawn/blob/main/.github/CONTRIBUTING.md#theme-code-principles)
- [X] Linted with [Theme Check](https://github.com/Shopify/theme-check)
- [X] Tested on [mobile](https://shopify.dev/themes/store/requirements#mobile-browser-requirements)
- [X] Tested on [multiple browsers](https://shopify.dev/themes/store/requirements#desktop-browser-requirements)
- [X] Tested for [accessibility](https://shopify.dev/themes/best-practices/accessibility)
