### PR TITLE
Cart content update

### DIFF
--- a/templates/cart.json
+++ b/templates/cart.json
@@ -21,8 +21,7 @@
     "featured-products": {
       "type": "featured-collection",
       "settings": {
-        "collection": "all",
-        "title": "Featured collection"
+        "collection": "all"
       }
     }
   },


### PR DESCRIPTION
We decided to make the default section title match the default section logic and not have a different or specific title for the Cart template.

So it would say `Shop best-sellers` anymore but `Featured collection`, like when you add a new `Featured collection` section to a template.

Goal: Remove the `Title` setting completely so it could display the default section name.

- [Editor link](https://os2-demo.myshopify.com/admin/themes/124597600278/editor?previewPath=%2Fcart)