### PR TITLE
Remove account icon in the header if menu exist on mobile

### DIFF
--- a/sections/header.liquid
+++ b/sections/header.liquid
@@ -387,7 +387,7 @@
       </details-modal>
 
       {%- if shop.customer_accounts_enabled -%}
-        <a href="{%- if customer -%}{{ routes.account_url }}{%- else -%}{{ routes.account_login_url }}{%- endif -%}" class="header__icon header__icon--account link link--text focus-inset">
+        <a href="{%- if customer -%}{{ routes.account_url }}{%- else -%}{{ routes.account_login_url }}{%- endif -%}" class="header__icon header__icon--account link link--text focus-inset{% if section.settings.menu != blank %} small-hide{% endif %}">
           {% render 'icon-account' %}
           <span class="visually-hidden">
             {%- liquid


### PR DESCRIPTION
**Why are these changes introduced?**

Fixes https://github.com/Shopify/dawn/issues/246

The goal of this PR is to remove the account icon in the header when:
- there is a menu
- account creation is enabled
- on mobile only

<details>

<summary>No menu</summary>

[![alt](https://screenshot.click/10-46-37pnx-3u0s9.png)](https://screenshot.click/10-46-37pnx-3u0s9.png)

</details>

<details>

<summary>With menu</summary>

[![alt](https://screenshot.click/10-46-9a02u-3xzkf.png)](https://screenshot.click/10-46-9a02u-3xzkf.png)

</details>

**What approach did you take?**

- Use Liquid condition to hide icon on mobile only

**Demo links**

- [Store](https://os2-demo.myshopify.com/?preview_theme_id=124592979990)
- [Editor](https://os2-demo.myshopify.com/admin/themes/124592979990/editor)

**Checklist**
- [x] Followed [theme code principles](https://github.com/Shopify/dawn/blob/main/.github/CONTRIBUTING.md#theme-code-principles)
- [x] Linted with [Theme Check](https://github.com/Shopify/theme-check)
- [x] Tested on [mobile](https://shopify.dev/themes/store/requirements#mobile-browser-requirements)
- [x] Tested on [multiple browsers](https://shopify.dev/themes/store/requirements#desktop-browser-requirements)
- [x] Tested for [accessibility](https://shopify.dev/themes/best-practices/accessibility)
- [x] Test when menu is removed - the account icon should be shown on mobile header
