### PR TITLE
Handle form inputs having brackets (e.g. name="properties[some-prop]")

### DIFF
--- a/assets/global.js
+++ b/assets/global.js
@@ -107,7 +107,13 @@ const serializeForm = form => {
   const obj = {};
   const formData = new FormData(form);
   for (const key of formData.keys()) {
-    obj[key] = formData.get(key);
+    const bracketMatch = key.match(/(.+?)\[(.*?)\]/);
+    if (bracketMatch) {
+      obj[bracketMatch[1]] = obj[bracketMatch[1]] || {};
+      obj[bracketMatch[1]][bracketMatch[2]] = formData.get(key);
+    } else {
+      obj[key] = formData.get(key);
+    }
   }
   return JSON.stringify(obj);
 };


### PR DESCRIPTION
Hi, as it stands, it seems that Dawn does not support line item properties. I have successfully tested this change on my dev store and it would solve the problem. Happy to discuss if there is a better mechanism to make this work.

**Why are these changes introduced?**

Adds support for line item properties.

**What approach did you take?**

Regex check in form serialization logic.

**Other considerations**

**Demo links**

- [Store](url)
- [Editor](url)

**Checklist**
- [x] Followed [theme code principles](https://github.com/Shopify/dawn/blob/main/.github/CONTRIBUTING.md#theme-code-principles)
- [x] Linted with [Theme Check](https://github.com/Shopify/theme-check)
- [x] Tested on [mobile](https://shopify.dev/themes/store/requirements#mobile-browser-requirements)
- [x] Tested on [multiple browsers](https://shopify.dev/themes/store/requirements#desktop-browser-requirements)
- [x] Tested for [accessibility](https://shopify.dev/themes/best-practices/accessibility)
