### PR TITLE
Fix purchase flow for IE11

### DIFF
--- a/assets/global.js
+++ b/assets/global.js
@@ -119,14 +119,6 @@ function fetchConfig(type = 'json') {
   };
 }
 
-function isIE() {
-  const ua = window.navigator.userAgent;
-  const msie = ua.indexOf('MSIE ');
-  const trident = ua.indexOf('Trident/');
-
-  return (msie > 0 || trident > 0);
-}
-
 /*
  * Shopify Common JS
  *

--- a/assets/global.js
+++ b/assets/global.js
@@ -119,6 +119,14 @@ function fetchConfig(type = 'json') {
   };
 }
 
+function isIE() {
+  const ua = window.navigator.userAgent;
+  const msie = ua.indexOf('MSIE ');
+  const trident = ua.indexOf('Trident/');
+
+  return (msie > 0 || trident > 0);
+}
+
 /*
  * Shopify Common JS
  *

--- a/sections/main-cart-footer.liquid
+++ b/sections/main-cart-footer.liquid
@@ -59,7 +59,7 @@
                   </button>
                 </noscript>
 
-                <button type="submit" class="cart__checkout-button button" name="checkout"{% if cart == empty %} disabled{% endif %} form="cart">
+                <button type="submit" id="checkout" class="cart__checkout-button button" name="checkout"{% if cart == empty %} disabled{% endif %} form="cart">
                   {{ 'sections.cart.checkout' | t }}
                 </button>
               </div>
@@ -92,6 +92,19 @@
 
   customElements.define('cart-note', CartNote);
 {% endjavascript %}
+
+<script>
+  document.addEventListener('DOMContentLoaded', function() {
+    if (!isIE()) return;
+    const cartSubmitInput = document.createElement('input');
+    cartSubmitInput.setAttribute('name', 'checkout');
+    cartSubmitInput.setAttribute('type', 'hidden');
+    document.querySelector('#cart').appendChild(cartSubmitInput);
+    document.querySelector('#checkout').addEventListener('click', function(event) {
+      document.querySelector('#cart').submit();
+    });
+  });
+</script>
 
 {% schema %}
 {

--- a/sections/main-cart-footer.liquid
+++ b/sections/main-cart-footer.liquid
@@ -95,6 +95,14 @@
 
 <script>
   document.addEventListener('DOMContentLoaded', function() {
+    function isIE() {
+      const ua = window.navigator.userAgent;
+      const msie = ua.indexOf('MSIE ');
+      const trident = ua.indexOf('Trident/');
+
+      return (msie > 0 || trident > 0);
+    }
+
     if (!isIE()) return;
     const cartSubmitInput = document.createElement('input');
     cartSubmitInput.setAttribute('name', 'checkout');

--- a/sections/main-product.liquid
+++ b/sections/main-product.liquid
@@ -235,7 +235,7 @@
               {%- endif -%}
             {%- endunless -%}
 
-            <noscript>
+            <noscript class="product-form__noscript-wrapper">
               <div class="product-form__input{% if product.has_only_default_variant %} hidden{% endif %}">
                 <label class="form__label" for="Variants-{{ section.id }}">{{ 'products.product.product_variants' | t }}</label>
                 <div class="select">
@@ -449,6 +449,21 @@
 
   customElements.define('product-modal', ProductModal);
 {% endjavascript %}
+
+<script>
+  document.addEventListener('DOMContentLoaded', function() {
+    if (!isIE()) return;
+    const hiddenInput = document.querySelector('product-form input[name="id"]');
+    const noScriptInputWrapper = document.createElement('div');
+    const variantSwitcher = document.querySelector('variant-radios') || document.querySelector('variant-selects');
+    noScriptInputWrapper.innerHTML = document.querySelector('.product-form__noscript-wrapper').textContent;
+    variantSwitcher.outerHTML = noScriptInputWrapper.outerHTML;
+
+    document.querySelector('select[name="id"]').addEventListener('change', function(event) {
+      hiddenInput.value = event.currentTarget.value;
+    });
+  });
+</script>
 
 {%- if first_3d_model -%}
   <script type="application/json" id="ProductJSON-{{ product.id }}">

--- a/sections/main-product.liquid
+++ b/sections/main-product.liquid
@@ -452,6 +452,14 @@
 
 <script>
   document.addEventListener('DOMContentLoaded', function() {
+    function isIE() {
+      const ua = window.navigator.userAgent;
+      const msie = ua.indexOf('MSIE ');
+      const trident = ua.indexOf('Trident/');
+
+      return (msie > 0 || trident > 0);
+    }
+
     if (!isIE()) return;
     const hiddenInput = document.querySelector('product-form input[name="id"]');
     const noScriptInputWrapper = document.createElement('div');


### PR DESCRIPTION
**Note** - I'm making this as a PR rather than a draft to get 👁️ 👄 👁️ on it.  I only tested the case with variants and expect it might be broken on non-variant products. Since I'll be off for a little while, hopefully someone can pick this up while I'm gone.

**Why are these changes introduced?**

Fixes #66.

While we don't explicitly support IE11, we want to make sure that if a buyer insists on using it, they can still add items to their cart and make their way to checkout.

**What approach did you take?**

The issue is that the `form` attribute on an input doesn't work in IE.  Originally, I was going to try a polyfill, but looking around they were pretty much all very complex and also relied on jQuery, so instead I went with the approach of just trying to make sure that the form itself got the inputs put into them instead.

To do this, I check if it's IE, and then if it is, I do some DOM manipulation to ensure that the form is complete when they try to submit it.

It's not the most beautiful approach, but it works.

**Other considerations**

I put this together pretty quickly, so there may be bugs.  Some thoughts...

* This doesn't currently scale to work with Featured product.  It probably needs another pass after that is merged if we want Featured product's add to cart to work as well.  
* I didn't test this on a product with no variants. We probably need an early return for that.
* This, of course, doesn't work JS disabled on IE but I think that's a 100% hopeless cause.  I can't imagine a way for us to support IE11 without JS.

**Demo links**

- [Store](https://os2-demo.myshopify.com/?_ab=0&_fd=0&_sc=1&preview_theme_id=124598386710)

**Testing cases**

Affected pages - Cart and Product

- [ ] IE - with variants
- [ ] IE - without variants
- [ ] Other browsers - with variants
- [ ] Other browsers - without variants

**Expected behaviour** - The site will not look very good, but you can make your way to a product page, add to cart (it will just add it, not AJAX), and then click Checkout and end up on the Checkout page with the correct items.  You can make changes to the variant on the product page and changes to the quantity on the cart and they will submit properly.

**Checklist**
- [x] Followed [theme code principles](https://github.com/Shopify/dawn/blob/main/.github/CONTRIBUTING.md#theme-code-principles)
- [x] Linted with [Theme Check](https://github.com/Shopify/theme-check)
- [x] Tested on [mobile](https://shopify.dev/themes/store/requirements#mobile-browser-requirements)
- [x] Tested on [multiple browsers](https://shopify.dev/themes/store/requirements#desktop-browser-requirements)
- [x] Tested for [accessibility](https://shopify.dev/themes/best-practices/accessibility)
