### PR TITLE
Product card spacing and price polish

### DIFF
--- a/assets/component-card.css
+++ b/assets/component-card.css
@@ -5,7 +5,13 @@
 }
 
 .card + .card-information {
-  margin-top: 2rem;
+  margin-top: 1.3rem;
+}
+
+@media screen and (min-width: 750px) {
+  .card + .card-information {
+    margin-top: 1.7rem;
+  }
 }
 
 .card.card--soft {
@@ -172,7 +178,6 @@
 
 .card-information__wrapper > .price {
   color: rgb(var(--color-foreground));
-  padding-top: 0.4rem;
 }
 
 .card-information__wrapper > *:not(.visually-hidden:first-child) + * {

--- a/assets/component-card.css
+++ b/assets/component-card.css
@@ -5,7 +5,7 @@
 }
 
 .card + .card-information {
-  margin-top: 1.2rem;
+  margin-top: 2rem;
 }
 
 .card.card--soft {
@@ -172,10 +172,11 @@
 
 .card-information__wrapper > .price {
   color: rgb(var(--color-foreground));
+  padding-top: 0.4rem;
 }
 
 .card-information__wrapper > *:not(.visually-hidden:first-child) + * {
-  margin-top: 1.1rem;
+  margin-top: 0.7rem;
 }
 
 .card-information__wrapper .caption {

--- a/assets/component-price.css
+++ b/assets/component-price.css
@@ -83,6 +83,7 @@
 .price--on-sale .price-item--regular {
   text-decoration: line-through;
   color: rgba(var(--color-foreground), 0.75);
+  font-size: 1.3rem;
 }
 
 .unit-price {

--- a/assets/component-price.css
+++ b/assets/component-price.css
@@ -27,7 +27,6 @@
   margin: 0 1rem 0 0;
 }
 
-.price dd:last-of-type,
 .price .price__last:last-of-type {
   margin: 0;
 }

--- a/assets/component-price.css
+++ b/assets/component-price.css
@@ -27,6 +27,7 @@
   margin: 0 1rem 0 0;
 }
 
+.price dd:last-of-type,
 .price .price__last:last-of-type {
   margin: 0;
 }

--- a/assets/customer.css
+++ b/assets/customer.css
@@ -473,15 +473,6 @@
   }
 }
 
-.order tbody td:nth-of-type(3) dd:nth-of-type(2) {
-  font-size: 1.1rem;
-  letter-spacing: 0.07rem;
-  line-height: 1.2;
-  margin-top: 0.2rem;
-  text-transform: uppercase;
-  color: var(--color-foreground-70);
-}
-
 .order tfoot tr:last-of-type td,
 .order tfoot tr:last-of-type th {
   font-size: 2.2rem;
@@ -615,6 +606,19 @@
 
 .order dd s {
   color: rgba(var(--color-foreground), 0.7);
+}
+
+.order .unit-price {
+  font-size: 1.1rem;
+  letter-spacing: 0.07rem;
+  line-height: 1.2;
+  margin-top: 0.2rem;
+  text-transform: uppercase;
+  color: var(--color-foreground-70);
+}
+
+.order .regular-price {
+  font-size: 1.3rem;
 }
 
 /* Addresses */

--- a/assets/customer.css
+++ b/assets/customer.css
@@ -614,7 +614,7 @@
   line-height: 1.2;
   margin-top: 0.2rem;
   text-transform: uppercase;
-  color: var(--color-foreground-70);
+  color: rgba(var(--color-foreground), 0.7);
 }
 
 .order .regular-price {

--- a/assets/section-main-product.css
+++ b/assets/section-main-product.css
@@ -262,7 +262,14 @@ a.product__text {
 
 .product .price {
   align-items: flex-start;
-  gap: 1rem;
+}
+
+.product .price--on-sale.price--unit-price {
+  margin-bottom: -0.5rem;
+}
+
+.product .price--on-sale.price--unit-price dl {
+  margin-bottom: 0.5rem;
 }
 
 .product .price--sold-out .price__badge-sold-out {

--- a/assets/section-main-product.css
+++ b/assets/section-main-product.css
@@ -262,6 +262,7 @@ a.product__text {
 
 .product .price {
   align-items: flex-start;
+  gap: 1rem;
 }
 
 .product .price--sold-out .price__badge-sold-out {

--- a/assets/section-main-product.css
+++ b/assets/section-main-product.css
@@ -276,6 +276,10 @@ a.product__text {
 }
 
 @media screen and (min-width: 750px) {
+  .product__info-container .price--on-sale .price-item--regular {
+    font-size: 1.6rem;
+  }
+
   .product__info-container > *:first-child {
     margin-top: 0;
   }

--- a/snippets/price.liquid
+++ b/snippets/price.liquid
@@ -34,7 +34,8 @@
   {%- if price_class %} {{ price_class }}{% endif -%}
   {%- if available == false %} price--sold-out {% endif -%}
   {%- if compare_at_price > price %} price--on-sale {% endif -%}
-  {%- if product.price_varies == false and product.compare_at_price_varies %} price--no-compare{% endif -%}">
+  {%- if product.price_varies == false and product.compare_at_price_varies %} price--no-compare {% endif -%}
+  {%- if product.selected_or_first_available_variant.unit_price_measurement != nil %} price--unit-price{% endif -%}">
   <dl>
     {%- comment -%}
       Explanation of description list:

--- a/templates/customers/order.liquid
+++ b/templates/customers/order.liquid
@@ -129,7 +129,7 @@
                       <dt>
                         <span class="visually-hidden">{{ 'products.product.price.regular_price' | t }}</span>
                       </dt>
-                      <dd>
+                      <dd class="regular-price">
                         <s>{{ line_item.original_price | money }}</s>
                       </dd>
                       <dt>
@@ -150,7 +150,7 @@
                       <dt>
                         <span class="visually-hidden">{{ 'products.product.price.unit_price' | t }}</span>
                       </dt>
-                      <dd>
+                      <dd class="unit-price">
                         <span>
                           {%- capture unit_price_separator -%}
                             <span aria-hidden="true">/</span><span class="visually-hidden">{{ 'accessibility.unit_price_separator' | t }}&nbsp;</span>
@@ -187,7 +187,7 @@
                     <dt>
                       <span class="visually-hidden">{{ 'products.product.price.regular_price' | t }}</span>
                     </dt>
-                    <dd>
+                    <dd class="regular-price">
                       <s>{{ line_item.original_line_price | money }}</s>
                     </dd>
                     <dt>


### PR DESCRIPTION
**Why are these changes introduced?**

Fixes #231 

Product card spacing:
- The space between the image and the first element should be 2rem (now 1.3 mobile/1.7 desktop)
- Space between vendor and title should reduce from 1.1rem to 0.7rem
- The space between title and price should be 1.1rem (now 0.7rem)

Update on sale regular price (strikethrough) font size:
- Product card 1.3rem
- Collage product card 1.3rem
- Product page 1.3rem (mobile) 1.6rem (desktop)
- Customer order page 1.3rem

Product page:
- Fix gap between sale badge and unit price https://screenshot.click/21-57-wos8h-o5r9k.png

**What approach did you take?**

I chose to update the regular price font size to 1.3rem directly in the price component and add a product page specific override that would bump this to 1.6rem on desktop.

For the customer order template, I added some classes to help target elements in the price columns specifically. This also fixes a bug where the on sale/regular price was unintentionally receiving the unit price styles. This section should now look [like this](https://screenshot.click/16-36-uwugp-ag9s9.png).


**Demo links**

- [Editor](https://os2-demo.myshopify.com/admin/themes/124611723286/editor)

**Checklist**
- [X] Followed [theme code principles](https://github.com/Shopify/dawn/blob/main/.github/CONTRIBUTING.md#theme-code-principles)
- [X] Linted with [Theme Check](https://github.com/Shopify/theme-check)
- [X] Tested on [mobile](https://shopify.dev/themes/store/requirements#mobile-browser-requirements)
- [X] Tested on [multiple browsers](https://shopify.dev/themes/store/requirements#desktop-browser-requirements)
- [X] Tested for [accessibility](https://shopify.dev/themes/best-practices/accessibility)
