### PR TITLE
Fix featured collection slider margins

### DIFF
--- a/assets/component-slider.css
+++ b/assets/component-slider.css
@@ -27,6 +27,7 @@ slider-component {
     scroll-behavior: smooth;
     scroll-padding-left: 1rem;
     -webkit-overflow-scrolling: touch;
+    margin-bottom: 0;
   }
 
   .slider.slider--mobile .slider__slide {
@@ -44,6 +45,7 @@ slider-component {
     scroll-behavior: smooth;
     scroll-padding-left: 1rem;
     -webkit-overflow-scrolling: touch;
+    margin-bottom: 0;
   }
 
   .slider.slider--tablet .slider__slide {

--- a/sections/featured-collection.liquid
+++ b/sections/featured-collection.liquid
@@ -17,7 +17,7 @@
   endif
 -%}
 <div class="collection page-width{% if section.settings.swipe_on_mobile == true and section.settings.collection.all_products_count > 2 and section.settings.products_to_show > 2 %} page-width-desktop{% endif %}">
-  <div class="{% if section.settings.show_view_all and section.settings.swipe_on_mobile %}title-wrapper-with-link{% endif %}{% if section.settings.title == blank %} title-wrapper-with-link--no-heading{% endif %}{% if section.settings.collection.all_products_count > 2 and section.settings.swipe_on_mobile and section.settings.products_to_show > 2 %} title-wrapper--self-padded-tablet-down{% endif %}">
+  <div class="title-wrapper-with-link{% if section.settings.title == blank %} title-wrapper-with-link--no-heading{% endif %}{% if section.settings.collection.all_products_count > 2 and section.settings.swipe_on_mobile and section.settings.products_to_show > 2 %} title-wrapper--self-padded-tablet-down{% endif %}">
     <h2 class="title{% if section.settings.title == blank %} title--no-heading{% endif %}">{{ section.settings.title | escape }}</h2>
 
     {%- if section.settings.show_view_all and section.settings.swipe_on_mobile and more_in_collection -%}


### PR DESCRIPTION
**Why are these changes introduced?**

Fixes #379 

**What approach did you take?**

The product grid changes introduced in #176 applied some negative vertical margins that don't play nice with the absolutely positioned slider buttons below the slides/grid items, specifically in the featured collection section which is using the product grid (other slider sections don't appear to be affected). 

The simplest fix seems to be declaring a default margin-bottom (of zero) on the slider class which will take priority over the default product grid margins. Slider slides (grid items) already set their own padding/margins in this way.

**Other considerations**

Another option is to just not apply the `product-grid` class at specific breakpoints when the slider setting is enabled, but we'd probably have to extend the product grid component to offer breakpoint exclusive classes (such as `product-grid--desktop`). I'm not sure this is necessary, but it's an option.

**Demo links**
- [Store](https://os2-demo.myshopify.com/?preview_theme_id=124613263382)
- [Editor](https://os2-demo.myshopify.com/admin/themes/124613263382/editor)

**Checklist**
- [ ] Followed [theme code principles](https://github.com/Shopify/dawn/blob/main/.github/CONTRIBUTING.md#theme-code-principles)
- [ ] Linted with [Theme Check](https://github.com/Shopify/theme-check)
- [ ] Tested on [mobile](https://shopify.dev/themes/store/requirements#mobile-browser-requirements)
- [ ] Tested on [multiple browsers](https://shopify.dev/themes/store/requirements#desktop-browser-requirements)
- [ ] Tested for [accessibility](https://shopify.dev/themes/best-practices/accessibility)
