### PR TITLE
Correcting support content in en.default.schema.json

### DIFF
--- a/locales/en.default.schema.json
+++ b/locales/en.default.schema.json
@@ -522,7 +522,7 @@
           "settings": {
             "heading": {
               "label": "Heading",
-              "info": "A heading is required to display the menu."
+              "info": "Heading required to display the menu."
             },
             "menu": {
               "label": "Menu",
@@ -615,7 +615,7 @@
           "label": "Custom logo width"
         },
         "logo_position": {
-          "label": "Logo position on large screen",
+          "label": "Logo position on large screens",
           "options__1": {
             "label": "Middle left"
           },


### PR DESCRIPTION
**Why are these changes introduced?** Fixes 2 small copy tense changes in sections. See `Heading required to display the menu` and `Video plays in a pop-up if the section contains other blocks.`

See  Header block and Collage section for these strings. 


- [Editor](https://os2-demo.myshopify.com/admin/themes/124615655446/editor)

