### PR TITLE
Click to dismiss product modal

### DIFF
--- a/assets/global.js
+++ b/assets/global.js
@@ -378,10 +378,17 @@ class ModalDialog extends HTMLElement {
       'click',
       this.hide.bind(this)
     );
+    this.querySelectorAll('img[data-media-id], [role="document"]').forEach(element => {
+      element.addEventListener('pointerup', (event) => {
+        if (event.pointerType === 'mouse' && event.target === event.currentTarget) {
+          this.hide();
+        }
+      })
+    });
     this.addEventListener('click', (event) => {
       if (event.target.nodeName === 'MODAL-DIALOG') this.hide();
     });
-    this.addEventListener('keyup', () => {
+    this.addEventListener('keyup', (event) => {
       if (event.code.toUpperCase() === 'ESCAPE') this.hide();
     });
   }


### PR DESCRIPTION
**Why are these changes introduced?**

Fixes #377 

**What approach did you take?**

To exclude touch events from mobile devices, I'm using `PointerEvent.pointerType`. Support for the `PointerEvent` interface looks good enough for us to utilize. Probably a minor detail, but worth noting I'm using the `pointerup` event. It seemed jarring for the modal to close immediately on mousedown.

To exclude media other than images from triggering a dismiss, I'm targeting img elements that have the `data-media-id` attribute. Deferred media types also include a poster img that would otherwise trigger the event.

**Other considerations**

Currently, clicks in the white space around the modal content will also close the modal, but I'm not sure if this is expected behavior or not. If this were a more standard modal with an overlay, clicking the overlay would definitely be expected to close the dialog, but clicking the background of the dialog itself (like it is here) probably wouldn't be. Just curious if anyone has any opinions on that.

I added this feature to our `ModalDialog` class, but do we need to limit the functionality to only the `ProductModal` (which extends ModalDialog)? 

**Demo links**

- [Store](url)
- [Editor](url)

**Checklist**
- [ ] Followed [theme code principles](https://github.com/Shopify/dawn/blob/main/.github/CONTRIBUTING.md#theme-code-principles)
- [ ] Linted with [Theme Check](https://github.com/Shopify/theme-check)
- [ ] Tested on [mobile](https://shopify.dev/themes/store/requirements#mobile-browser-requirements)
- [ ] Tested on [multiple browsers](https://shopify.dev/themes/store/requirements#desktop-browser-requirements)
- [ ] Tested for [accessibility](https://shopify.dev/themes/best-practices/accessibility)
