### PR TITLE
Update price sale badge spacing

### DIFF
--- a/assets/section-main-product.css
+++ b/assets/section-main-product.css
@@ -263,11 +263,7 @@ a.product__text {
   align-items: flex-start;
 }
 
-.product .price--on-sale.price--unit-price {
-  margin-bottom: -0.5rem;
-}
-
-.product .price--on-sale.price--unit-price dl {
+.product .price--on-sale dl {
   margin-bottom: 0.5rem;
 }
 

--- a/snippets/price.liquid
+++ b/snippets/price.liquid
@@ -34,8 +34,7 @@
   {%- if price_class %} {{ price_class }}{% endif -%}
   {%- if available == false %} price--sold-out {% endif -%}
   {%- if compare_at_price > price %} price--on-sale {% endif -%}
-  {%- if product.price_varies == false and product.compare_at_price_varies %} price--no-compare {% endif -%}
-  {%- if product.selected_or_first_available_variant.unit_price_measurement != nil %} price--unit-price{% endif -%}">
+  {%- if product.price_varies == false and product.compare_at_price_varies %} price--no-compare{% endif -%}">
   <dl>
     {%- comment -%}
       Explanation of description list:


### PR DESCRIPTION
**Why are these changes introduced?**

Adds more spacing between prices and sale badge when the badge wraps.

Follow up to #407 
See https://github.com/Shopify/dawn/pull/407#discussion_r691341065

**What approach did you take?**

The original solution attempted to avoid increasing the spacing between the price block and the variant block below when the badge doesn't wrap. Design later agreed the additional 5px that the simplest solution adds is an acceptable compromise. This PR also removes a class name in the price snippet that was added for this purpose.

[The spacing desired when wrapped](https://screenshot.click/18-39-2r8q6-i8lie.png)
[The same spacing when not wrapped](https://screenshot.click/18-37-npn55-upwnz.png)

**Demo links**

- [Store](https://os2-demo.myshopify.com/?preview_theme_id=124632072214)
- [Editor](https://os2-demo.myshopify.com/admin/themes/124632072214/editor)

**Checklist**
- [ ] Followed [theme code principles](https://github.com/Shopify/dawn/blob/main/.github/CONTRIBUTING.md#theme-code-principles)
- [ ] Linted with [Theme Check](https://github.com/Shopify/theme-check)
- [ ] Tested on [mobile](https://shopify.dev/themes/store/requirements#mobile-browser-requirements)
- [ ] Tested on [multiple browsers](https://shopify.dev/themes/store/requirements#desktop-browser-requirements)
- [ ] Tested for [accessibility](https://shopify.dev/themes/best-practices/accessibility)
