### PR TITLE
Update webkit autofill styles for field labels/buttons

### DIFF
--- a/assets/base.css
+++ b/assets/base.css
@@ -1466,6 +1466,12 @@ details[open] > .share-button__fallback {
   width: 2.5rem;
 }
 
+.field__input:-webkit-autofill ~ .field__button,
+.field__input:-webkit-autofill ~ .field__label,
+.customer .field input:-webkit-autofill ~ label {
+  color: rgb(0,0,0);
+}
+
 /* Text area */
 
 .text-area {


### PR DESCRIPTION
**Why are these changes introduced?**

Fixes #422 

**What approach did you take?**

The problem comes from webkit browsers forcing different styling on inputs when autofilled. This is more notable when the input is on a dark background with light text. It doesn't appear we can override these styles with !important so the best option is to adjust the inline label and submit button icon to just play nice with these forced styles. The browser changes the input text to pure black so I've updated the label and button to display black as well. [See here](https://screenshot.click/19-51-ptueq-olvf8.png)

The issue was noticed on the email signup section, but I made this a global change in base.css because this could occur wherever there is a form and a dark background.

Note: These changes should only apply to webkit browsers and to inputs that have been autofilled.

**Other considerations**

There _is_ a potential hack we could use to hide the browser's styles, which involves utilizing the `box-shadow` css property to create a faux background, but we currently use this property to form the border/outline of inputs, so we'd have to change that, at least for this case. I don't think it would be worth the effort and could be fragile, but if anyone _really_ hates the browser styles we can discuss.

**Demo links**

- [Store](https://os2-demo.myshopify.com/?preview_theme_id=126268375062)
- [Editor](https://os2-demo.myshopify.com/admin/themes/126268375062/editor)

**Checklist**
- [ ] Followed [theme code principles](https://github.com/Shopify/dawn/blob/main/.github/CONTRIBUTING.md#theme-code-principles)
- [ ] Linted with [Theme Check](https://github.com/Shopify/theme-check)
- [ ] Tested on [mobile](https://shopify.dev/themes/store/requirements#mobile-browser-requirements)
- [ ] Tested on [multiple browsers](https://shopify.dev/themes/store/requirements#desktop-browser-requirements)
- [ ] Tested for [accessibility](https://shopify.dev/themes/best-practices/accessibility)
