### PR TITLE
Safari/iOS focus-visible fallback

### DIFF
--- a/assets/base.css
+++ b/assets/base.css
@@ -723,6 +723,11 @@ summary::-webkit-details-marker {
   box-shadow: 0 0 0.2rem 0 rgba(var(--color-foreground), 0.3);
 }
 
+.no-js .focus-inset:focus:not(:focus-visible) {
+  outline: 0;
+  box-shadow: none;
+}
+
 /*
   Focus ring - none
 */

--- a/assets/base.css
+++ b/assets/base.css
@@ -693,12 +693,19 @@ summary::-webkit-details-marker {
 }
 
 /* Fallback - for browsers that don't support :focus-visible, a fallback is set for :focus */
-.focused {
+.focused, .no-js *:focus {
   outline: 0.2rem solid rgba(var(--color-foreground), 0.5);
   outline-offset: 0.3rem;
   box-shadow: 0 0 0 0.3rem rgb(var(--color-background)),
     0 0 0.5rem 0.4rem rgba(var(--color-foreground), 0.3);
 }
+
+/* Negate the fallback side-effect for browsers that support :focus-visible */
+.no-js *:focus:not(:focus-visible) {
+  outline: 0;
+  box-shadow: none;
+}
+
 
 /*
   Focus ring - inset
@@ -710,7 +717,7 @@ summary::-webkit-details-marker {
   box-shadow: 0 0 0.2rem 0 rgba(var(--color-foreground), 0.3);
 }
 
-.focused.focus-inset {
+.focused.focus-inset, .no-js .focus-inset:focus {
   outline: 0.2rem solid rgba(var(--color-foreground), 0.5);
   outline-offset: -0.2rem;
   box-shadow: 0 0 0.2rem 0 rgba(var(--color-foreground), 0.3);
@@ -733,11 +740,16 @@ summary::-webkit-details-marker {
     0 0 0.2rem 1.2rem rgba(var(--color-foreground), 0.3);
 }
 
-.focus-offset.focused {
+.focus-offset.focused, .no-js .focus-offset:focus {
   outline: 0.2rem solid rgba(var(--color-foreground), 0.5);
   outline-offset: 1rem;
   box-shadow: 0 0 0 1rem rgb(var(--color-background)),
     0 0 0.2rem 1.2rem rgba(var(--color-foreground), 0.3);
+}
+
+.no-js .focus-offset:focus:not(:focus-visible) {
+  outline: 0;
+  box-shadow: none;
 }
 
 /* component-title */

--- a/assets/base.css
+++ b/assets/base.css
@@ -680,6 +680,11 @@ summary::-webkit-details-marker {
   Focus ring - default (with offset)
 */
 
+*:focus {
+  outline: 0;
+  box-shadow: none;
+}
+
 *:focus-visible {
   outline: 0.2rem solid rgba(var(--color-foreground), 0.5);
   outline-offset: 0.3rem;
@@ -688,17 +693,11 @@ summary::-webkit-details-marker {
 }
 
 /* Fallback - for browsers that don't support :focus-visible, a fallback is set for :focus */
-*:focus {
+.focused {
   outline: 0.2rem solid rgba(var(--color-foreground), 0.5);
   outline-offset: 0.3rem;
   box-shadow: 0 0 0 0.3rem rgb(var(--color-background)),
     0 0 0.5rem 0.4rem rgba(var(--color-foreground), 0.3);
-}
-
-/* Negate the fallback side-effect for browsers that support :focus-visible */
-*:focus:not(:focus-visible) {
-  outline: 0;
-  box-shadow: none;
 }
 
 /*
@@ -711,16 +710,10 @@ summary::-webkit-details-marker {
   box-shadow: 0 0 0.2rem 0 rgba(var(--color-foreground), 0.3);
 }
 
-/* Fallback */
-.focus-inset:focus {
+.focused.focus-inset {
   outline: 0.2rem solid rgba(var(--color-foreground), 0.5);
   outline-offset: -0.2rem;
   box-shadow: 0 0 0.2rem 0 rgba(var(--color-foreground), 0.3);
-}
-
-.focus-inset:focus:not(:focus-visible) {
-  outline: 0;
-  box-shadow: none;
 }
 
 /*
@@ -740,16 +733,11 @@ summary::-webkit-details-marker {
     0 0 0.2rem 1.2rem rgba(var(--color-foreground), 0.3);
 }
 
-.focus-offset:focus {
+.focus-offset.focused {
   outline: 0.2rem solid rgba(var(--color-foreground), 0.5);
   outline-offset: 1rem;
   box-shadow: 0 0 0 1rem rgb(var(--color-background)),
     0 0 0.2rem 1.2rem rgba(var(--color-foreground), 0.3);
-}
-
-.focus-offset:focus:not(:focus-visible) {
-  outline: 0;
-  box-shadow: none;
 }
 
 /* component-title */

--- a/assets/component-slider.css
+++ b/assets/component-slider.css
@@ -187,3 +187,7 @@ slider-component .slider-buttons {
 .slider-button:focus-visible {
   z-index: 1;
 }
+
+.slider-button.focused {
+  z-index: 1;
+}

--- a/assets/component-slider.css
+++ b/assets/component-slider.css
@@ -183,11 +183,3 @@ slider-component .slider-buttons {
 .slider-button--prev:not([disabled]):hover .icon {
   transform: rotate(90deg) translateX(-0.15rem) scale(1.07);
 }
-
-.slider-button:focus-visible {
-  z-index: 1;
-}
-
-.slider-button.focused {
-  z-index: 1;
-}

--- a/assets/global.js
+++ b/assets/global.js
@@ -64,7 +64,7 @@ try {
 }
 
 function focusVisiblePolyfill() {
-  const navKeys = ['ARROWUP', 'ARROWDOWN', 'ARROWLEFT', 'ARROWRIGHT', 'TAB', 'ENTER', 'SPACE']
+  const navKeys = ['ARROWUP', 'ARROWDOWN', 'ARROWLEFT', 'ARROWRIGHT', 'TAB', 'ENTER', 'SPACE', 'ESCAPE']
   let currentFocusedElement = null;
 
   window.addEventListener('keydown', (event) => {
@@ -74,15 +74,16 @@ function focusVisiblePolyfill() {
       window.setTimeout(() => {
         currentFocusedElement = document.activeElement;
         currentFocusedElement.classList.add('focused');
-      }, 120);
+      });
       // adding a timeout value here helps as for some reasons when pressing the space bar (qty selector for example), adding the class is happening too quickly and the button is loosing its focus ring. Though similarly the cart dropdown doesn't receive focus on its wrapper due to the time it takes for it to show up.
     }
   });
 
   window.addEventListener('click', (event) => {
+    // this is a way for me to check if the click event was triggered by the keyboard. And if it is, don't remove the class.
+    if (event.offsetX === 0 && event.offsetY == 0) return;
     currentFocusedElement?.classList.remove('focused');
   });
-
 }
 
 function pauseAllMedia() {

--- a/assets/global.js
+++ b/assets/global.js
@@ -54,6 +54,37 @@ function trapFocus(container, elementToFocus = container) {
   elementToFocus.focus();
 }
 
+// Here I can run the querySelector to figure out if the browser supports :focus-visible or not and run code based on it.
+try {
+  document.querySelector(":focus-visible");
+  console.log('not an error')
+} catch {
+  // Here I could run the function that deals with browsers not supporting :focus-visible.
+  focusVisiblePolyfill();
+}
+
+function focusVisiblePolyfill() {
+  const navKeys = ['ARROWLEFT', 'ARROWRIGHT', 'TAB']
+  let currentFocusedElement = null;
+
+  window.addEventListener('keydown', (event) => {
+    if(navKeys.includes(event.code.toUpperCase())) {
+      currentFocusedElement?.classList.remove('focused');
+
+      window.setTimeout(() => {
+        currentFocusedElement = document.activeElement;
+        console.log(currentFocusedElement);
+        currentFocusedElement.classList.add('focused');
+      });
+    }
+  });
+
+  window.addEventListener('click', (event) => {
+    currentFocusedElement?.classList.remove('focused');
+  });
+
+}
+
 function pauseAllMedia() {
   document.querySelectorAll('.js-youtube').forEach((video) => {
     video.contentWindow.postMessage('{"event":"command","func":"' + 'pauseVideo' + '","args":""}', '*');

--- a/assets/global.js
+++ b/assets/global.js
@@ -73,9 +73,9 @@ function focusVisiblePolyfill() {
 
       window.setTimeout(() => {
         currentFocusedElement = document.activeElement;
-        console.log(currentFocusedElement);
         currentFocusedElement.classList.add('focused');
-      });
+      }, 120);
+      // adding a timeout value here helps as for some reasons when pressing the space bar (qty selector for example), adding the class is happening too quickly and the button is loosing its focus ring. Though similarly the cart dropdown doesn't receive focus on its wrapper due to the time it takes for it to show up.
     }
   });
 

--- a/assets/global.js
+++ b/assets/global.js
@@ -66,24 +66,30 @@ try {
 function focusVisiblePolyfill() {
   const navKeys = ['ARROWUP', 'ARROWDOWN', 'ARROWLEFT', 'ARROWRIGHT', 'TAB', 'ENTER', 'SPACE', 'ESCAPE']
   let currentFocusedElement = null;
+  let mouseClick = null;
 
   window.addEventListener('keydown', (event) => {
     if(navKeys.includes(event.code.toUpperCase())) {
-      currentFocusedElement?.classList.remove('focused');
-
-      window.setTimeout(() => {
-        currentFocusedElement = document.activeElement;
-        currentFocusedElement.classList.add('focused');
-      });
-      // adding a timeout value here helps as for some reasons when pressing the space bar (qty selector for example), adding the class is happening too quickly and the button is loosing its focus ring. Though similarly the cart dropdown doesn't receive focus on its wrapper due to the time it takes for it to show up.
+      mouseClick = false;
     }
   });
 
-  window.addEventListener('click', (event) => {
+  window.addEventListener('mousedown', (event) => {
     // this is a way for me to check if the click event was triggered by the keyboard. And if it is, don't remove the class.
     if (event.offsetX === 0 && event.offsetY == 0) return;
-    currentFocusedElement?.classList.remove('focused');
+    mouseClick = true;
   });
+
+  window.addEventListener('focus', () => {
+    currentFocusedElement?.classList.remove('focused');
+
+    if (mouseClick) return;
+
+    window.setTimeout(() => {
+      currentFocusedElement = document.activeElement;
+      currentFocusedElement.classList.add('focused');
+    });
+  }, true);
 }
 
 function pauseAllMedia() {

--- a/assets/global.js
+++ b/assets/global.js
@@ -64,7 +64,7 @@ try {
 }
 
 function focusVisiblePolyfill() {
-  const navKeys = ['ARROWUP', 'ARROWDOWN', 'ARROWLEFT', 'ARROWRIGHT', 'TAB', 'ENTER', 'SPACE', 'ESCAPE']
+  const navKeys = ['ARROWUP', 'ARROWDOWN', 'ARROWLEFT', 'ARROWRIGHT', 'TAB', 'ENTER', 'SPACE', 'ESCAPE', 'HOME', 'END', 'PAGEUP', 'PAGEDOWN']
   let currentFocusedElement = null;
   let mouseClick = null;
 
@@ -76,19 +76,17 @@ function focusVisiblePolyfill() {
 
   window.addEventListener('mousedown', (event) => {
     // this is a way for me to check if the click event was triggered by the keyboard. And if it is, don't remove the class.
-    if (event.offsetX === 0 && event.offsetY == 0) return;
     mouseClick = true;
   });
 
   window.addEventListener('focus', () => {
-    currentFocusedElement?.classList.remove('focused');
+    if (currentFocusedElement) currentFocusedElement.classList.remove('focused');
 
     if (mouseClick) return;
 
-    window.setTimeout(() => {
-      currentFocusedElement = document.activeElement;
-      currentFocusedElement.classList.add('focused');
-    });
+    currentFocusedElement = document.activeElement;
+    currentFocusedElement.classList.add('focused');
+
   }, true);
 }
 

--- a/assets/global.js
+++ b/assets/global.js
@@ -64,7 +64,7 @@ try {
 }
 
 function focusVisiblePolyfill() {
-  const navKeys = ['ARROWLEFT', 'ARROWRIGHT', 'TAB']
+  const navKeys = ['ARROWUP', 'ARROWDOWN', 'ARROWLEFT', 'ARROWRIGHT', 'TAB', 'ENTER', 'SPACE']
   let currentFocusedElement = null;
 
   window.addEventListener('keydown', (event) => {

--- a/assets/global.js
+++ b/assets/global.js
@@ -54,12 +54,10 @@ function trapFocus(container, elementToFocus = container) {
   elementToFocus.focus();
 }
 
-// Here I can run the querySelector to figure out if the browser supports :focus-visible or not and run code based on it.
+// Here run the querySelector to figure out if the browser supports :focus-visible or not and run code based on it.
 try {
   document.querySelector(":focus-visible");
-  console.log('not an error')
 } catch {
-  // Here I could run the function that deals with browsers not supporting :focus-visible.
   focusVisiblePolyfill();
 }
 
@@ -75,7 +73,6 @@ function focusVisiblePolyfill() {
   });
 
   window.addEventListener('mousedown', (event) => {
-    // this is a way for me to check if the click event was triggered by the keyboard. And if it is, don't remove the class.
     mouseClick = true;
   });
 
@@ -453,7 +450,7 @@ class ModalOpener extends HTMLElement {
     super();
 
     const button = this.querySelector('button');
-    
+
     if (!button) return;
     button.addEventListener('click', () => {
       const modal = document.querySelector(this.getAttribute('data-modal'));
@@ -468,7 +465,7 @@ class DeferredMedia extends HTMLElement {
     super();
     const poster = this.querySelector('[id^="Deferred-Poster-"]');
     if (!poster) return;
-    poster.addEventListener('click', this.loadContent.bind(this)); 
+    poster.addEventListener('click', this.loadContent.bind(this));
   }
 
   loadContent() {
@@ -581,7 +578,7 @@ class VariantSelects extends HTMLElement {
   }
 
   updateMedia() {
-    if (!this.currentVariant) return; 
+    if (!this.currentVariant) return;
     if (!this.currentVariant.featured_media) return;
     const newMedia = document.querySelector(
       `[data-media-id="${this.dataset.section}-${this.currentVariant.featured_media.id}"]`

--- a/assets/section-main-product.css
+++ b/assets/section-main-product.css
@@ -59,7 +59,7 @@
   min-height: 4.6rem;
 }
 
-.shopify-payment-button__button [role="button"]:focus {
+.shopify-payment-button__button [role="button"].focused {
   outline: .2rem solid rgba(var(--color-foreground),.5) !important;
   outline-offset: 0.3rem;
   box-shadow: 0 0 0 .1rem rgba(var(--color-button),var(--alpha-button-border)),0 0 0 .3rem rgb(var(--color-background)),0 0 .5rem .4rem rgba(var(--color-foreground),.3) !important;
@@ -179,14 +179,9 @@ fieldset.product-form__input .form__label {
 }
 
 /* Fallback */
-.product-form__input input[type='radio']:focus + label {
+.product-form__input input[type='radio'].focused + label {
   box-shadow: 0 0 0 0.3rem rgb(var(--color-background)),
     0 0 0 0.5rem rgba(var(--color-foreground), 0.55);
-}
-
-/* No outline when focus-visible is available in the browser */
-.product-form__input input[type='radio']:focus:not(:focus-visible) + label {
-  box-shadow: none;
 }
 
 .product-form__input .select {

--- a/assets/section-main-product.css
+++ b/assets/section-main-product.css
@@ -59,7 +59,8 @@
   min-height: 4.6rem;
 }
 
-.shopify-payment-button__button [role="button"].focused {
+.shopify-payment-button__button [role="button"].focused,
+.no-js .shopify-payment-button__button [role="button"]:focus {
   outline: .2rem solid rgba(var(--color-foreground),.5) !important;
   outline-offset: 0.3rem;
   box-shadow: 0 0 0 .1rem rgba(var(--color-button),var(--alpha-button-border)),0 0 0 .3rem rgb(var(--color-background)),0 0 .5rem .4rem rgba(var(--color-foreground),.3) !important;
@@ -179,9 +180,15 @@ fieldset.product-form__input .form__label {
 }
 
 /* Fallback */
-.product-form__input input[type='radio'].focused + label {
+.product-form__input input[type='radio'].focused + label,
+.no-js .shopify-payment-button__button [role="button"]:focus + label {
   box-shadow: 0 0 0 0.3rem rgb(var(--color-background)),
     0 0 0 0.5rem rgba(var(--color-foreground), 0.55);
+}
+
+/* No outline when focus-visible is available in the browser */
+.no-js .product-form__input input[type='radio']:focus:not(:focus-visible) + label {
+  box-shadow: none;
 }
 
 .product-form__input .select {

--- a/assets/template-collection.css
+++ b/assets/template-collection.css
@@ -191,18 +191,12 @@
     0 0 0.2rem 1.2rem rgba(var(--color-foreground), 0.3);
 }
 
-.collection-filters__sort:focus,
-.mobile-facets__sort .select__select:focus  {
+.collection-filters__sort.focused,
+.mobile-facets__sort .select__select.focused  {
   outline: 0.2rem solid rgba(var(--color-foreground), 0.5);
   outline-offset: 1rem;
   box-shadow: 0 0 0 1rem rgb(var(--color-background)),
     0 0 0.2rem 1.2rem rgba(var(--color-foreground), 0.3);
-}
-
-.collection-filters__sort:focus:not(:focus-visible),
-.mobile-facets__sort .select__select:focus:not(:focus-visible)  {
-  outline: 0;
-  box-shadow: none;
 }
 
 .collection-filters__sort + .icon-caret {
@@ -481,14 +475,24 @@ span.active-facets__button-inner {
   box-shadow: 0 0 0 0.2rem rgba(var(--color-foreground), 0.4);
 }
 
-a.active-facets__button:focus-visible,
-a.active-facets__button:focus {
+a.active-facets__button:focus-visible {
   outline: none;
   box-shadow: none;
 }
 
-a.active-facets__button:focus-visible .active-facets__button-inner,
-a.active-facets__button:focus .active-facets__button-inner {
+a.active-facets__button.focused {
+  outline: none;
+  box-shadow: none;
+}
+
+a.active-facets__button:focus-visible .active-facets__button-inner {
+  box-shadow: 0 0 0 0.1rem rgba(var(--color-foreground), 0.2),
+    0 0 0 0.2rem rgb(var(--color-background)),
+    0 0 0 0.4rem rgb(var(--color-foreground));
+  outline: none;
+}
+
+a.active-facets__button.focused .active-facets__button-inner {
   box-shadow: 0 0 0 0.1rem rgba(var(--color-foreground), 0.2),
     0 0 0 0.2rem rgb(var(--color-background)),
     0 0 0 0.4rem rgb(var(--color-foreground));

--- a/assets/template-collection.css
+++ b/assets/template-collection.css
@@ -192,11 +192,19 @@
 }
 
 .collection-filters__sort.focused,
-.mobile-facets__sort .select__select.focused  {
+.no-js .collection-filters__sort:focus,
+.mobile-facets__sort .select__select.focused,
+.no-js .mobile-facets__sort .select__select:focus  {
   outline: 0.2rem solid rgba(var(--color-foreground), 0.5);
   outline-offset: 1rem;
   box-shadow: 0 0 0 1rem rgb(var(--color-background)),
     0 0 0.2rem 1.2rem rgba(var(--color-foreground), 0.3);
+}
+
+.no-js .collection-filters__sort:focus:not(:focus-visible),
+.no-js .mobile-facets__sort .select__select:focus:not(:focus-visible)  {
+  outline: 0;
+  box-shadow: none;
 }
 
 .collection-filters__sort + .icon-caret {
@@ -480,7 +488,8 @@ a.active-facets__button:focus-visible {
   box-shadow: none;
 }
 
-a.active-facets__button.focused {
+a.active-facets__button.focused,
+.no-js a.active-facets__button:focus {
   outline: none;
   box-shadow: none;
 }
@@ -492,7 +501,8 @@ a.active-facets__button:focus-visible .active-facets__button-inner {
   outline: none;
 }
 
-a.active-facets__button.focused .active-facets__button-inner {
+a.active-facets__button.focused .active-facets__button-inner,
+.no-js a.active-facets__button:focus .active-facets__button-inner {
   box-shadow: 0 0 0 0.1rem rgba(var(--color-foreground), 0.2),
     0 0 0 0.2rem rgb(var(--color-background)),
     0 0 0 0.4rem rgb(var(--color-foreground));

--- a/assets/template-giftcard.css
+++ b/assets/template-giftcard.css
@@ -324,25 +324,17 @@ h2,
   Focus ring - default (with offset)
 */
 
+/* Fallback - for browsers that don't support :focus-visible, a fallback is set for :focus */
+*:focus {
+  outline: 0;
+  box-shadow: none;
+}
+
 *:focus-visible {
   outline: 0.2rem solid rgba(var(--color-base-text), 0.5);
   outline-offset: 0.3rem;
   box-shadow: 0 0 0 0.3rem rgb(var(--color-base-background-1)),
     0 0 0.5rem 0.4rem rgba(var(--color-base-text), 0.3);
-}
-
-/* Fallback - for browsers that don't support :focus-visible, a fallback is set for :focus */
-*:focus {
-  outline: 0.2rem solid rgba(var(--color-base-text), 0.5);
-  outline-offset: 0.3rem;
-  box-shadow: 0 0 0 0.3rem rgb(var(--color-base-background-1)),
-    0 0 0.5rem 0.4rem rgba(var(--color-base-text), 0.3);
-}
-
-/* Negate the fallback side-effect for browsers that support :focus-visible */
-*:focus:not(:focus-visible) {
-  outline: 0;
-  box-shadow: none;
 }
 
 .button:focus-visible {

--- a/assets/template-giftcard.css
+++ b/assets/template-giftcard.css
@@ -337,10 +337,24 @@ h2,
     0 0 0.5rem 0.4rem rgba(var(--color-base-text), 0.3);
 }
 
+/* Fallback - for browsers that don't support :focus-visible, a fallback is set for :focus */
+.focused, .no-js *:focus {
+  outline: 0.2rem solid rgba(var(--color-foreground), 0.5);
+  outline-offset: 0.3rem;
+  box-shadow: 0 0 0 0.3rem rgb(var(--color-background)),
+    0 0 0.5rem 0.4rem rgba(var(--color-foreground), 0.3);
+}
+
 .button:focus-visible {
   box-shadow: 0 0 0 0.1rem rgb(var(--color-base-accent-1)),
     0 0 0 0.3rem rgb(var(--color-base-background-1)),
     0 0 0.5rem 0.4rem rgba(var(--color-base-text), 0.3);
+}
+
+/* Negate the fallback side-effect for browsers that support :focus-visible */
+.no-js *:focus:not(:focus-visible) {
+  outline: 0;
+  box-shadow: none;
 }
 
 .button:focus {


### PR DESCRIPTION
**Why are these changes introduced?**

Fixes #344 

**What approach did you take?**

Followed the suggested idea from Tyler.
Also kept the original styling for the `no-js` behaviour. 

**Other considerations**

There are a few things I need to look into: 
- is `Tab`, `ArrowLeft` and `ArrowRight` the only keys used to navigate around and shift focus ? I added `SPACE`, `ESC` and `ENTER` but should I also add `HOME` and `END` which seem to be used for navigating sliders 🤔 
- focus is not passed to element with the attribute `tabindex="-1"` (ex: cart notification popup, skip to product info). It most likely is more of an issue even on slower connection. So I actually added an event listener for `focus` and it seem to work now.  

**Demo links**

- [Store](https://os2-demo.myshopify.com/?preview_theme_id=126283513878)
- [Editor](https://os2-demo.myshopify.com/admin/themes/126283513878/editor)

**Checklist**
- [ ] Followed [theme code principles](https://github.com/Shopify/dawn/blob/main/.github/CONTRIBUTING.md#theme-code-principles)
- [ ] Linted with [Theme Check](https://github.com/Shopify/theme-check)
- [ ] Tested on [mobile](https://shopify.dev/themes/store/requirements#mobile-browser-requirements)
- [ ] Tested on [multiple browsers](https://shopify.dev/themes/store/requirements#desktop-browser-requirements)
- [ ] Tested for [accessibility](https://shopify.dev/themes/best-practices/accessibility)
