### PR TITLE
Add escape key functionality on facets filters

### DIFF
--- a/assets/collection-filters-form.js
+++ b/assets/collection-filters-form.js
@@ -10,6 +10,8 @@ class CollectionFiltersForm extends HTMLElement {
 
     this.querySelector('form').addEventListener('input', this.debouncedOnSubmit.bind(this));
     window.addEventListener('popstate', this.onHistoryChange.bind(this));
+
+    this.querySelector('#FacetsWrapperDesktop')?.addEventListener('keyup', this.onKeyUp);
   }
 
   onSubmitHandler(event) {
@@ -28,6 +30,17 @@ class CollectionFiltersForm extends HTMLElement {
   onHistoryChange(event) {
     const searchParams = event.state?.searchParams || '';
     this.renderPage(searchParams, null, false);
+  }
+
+  onKeyUp(event) {
+    if(event.code.toUpperCase() !== 'ESCAPE') return;
+
+    const openDetailsElement = event.target.closest('details[open]');
+    if (!openDetailsElement) return;
+
+    const summaryElement = openDetailsElement.querySelector('summary');
+    openDetailsElement.removeAttribute('open');
+    summaryElement.focus();
   }
 
   toggleActiveFacets(disable = true) {

--- a/assets/collection-filters-form.js
+++ b/assets/collection-filters-form.js
@@ -11,7 +11,11 @@ class CollectionFiltersForm extends HTMLElement {
     this.querySelector('form').addEventListener('input', this.debouncedOnSubmit.bind(this));
     window.addEventListener('popstate', this.onHistoryChange.bind(this));
 
-    this.querySelector('#FacetsWrapperDesktop')?.addEventListener('keyup', onKeyUpEscape);
+    const facetWrapper = this.querySelector('#FacetsWrapperDesktop');
+    if(!facetWrapper) return;
+    
+    this.querySelector('#FacetsWrapperDesktop').addEventListener('keyup', onKeyUpEscape);
+    this.querySelector('#FacetsWrapperDesktop').addEventListener('focusout', this.onFocusOut);
   }
 
   onSubmitHandler(event) {
@@ -30,6 +34,17 @@ class CollectionFiltersForm extends HTMLElement {
   onHistoryChange(event) {
     const searchParams = event.state?.searchParams || '';
     this.renderPage(searchParams, null, false);
+  }
+
+  onFocusOut(event) {
+    setTimeout(() => {
+      const openDetailsElement = event.target.closest('details[open]');
+      if (!openDetailsElement) return;
+      
+      if (!openDetailsElement.contains(document.activeElement)) {
+        openDetailsElement.removeAttribute('open');
+      }
+    })
   }
 
   toggleActiveFacets(disable = true) {

--- a/assets/collection-filters-form.js
+++ b/assets/collection-filters-form.js
@@ -12,8 +12,7 @@ class CollectionFiltersForm extends HTMLElement {
     window.addEventListener('popstate', this.onHistoryChange.bind(this));
 
     const facetWrapper = this.querySelector('#FacetsWrapperDesktop');
-    if(!facetWrapper) return;
-    this.querySelector('#FacetsWrapperDesktop').addEventListener('keyup', onKeyUpEscape);
+    if (facetWrapper) facetWrapper.addEventListener('keyup', onKeyUpEscape);
   }
 
   onSubmitHandler(event) {

--- a/assets/collection-filters-form.js
+++ b/assets/collection-filters-form.js
@@ -11,7 +11,7 @@ class CollectionFiltersForm extends HTMLElement {
     this.querySelector('form').addEventListener('input', this.debouncedOnSubmit.bind(this));
     window.addEventListener('popstate', this.onHistoryChange.bind(this));
 
-    this.querySelector('#FacetsWrapperDesktop')?.addEventListener('keyup', this.onKeyUp);
+    this.querySelector('#FacetsWrapperDesktop')?.addEventListener('keyup', onKeyUpEscape);
   }
 
   onSubmitHandler(event) {
@@ -30,17 +30,6 @@ class CollectionFiltersForm extends HTMLElement {
   onHistoryChange(event) {
     const searchParams = event.state?.searchParams || '';
     this.renderPage(searchParams, null, false);
-  }
-
-  onKeyUp(event) {
-    if(event.code.toUpperCase() !== 'ESCAPE') return;
-
-    const openDetailsElement = event.target.closest('details[open]');
-    if (!openDetailsElement) return;
-
-    const summaryElement = openDetailsElement.querySelector('summary');
-    openDetailsElement.removeAttribute('open');
-    summaryElement.focus();
   }
 
   toggleActiveFacets(disable = true) {

--- a/assets/collection-filters-form.js
+++ b/assets/collection-filters-form.js
@@ -13,9 +13,7 @@ class CollectionFiltersForm extends HTMLElement {
 
     const facetWrapper = this.querySelector('#FacetsWrapperDesktop');
     if(!facetWrapper) return;
-    
     this.querySelector('#FacetsWrapperDesktop').addEventListener('keyup', onKeyUpEscape);
-    this.querySelector('#FacetsWrapperDesktop').addEventListener('focusout', this.onFocusOut);
   }
 
   onSubmitHandler(event) {
@@ -34,17 +32,6 @@ class CollectionFiltersForm extends HTMLElement {
   onHistoryChange(event) {
     const searchParams = event.state?.searchParams || '';
     this.renderPage(searchParams, null, false);
-  }
-
-  onFocusOut(event) {
-    setTimeout(() => {
-      const openDetailsElement = event.target.closest('details[open]');
-      if (!openDetailsElement) return;
-      
-      if (!openDetailsElement.contains(document.activeElement)) {
-        openDetailsElement.removeAttribute('open');
-      }
-    })
   }
 
   toggleActiveFacets(disable = true) {

--- a/assets/details-disclosure.js
+++ b/assets/details-disclosure.js
@@ -3,19 +3,8 @@ class DetailsDisclosure extends HTMLElement {
     super();
     this.mainDetailsToggle = this.querySelector('details');
 
-    this.addEventListener('keyup', this.onKeyUp);
+    this.addEventListener('keyup', onKeyUpEscape);
     this.mainDetailsToggle.addEventListener('focusout', this.onFocusOut.bind(this));
-  }
-
-  onKeyUp(event) {
-    if(event.code.toUpperCase() !== 'ESCAPE') return;
-
-    const openDetailsElement = event.target.closest('details[open]');
-    if (!openDetailsElement) return;
-
-    const summaryElement = openDetailsElement.querySelector('summary');
-    openDetailsElement.removeAttribute('open');
-    summaryElement.focus();
   }
 
   onFocusOut() {

--- a/assets/global.js
+++ b/assets/global.js
@@ -73,6 +73,17 @@ function removeTrapFocus(elementToFocus = null) {
   if (elementToFocus) elementToFocus.focus();
 }
 
+function onKeyUpEscape(event) {
+  if(event.code.toUpperCase() !== 'ESCAPE') return;
+
+  const openDetailsElement = event.target.closest('details[open]');
+  if (!openDetailsElement) return;
+
+  const summaryElement = openDetailsElement.querySelector('summary');
+  openDetailsElement.removeAttribute('open');
+  summaryElement.focus();
+}
+
 class QuantityInput extends HTMLElement {
   constructor() {
     super();

--- a/assets/global.js
+++ b/assets/global.js
@@ -74,7 +74,7 @@ function removeTrapFocus(elementToFocus = null) {
 }
 
 function onKeyUpEscape(event) {
-  if(event.code.toUpperCase() !== 'ESCAPE') return;
+  if (event.code.toUpperCase() !== 'ESCAPE') return;
 
   const openDetailsElement = event.target.closest('details[open]');
   if (!openDetailsElement) return;

--- a/sections/main-collection-product-grid.liquid
+++ b/sections/main-collection-product-grid.liquid
@@ -20,7 +20,7 @@
       <collection-filters-form class="facets small-hide">
         <form id="CollectionFiltersForm" class="facets__form">
           {% if section.settings.enable_filtering %}
-            <div class="facets__wrapper">
+            <div id="FacetsWrapperDesktop" class="facets__wrapper">
               {%- unless collection.filters == empty -%}
                 <p class="facets__heading caption-large">{{ 'sections.collection_template.filter_by_label' | t }}</p>
               {%- endunless -%}


### PR DESCRIPTION
**Why are these changes introduced?**

Fixes https://github.com/Shopify/dawn/issues/108

The goal of this PR is to add the "escape" key functionality when interacting with the facets filtering on collection page. I noticed the mobile drawer already works so I added this behavior only on desktop.

![filter_gif_compressed](https://user-images.githubusercontent.com/658169/130681767-86bc6418-2122-41ee-9bde-6d25fa9e139d.gif)

**What approach did you take?**

- Add escape functionality in the `keyup` event on the desktop facets, essentially took the same functionality as [details disclosure](https://github.com/Shopify/dawn/blob/f272a08f6bf59a4f78c5ac3c1285951a83dc698b/assets/details-disclosure.js#L10-L19) so I'm wondering if I should create a common function

**Demo links**

- [Store](https://os2-demo.myshopify.com/collections/all?preview_theme_id=126277124118)
- [Editor](https://os2-demo.myshopify.com/admin/themes/126277124118/editor)

**Checklist**
- [x] Followed [theme code principles](https://github.com/Shopify/dawn/blob/main/.github/CONTRIBUTING.md#theme-code-principles)
- [x] Linted with [Theme Check](https://github.com/Shopify/theme-check)
- [x] Tested on [mobile](https://shopify.dev/themes/store/requirements#mobile-browser-requirements)
- [x] Tested on [multiple browsers](https://shopify.dev/themes/store/requirements#desktop-browser-requirements)
- [x] Tested for [accessibility](https://shopify.dev/themes/best-practices/accessibility)
