### PR TITLE
Change "product" url to "product variant" url in cart line item

### DIFF
--- a/sections/main-cart-items.liquid
+++ b/sections/main-cart-items.liquid
@@ -46,7 +46,7 @@
                 <tr class="cart-item" id="CartItem-{{ item.index | plus: 1 }}">
                   <td class="cart-item__media">
                     {% if item.image %}
-                      <a href="{{ item.product.url }}">
+                      <a href="{{ item.url }}">
                         <img class="cart-item__image"
                           src="{{ item.image | img_url: '150x' }}"
                           alt="{{ item.image.alt | escape }}"
@@ -63,7 +63,7 @@
                       <p class="caption-with-letter-spacing light">{{ item.product.vendor }}</p>
                     {%- endif -%}
 
-                    <a href="{{ item.product.url }}" class="cart-item__name break">{{ item.product.title | escape }}</a>
+                    <a href="{{ item.url }}" class="cart-item__name break">{{ item.product.title | escape }}</a>
 
                     {%- if item.product.has_only_default_variant == false or item.properties.size != 0 or item.selling_plan_allocation != nil -%}
                       <dl>


### PR DESCRIPTION
**Why are these changes introduced?**

Issues: https://github.com/Shopify/dawn/pull/411#discussion_r695122153

The goal of this PR is to use product variant url instead of product url in the cart line item (cart template)

**What approach did you take?**

- Replace `item.product.url` (product url) to `item.url` (product variant url)

**Demo links**

- [Store](https://os2-demo.myshopify.com/?preview_theme_id=126277550102)
- [Editor](https://os2-demo.myshopify.com/admin/themes/126277550102/editor)

**Checklist**
- [x] Followed [theme code principles](https://github.com/Shopify/dawn/blob/main/.github/CONTRIBUTING.md#theme-code-principles)
- [x] Linted with [Theme Check](https://github.com/Shopify/theme-check)
- [x] Tested on [mobile](https://shopify.dev/themes/store/requirements#mobile-browser-requirements)
- [x] Tested on [multiple browsers](https://shopify.dev/themes/store/requirements#desktop-browser-requirements)
- [x] Tested for [accessibility](https://shopify.dev/themes/best-practices/accessibility)
