### PR TITLE
Fix z-index for filter so it doesnt overlap the sticky header

### DIFF
--- a/assets/base.css
+++ b/assets/base.css
@@ -689,7 +689,6 @@ summary::-webkit-details-marker {
 @media screen and (min-width: 750px) {
   .disclosure-has-popup[open] > summary + * {
     z-index: 2;
-    /* test */
   }
 }
 


### PR DESCRIPTION
**Why are these changes introduced?**

Fixes #357.

**What approach did you take?**
Update the z-index to be 2 on desktop. The sticky header has a z-index of 3 and the filtering originally had a z-index of 100 because on mobile it becomes a popup. But since we dont need this behaviour on desktop I updated it to be different on mobile vs desktop.

**Checklist**
- [ ] Followed [theme code principles](https://github.com/Shopify/dawn/blob/main/.github/CONTRIBUTING.md#theme-code-principles)
- [ ] Linted with [Theme Check](https://github.com/Shopify/theme-check)
- [ ] Tested on [mobile](https://shopify.dev/themes/store/requirements#mobile-browser-requirements)
- [ ] Tested on [multiple browsers](https://shopify.dev/themes/store/requirements#desktop-browser-requirements)
- [ ] Tested for [accessibility](https://shopify.dev/themes/best-practices/accessibility)
