### PR TITLE
Fix sticky header JS error

### DIFF
--- a/assets/global.js
+++ b/assets/global.js
@@ -550,7 +550,9 @@ class VariantSelects extends HTMLElement {
     modalContent.prepend(newMediaModal);
     parent.prepend(newMedia);
     this.stickyHeader = this.stickyHeader || document.querySelector('sticky-header');
-    this.stickyHeader.dispatchEvent(new Event('preventHeaderReveal'));
+    if(this.stickyHeader) {
+      this.stickyHeader.dispatchEvent(new Event('preventHeaderReveal'));
+    }
     window.setTimeout(() => { parent.querySelector('li.product__media-item').scrollIntoView({behavior: "smooth"}); });
   }
 


### PR DESCRIPTION
**Why are these changes introduced?**

The goal of this PR is to fix a JS error when sticky header is not enabled while switching to different variant pointing to a different image on product page. The criteria are:

- Have multiple variants
- Have different variant pointing to different image
- Header sticky setting is disabled

![image](https://user-images.githubusercontent.com/658169/130856214-51a81607-fdcc-4191-b725-eb88b7759c19.png)

**What approach did you take?**

- Add JS condition to prevent errors

**Demo links**

- [Store - make sure to toggle each variant](https://os2-demo.myshopify.com/products/louise-slide-sandal?preview_theme_id=126283087894)
- [Editor](https://os2-demo.myshopify.com/admin/themes/126283087894/editor)

**Checklist**
- [x] Followed [theme code principles](https://github.com/Shopify/dawn/blob/main/.github/CONTRIBUTING.md#theme-code-principles)
- [x] Linted with [Theme Check](https://github.com/Shopify/theme-check)
- [x] Tested on [mobile](https://shopify.dev/themes/store/requirements#mobile-browser-requirements)
- [x] Tested on [multiple browsers](https://shopify.dev/themes/store/requirements#desktop-browser-requirements)
- [x] Tested for [accessibility](https://shopify.dev/themes/best-practices/accessibility)
