### PR TITLE
free default variant positioning in button list or dropdown

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,19 +1,21 @@
 **Why are these changes introduced?**
 
-Fixes #0.
+Fixes #492
+
+The goal of this PR is to place the pre-selected default variant at any position. Since variant.selected is not changeable via source code, I decided to design the graphical representation dynamically instead. 
+
 
 **What approach did you take?**
-
-**Other considerations**
+Ich habe dem variant_picker um ein Optionsfeld erweitert und im main-product.liquid das Anlegen der HTML Elemente angepasst. 
 
 **Demo links**
 
-- [Store](url)
-- [Editor](url)
+- [Store](https://your-custom-puzzle.com)
+- [Editor](https://shopwerk-7.myshopify.com/admin)
 
 **Checklist**
-- [ ] Followed [theme code principles](https://github.com/Shopify/dawn/blob/main/.github/CONTRIBUTING.md#theme-code-principles)
-- [ ] Linted with [Theme Check](https://github.com/Shopify/theme-check)
-- [ ] Tested on [mobile](https://shopify.dev/themes/store/requirements#mobile-browser-requirements)
-- [ ] Tested on [multiple browsers](https://shopify.dev/themes/store/requirements#desktop-browser-requirements)
-- [ ] Tested for [accessibility](https://shopify.dev/themes/best-practices/accessibility)
+- [x] Followed [theme code principles](https://github.com/Shopify/dawn/blob/main/.github/CONTRIBUTING.md#theme-code-principles)
+- [x] Linted with [Theme Check](https://github.com/Shopify/theme-check)
+- [x] Tested on [mobile](https://shopify.dev/themes/store/requirements#mobile-browser-requirements)
+- [x] Tested on [multiple browsers](https://shopify.dev/themes/store/requirements#desktop-browser-requirements)
+- [x] Tested for [accessibility](https://shopify.dev/themes/best-practices/accessibility)

--- a/locales/en.default.schema.json
+++ b/locales/en.default.schema.json
@@ -566,6 +566,9 @@
               "options__2": {
                 "label": "Button"
               }
+            },
+            "default_position": {
+              "label": "Default Variant Position"
             }
           }
         },

--- a/sections/main-product.liquid
+++ b/sections/main-product.liquid
@@ -192,16 +192,33 @@
                   {%- for option in product.options_with_values -%}
                       <fieldset class="js product-form__input">
                         <legend class="form__label">{{ option.name }}</legend>
+                        {% comment %} option.value[0] is allways the pre selected variant{% endcomment %}
+                        {% assign defaultVariantValue = option.values[0] %}
                         {%- for value in option.values -%}
-                          <input type="radio" id="{{ section.id }}-{{ option.name }}-{{ forloop.index0 }}"
-                                name="{{ option.name }}"
-                                value="{{ value | escape }}"
-                                form="product-form-{{ section.id }}"
-                                {% if option.selected_value == value %}checked{% endif %}
-                          >
-                          <label for="{{ section.id }}-{{ option.name }}-{{ forloop.index0 }}">
-                            {{ value }}
-                          </label>
+                          {% comment %} If index isn't 0 and the pre selected should be inserted at this position, the ordinary variant of this inde must be inserted first {% endcomment %}
+                          {% if forloop.index0 !=  0%}
+                            <input type="radio" id="{{ section.id }}-{{ option.name }}-{{ forloop.index0 }}"
+                              name="{{ option.name }}"
+                              value="{{ value | escape }}"
+                              form="product-form-{{ section.id }}"
+                              {% if option.selected_value == value %}checked{% endif %}
+                            >
+                            <label for="{{ section.id }}-{{ option.name }}-{{ forloop.index0 }}">
+                              {{ value }}
+                            </label>
+                          {% endif %}
+                          {% comment %} insert default variant at defined position {% endcomment %}
+                          {% if forloop.index0 == block.settings.default_variant_position %}
+                            <input type="radio" id="{{ section.id }}-{{ option.name }}-0"
+                              name="{{ option.name }}"
+                              value="{{ defaultVariantValue | escape }}"
+                              form="product-form-{{ section.id }}"
+                              {% if option.selected_value == defaultVariantValue %}checked{% endif %}
+                            >
+                            <label for="{{ section.id }}-{{ option.name }}-0">
+                              {{ defaultVariantValue }}
+                            </label>
+                          {% endif %}
                         {%- endfor -%}
                       </fieldset>
                   {%- endfor -%}
@@ -222,10 +239,21 @@
                           name="options[{{ option.name | escape }}]"
                           form="product-form-{{ section.id }}"
                         >
+                        {% comment %} option.value[0] is allways the pre selected variant{% endcomment %}
+                        {% assign defaultVariantValue = option.values[0] %}
                           {%- for value in option.values -%}
-                            <option value="{{ value | escape }}" {% if option.selected_value == value %}selected="selected"{% endif %}>
-                              {{ value }}
-                            </option>
+                            {% comment %} If index isn't 0 and the pre selected should be inserted at this position, the ordinary variant of this inde must be inserted first {% endcomment %}
+                            {% if forloop.index0 !=  0%}
+                              <option value="{{ value | escape }}" {% if option.selected_value == value %}selected="selected"{% endif %}>
+                                {{ value }}
+                              </option>
+                            {% endif %}
+                            {% comment %} insert default variant at defined position {% endcomment %}
+                            {% if forloop.index0 == block.settings.default_variant_position %}
+                              <option value="{{ defaultVariantValue | escape }}" {% if option.selected_value == defaultVariantValue %}selected="selected"{% endif %}>
+                                {{ defaultVariantValue }}
+                              </option>
+                            {% endif %}
                           {%- endfor -%}
                         </select>
                         {% render 'icon-caret' %}
@@ -564,6 +592,12 @@
           ],
           "default": "button",
           "label": "t:sections.main-product.blocks.variant_picker.settings.picker_type.label"
+        },
+        {
+          "type": "number",
+          "id": "default_variant_position",
+          "label": "t:sections.main-product.blocks.variant_picker.settings.default_position.label",
+          "default": 0
         }
       ]
     },


### PR DESCRIPTION
**Why are these changes introduced?**

Fixes #492 
The goal of this PR is to place the pre-selected default variant at any position. Since variant.selected is not changeable via source code, I decided to design the graphical representation dynamically instead.
![preview_result](https://user-images.githubusercontent.com/88880084/130934569-02d36067-bd0a-49d7-bbe5-c963174e14a6.png)


**What approach did you take?**
I added an option field to the variant_picker and adjusted the creation of the HTML elements in the main-product.liquid.
![preview_picker_extension](https://user-images.githubusercontent.com/88880084/130934785-2024c44e-c509-44ab-95f9-6d55e0ecaf6e.png)

**Demo links**

- [Store](https://your-custom-puzzle.com)
- [Editor](https://shopwerk-7.myshopify.com/admin)


**Checklist**
- [x] Followed [theme code principles](https://github.com/Shopify/dawn/blob/main/.github/CONTRIBUTING.md#theme-code-principles)
- [x] Linted with [Theme Check](https://github.com/Shopify/theme-check)
- [x] Tested on [mobile](https://shopify.dev/themes/store/requirements#mobile-browser-requirements)
- [x] Tested on [multiple browsers](https://shopify.dev/themes/store/requirements#desktop-browser-requirements)
- [x] Tested for [accessibility](https://shopify.dev/themes/best-practices/accessibility)