### PR TITLE
Increase max_blocks to 15 for Collection list

### DIFF
--- a/sections/collection-list.liquid
+++ b/sections/collection-list.liquid
@@ -121,7 +121,7 @@
   "name": "t:sections.collection-list.name",
   "tag": "section",
   "class": "spaced-section collection-list-section",
-  "max_blocks": 12,
+  "max_blocks": 15,
   "settings": [
     {
       "type": "text",


### PR DESCRIPTION
Increase `max_blocks` from 12 to 15 since the new max is 16. Since [we display](https://screenshot.click/21-08-xmyh6-m1764.mp4) collection cards by 3 on one row on large screens and goes on 1 column on smaller screens, it is keeping a multiple of 3 to encourage a clean grid at all time.

- [Preview of the new limit
](https://screenshot.click/21-08-q8l9l-72h6k.png)

- [Editor link](https://os2-demo.myshopify.com/admin/themes/126286561302/editor)