### PR TITLE
Header hiding bug

### DIFF
--- a/sections/header.liquid
+++ b/sections/header.liquid
@@ -465,23 +465,24 @@
     onScroll() {
       const scrollTop = window.pageYOffset || document.documentElement.scrollTop;
 
-      if (this.preventReveal) {
-        window.clearTimeout(this.isScrolling);
-
-        this.isScrolling = setTimeout(() => {
-          this.preventReveal = false;
-        }, 66);
-
+      if (scrollTop > this.currentScrollTop && scrollTop > this.headerBounds.bottom) {
         requestAnimationFrame(this.hide.bind(this));
-      } else {
-        if (scrollTop > this.currentScrollTop && scrollTop > this.headerBounds.bottom) {
-          requestAnimationFrame(this.hide.bind(this));
-        } else if (scrollTop < this.currentScrollTop && scrollTop > this.headerBounds.bottom) {
+      } else if (scrollTop < this.currentScrollTop && scrollTop > this.headerBounds.bottom) {
+        if (!this.preventReveal) {
           requestAnimationFrame(this.reveal.bind(this));
-        } else if (scrollTop <= this.headerBounds.top) {
-          requestAnimationFrame(this.reset.bind(this));
+        } else {
+          window.clearTimeout(this.isScrolling);
+
+          this.isScrolling = setTimeout(() => {
+            this.preventReveal = false;
+          }, 66);
+
+          requestAnimationFrame(this.hide.bind(this));
         }
+      } else if (scrollTop <= this.headerBounds.top) {
+        requestAnimationFrame(this.reset.bind(this));
       }
+
 
       this.currentScrollTop = scrollTop;
     }


### PR DESCRIPTION
**Why are these changes introduced?**

Fixes #491 

**What approach did you take?**

I moved the part that was preventing the header from being `reveal`ed into the specific part it's needed. So instead of running even when scrolling down (say you're at the top of the page and click on a different variant, since you're scrolling down to the image) to prevent the `reveal` as it wasn't going to happen anyway. 

**Other considerations**

**Demo links**

- [Store](https://os2-demo.myshopify.com/?preview_theme_id=126287020054)
- [Editor](https://os2-demo.myshopify.com/admin/themes/126287020054/editor)

**Checklist**
- [ ] Followed [theme code principles](https://github.com/Shopify/dawn/blob/main/.github/CONTRIBUTING.md#theme-code-principles)
- [ ] Linted with [Theme Check](https://github.com/Shopify/theme-check)
- [ ] Tested on [mobile](https://shopify.dev/themes/store/requirements#mobile-browser-requirements)
- [ ] Tested on [multiple browsers](https://shopify.dev/themes/store/requirements#desktop-browser-requirements)
- [ ] Tested for [accessibility](https://shopify.dev/themes/best-practices/accessibility)
