### PR TITLE
Fix collection page z-index

### DIFF
--- a/assets/template-collection.css
+++ b/assets/template-collection.css
@@ -199,7 +199,7 @@
 }
 
 .collection-filters__sort:focus,
-.mobile-facets__sort .select__select:focus  {
+.mobile-facets__sort .select__select:focus {
   outline: 0.2rem solid rgba(var(--color-foreground), 0.5);
   outline-offset: 1rem;
   box-shadow: 0 0 0 1rem rgb(var(--color-background)),
@@ -207,7 +207,7 @@
 }
 
 .collection-filters__sort:focus:not(:focus-visible),
-.mobile-facets__sort .select__select:focus:not(:focus-visible)  {
+.mobile-facets__sort .select__select:focus:not(:focus-visible) {
   outline: 0;
   box-shadow: none;
 }
@@ -278,7 +278,7 @@
 }
 
 .disclosure-has-popup[open] > .facets__summary::before {
-  z-index: 3;
+  z-index: 2;
 }
 
 .facets__summary > span {


### PR DESCRIPTION
**Why are these changes introduced?**

Currently we are unable to click on the filters because of this PR: https://github.com/Shopify/dawn/pull/486

**What approach did you take?**

Update the z-index to match the new z-index

**Other considerations**

Video: https://screenshot.click/21-08-ku39z-xx047.mp4


**Checklist**
- [ ] Followed [theme code principles](https://github.com/Shopify/dawn/blob/main/.github/CONTRIBUTING.md#theme-code-principles)
- [ ] Linted with [Theme Check](https://github.com/Shopify/theme-check)
- [ ] Tested on [mobile](https://shopify.dev/themes/store/requirements#mobile-browser-requirements)
- [ ] Tested on [multiple browsers](https://shopify.dev/themes/store/requirements#desktop-browser-requirements)
- [ ] Tested for [accessibility](https://shopify.dev/themes/best-practices/accessibility)
