### PR TITLE
Fix line item properties when adding a product to cart

### DIFF
--- a/assets/global.js
+++ b/assets/global.js
@@ -108,7 +108,7 @@ const serializeForm = form => {
   const formData = new FormData(form);
 
   for (const key of formData.keys()) {
-    const regex = /(?:^(properties\[))(.*?)(?:\])/;
+    const regex = /(?:^(properties\[))(.*?)(?:\]$)/;
 
     if (regex.test(key)) { 
       obj.properties = obj.properties || {};

--- a/assets/global.js
+++ b/assets/global.js
@@ -106,9 +106,18 @@ function debounce(fn, wait) {
 const serializeForm = form => {
   const obj = {};
   const formData = new FormData(form);
+
   for (const key of formData.keys()) {
-    obj[key] = formData.get(key);
+    if(key.indexOf('properties[') !== -1) {
+      obj.properties = obj.properties || {};
+      const lineItem = key.split('[');
+      const propertyKey = lineItem[1].substring(0, lineItem[1].length-1)
+      obj.properties[propertyKey] = formData.get(key);
+    } else {
+      obj[key] = formData.get(key);
+    }
   }
+
   return JSON.stringify(obj);
 };
 

--- a/assets/global.js
+++ b/assets/global.js
@@ -108,11 +108,11 @@ const serializeForm = form => {
   const formData = new FormData(form);
 
   for (const key of formData.keys()) {
-    if(key.indexOf('properties[') !== -1) {
+    const regex = /(?:^(properties\[))(.*?)(?:\])/;
+
+    if (regex.test(key)) { 
       obj.properties = obj.properties || {};
-      const lineItem = key.split('[');
-      const propertyKey = lineItem[1].substring(0, lineItem[1].length-1)
-      obj.properties[propertyKey] = formData.get(key);
+      obj.properties[regex.exec(key)[2]] = formData.get(key);
     } else {
       obj[key] = formData.get(key);
     }

--- a/sections/main-product.liquid
+++ b/sections/main-product.liquid
@@ -70,6 +70,21 @@
       <div id="ProductInfo-{{ section.id }}" class="product__info-container{% if section.settings.enable_sticky_info %} product__info-container--sticky{% endif %}">
         {%- assign product_form_id = 'product-form-' | append: section.id -%}
 
+        <div class="field">
+          <input class="field__input"
+            type="text"
+            id="engraving" 
+            name="properties[engraving]"
+            form="product-form-{{ section.id }}"
+          >
+          <label class="field__label" for="engraving">Engraving</label>
+        </div>
+
+        <div class="field">
+          <label for="upload">Upload your image here</label>
+          <input id="upload" type="file" name="properties[image]" form="product-form-{{ section.id }}">
+        </div>
+
         {%- for block in section.blocks -%}
           {%- case block.type -%}
           {%- when '@app' -%}

--- a/sections/main-product.liquid
+++ b/sections/main-product.liquid
@@ -70,21 +70,6 @@
       <div id="ProductInfo-{{ section.id }}" class="product__info-container{% if section.settings.enable_sticky_info %} product__info-container--sticky{% endif %}">
         {%- assign product_form_id = 'product-form-' | append: section.id -%}
 
-        <div class="field">
-          <input class="field__input"
-            type="text"
-            id="engraving" 
-            name="properties[engraving]"
-            form="product-form-{{ section.id }}"
-          >
-          <label class="field__label" for="engraving">Engraving</label>
-        </div>
-
-        <div class="field">
-          <label for="upload">Upload your image here</label>
-          <input id="upload" type="file" name="properties[image]" form="product-form-{{ section.id }}">
-        </div>
-
         {%- for block in section.blocks -%}
           {%- case block.type -%}
           {%- when '@app' -%}


### PR DESCRIPTION
**Why are these changes introduced?**

Fixes https://github.com/Shopify/dawn/issues/243

The goal of this PR is to add line item properties when adding product to the cart. Previously, it was not possible due to the fact that `properties` object was passing as an `Array` structure instead of an `Object`.

**Actual**
```
"properties[engraving]": "Happy birthday",
"properties[isMatte]": "on"
```

**Expected**
```
"properties": {
   "engraving": "Happy birthday",
   "isMatte": "on"
}
```

![image](https://user-images.githubusercontent.com/658169/131169687-0b6cd295-0565-485a-98e5-c564acc61015.png)

There are other different approaches such as https://github.com/Shopify/dawn/pull/257 and https://github.com/Shopify/dawn/pull/163 but this approach is saving a few lines of JS.

Also, it is normal that we can't see line item properties in the cart notification. It's missing some Liquid code. There is a PR already made here: https://github.com/Shopify/dawn/pull/195

**What approach did you take?**

- Detect if `properties[]` field exist before sending the request to the server by using regex

Note that this doesn’t work is uploaded files (`<input type="file" />`): I assume due to the `Content-Type` being set as 'Content-Type': 'application/json', the form expects to receive only JSON format data, but when I try to switch to `Content-Type: multipart/form-data` in the fetch config (which is the way to upload files), it doesn’t work. I believe because we’re mixing JSON file and uploaded files, but I could be wrong.

If I disable JS and rely on the native form, the form will submit on the `<form>` element which has `enctype="multipart/form-data"` so the browser is natively taking care of everything, and I see uploaded files on the cart

**Demo links**

- [Store](https://os2-demo.myshopify.com/?preview_theme_id=126290919446)
- [Editor](https://os2-demo.myshopify.com/admin/themes/126290919446/editor)

**Checklist**
- [ ] Followed [theme code principles](https://github.com/Shopify/dawn/blob/main/.github/CONTRIBUTING.md#theme-code-principles)
- [ ] Linted with [Theme Check](https://github.com/Shopify/theme-check)
- [ ] Tested on [mobile](https://shopify.dev/themes/store/requirements#mobile-browser-requirements)
- [ ] Tested on [multiple browsers](https://shopify.dev/themes/store/requirements#desktop-browser-requirements)
- [ ] Tested for [accessibility](https://shopify.dev/themes/best-practices/accessibility)

**Testing**
1. Checkout the branch
2. Add the following in the `main-product.liquid` form

```
<div class="field">
  <input 
    type="checkbox"
     id="isMatte" 
    name="properties[isMatte]"
    form="product-form-{{ section.id }}"
  >
  <label class="field__label" for="isMatte">Matte option</label>
</div>

<div class="field">
  <input class="field__input"
    type="text"
    id="engraving" 
    name="properties[engraving]"
    form="product-form-{{ section.id }}"
  >
  <label class="field__label" for="engraving">Engraving</label>
</div>
```

3. Add the product and make sure we see line item properties.
