### PR TITLE
Fix add to cart on cart template

### DIFF
--- a/sections/header.liquid
+++ b/sections/header.liquid
@@ -425,7 +425,6 @@
 
 {%- render 'cart-notification' -%}
 
-
 {% javascript %}
   class StickyHeader extends HTMLElement {
     constructor() {


### PR DESCRIPTION
**Why are these changes introduced?**
If a merchant adds a featured product to the cart page, the buyer is unable to add to cart because the cart notification is not present. This resulted in an error and as a result, broken JS.  

**What approach did you take?**
Removed the conditional rendering of the cart notification.

**Other considerations**
N/A

**Demo links**

- [Store](https://os2-demo.myshopify.com/?preview_theme_id=126291673110)
- [Editor](https://os2-demo.myshopify.com/admin/themes/126291673110/editor)

**Testing**
* Cart page
* Product page
* Featured product 

**Checklist**
- [ ] Followed [theme code principles](https://github.com/Shopify/dawn/blob/main/.github/CONTRIBUTING.md#theme-code-principles)
- [ ] Linted with [Theme Check](https://github.com/Shopify/theme-check)
- [ ] Tested on [mobile](https://shopify.dev/themes/store/requirements#mobile-browser-requirements)
- [ ] Tested on [multiple browsers](https://shopify.dev/themes/store/requirements#desktop-browser-requirements)
- [ ] Tested for [accessibility](https://shopify.dev/themes/best-practices/accessibility)
