### PR TITLE
Update Featured Prodct metafield default value

### DIFF
--- a/sections/featured-product.liquid
+++ b/sections/featured-product.liquid
@@ -566,7 +566,7 @@
         {
           "type": "text",
           "settings": {
-            "text": "{{ product.vendor }}",
+            "text": "{{ section.settings.product.vendor }}",
             "text_style": "uppercase"
           }
         },
@@ -576,7 +576,7 @@
         {
           "type": "text",
           "settings": {
-            "text": "{{ product.metafields.descriptors.subtitle.value }}",
+            "text": "{{ section.settings.product.metafields.descriptors.subtitle.value }}",
             "text_style": "subtitle"
           }
         },


### PR DESCRIPTION
**Why are these changes introduced?**
Fixes a bug with the featured product section, where the default metafield for the text blocks had invalid values.

<img src="https://user-images.githubusercontent.com/37168033/131346124-d6c696d0-e8bf-4ab7-863b-189400e29080.png" width="340">


**What approach did you take?**

Update from `product`, a variable that is not available on the context of this section, to `section.settings.product`

**Demo links**

- [Store](https://os2-demo.myshopify.com/?preview_theme_id=126296817686)
- [Editor](https://os2-demo.myshopify.com/admin/themes/126296817686/editor)

**Checklist**
- [x] Followed [theme code principles](https://github.com/Shopify/dawn/blob/main/.github/CONTRIBUTING.md#theme-code-principles)
- [x] Linted with [Theme Check](https://github.com/Shopify/theme-check)
- [x] Tested on [mobile](https://shopify.dev/themes/store/requirements#mobile-browser-requirements)
- [x] Tested on [multiple browsers](https://shopify.dev/themes/store/requirements#desktop-browser-requirements)
- [x] Tested for [accessibility](https://shopify.dev/themes/best-practices/accessibility)
