### PR TITLE
Apply button text color to payment button

### DIFF
--- a/assets/section-main-product.css
+++ b/assets/section-main-product.css
@@ -78,6 +78,7 @@
 .shopify-payment-button__button--unbranded {
   background-color: rgba(var(--color-button), var(--alpha-button-background));
   box-shadow: 0 0 0 0.1rem rgba(var(--color-button), var(--alpha-button-border));
+  color: rgb(var(--color-button-text));
   font-size: 1.4rem;
   line-height: 1.2;
   letter-spacing: 0.07rem;


### PR DESCRIPTION
**Why are these changes introduced?**

Fixes #518 

**What approach did you take?**

Added `--color-button-text` where we're already adding other styles for the payment button.

**Demo links**

- [Editor](https://os2-demo.myshopify.com/admin/themes/126298750998/editor)

**Checklist**
- [ ] Followed [theme code principles](https://github.com/Shopify/dawn/blob/main/.github/CONTRIBUTING.md#theme-code-principles)
- [ ] Linted with [Theme Check](https://github.com/Shopify/theme-check)
- [ ] Tested on [mobile](https://shopify.dev/themes/store/requirements#mobile-browser-requirements)
- [ ] Tested on [multiple browsers](https://shopify.dev/themes/store/requirements#desktop-browser-requirements)
- [ ] Tested for [accessibility](https://shopify.dev/themes/best-practices/accessibility)
