### PR TITLE
Hide active variant images on modals

### DIFF
--- a/assets/section-main-product.css
+++ b/assets/section-main-product.css
@@ -398,6 +398,22 @@ a.product__text {
   .product__media-item:first-child {
     width: 100%;
   }
+
+  .product-media-modal__content > .product__media-item--variant.product__media-item--variant {
+    display: none;
+  }
+
+  .product-media-modal__content > .product__media-item--variant:first-child {
+    display: block;
+  }
+}
+
+.product__media-item--variant {
+  display: none;
+}
+
+.product__media-item--variant:first-child {
+  display: block;
 }
 
 @media screen and (min-width: 750px) and (max-width: 989px) {
@@ -410,16 +426,6 @@ a.product__text {
     width: 100%;
   }
 }
-
-  .product__media-item--variant,
-  .product-media-modal__content > .product__media-item--variant.product__media-item--variant {
-    display: none;
-  }
-
-  .product__media-item--variant:first-child,
-  .product-media-modal__content > .product__media-item--variant:first-child {
-    display: block;
-  }
 
 .product__media-icon .icon {
   width: 1.2rem;


### PR DESCRIPTION
**Why are these changes introduced?**
Fix an issue where the `Hide other variants’ media after selecting a variant` was causing the active variant media to be shown on mobile.

**What approach did you take?**
Restrict the variant image visibility CSS to desktop media queries. Mobile devices should display **only a single media** inside the modal.

**Demo links**
- [Before](https://os2-demo.myshopify.com/products/brick-apple?preview_theme_id=126297997334)
- [After](https://os2-demo.myshopify.com/products/brick-apple?preview_theme_id=126301306902)
- [Editor](https://os2-demo.myshopify.com/admin/themes/126301306902/editor)

**Checklist**
- [x] Followed [theme code principles](https://github.com/Shopify/dawn/blob/main/.github/CONTRIBUTING.md#theme-code-principles)
- [x] Linted with [Theme Check](https://github.com/Shopify/theme-check)
- [x] Tested on [mobile](https://shopify.dev/themes/store/requirements#mobile-browser-requirements)
- [x] Tested on [multiple browsers](https://shopify.dev/themes/store/requirements#desktop-browser-requirements)
- [x] Tested for [accessibility](https://shopify.dev/themes/best-practices/accessibility)