### PR TITLE
Filter drawer z-index fix

### DIFF
--- a/assets/base.css
+++ b/assets/base.css
@@ -693,6 +693,10 @@ summary::-webkit-details-marker {
 
 @media screen and (min-width: 750px) {
   .disclosure-has-popup[open] > summary + * {
+    z-index: 4;
+  }
+
+  .facets.small-hide .disclosure-has-popup[open] > summary + * {
     z-index: 2;
   }
 }

--- a/assets/base.css
+++ b/assets/base.css
@@ -696,7 +696,7 @@ summary::-webkit-details-marker {
     z-index: 4;
   }
 
-  .facets.small-hide .disclosure-has-popup[open] > summary + * {
+  .facets .disclosure-has-popup[open] > summary + * {
     z-index: 2;
   }
 }


### PR DESCRIPTION
**Why are these changes introduced?**

Fixes #529 

There is a setting to keep the drawer on desktop which wasn't tested on some recent changes about the `z-index` for the collection filters. 

**What approach did you take?**

I kept the current z-index for when the collection filter has those classes: `facets small-hide`
And when it doesn't on desktop, it has a greater `z-index` of `4` which makes it come above the header and announcement bar. 

**Other considerations**

**Demo links**

- [Store](https://os2-demo.myshopify.com/?preview_theme_id=126304780310)
- [Editor](https://os2-demo.myshopify.com/admin/themes/126304780310/editor)

**Checklist**
- [ ] Followed [theme code principles](https://github.com/Shopify/dawn/blob/main/.github/CONTRIBUTING.md#theme-code-principles)
- [ ] Linted with [Theme Check](https://github.com/Shopify/theme-check)
- [ ] Tested on [mobile](https://shopify.dev/themes/store/requirements#mobile-browser-requirements)
- [ ] Tested on [multiple browsers](https://shopify.dev/themes/store/requirements#desktop-browser-requirements)
- [ ] Tested for [accessibility](https://shopify.dev/themes/best-practices/accessibility)
