### PR TITLE
Cart line-item error a11y

### DIFF
--- a/assets/component-cart-items.css
+++ b/assets/component-cart-items.css
@@ -144,12 +144,12 @@ cart-remove-button .icon-remove {
 }
 
 .cart-item__error {
-  font-size: 1.2rem;
   display: flex;
   align-items: flex-start;
 }
 
 .cart-item__error-text {
+  font-size: 1.2rem;
   order: 1;
 }
 

--- a/sections/main-cart-items.liquid
+++ b/sections/main-cart-items.liquid
@@ -107,15 +107,15 @@
                       {%- endfor -%}
                     </ul>
 
-                    <p class="cart-item__error" id="Line-item-error-{{ item.index | plus: 1 }}">
-                      <span class="cart-item__error-text"></span>
+                    <div class="cart-item__error" id="Line-item-error-{{ item.index | plus: 1 }}" role="status">
+                      <small class="cart-item__error-text"></small>
                       <svg aria-hidden="true" focusable="false" role="presentation" class="icon icon-error" viewBox="0 0 13 13">
                         <circle cx="6.5" cy="6.50049" r="5.5" stroke="white" stroke-width="2"/>
                         <circle cx="6.5" cy="6.5" r="5.5" fill="#EB001B" stroke="#EB001B" stroke-width="0.7"/>
                         <path d="M5.87413 3.52832L5.97439 7.57216H7.02713L7.12739 3.52832H5.87413ZM6.50076 9.66091C6.88091 9.66091 7.18169 9.37267 7.18169 9.00504C7.18169 8.63742 6.88091 8.34917 6.50076 8.34917C6.12061 8.34917 5.81982 8.63742 5.81982 9.00504C5.81982 9.37267 6.12061 9.66091 6.50076 9.66091Z" fill="white"/>
                         <path d="M5.87413 3.17832H5.51535L5.52424 3.537L5.6245 7.58083L5.63296 7.92216H5.97439H7.02713H7.36856L7.37702 7.58083L7.47728 3.537L7.48617 3.17832H7.12739H5.87413ZM6.50076 10.0109C7.06121 10.0109 7.5317 9.57872 7.5317 9.00504C7.5317 8.43137 7.06121 7.99918 6.50076 7.99918C5.94031 7.99918 5.46982 8.43137 5.46982 9.00504C5.46982 9.57872 5.94031 10.0109 6.50076 10.0109Z" fill="white" stroke="#EB001B" stroke-width="0.7">
                       </svg>
-                    </p>
+                    </div>
                   </td>
 
                   <td class="cart-item__totals right medium-hide large-up-hide">


### PR DESCRIPTION
**Why are these changes introduced?**

Fixes #471 

**What approach did you take?**

Followed the recommendations posted in the issue. Added a `role="status"` on the error text and changed the elements used. 

**Other considerations**

**Demo links**

- [Store](https://os2-demo.myshopify.com/?preview_theme_id=126317101078)
- [Editor](https://os2-demo.myshopify.com/admin/themes/126317101078/editor)

**Checklist**
- [ ] Followed [theme code principles](https://github.com/Shopify/dawn/blob/main/.github/CONTRIBUTING.md#theme-code-principles)
- [ ] Linted with [Theme Check](https://github.com/Shopify/theme-check)
- [ ] Tested on [mobile](https://shopify.dev/themes/store/requirements#mobile-browser-requirements)
- [ ] Tested on [multiple browsers](https://shopify.dev/themes/store/requirements#desktop-browser-requirements)
- [ ] Tested for [accessibility](https://shopify.dev/themes/best-practices/accessibility)
