### PR TITLE
Line-item content spacing on larger screens

### DIFF
--- a/assets/component-cart-items.css
+++ b/assets/component-cart-items.css
@@ -25,7 +25,13 @@
 
 .cart-item__image {
   height: auto;
-  max-width: 100%;
+  max-width: 10rem;
+}
+
+@media screen and (min-width: 750px) {
+  .cart-item__image {
+    max-width: 100%;
+  }
 }
 
 .cart-item__details {

--- a/assets/component-cart-items.css
+++ b/assets/component-cart-items.css
@@ -300,9 +300,3 @@ cart-remove-button .icon-remove {
     width: 60%;
   }
 }
-
-@media screen and (min-width: 1250px) {
-  .cart-item > td + td {
-    padding-left: 2rem;
-  }
-}

--- a/assets/component-cart-items.css
+++ b/assets/component-cart-items.css
@@ -300,3 +300,9 @@ cart-remove-button .icon-remove {
     width: 60%;
   }
 }
+
+@media screen and (min-width: 1250px) {
+  .cart-item > td + td {
+    padding-left: 2rem;
+  }
+}

--- a/sections/main-cart-items.liquid
+++ b/sections/main-cart-items.liquid
@@ -48,11 +48,11 @@
                     {% if item.image %}
                       <a href="{{ item.url }}">
                         <img class="cart-item__image"
-                          src="{{ item.image | img_url: '150x' }}"
+                          src="{{ item.image | img_url: '300x' }}"
                           alt="{{ item.image.alt | escape }}"
                           loading="lazy"
-                          width="100"
-                          height="{{ 100 | divided_by: item.image.aspect_ratio | ceil }}"
+                          width="150"
+                          height="{{ 150 | divided_by: item.image.aspect_ratio | ceil }}"
                         >
                       </a>
                     {% endif %}


### PR DESCRIPTION
**Why are these changes introduced?**

Fixes #531 

**What approach did you take?**

At first I thought with dealing with the `padding-left` of the `.cart-item__details` but instead I think it makes sense to have the image grow bigger. Looks like the space it takes can go up to `150px` right now so I changed the image size to match. I also changed the source of the image to be twice the size of the image so that it can be a good quality image. 

**Other considerations**

On bigger screens the product image might make the line use more space but it might not be a bad thing 🤔 
cc: @Oliviammarcello & @wiktoriaswiecicka :) ([video explanation](https://screenshot.click/21-09-bbr1t-ruy4n.mp4))

**Demo links**

- [Store](https://os2-demo.myshopify.com/?preview_theme_id=126323589142)

**Checklist**
- [ ] Followed [theme code principles](https://github.com/Shopify/dawn/blob/main/.github/CONTRIBUTING.md#theme-code-principles)
- [ ] Linted with [Theme Check](https://github.com/Shopify/theme-check)
- [ ] Tested on [mobile](https://shopify.dev/themes/store/requirements#mobile-browser-requirements)
- [ ] Tested on [multiple browsers](https://shopify.dev/themes/store/requirements#desktop-browser-requirements)
- [ ] Tested for [accessibility](https://shopify.dev/themes/best-practices/accessibility)

**To test**
- You can add an item to the cart and then resize your browser to check how it looks on larger screens (past a 1000px wide)
