### PR TITLE
Blog zoom in duration

### DIFF
--- a/assets/component-article-card.css
+++ b/assets/component-article-card.css
@@ -66,7 +66,7 @@
 }
 
 .article-content img {
-  transition: transform var(--duration-default) ease;
+  transition: transform var(--duration-long) ease;
 }
 
 .article-content:hover img {

--- a/assets/component-card.css
+++ b/assets/component-card.css
@@ -255,7 +255,8 @@
 
 @media screen and (min-width: 990px) {
   .card .media.media--hover-effect > img:only-child,
-  .card-wrapper .media.media--hover-effect > img:only-child {
+  .card-wrapper .media.media--hover-effect > img:only-child,
+  .card--search img {
     transition: transform var(--duration-long) ease;
   }
 
@@ -279,10 +280,6 @@
   .card-wrapper:hover .card-information__text {
     text-decoration: underline;
     text-underline-offset: 0.3rem;
-  }
-
-  .card--search img {
-    transition: transform var(--duration-default) ease;
   }
 
   .card-wrapper:hover .card--search img {


### PR DESCRIPTION
**Why are these changes introduced?**

Fixes #421 

**What approach did you take?**

Change the variable it's using for the animation. Exactly what's mentioned in the issue, to change the duration from `200ms` to `500ms`. 

**Other considerations**

**Demo links**

- [Store](https://os2-demo.myshopify.com/?preview_theme_id=126324539414)

**Checklist**
- [ ] Followed [theme code principles](https://github.com/Shopify/dawn/blob/main/.github/CONTRIBUTING.md#theme-code-principles)
- [ ] Linted with [Theme Check](https://github.com/Shopify/theme-check)
- [ ] Tested on [mobile](https://shopify.dev/themes/store/requirements#mobile-browser-requirements)
- [ ] Tested on [multiple browsers](https://shopify.dev/themes/store/requirements#desktop-browser-requirements)
- [ ] Tested for [accessibility](https://shopify.dev/themes/best-practices/accessibility)

**To test** 
Go into the footer menu and click on `News` then hover over the blog images. 
