### PR TITLE
Fix html closing tags order on desktop price range filter

### DIFF
--- a/sections/main-collection-product-grid.liquid
+++ b/sections/main-collection-product-grid.liquid
@@ -146,8 +146,8 @@
                           </input>
                           <label class="field__label" for="Filter-{{ filter.label | escape }}-LTE">{{ 'sections.collection_template.to' | t }}</label>
                         </div>
-                      </div>
-                    </price-range>
+                      </price-range>
+                    </div>
                   </details>
                 {% endcase %}
               {%- endfor -%}


### PR DESCRIPTION
On desktop collection filters the price range custom element contains an extra `</div>` closing tag.

I swapped the `</div>` and `</price-range>` closing tags because the div closing tag belongs to the `.facets__display` div.

**Checklist**
- [x] Followed [theme code principles](https://github.com/Shopify/dawn/blob/main/.github/CONTRIBUTING.md#theme-code-principles)
- [x] Tested on [mobile](https://shopify.dev/themes/store/requirements#mobile-browser-requirements)
- [x] Tested on [multiple browsers](https://shopify.dev/themes/store/requirements#desktop-browser-requirements)
