### PR TITLE
Replace ResizeObserver by Resize event

### DIFF
--- a/assets/global.js
+++ b/assets/global.js
@@ -156,7 +156,7 @@ const serializeForm = form => {
   for (const key of formData.keys()) {
     const regex = /(?:^(properties\[))(.*?)(?:\]$)/;
 
-    if (regex.test(key)) { 
+    if (regex.test(key)) {
       obj.properties = obj.properties || {};
       obj.properties[regex.exec(key)[2]] = formData.get(key);
     } else {
@@ -514,8 +514,11 @@ class SliderComponent extends HTMLElement {
 
     if (!this.slider || !this.nextButton) return;
 
-    const resizeObserver = new ResizeObserver(entries => this.initPages());
-    resizeObserver.observe(this.slider);
+    // const resizeObserver = new ResizeObserver(entries => this.initPages());
+    // resizeObserver.observe(this.slider);
+
+    this.initPages()
+    window.addEventListener('resize', () => { this.initPages()});
 
     this.slider.addEventListener('scroll', this.update.bind(this));
     this.prevButton.addEventListener('click', this.onButtonClick.bind(this));


### PR DESCRIPTION
**Why are these changes introduced?**

Fixes #510 

**What approach did you take?**

Replaced the `ResizeObserver` by a `Resize` event which applies to the window instead of just the slider element. 

**Other considerations**

I still need to look into the `IntersectionObserver` but when I tested on a laptop that has Safari 12.1.2 and browserstack iOS 12, I didn't get errors like I did before and language selector, cart notification, slider and product modal do work. 

From what I'm seeing it's just the sticky header and product recos that do not work. So product recos never show up and the header behave like a non sticky one, stays at the top of the page at all time, so you have to scroll back up to get to it. 

Would this be acceptable enough ? I think it prevents us from having too many work arounds/extra code and offer a decent experience on those older browser versions. 

**Demo links**

- [Store](https://os2-demo.myshopify.com/?preview_theme_id=126328111126)
- [Editor](https://os2-demo.myshopify.com/admin/themes/126328111126/editor)

**Checklist**
- [ ] Followed [theme code principles](https://github.com/Shopify/dawn/blob/main/.github/CONTRIBUTING.md#theme-code-principles)
- [ ] Linted with [Theme Check](https://github.com/Shopify/theme-check)
- [ ] Tested on [mobile](https://shopify.dev/themes/store/requirements#mobile-browser-requirements)
- [ ] Tested on [multiple browsers](https://shopify.dev/themes/store/requirements#desktop-browser-requirements)
- [ ] Tested for [accessibility](https://shopify.dev/themes/best-practices/accessibility)


**Things to test**
Use browserstack to test iOS 12 and the Mojave OS with version 12 for Safari.
- local selector in the footer,
- product modal,
- cart notification,
- and general functionality of the theme