### PR TITLE
Rich Text section page width fix

### DIFF
--- a/assets/section-rich-text.css
+++ b/assets/section-rich-text.css
@@ -1,9 +1,6 @@
 .rich-text {
   margin: auto;
-  max-width: 110rem;
   text-align: center;
-  /* 1.5rem margin on left & right */
-  width: calc(100% - 3rem);
 }
 
 .rich-text.rich-text--full-width {
@@ -38,11 +35,6 @@
 }
 
 @media screen and (min-width: 750px) {
-  .rich-text {
-    /* 5rem margin on left & right */
-    width: calc(100% - 10rem);
-  }
-
   .rich-text__blocks {
     max-width: 50rem;
   }

--- a/sections/rich-text.liquid
+++ b/sections/rich-text.liquid
@@ -4,20 +4,22 @@
 <noscript>{{ 'component-rte.css' | asset_url | stylesheet_tag }}</noscript>
 <noscript>{{ 'section-rich-text.css' | asset_url | stylesheet_tag }}</noscript>
 
-<div class="rich-text color-{{ section.settings.color_scheme }} gradient{% if section.settings.full_width %} rich-text--full-width{% endif %}">
-  <div class="rich-text__blocks">
-    {%- for block in section.blocks -%}
-      {%- case block.type -%}
-        {%- when 'heading' -%}
-          <h2 class="{{ block.settings.heading_size }}" {{ block.shopify_attributes }}>{{ block.settings.heading | escape }}</h2>
-        {%- when 'text' -%}
-          <div class="rich-text__text rte" {{ block.shopify_attributes }}>{{ block.settings.text }}</div>
-        {%- when 'button' -%}
-          <a{% if block.settings.button_link == blank %} aria-disabled="true"{% else %} href="{{ block.settings.button_link }}"{% endif %} class="button{% if block.settings.button_style_secondary %} button--secondary{% else %} button--primary{% endif %}" {{ block.shopify_attributes }}>
-            {{ block.settings.button_label | escape }}
-          </a>
-      {%- endcase -%}
-    {%- endfor -%}
+<div class="{% unless section.settings.full_width %}page-width{% endunless %}">
+  <div class="rich-text color-{{ section.settings.color_scheme }} gradient{% if section.settings.full_width %} rich-text--full-width{% endif %}">
+    <div class="rich-text__blocks">
+      {%- for block in section.blocks -%}
+        {%- case block.type -%}
+          {%- when 'heading' -%}
+            <h2 class="{{ block.settings.heading_size }}" {{ block.shopify_attributes }}>{{ block.settings.heading | escape }}</h2>
+          {%- when 'text' -%}
+            <div class="rich-text__text rte" {{ block.shopify_attributes }}>{{ block.settings.text }}</div>
+          {%- when 'button' -%}
+            <a{% if block.settings.button_link == blank %} aria-disabled="true"{% else %} href="{{ block.settings.button_link }}"{% endif %} class="button{% if block.settings.button_style_secondary %} button--secondary{% else %} button--primary{% endif %}" {{ block.shopify_attributes }}>
+              {{ block.settings.button_label | escape }}
+            </a>
+        {%- endcase -%}
+      {%- endfor -%}
+    </div>
   </div>
 </div>
 


### PR DESCRIPTION
**Why are these changes introduced?**

Fixes #519 

**What approach did you take?**

The width/max-width were hard coded in the rich text stylesheet. I've adjusted to let the `page-width` handle these styles to ensure consistency with other sections.

**Demo links**

- [Editor](https://os2-demo.myshopify.com/admin/themes/126327980054/editor)

**Checklist**
- [X] Followed [theme code principles](https://github.com/Shopify/dawn/blob/main/.github/CONTRIBUTING.md#theme-code-principles)
- [X] Linted with [Theme Check](https://github.com/Shopify/theme-check)
- [X] Tested on [mobile](https://shopify.dev/themes/store/requirements#mobile-browser-requirements)
- [X] Tested on [multiple browsers](https://shopify.dev/themes/store/requirements#desktop-browser-requirements)
- [X] Tested for [accessibility](https://shopify.dev/themes/best-practices/accessibility)
