### PR TITLE
Password modal z-index

### DIFF
--- a/assets/base.css
+++ b/assets/base.css
@@ -1708,7 +1708,7 @@ input[type='checkbox'] {
   right: 0;
   bottom: 0;
   background: rgb(var(--color-background));
-  z-index: 1;
+  z-index: 3;
   display: flex;
   justify-content: center;
   align-items: center;


### PR DESCRIPTION
**Why are these changes introduced?**

Fixes #557 

**What approach did you take?**

Updated the `z-index` value of the `.modal__content` to 3 instead of 1. 

I added all the sections available on the password page and test how it played with the modal. A `z-index: 3;` seemed to suffice to resolve the issue. 

**Other considerations**

**Demo links**

- [Store](https://os2-demo.myshopify.com/?preview_theme_id=126328864790)
- [Editor](https://os2-demo.myshopify.com/admin/themes/126328864790/editor)

**Checklist**
- [ ] Followed [theme code principles](https://github.com/Shopify/dawn/blob/main/.github/CONTRIBUTING.md#theme-code-principles)
- [ ] Linted with [Theme Check](https://github.com/Shopify/theme-check)
- [ ] Tested on [mobile](https://shopify.dev/themes/store/requirements#mobile-browser-requirements)
- [ ] Tested on [multiple browsers](https://shopify.dev/themes/store/requirements#desktop-browser-requirements)
- [ ] Tested for [accessibility](https://shopify.dev/themes/best-practices/accessibility)


**To test**
In the theme editor, go to the password page and add sections, then open the modal by clicking on `Enter password` and see if anything shows up on top of it. 