### PR TITLE
Description defaults to true for collection

### DIFF
--- a/sections/main-collection-banner.liquid
+++ b/sections/main-collection-banner.liquid
@@ -46,7 +46,7 @@
     {
       "type": "checkbox",
       "id": "show_collection_description",
-      "default": false,
+      "default": true,
       "label": "t:sections.main-collection-banner.settings.show_collection_description.label"
     },
     {


### PR DESCRIPTION
**Why are these changes introduced?**

Very quick PR to make the description on by default on the collection page.  Discussed with @Oliviammarcello and Shawn Rudolph.    This is good for SEO as well as for merchant expectations - they don't need to go to another place to see the collection description when they add one to their collection.

**What approach did you take?**

Switched a boolean 🤯 

**Checklist**
- [x] Followed [theme code principles](https://github.com/Shopify/dawn/blob/main/.github/CONTRIBUTING.md#theme-code-principles)
- [x] Linted with [Theme Check](https://github.com/Shopify/theme-check)
- [x] Tested on [mobile](https://shopify.dev/themes/store/requirements#mobile-browser-requirements)
- [x] Tested on [multiple browsers](https://shopify.dev/themes/store/requirements#desktop-browser-requirements)
- [x] Tested for [accessibility](https://shopify.dev/themes/best-practices/accessibility)
