### PR TITLE
Blog layout enhancements

### DIFF
--- a/assets/base.css
+++ b/assets/base.css
@@ -177,15 +177,13 @@ html.no-js .no-js-hidden {
   padding: 0 1.5rem;
 }
 
-.page-width-desktop,
-.page-width-tablet {
+.page-width-desktop {
   padding: 0;
   margin: 0 auto;
 }
 
 @media screen and (min-width: 750px) {
-  .page-width,
-  .page-width-tablet {
+  .page-width {
     padding: 0 5rem;
   }
 
@@ -196,6 +194,10 @@ html.no-js .no-js-hidden {
   .page-width-desktop {
     padding: 0;
   }
+
+  .page-width-tablet {
+    padding: 0 5rem;
+  }
 }
 
 @media screen and (min-width: 990px) {
@@ -204,8 +206,7 @@ html.no-js .no-js-hidden {
     padding: 0;
   }
 
-  .page-width-desktop,
-  .page-width-tablet {
+  .page-width-desktop {
     max-width: var(--page-width);
     padding: 0 5rem;
   }

--- a/assets/base.css
+++ b/assets/base.css
@@ -177,13 +177,15 @@ html.no-js .no-js-hidden {
   padding: 0 1.5rem;
 }
 
-.page-width-desktop {
+.page-width-desktop,
+.page-width-tablet {
   padding: 0;
   margin: 0 auto;
 }
 
 @media screen and (min-width: 750px) {
-  .page-width {
+  .page-width,
+  .page-width-tablet {
     padding: 0 5rem;
   }
 
@@ -202,7 +204,8 @@ html.no-js .no-js-hidden {
     padding: 0;
   }
 
-  .page-width-desktop {
+  .page-width-desktop,
+  .page-width-tablet {
     max-width: var(--page-width);
     padding: 0 5rem;
   }

--- a/assets/component-article-card.css
+++ b/assets/component-article-card.css
@@ -125,6 +125,10 @@
   margin-top: auto;
 }
 
+.article-card__excerpt {
+  width: 100%;
+}
+
 .article-card__link:not(:only-child) {
   margin-right: 3rem;
 }

--- a/assets/component-article-card.css
+++ b/assets/component-article-card.css
@@ -138,3 +138,43 @@
     margin-right: 4rem;
   }
 }
+
+.article-card__image--small {
+  padding-bottom: 11.0rem;
+}
+
+.article-card__image--medium {
+  padding-bottom: 22.0rem;
+}
+
+.article-card__image--large {
+  padding-bottom: 33.0rem;
+}
+
+@media screen and (min-width: 750px) {
+  .article-card__image--small {
+    padding-bottom: 14.3rem;
+  }
+
+  .article-card__image--medium {
+    padding-bottom: 21.9rem;
+  }
+
+  .article-card__image--large {
+    padding-bottom: 27.5rem;
+  }
+}
+
+@media screen and (min-width: 990px) {
+  .article-card__image--small {
+    padding-bottom: 17.7rem;
+  }
+
+  .article-card__image--medium {
+    padding-bottom: 30.7rem;
+  }
+
+  .article-card__image--large {
+    padding-bottom: 40.7rem;
+  }
+}

--- a/assets/component-article-card.css
+++ b/assets/component-article-card.css
@@ -140,15 +140,15 @@
 }
 
 .article-card__image--small {
-  padding-bottom: 11.0rem;
+  padding-bottom: 11rem;
 }
 
 .article-card__image--medium {
-  padding-bottom: 22.0rem;
+  padding-bottom: 22rem;
 }
 
 .article-card__image--large {
-  padding-bottom: 33.0rem;
+  padding-bottom: 33rem;
 }
 
 @media screen and (min-width: 750px) {

--- a/assets/component-article-card.css
+++ b/assets/component-article-card.css
@@ -8,10 +8,6 @@
   }
 }
 
-.articles-wrapper .article {
-  max-width: 100%;
-}
-
 @media screen and (max-width: 749px) {
   .articles-wrapper .article {
     width: 100%;

--- a/assets/section-blog-post.css
+++ b/assets/section-blog-post.css
@@ -19,31 +19,43 @@
   }
 }
 
+.article-template__hero-small {
+  height: 11rem;
+}
+
 .article-template__hero-medium {
-  height: 15.6rem;
+  height: 22rem;
 }
 
 .article-template__hero-large {
-  height: 19rem;
+  height: 33rem;
 }
 
 @media screen and (min-width: 750px) and (max-width: 989px) {
-  .article-template__hero-medium {
-    height: 34.9rem;
+  .article-template__hero-small {
+    height: 22rem;
   }
 
-  .article-template__hero-large {
-    height: 42.3rem;
-  }
-}
-
-@media screen and (min-width: 990px) {
   .article-template__hero-medium {
-    height: 54.5rem;
+    height: 44rem;
   }
 
   .article-template__hero-large {
     height: 66rem;
+  }
+}
+
+@media screen and (min-width: 990px) {
+  .article-template__hero-small {
+    height: 27.5rem;
+  }
+
+  .article-template__hero-medium {
+    height: 55rem;
+  }
+
+  .article-template__hero-large {
+    height: 82.5rem;
   }
 }
 

--- a/assets/section-featured-blog.css
+++ b/assets/section-featured-blog.css
@@ -84,12 +84,6 @@
   margin-bottom: 1rem;
 }
 
-@media screen and (min-width: 750px) {
-  .blog__post:only-child {
-    text-align: center;
-  }
-}
-
 @media screen and (min-width: 990px) {
   .blog__posts.articles-wrapper {
     margin-bottom: 0;

--- a/assets/section-featured-blog.css
+++ b/assets/section-featured-blog.css
@@ -25,6 +25,7 @@
 @media screen and (min-width: 750px) {
   .blog-placeholder {
     text-align: center;
+    width: 50%;
   }
 }
 
@@ -119,18 +120,5 @@
 @media screen and (min-width: 750px) {
   .blog__button {
     margin-top: 5rem;
-  }
-}
-
-@media screen and (max-width: 749px) {
-  .slider.blog__posts--1-items {
-    padding-bottom: 0;
-  }
-}
-
-@media screen and (min-width: 750px) and (max-width: 989px) {
-  .slider.blog__posts--1-items,
-  .slider.blog__posts--2-items {
-    padding-bottom: 0;
   }
 }

--- a/assets/section-featured-blog.css
+++ b/assets/section-featured-blog.css
@@ -26,11 +26,6 @@
   .blog-placeholder {
     text-align: center;
     width: 50%;
-  }
-}
-
-@media screen and (min-width: 990px) {
-  .blog-placeholder {
     margin: 0;
   }
 }

--- a/assets/section-main-blog.css
+++ b/assets/section-main-blog.css
@@ -8,11 +8,34 @@
     grid-template-columns: 1fr 1fr;
   }
 
-  .blog-articles > *:first-child,
-  .blog-articles > *:nth-child(4),
-  .blog-articles > *:last-child:nth-child(2),
-  .blog-articles > *:last-child:nth-child(5) {
+  .blog-articles--collage > *:nth-child(3n + 1) {
     grid-column: span 2;
     text-align: center;
+  }
+
+  .blog-articles--collage > *:nth-child(3n + 1) .article-card__image--small {
+    padding-bottom: 22.0rem;
+  }
+
+  .blog-articles--collage > *:nth-child(3n + 1) .article-card__image--medium {
+    padding-bottom: 44.0rem;
+  }
+
+  .blog-articles--collage > *:nth-child(3n + 1) .article-card__image--large {
+    padding-bottom: 66.0rem;
+  }
+}
+
+@media screen and (min-width: 990px) {
+  .blog-articles--collage > *:nth-child(3n + 1) .article-card__image--small {
+    padding-bottom: 27.5rem;
+  }
+
+  .blog-articles--collage > *:nth-child(3n + 1) .article-card__image--medium {
+    padding-bottom: 55.0rem;
+  }
+
+  .blog-articles--collage > *:nth-child(3n + 1) .article-card__image--large {
+    padding-bottom: 82.5rem;
   }
 }

--- a/assets/section-main-blog.css
+++ b/assets/section-main-blog.css
@@ -14,15 +14,15 @@
   }
 
   .blog-articles--collage > *:nth-child(3n + 1) .article-card__image--small {
-    padding-bottom: 22.0rem;
+    padding-bottom: 22rem;
   }
 
   .blog-articles--collage > *:nth-child(3n + 1) .article-card__image--medium {
-    padding-bottom: 44.0rem;
+    padding-bottom: 44rem;
   }
 
   .blog-articles--collage > *:nth-child(3n + 1) .article-card__image--large {
-    padding-bottom: 66.0rem;
+    padding-bottom: 66rem;
   }
 }
 
@@ -32,7 +32,7 @@
   }
 
   .blog-articles--collage > *:nth-child(3n + 1) .article-card__image--medium {
-    padding-bottom: 55.0rem;
+    padding-bottom: 55rem;
   }
 
   .blog-articles--collage > *:nth-child(3n + 1) .article-card__image--large {

--- a/assets/section-main-blog.css
+++ b/assets/section-main-blog.css
@@ -8,34 +8,41 @@
     grid-template-columns: 1fr 1fr;
   }
 
-  .blog-articles--collage > *:nth-child(3n + 1) {
+  .blog-articles--collage > *:nth-child(3n + 1),
+  .blog-articles--collage > *:nth-child(3n + 2):last-child {
     grid-column: span 2;
     text-align: center;
   }
 
-  .blog-articles--collage > *:nth-child(3n + 1) .article-card__image--small {
+  .blog-articles--collage > *:nth-child(3n + 1) .article-card__image--small,
+  .blog-articles--collage > *:nth-child(3n + 2):last-child .article-card__image--small {
     padding-bottom: 22rem;
   }
 
-  .blog-articles--collage > *:nth-child(3n + 1) .article-card__image--medium {
+  .blog-articles--collage > *:nth-child(3n + 1) .article-card__image--medium,
+  .blog-articles--collage > *:nth-child(3n + 2):last-child .article-card__image--medium {
     padding-bottom: 44rem;
   }
 
-  .blog-articles--collage > *:nth-child(3n + 1) .article-card__image--large {
+  .blog-articles--collage > *:nth-child(3n + 1) .article-card__image--large,
+  .blog-articles--collage > *:nth-child(3n + 2):last-child .article-card__image--large {
     padding-bottom: 66rem;
   }
 }
 
 @media screen and (min-width: 990px) {
-  .blog-articles--collage > *:nth-child(3n + 1) .article-card__image--small {
+  .blog-articles--collage > *:nth-child(3n + 1) .article-card__image--small,
+  .blog-articles--collage > *:nth-child(3n + 2):last-child .article-card__image--small {
     padding-bottom: 27.5rem;
   }
 
-  .blog-articles--collage > *:nth-child(3n + 1) .article-card__image--medium {
+  .blog-articles--collage > *:nth-child(3n + 1) .article-card__image--medium,
+  .blog-articles--collage > *:nth-child(3n + 2):last-child .article-card__image--medium {
     padding-bottom: 55rem;
   }
 
-  .blog-articles--collage > *:nth-child(3n + 1) .article-card__image--large {
+  .blog-articles--collage > *:nth-child(3n + 1) .article-card__image--large,
+  .blog-articles--collage > *:nth-child(3n + 2):last-child .article-card__image--large {
     padding-bottom: 82.5rem;
   }
 }

--- a/locales/cs.schema.json
+++ b/locales/cs.schema.json
@@ -928,9 +928,12 @@
                 "label": "Přizpůsobení obrázku"
               },
               "options__2": {
-                "label": "Střední"
+                "label": "Malá"
               },
               "options__3": {
+                "label": "Střední"
+              },
+              "options__4": {
                 "label": "Velká"
               }
             }
@@ -987,6 +990,31 @@
         },
         "show_author": {
           "label": "Zobrazit autora"
+        },
+        "layout": {
+          "label": "Rozvržení na velkých obrazovkách",
+          "options__1": {
+            "label": "Mřížka"
+          },
+          "options__2": {
+            "label": "Koláž"
+          }
+        },
+        "image_height": {
+          "label": "Výška propagovaného obrázku",
+          "info": "Nejlepších výsledků dosáhnete pomocí obrázku s poměrem stran 2:3. [Zjistit více](https://help.shopify.com/en/manual/shopify-admin/productivity-tools/image-editor#understanding-image-aspect-ratio)",
+          "options__1": {
+            "label": "Přizpůsobení obrázku"
+          },
+          "options__2": {
+            "label": "Malá"
+          },
+          "options__3": {
+            "label": "Střední"
+          },
+          "options__4": {
+            "label": "Velká"
+          }
         }
       },
       "blocks": {

--- a/locales/da.schema.json
+++ b/locales/da.schema.json
@@ -927,12 +927,15 @@
                 "label": "Tilpas til billede"
               },
               "options__2": {
-                "label": "Medium"
+                "label": "Lille"
               },
               "options__3": {
-                "label": "Stor"
+                "label": "Medium"
               },
-              "info": "Brug et billede med et højde-bredde-forhold på 16:9 for at opnå det bedste resultat. [Få mere at vide](https://help.shopify.com/en/manual/shopify-admin/productivity-tools/image-editor#understanding-image-aspect-ratio)"
+              "info": "Brug et billede med et højde-bredde-forhold på 16:9 for at opnå det bedste resultat. [Få mere at vide](https://help.shopify.com/en/manual/shopify-admin/productivity-tools/image-editor#understanding-image-aspect-ratio)",
+              "options__4": {
+                "label": "Stor"
+              }
             }
           }
         },
@@ -987,6 +990,31 @@
         },
         "show_author": {
           "label": "Vis forfatter"
+        },
+        "layout": {
+          "label": "Layout på store skærme",
+          "options__1": {
+            "label": "Gitter"
+          },
+          "options__2": {
+            "label": "Kollage"
+          }
+        },
+        "image_height": {
+          "label": "Højde på udvalgt billede",
+          "options__1": {
+            "label": "Tilpas til billede"
+          },
+          "options__2": {
+            "label": "Lille"
+          },
+          "options__3": {
+            "label": "Medium"
+          },
+          "options__4": {
+            "label": "Stor"
+          },
+          "info": "Brug et billede med et højde-bredde-forhold på 2:3 for at opnå det bedste resultat. [Få mere at vide](https://help.shopify.com/en/manual/shopify-admin/productivity-tools/image-editor#understanding-image-aspect-ratio)"
         }
       },
       "blocks": {

--- a/locales/de.schema.json
+++ b/locales/de.schema.json
@@ -927,12 +927,15 @@
                 "label": "An Bild anpassen"
               },
               "options__2": {
-                "label": "Mittel"
+                "label": "Klein"
               },
               "options__3": {
-                "label": "Groß"
+                "label": "Mittel"
               },
-              "info": "Verwende für Bilder ein Seitenverhältnis von 16:9 für optimale Ergebnisse. [Mehr Informationen](https://help.shopify.com/en/manual/shopify-admin/productivity-tools/image-editor#understanding-image-aspect-ratio)"
+              "info": "Verwende für Bilder ein Seitenverhältnis von 16:9 für optimale Ergebnisse. [Mehr Informationen](https://help.shopify.com/en/manual/shopify-admin/productivity-tools/image-editor#understanding-image-aspect-ratio)",
+              "options__4": {
+                "label": "Groß"
+              }
             }
           }
         },
@@ -987,6 +990,31 @@
         },
         "show_author": {
           "label": "Autor anzeigen"
+        },
+        "layout": {
+          "label": "Layout auf großen Bildschirmen",
+          "options__1": {
+            "label": "Raster"
+          },
+          "options__2": {
+            "label": "Collage"
+          }
+        },
+        "image_height": {
+          "label": "Höhe des Feature-Bildes",
+          "options__1": {
+            "label": "An Bild anpassen"
+          },
+          "options__2": {
+            "label": "Klein"
+          },
+          "options__3": {
+            "label": "Mittel"
+          },
+          "options__4": {
+            "label": "Groß"
+          },
+          "info": "Verwende für Bilder ein Seitenverhältnis von 2:3 für optimale Ergebnisse. [Mehr Informationen](https://help.shopify.com/en/manual/shopify-admin/productivity-tools/image-editor#understanding-image-aspect-ratio)"
         }
       },
       "blocks": {

--- a/locales/en.default.schema.json
+++ b/locales/en.default.schema.json
@@ -1072,6 +1072,31 @@
         },
         "paragraph": {
           "content": "Change excerpts by editing your blog posts. [Learn more](https://help.shopify.com/en/manual/online-store/blogs/writing-blogs#display-an-excerpt-from-a-blog-post)"
+        },
+        "layout": {
+          "label": "Layout on large screens",
+          "options__1": {
+            "label": "Grid"
+          },
+          "options__2": {
+            "label": "Collage"
+          }
+        },
+        "image_height": {
+          "label": "Featured image height",
+          "options__1": {
+            "label": "Adapt to image"
+          },
+          "options__2": {
+            "label": "Small"
+          },
+          "options__3": {
+            "label": "Medium"
+          },
+          "options__4": {
+            "label": "Large"
+          },
+          "info": "For best results, use an image with a 2:3 aspect ratio. [Learn more](https://help.shopify.com/en/manual/shopify-admin/productivity-tools/image-editor#understanding-image-aspect-ratio)"
         }
       }
     },

--- a/locales/en.default.schema.json
+++ b/locales/en.default.schema.json
@@ -1015,9 +1015,12 @@
                 "label": "Adapt to image"
               },
               "options__2": {
-                "label": "Medium"
+                "label": "Small"
               },
               "options__3": {
+                "label": "Medium"
+              },
+              "options__4": {
                 "label": "Large"
               },
               "info": "For best results, use an image with a 16:9 aspect ratio. [Learn more](https://help.shopify.com/en/manual/shopify-admin/productivity-tools/image-editor#understanding-image-aspect-ratio)"

--- a/locales/es.schema.json
+++ b/locales/es.schema.json
@@ -927,12 +927,15 @@
                 "label": "Adaptar a la imagen"
               },
               "options__2": {
-                "label": "Mediano"
+                "label": "Pequeña"
               },
               "options__3": {
-                "label": "Grande"
+                "label": "Mediana"
               },
-              "info": "Para mejores resultados, utiliza una imagen con una relación de aspecto 16:9. [Más información](https://help.shopify.com/en/manual/shopify-admin/productivity-tools/image-editor#understanding-image-aspect-ratio)"
+              "info": "Para mejores resultados, utiliza una imagen con una relación de aspecto 16:9. [Más información](https://help.shopify.com/en/manual/shopify-admin/productivity-tools/image-editor#understanding-image-aspect-ratio)",
+              "options__4": {
+                "label": "Grande"
+              }
             }
           }
         },
@@ -987,6 +990,31 @@
         },
         "show_author": {
           "label": "Mostrar autor"
+        },
+        "layout": {
+          "label": "Diseño en pantallas grandes",
+          "options__1": {
+            "label": "Cuadrícula"
+          },
+          "options__2": {
+            "label": "Collage"
+          }
+        },
+        "image_height": {
+          "label": "Altura de imagen destacada",
+          "options__1": {
+            "label": "Adaptar a la imagen"
+          },
+          "options__2": {
+            "label": "Pequeña"
+          },
+          "options__3": {
+            "label": "Mediana"
+          },
+          "options__4": {
+            "label": "Grande"
+          },
+          "info": "Para mejores resultados, utiliza una imagen con una relación de aspecto 2:3. [Más información](https://help.shopify.com/en/manual/shopify-admin/productivity-tools/image-editor#understanding-image-aspect-ratio)"
         }
       },
       "blocks": {

--- a/locales/fi.schema.json
+++ b/locales/fi.schema.json
@@ -927,12 +927,15 @@
                 "label": "Sovita kuvaan"
               },
               "options__2": {
-                "label": "Keskisuuri"
+                "label": "Pieni"
               },
               "options__3": {
-                "label": "Suuri"
+                "label": "Keskisuuri"
               },
-              "info": "Saat parhaat tulokset käyttämällä kuvaa, jonka kuvasuhde on 16:9. [Lisätietoja](https://help.shopify.com/en/manual/shopify-admin/productivity-tools/image-editor#understanding-image-aspect-ratio)"
+              "info": "Saat parhaat tulokset käyttämällä kuvaa, jonka kuvasuhde on 16:9. [Lisätietoja](https://help.shopify.com/en/manual/shopify-admin/productivity-tools/image-editor#understanding-image-aspect-ratio)",
+              "options__4": {
+                "label": "Suuri"
+              }
             }
           }
         },
@@ -987,6 +990,31 @@
         },
         "show_author": {
           "label": "Näytä tekijä"
+        },
+        "layout": {
+          "label": "Asettelu suurilla näytöillä",
+          "options__1": {
+            "label": "Ruudukko"
+          },
+          "options__2": {
+            "label": "Kollaasi"
+          }
+        },
+        "image_height": {
+          "label": "Esittelykuvan korkeus",
+          "options__1": {
+            "label": "Sovita kuvaan"
+          },
+          "options__2": {
+            "label": "Pieni"
+          },
+          "options__3": {
+            "label": "Keskisuuri"
+          },
+          "options__4": {
+            "label": "Suuri"
+          },
+          "info": "Saat parhaat tulokset käyttämällä kuvaa, jonka kuvasuhde on 2:3. [Lisätietoja](https://help.shopify.com/en/manual/shopify-admin/productivity-tools/image-editor#understanding-image-aspect-ratio)"
         }
       },
       "blocks": {

--- a/locales/fr.schema.json
+++ b/locales/fr.schema.json
@@ -927,12 +927,15 @@
                 "label": "Adapter à l'image"
               },
               "options__2": {
-                "label": "Moyen"
+                "label": "Petit"
               },
               "options__3": {
-                "label": "Grand"
+                "label": "Moyen"
               },
-              "info": "Pour optimiser vos résultats, utilisez une image ayant un rapport d'aspect de 16:9. [En savoir plus](https://help.shopify.com/en/manual/shopify-admin/productivity-tools/image-editor#understanding-image-aspect-ratio)"
+              "info": "Pour optimiser vos résultats, utilisez une image ayant un rapport d'aspect de 16:9. [En savoir plus](https://help.shopify.com/en/manual/shopify-admin/productivity-tools/image-editor#understanding-image-aspect-ratio)",
+              "options__4": {
+                "label": "Grand"
+              }
             }
           }
         },
@@ -987,6 +990,31 @@
         },
         "show_author": {
           "label": "Afficher l'auteur"
+        },
+        "layout": {
+          "label": "Mise en page sur les grands écrans",
+          "options__1": {
+            "label": "Grille"
+          },
+          "options__2": {
+            "label": "Collage"
+          }
+        },
+        "image_height": {
+          "label": "Hauteur de l'image vedette",
+          "options__1": {
+            "label": "Adapter à l'image"
+          },
+          "options__2": {
+            "label": "Petit"
+          },
+          "options__3": {
+            "label": "Moyen"
+          },
+          "options__4": {
+            "label": "Grand"
+          },
+          "info": "Pour optimiser vos résultats, utilisez une image ayant un rapport d'aspect de 2:3. [En savoir plus](https://help.shopify.com/en/manual/shopify-admin/productivity-tools/image-editor#understanding-image-aspect-ratio)"
         }
       },
       "blocks": {

--- a/locales/it.schema.json
+++ b/locales/it.schema.json
@@ -927,12 +927,15 @@
                 "label": "Adatta all'immagine"
               },
               "options__2": {
-                "label": "Media"
+                "label": "Piccola"
               },
               "options__3": {
-                "label": "Grande"
+                "label": "Media"
               },
-              "info": "Per un risultato ottimale utilizza un'immagine con proporzioni 16:9. [Maggiori informazioni](https://help.shopify.com/en/manual/shopify-admin/productivity-tools/image-editor#understanding-image-aspect-ratio)"
+              "info": "Per un risultato ottimale utilizza un'immagine con proporzioni 16:9. [Maggiori informazioni](https://help.shopify.com/en/manual/shopify-admin/productivity-tools/image-editor#understanding-image-aspect-ratio)",
+              "options__4": {
+                "label": "Grande"
+              }
             }
           }
         },
@@ -987,6 +990,31 @@
         },
         "show_author": {
           "label": "Mostra autore"
+        },
+        "layout": {
+          "label": "Layout su schermi grandi",
+          "options__1": {
+            "label": "Griglia"
+          },
+          "options__2": {
+            "label": "Collage"
+          }
+        },
+        "image_height": {
+          "label": "Altezza immagine in evidenza",
+          "options__1": {
+            "label": "Adatta all'immagine"
+          },
+          "options__2": {
+            "label": "Piccola"
+          },
+          "options__3": {
+            "label": "Media"
+          },
+          "options__4": {
+            "label": "Grande"
+          },
+          "info": "Per un risultato ottimale, utilizza un'immagine con proporzioni 2:3. [Maggiori informazioni](https://help.shopify.com/en/manual/shopify-admin/productivity-tools/image-editor#understanding-image-aspect-ratio)"
         }
       },
       "blocks": {

--- a/locales/ja.schema.json
+++ b/locales/ja.schema.json
@@ -934,12 +934,15 @@
                 "label": "画像に合わせる"
               },
               "options__2": {
-                "label": "中"
+                "label": "小"
               },
               "options__3": {
-                "label": "大"
+                "label": "中"
               },
-              "info": "画像のアスペクト比が16:9のものを使用すると最適です。[詳しくはこちら](https://help.shopify.com/en/manual/shopify-admin/productivity-tools/image-editor#understanding-image-aspect-ratio)"
+              "info": "画像のアスペクト比が16:9のものを使用すると最適です。[詳しくはこちら](https://help.shopify.com/en/manual/shopify-admin/productivity-tools/image-editor#understanding-image-aspect-ratio)",
+              "options__4": {
+                "label": "大"
+              }
             }
           },
           "name": "記事のサムネイル"
@@ -995,6 +998,31 @@
         },
         "show_author": {
           "label": "執筆者を表示する"
+        },
+        "layout": {
+          "label": "大画面でのレイアウト",
+          "options__1": {
+            "label": "グリッド"
+          },
+          "options__2": {
+            "label": "コラージュ"
+          }
+        },
+        "image_height": {
+          "label": "記事のサムネイルの高さ",
+          "options__1": {
+            "label": "画像に合わせる"
+          },
+          "options__2": {
+            "label": "小"
+          },
+          "options__3": {
+            "label": "中"
+          },
+          "options__4": {
+            "label": "大"
+          },
+          "info": "画像のアスペクト比が2:3のものを使用すると最適です。[詳しくはこちら](https://help.shopify.com/en/manual/shopify-admin/productivity-tools/image-editor#understanding-image-aspect-ratio)"
         }
       },
       "blocks": {

--- a/locales/ko.schema.json
+++ b/locales/ko.schema.json
@@ -934,12 +934,15 @@
                 "label": "이미지에 맞춤"
               },
               "options__2": {
-                "label": "보통"
+                "label": "작게"
               },
               "options__3": {
-                "label": "크게"
+                "label": "보통"
               },
-              "info": "최고의 결과를 얻으려면 이미지의 가로 세로 비율을 16:9로 사용하십시오. [자세히 알아보기](https://help.shopify.com/en/manual/shopify-admin/productivity-tools/image-editor#understanding-image-aspect-ratio)"
+              "info": "최고의 결과를 얻으려면 이미지의 가로 세로 비율을 16:9로 사용하십시오. [자세히 알아보기](https://help.shopify.com/en/manual/shopify-admin/productivity-tools/image-editor#understanding-image-aspect-ratio)",
+              "options__4": {
+                "label": "크게"
+              }
             }
           },
           "name": "추천 이미지"
@@ -995,6 +998,31 @@
         },
         "show_author": {
           "label": "작성자 표시"
+        },
+        "layout": {
+          "label": "큰 화면 레이아웃",
+          "options__1": {
+            "label": "그리드"
+          },
+          "options__2": {
+            "label": "콜라주"
+          }
+        },
+        "image_height": {
+          "label": "추천 이미지 높이",
+          "options__1": {
+            "label": "이미지에 맞춤"
+          },
+          "options__2": {
+            "label": "작게"
+          },
+          "options__3": {
+            "label": "보통"
+          },
+          "options__4": {
+            "label": "크게"
+          },
+          "info": "최고의 결과를 얻으려면 이미지의 가로 세로 비율을 2:3으로 사용하십시오. [자세히 알아보기](https://help.shopify.com/en/manual/shopify-admin/productivity-tools/image-editor#understanding-image-aspect-ratio)"
         }
       },
       "blocks": {

--- a/locales/nb.schema.json
+++ b/locales/nb.schema.json
@@ -927,12 +927,15 @@
                 "label": "Tilpass til bilde"
               },
               "options__2": {
-                "label": "Middels"
+                "label": "Liten"
               },
               "options__3": {
-                "label": "Stor"
+                "label": "Middels"
               },
-              "info": "Bruk et bilde med størrelsesforhold 16:9 for best resultat. [Finn ut mer](https://help.shopify.com/en/manual/shopify-admin/productivity-tools/image-editor#understanding-image-aspect-ratio)"
+              "info": "Bruk et bilde med størrelsesforhold 16:9 for best resultat. [Finn ut mer](https://help.shopify.com/en/manual/shopify-admin/productivity-tools/image-editor#understanding-image-aspect-ratio)",
+              "options__4": {
+                "label": "Stor"
+              }
             }
           }
         },
@@ -987,6 +990,31 @@
         },
         "show_author": {
           "label": "Vis forfatter"
+        },
+        "layout": {
+          "label": "Layout på store skjermer",
+          "options__1": {
+            "label": "Rutenett"
+          },
+          "options__2": {
+            "label": "Fotomontasje"
+          }
+        },
+        "image_height": {
+          "label": "Høyde på fremhevet bilde",
+          "options__1": {
+            "label": "Tilpass til bilde"
+          },
+          "options__2": {
+            "label": "Liten"
+          },
+          "options__3": {
+            "label": "Middels"
+          },
+          "options__4": {
+            "label": "Stor"
+          },
+          "info": "Bruk et bilde med størrelsesforhold 2:3 for best resultat. [Finn ut mer](https://help.shopify.com/en/manual/shopify-admin/productivity-tools/image-editor#understanding-image-aspect-ratio)"
         }
       },
       "blocks": {

--- a/locales/nl.schema.json
+++ b/locales/nl.schema.json
@@ -927,12 +927,15 @@
                 "label": "Aanpassen aan afbeelding"
               },
               "options__2": {
-                "label": "Medium"
+                "label": "Klein"
               },
               "options__3": {
-                "label": "Groot"
+                "label": "Gemiddeld"
               },
-              "info": "Gebruik voor de beste resultaten een afbeelding met een beeldverhouding van 16:9. [Meer informatie](https://help.shopify.com/en/manual/shopify-admin/productivity-tools/image-editor#understanding-image-aspect-ratio)"
+              "info": "Gebruik voor de beste resultaten een afbeelding met een beeldverhouding van 16:9. [Meer informatie](https://help.shopify.com/en/manual/shopify-admin/productivity-tools/image-editor#understanding-image-aspect-ratio)",
+              "options__4": {
+                "label": "Groot"
+              }
             }
           }
         },
@@ -987,6 +990,31 @@
         },
         "show_author": {
           "label": "Auteur weergeven"
+        },
+        "layout": {
+          "label": "Opmaak op grote schermen",
+          "options__1": {
+            "label": "Grid"
+          },
+          "options__2": {
+            "label": "Collage"
+          }
+        },
+        "image_height": {
+          "label": "Hoogte van uitgelichte afbeelding",
+          "options__1": {
+            "label": "Aanpassen aan afbeelding"
+          },
+          "options__2": {
+            "label": "Klein"
+          },
+          "options__3": {
+            "label": "Gemiddeld"
+          },
+          "options__4": {
+            "label": "Groot"
+          },
+          "info": "Gebruik voor de beste resultaten een afbeelding met een beeldverhouding van 2:3. [Meer informatie](https://help.shopify.com/en/manual/shopify-admin/productivity-tools/image-editor#understanding-image-aspect-ratio)"
         }
       },
       "blocks": {

--- a/locales/pl.schema.json
+++ b/locales/pl.schema.json
@@ -928,9 +928,12 @@
                 "label": "Dostosuj do obrazu"
               },
               "options__2": {
-                "label": "Średni"
+                "label": "Mały"
               },
               "options__3": {
+                "label": "Średni"
+              },
+              "options__4": {
                 "label": "Duży"
               }
             }
@@ -987,6 +990,31 @@
         },
         "show_author": {
           "label": "Pokaż autora"
+        },
+        "layout": {
+          "label": "Układ na dużych ekranach",
+          "options__1": {
+            "label": "Siatka"
+          },
+          "options__2": {
+            "label": "Kolaż"
+          }
+        },
+        "image_height": {
+          "label": "Wysokość wyróżnionego obrazu",
+          "info": "Aby uzyskać najlepsze wyniki, użyj obrazu o współczynniku proporcji 2:3. [Dowiedz się więcej](https://help.shopify.com/en/manual/shopify-admin/productivity-tools/image-editor#understanding-image-aspect-ratio)",
+          "options__1": {
+            "label": "Dostosuj do obrazu"
+          },
+          "options__2": {
+            "label": "Mały"
+          },
+          "options__3": {
+            "label": "Średni"
+          },
+          "options__4": {
+            "label": "Duży"
+          }
         }
       },
       "blocks": {

--- a/locales/pt-BR.schema.json
+++ b/locales/pt-BR.schema.json
@@ -1014,7 +1014,7 @@
           "options__4": {
             "label": "Grande"
           },
-          "info": "Use uma imagem com taxa de proporção de 2:3 para ter os melhores resultados. [Saiba mais.](https://help.shopify.com/en/manual/shopify-admin/productivity-tools/image-editor#understanding-image-aspect-ratio)"
+          "info": "Use uma imagem com proporção 2:3 para ter os melhores resultados. [Saiba mais.](https://help.shopify.com/en/manual/shopify-admin/productivity-tools/image-editor#understanding-image-aspect-ratio)"
         }
       },
       "blocks": {

--- a/locales/pt-BR.schema.json
+++ b/locales/pt-BR.schema.json
@@ -927,9 +927,12 @@
                 "label": "Adaptar à imagem"
               },
               "options__2": {
-                "label": "Médio"
+                "label": "Pequena"
               },
               "options__3": {
+                "label": "Média"
+              },
+              "options__4": {
                 "label": "Grande"
               },
               "info": "Use uma imagem com proporção 16:9 para ter os melhores resultados. [Saiba mais](https://help.shopify.com/en/manual/shopify-admin/productivity-tools/image-editor#understanding-image-aspect-ratio)"
@@ -987,6 +990,31 @@
         },
         "show_author": {
           "label": "Exibir autor"
+        },
+        "layout": {
+          "label": "Layout em telas grandes",
+          "options__1": {
+            "label": "Grade"
+          },
+          "options__2": {
+            "label": "Colagem"
+          }
+        },
+        "image_height": {
+          "label": "Altura da imagem em destaque",
+          "options__1": {
+            "label": "Adaptar à imagem"
+          },
+          "options__2": {
+            "label": "Pequena"
+          },
+          "options__3": {
+            "label": "Média"
+          },
+          "options__4": {
+            "label": "Grande"
+          },
+          "info": "Use uma imagem com taxa de proporção de 2:3 para ter os melhores resultados. [Saiba mais.](https://help.shopify.com/en/manual/shopify-admin/productivity-tools/image-editor#understanding-image-aspect-ratio)"
         }
       },
       "blocks": {

--- a/locales/pt-PT.schema.json
+++ b/locales/pt-PT.schema.json
@@ -934,12 +934,15 @@
                 "label": "Adaptar à imagem"
               },
               "options__2": {
-                "label": "Média"
+                "label": "Pequeno"
               },
               "options__3": {
-                "label": "Grande"
+                "label": "Médio"
               },
-              "info": "Para obter os melhores resultados, utilize uma imagem com uma proporção de 16:9. [Saber mais](https://help.shopify.com/en/manual/shopify-admin/productivity-tools/image-editor#understanding-image-aspect-ratio)"
+              "info": "Para obter os melhores resultados, utilize uma imagem com uma proporção de 16:9. [Saber mais](https://help.shopify.com/en/manual/shopify-admin/productivity-tools/image-editor#understanding-image-aspect-ratio)",
+              "options__4": {
+                "label": "Grande"
+              }
             }
           },
           "name": "Imagem em destaque"
@@ -995,6 +998,31 @@
         },
         "show_author": {
           "label": "Mostrar autor"
+        },
+        "layout": {
+          "label": "Esquema em ecrãs grandes",
+          "options__1": {
+            "label": "Grelha"
+          },
+          "options__2": {
+            "label": "Colagem"
+          }
+        },
+        "image_height": {
+          "label": "Altura da imagem em destaque",
+          "options__1": {
+            "label": "Adaptar à imagem"
+          },
+          "options__2": {
+            "label": "Pequeno"
+          },
+          "options__3": {
+            "label": "Médio"
+          },
+          "options__4": {
+            "label": "Grande"
+          },
+          "info": "Para obter os melhores resultados, utilize uma imagem com uma proporção de 2:3. [Saber mais](https://help.shopify.com/en/manual/shopify-admin/productivity-tools/image-editor#understanding-image-aspect-ratio)"
         }
       },
       "blocks": {

--- a/locales/sv.schema.json
+++ b/locales/sv.schema.json
@@ -934,12 +934,15 @@
                 "label": "Anpassa till bild"
               },
               "options__2": {
-                "label": "Medel"
+                "label": "Liten"
               },
               "options__3": {
-                "label": "Stor"
+                "label": "Medel"
               },
-              "info": "Använd en bild med bildformat 16:9, för bästa resultat. [Mer information](https://help.shopify.com/en/manual/shopify-admin/productivity-tools/image-editor#understanding-image-aspect-ratio)"
+              "info": "Använd en bild med bildformat 16:9, för bästa resultat. [Mer information](https://help.shopify.com/en/manual/shopify-admin/productivity-tools/image-editor#understanding-image-aspect-ratio)",
+              "options__4": {
+                "label": "Stor"
+              }
             }
           },
           "name": "Utvald bild"
@@ -995,6 +998,31 @@
         },
         "show_author": {
           "label": "Visa författare"
+        },
+        "layout": {
+          "label": "Layout på stora skärmar",
+          "options__1": {
+            "label": "Rutnät"
+          },
+          "options__2": {
+            "label": "Kollage"
+          }
+        },
+        "image_height": {
+          "label": "Bildhöjd på utvald bild",
+          "options__1": {
+            "label": "Anpassa till bild"
+          },
+          "options__2": {
+            "label": "Liten"
+          },
+          "options__3": {
+            "label": "Medel"
+          },
+          "options__4": {
+            "label": "Stor"
+          },
+          "info": "Använd en bild med bildformat 2:3, för bästa resultat. [Mer information](https://help.shopify.com/en/manual/shopify-admin/productivity-tools/image-editor#understanding-image-aspect-ratio)"
         }
       },
       "blocks": {

--- a/locales/th.schema.json
+++ b/locales/th.schema.json
@@ -934,12 +934,15 @@
                 "label": "ปรับตามรูปภาพ"
               },
               "options__2": {
-                "label": "ปานกลาง"
+                "label": "เล็ก"
               },
               "options__3": {
-                "label": "ใหญ่"
+                "label": "ปานกลาง"
               },
-              "info": "ใช้รูปภาพที่มีอัตราส่วนภาพ 16:9 เพื่อผลลัพธ์ที่ดีที่สุด [ดูข้อมูลเพิ่มเติม](https://help.shopify.com/en/manual/shopify-admin/productivity-tools/image-editor#understanding-image-aspect-ratio)"
+              "info": "ใช้รูปภาพที่มีอัตราส่วนภาพ 16:9 เพื่อผลลัพธ์ที่ดีที่สุด [ดูข้อมูลเพิ่มเติม](https://help.shopify.com/en/manual/shopify-admin/productivity-tools/image-editor#understanding-image-aspect-ratio)",
+              "options__4": {
+                "label": "ใหญ่"
+              }
             }
           },
           "name": "รูปภาพที่แสดง"
@@ -995,6 +998,31 @@
         },
         "show_author": {
           "label": "แสดงผู้เขียน"
+        },
+        "layout": {
+          "label": "เลย์เอาต์บนหน้าจอใหญ่",
+          "options__1": {
+            "label": "กริด"
+          },
+          "options__2": {
+            "label": "คอลลาจ"
+          }
+        },
+        "image_height": {
+          "label": "ความสูงของรูปภาพที่แสดง",
+          "options__1": {
+            "label": "ปรับตามรูปภาพ"
+          },
+          "options__2": {
+            "label": "เล็ก"
+          },
+          "options__3": {
+            "label": "ปานกลาง"
+          },
+          "options__4": {
+            "label": "ใหญ่"
+          },
+          "info": "ใช้รูปภาพที่มีอัตราส่วนภาพ 2:3 เพื่อผลลัพธ์ที่ดีที่สุด [ดูข้อมูลเพิ่มเติม](https://help.shopify.com/en/manual/shopify-admin/productivity-tools/image-editor#understanding-image-aspect-ratio)"
         }
       },
       "blocks": {

--- a/locales/tr.schema.json
+++ b/locales/tr.schema.json
@@ -927,12 +927,15 @@
                 "label": "Görsele uyarla"
               },
               "options__2": {
-                "label": "Orta"
+                "label": "Küçük"
               },
               "options__3": {
-                "label": "Büyük"
+                "label": "Orta"
               },
-              "info": "En iyi sonuçlar için 16:9 en-boy oranına sahip bir görsel kullanın. [Daha fazla bilgi edinin](https://help.shopify.com/en/manual/shopify-admin/productivity-tools/image-editor#understanding-image-aspect-ratio)"
+              "info": "En iyi sonuçlar için 16:9 en-boy oranına sahip bir görsel kullanın. [Daha fazla bilgi edinin](https://help.shopify.com/en/manual/shopify-admin/productivity-tools/image-editor#understanding-image-aspect-ratio)",
+              "options__4": {
+                "label": "Büyük"
+              }
             }
           }
         },
@@ -987,6 +990,31 @@
         },
         "show_author": {
           "label": "Yazarı göster"
+        },
+        "layout": {
+          "label": "Geniş ekranlardaki düzen",
+          "options__1": {
+            "label": "Izgara"
+          },
+          "options__2": {
+            "label": "Kolaj"
+          }
+        },
+        "image_height": {
+          "label": "Öne çıkan görsel yüksekliği",
+          "options__1": {
+            "label": "Görsele uyarla"
+          },
+          "options__2": {
+            "label": "Küçük"
+          },
+          "options__3": {
+            "label": "Orta"
+          },
+          "options__4": {
+            "label": "Büyük"
+          },
+          "info": "En iyi sonuçlar için 2:3 en-boy oranına sahip bir görsel kullanın. [Daha fazla bilgi edinin](https://help.shopify.com/en/manual/shopify-admin/productivity-tools/image-editor#understanding-image-aspect-ratio)"
         }
       },
       "blocks": {

--- a/locales/vi.schema.json
+++ b/locales/vi.schema.json
@@ -927,12 +927,15 @@
                 "label": "Điều chỉnh theo hình ảnh"
               },
               "options__2": {
-                "label": "Trung bình"
+                "label": "Nhỏ"
               },
               "options__3": {
-                "label": "Lớn"
+                "label": "Trung bình"
               },
-              "info": "Để có kết quả tốt nhất, hãy sử dụng hình ảnh có tỷ lệ khung hình 16:9. [Tìm hiểu thêm](https://help.shopify.com/en/manual/shopify-admin/productivity-tools/image-editor#understanding-image-aspect-ratio)"
+              "info": "Để có kết quả tốt nhất, hãy sử dụng hình ảnh có tỷ lệ khung hình 16:9. [Tìm hiểu thêm](https://help.shopify.com/en/manual/shopify-admin/productivity-tools/image-editor#understanding-image-aspect-ratio)",
+              "options__4": {
+                "label": "Lớn"
+              }
             }
           }
         },
@@ -987,6 +990,31 @@
         },
         "show_author": {
           "label": "Hiển thị tác giả"
+        },
+        "layout": {
+          "label": "Bố cục trên màn hình lớn",
+          "options__1": {
+            "label": "Lưới"
+          },
+          "options__2": {
+            "label": "Ghép"
+          }
+        },
+        "image_height": {
+          "label": "Chiều cao hình ảnh nổi bật",
+          "options__1": {
+            "label": "Điều chỉnh theo hình ảnh"
+          },
+          "options__2": {
+            "label": "Nhỏ"
+          },
+          "options__3": {
+            "label": "Trung bình"
+          },
+          "options__4": {
+            "label": "Lớn"
+          },
+          "info": "Để có kết quả tốt nhất, hãy sử dụng hình ảnh có tỷ lệ khung hình 2:3. [Tìm hiểu thêm](https://help.shopify.com/en/manual/shopify-admin/productivity-tools/image-editor#understanding-image-aspect-ratio)"
         }
       },
       "blocks": {

--- a/locales/zh-CN.schema.json
+++ b/locales/zh-CN.schema.json
@@ -934,12 +934,15 @@
                 "label": "适应图片"
               },
               "options__2": {
-                "label": "中"
+                "label": "小"
               },
               "options__3": {
-                "label": "大"
+                "label": "中"
               },
-              "info": "若要获得最佳效果，请使用纵横比为 16:9 的图片。[了解详细信息](https://help.shopify.com/en/manual/shopify-admin/productivity-tools/image-editor#understanding-image-aspect-ratio)"
+              "info": "若要获得最佳效果，请使用纵横比为 16:9 的图片。[了解详细信息](https://help.shopify.com/en/manual/shopify-admin/productivity-tools/image-editor#understanding-image-aspect-ratio)",
+              "options__4": {
+                "label": "大"
+              }
             }
           },
           "name": "配图"
@@ -995,6 +998,31 @@
         },
         "show_author": {
           "label": "显示作者"
+        },
+        "layout": {
+          "label": "在大屏幕上的布局",
+          "options__1": {
+            "label": "网格"
+          },
+          "options__2": {
+            "label": "拼贴"
+          }
+        },
+        "image_height": {
+          "label": "配图高度",
+          "options__1": {
+            "label": "适应图片"
+          },
+          "options__2": {
+            "label": "小"
+          },
+          "options__3": {
+            "label": "中"
+          },
+          "options__4": {
+            "label": "大"
+          },
+          "info": "若要获得最佳效果，请使用纵横比为 2:3 的图片。[了解详细信息](https://help.shopify.com/en/manual/shopify-admin/productivity-tools/image-editor#understanding-image-aspect-ratio)"
         }
       },
       "blocks": {

--- a/locales/zh-TW.schema.json
+++ b/locales/zh-TW.schema.json
@@ -934,12 +934,15 @@
                 "label": "配合圖片"
               },
               "options__2": {
-                "label": "中等"
+                "label": "小"
               },
               "options__3": {
-                "label": "大"
+                "label": "中等"
               },
-              "info": "若想要獲得最佳結果，請使用寬高比為 16:9 的圖片。[瞭解詳情](https://help.shopify.com/en/manual/shopify-admin/productivity-tools/image-editor#understanding-image-aspect-ratio)"
+              "info": "若想要獲得最佳結果，請使用寬高比為 16:9 的圖片。[瞭解詳情](https://help.shopify.com/en/manual/shopify-admin/productivity-tools/image-editor#understanding-image-aspect-ratio)",
+              "options__4": {
+                "label": "大"
+              }
             }
           },
           "name": "主要圖片"
@@ -995,6 +998,31 @@
         },
         "show_author": {
           "label": "顯示作者"
+        },
+        "layout": {
+          "label": "大型螢幕上的版面配置",
+          "options__1": {
+            "label": "網格"
+          },
+          "options__2": {
+            "label": "拼貼"
+          }
+        },
+        "image_height": {
+          "label": "主要圖片高度",
+          "options__1": {
+            "label": "配合圖片"
+          },
+          "options__2": {
+            "label": "小"
+          },
+          "options__3": {
+            "label": "中等"
+          },
+          "options__4": {
+            "label": "大"
+          },
+          "info": "若想要獲得最佳結果，請使用寬高比為 2:3 的圖片。[瞭解詳情](https://help.shopify.com/en/manual/shopify-admin/productivity-tools/image-editor#understanding-image-aspect-ratio)"
         }
       },
       "blocks": {

--- a/sections/featured-blog.liquid
+++ b/sections/featured-blog.liquid
@@ -8,10 +8,16 @@
 <noscript>{{ 'component-article-card.css' | asset_url | stylesheet_tag }}</noscript>
 
 {{ 'section-featured-blog.css' | asset_url | stylesheet_tag }}
-
+{%- liquid
+  assign posts_displayed = section.settings.blog.articles_count
+  if section.settings.post_limit <= section.settings.blog.articles_count
+    assign posts_exceed_limit = true
+    assign posts_displayed = section.settings.post_limit
+  endif
+-%}
 <div class="blog{% if section.settings.soft_background %} background-secondary{% endif %}{% if section.settings.heading == blank %} no-heading{% endif %}">
-  <div class="page-width-desktop">
-    <div class="title-wrapper-with-link{% if section.settings.heading == blank %} title-wrapper-with-link--no-heading{% endif %} title-wrapper--self-padded-tablet-down">
+  <div class="{% if posts_displayed < 3 %}page-width-tablet{% else %}page-width-desktop{% endif %}">
+    <div class="title-wrapper-with-link{% if section.settings.heading == blank %} title-wrapper-with-link--no-heading{% endif %} {% if posts_displayed > 2 %}title-wrapper--self-padded-tablet-down{% else %}title-wrapper--self-padded-mobile{% endif %}">
       <h2 class="blog__title">{{ section.settings.heading | escape }}</h2>
 
       {%- if section.settings.blog != blank and section.settings.show_view_all and section.settings.post_limit < section.settings.blog.articles_count -%}
@@ -22,15 +28,10 @@
         </a>
       {%- endif -%}
     </div>
-    {%- liquid
-      if section.settings.post_limit <= section.settings.blog.articles_count
-        assign posts_exceed_limit = true
-      endif
-    -%}
     {%- if section.settings.blog != blank and section.settings.blog.articles_count > 0 -%}
       <slider-component class="slider-mobile-gutter">
         <ul id="Slider-{{ section.id }}"
-          class="blog__posts articles-wrapper grid grid--peek grid--2-col-tablet grid--3-col-desktop slider slider--tablet{% if posts_exceed_limit %} blog__posts--{{ section.settings.post_limit }}-items{% else %} blog__posts--{{ section.settings.blog.articles_count }}-items{% endif %}"
+          class="blog__posts articles-wrapper grid grid--peek grid--2-col-tablet grid--4-col-desktop slider {% if posts_displayed > 2 %}slider--tablet{% else %}slider--mobile{% endif %}"
           role="list"
         >
           {%- for article in section.settings.blog.articles limit: section.settings.post_limit -%}
@@ -98,8 +99,8 @@
     {
       "type": "range",
       "id": "post_limit",
-      "min": 1,
-      "max": 3,
+      "min": 2,
+      "max": 4,
       "step": 1,
       "default": 3,
       "label": "t:sections.featured-blog.settings.post_limit.label"

--- a/sections/featured-blog.liquid
+++ b/sections/featured-blog.liquid
@@ -16,7 +16,7 @@
   endif
 -%}
 <div class="blog{% if section.settings.soft_background %} background-secondary{% endif %}{% if section.settings.heading == blank %} no-heading{% endif %}">
-  <div class="{% if posts_displayed < 3 %}page-width-tablet{% else %}page-width-desktop{% endif %}">
+  <div class="page-width-desktop{% if posts_displayed < 3 %} page-width-tablet{% endif %}">
     <div class="title-wrapper-with-link{% if section.settings.heading == blank %} title-wrapper-with-link--no-heading{% endif %} {% if posts_displayed > 2 %}title-wrapper--self-padded-tablet-down{% else %}title-wrapper--self-padded-mobile{% endif %}">
       <h2 class="blog__title">{{ section.settings.heading | escape }}</h2>
 

--- a/sections/main-article.liquid
+++ b/sections/main-article.liquid
@@ -307,12 +307,16 @@
               "label": "t:sections.main-article.blocks.featured_image.settings.image_height.options__1.label"
             },
             {
-              "value": "medium",
+              "value": "small",
               "label": "t:sections.main-article.blocks.featured_image.settings.image_height.options__2.label"
             },
             {
-              "value": "large",
+              "value": "medium",
               "label": "t:sections.main-article.blocks.featured_image.settings.image_height.options__3.label"
+            },
+            {
+              "value": "large",
+              "label": "t:sections.main-article.blocks.featured_image.settings.image_height.options__4.label"
             }
           ],
           "default": "adapt",

--- a/sections/main-blog.liquid
+++ b/sections/main-blog.liquid
@@ -45,7 +45,7 @@
           "label": "t:sections.main-blog.settings.layout.options__2.label"
         }
       ],
-      "default": "grid",
+      "default": "collage",
       "label": "t:sections.main-blog.settings.layout.label"
     },
     {
@@ -75,7 +75,7 @@
           "label": "t:sections.main-blog.settings.image_height.options__4.label"
         }
       ],
-      "default": "small",
+      "default": "medium",
       "label": "t:sections.main-blog.settings.image_height.label",
       "info": "t:sections.main-blog.settings.image_height.info"
     },

--- a/sections/main-blog.liquid
+++ b/sections/main-blog.liquid
@@ -8,10 +8,10 @@
   <div class="main-blog page-width">
     <h1 class="title--primary">{{ blog.title | escape }}</h1>
 
-    <div class="blog-articles">
+    <div class="blog-articles {% if section.settings.layout == 'collage' %}blog-articles--collage{% endif %}">
       {%- for article in blog.articles -%}
         <div class="blog-articles__article article">
-          {%- render 'article-card', article: article, show_image: section.settings.show_image, show_date: section.settings.show_date, show_author: section.settings.show_author -%}
+          {%- render 'article-card', article: article, image_height: section.settings.image_height, show_image: section.settings.show_image, show_date: section.settings.show_date, show_author: section.settings.show_author -%}
         </div>
       {%- endfor -%}
     </div>
@@ -33,11 +33,51 @@
       "content": "t:sections.main-blog.settings.header.content"
     },
     {
+      "type": "select",
+      "id": "layout",
+      "options": [
+        {
+          "value": "grid",
+          "label": "t:sections.main-blog.settings.layout.options__1.label"
+        },
+        {
+          "value": "collage",
+          "label": "t:sections.main-blog.settings.layout.options__2.label"
+        }
+      ],
+      "default": "grid",
+      "label": "t:sections.main-blog.settings.layout.label"
+    },
+    {
       "type": "checkbox",
       "id": "show_image",
       "default": true,
-      "label": "t:sections.main-blog.settings.show_image.label",
-      "info": "t:sections.main-blog.settings.show_image.info"
+      "label": "t:sections.main-blog.settings.show_image.label"
+    },
+    {
+      "type": "select",
+      "id": "image_height",
+      "options": [
+        {
+          "value": "adapt",
+          "label": "t:sections.main-blog.settings.image_height.options__1.label"
+        },
+        {
+          "value": "small",
+          "label": "t:sections.main-blog.settings.image_height.options__2.label"
+        },
+        {
+          "value": "medium",
+          "label": "t:sections.main-blog.settings.image_height.options__3.label"
+        },
+        {
+          "value": "large",
+          "label": "t:sections.main-blog.settings.image_height.options__4.label"
+        }
+      ],
+      "default": "adapt",
+      "label": "t:sections.main-blog.settings.image_height.label",
+      "info": "t:sections.main-blog.settings.image_height.info"
     },
     {
       "type": "checkbox",

--- a/sections/main-blog.liquid
+++ b/sections/main-blog.liquid
@@ -75,7 +75,7 @@
           "label": "t:sections.main-blog.settings.image_height.options__4.label"
         }
       ],
-      "default": "adapt",
+      "default": "small",
       "label": "t:sections.main-blog.settings.image_height.label",
       "info": "t:sections.main-blog.settings.image_height.info"
     },

--- a/snippets/article-card.liquid
+++ b/snippets/article-card.liquid
@@ -17,7 +17,7 @@
   <a href="{{ article.url }}" class="article-content motion-reduce">
     {%- if show_image == true and article.image -%}
       <div class="article-card__image-wrapper">
-        <div class="article-card__image media article-card__image--{{ image_height }}" {% if section.settings.image_height == 'adapt' %}style="padding-bottom: {{ 1 | divided_by: article.image.aspect_ratio | times: 100 }}%;"{% endif %}>
+        <div class="article-card__image media {% if image_height %}article-card__image--{{ image_height }}{% else %}media--landscape{% endif %}" {% if section.settings.image_height == 'adapt' %} style="padding-bottom: {{ 1 | divided_by: article.image.aspect_ratio | times: 100 }}%;"{% endif %}>
           <img
             srcset="{%- if article.image.src.width >= 165 -%}{{ article.image.src | img_url: '165x' }} 165w,{%- endif -%}
               {%- if article.image.src.width >= 360 -%}{{ article.image.src | img_url: '360x' }} 360w,{%- endif -%}

--- a/snippets/article-card.liquid
+++ b/snippets/article-card.liquid
@@ -4,6 +4,7 @@
     Accepts:
     - blog: {Object} Blog object
     - article: {Object} Article object
+    - image_height: {String} The setting changes the height of the article image, if shown
     - show_image: {String} The setting either show the article image or not. If it's not included it will show the image by default
     - show_date: {String} The setting either show the article date or not. If it's not included it will not show the image by default
     - show_author: {String} The setting either show the article author or not. If it's not included it will not show the author by default
@@ -16,7 +17,7 @@
   <a href="{{ article.url }}" class="article-content motion-reduce">
     {%- if show_image == true and article.image -%}
       <div class="article-card__image-wrapper">
-        <div class="article-card__image media media--landscape">
+        <div class="article-card__image media article-card__image--{{ image_height }}" {% if section.settings.image_height == 'adapt' %}style="padding-bottom: {{ 1 | divided_by: article.image.aspect_ratio | times: 100 }}%;"{% endif %}>
           <img
             srcset="{%- if article.image.src.width >= 165 -%}{{ article.image.src | img_url: '165x' }} 165w,{%- endif -%}
               {%- if article.image.src.width >= 360 -%}{{ article.image.src | img_url: '360x' }} 360w,{%- endif -%}


### PR DESCRIPTION
**Why are these changes introduced?**

Fixes #418 

- Add desktop layout setting to main blog
- Add image height setting to article and article cards (main blog and featured blog)
- Prevent single blog post from going width (on large screens) in featured blog section

**What approach did you take?**

Explicit image heights were added for each breakpoint/setting combination according to the design. If we were concerned about the number of lines of css this adds (and we didn't mind the heights being less fixed across viewport sizes), we may be able to use percentage based heights that were shared across at least some of the breakpoints. This could save some css.

**Demo links**

- [Editor](https://os2-demo.myshopify.com/admin/themes/126343806998/editor)

**Checklist**
- [ ] Followed [theme code principles](https://github.com/Shopify/dawn/blob/main/.github/CONTRIBUTING.md#theme-code-principles)
- [ ] Linted with [Theme Check](https://github.com/Shopify/theme-check)
- [ ] Tested on [mobile](https://shopify.dev/themes/store/requirements#mobile-browser-requirements)
- [ ] Tested on [multiple browsers](https://shopify.dev/themes/store/requirements#desktop-browser-requirements)
- [ ] Tested for [accessibility](https://shopify.dev/themes/best-practices/accessibility)
