### PR TITLE
Fix add to cart error messaging

### DIFF
--- a/assets/global.js
+++ b/assets/global.js
@@ -573,6 +573,7 @@ class VariantSelects extends HTMLElement {
     this.updateMasterId();
     this.toggleAddButton(true, '', false);
     this.updatePickupAvailability();
+    this.removeErrorMessage();
 
     if (!this.currentVariant) {
       this.toggleAddButton(true, '', true);
@@ -642,6 +643,14 @@ class VariantSelects extends HTMLElement {
       pickUpAvailability.removeAttribute('available');
       pickUpAvailability.innerHTML = '';
     }
+  }
+
+  removeErrorMessage() {
+    const section = this.closest('section');
+    if (!section) return;
+
+    const productForm = section.querySelector('product-form');
+    if (productForm) productForm.handleErrorMessage();
   }
 
   renderProductInfo() {

--- a/assets/product-form.js
+++ b/assets/product-form.js
@@ -10,6 +10,7 @@ if (!customElements.get('product-form')) {
 
     onSubmitHandler(evt) {
       evt.preventDefault();
+      this.handleErrorMessage();
       this.cartNotification.setActiveElement(document.activeElement);
 
       const submitButton = this.querySelector('[type="submit"]');

--- a/assets/product-form.js
+++ b/assets/product-form.js
@@ -17,16 +17,23 @@ if (!customElements.get('product-form')) {
       submitButton.setAttribute('disabled', true);
       submitButton.classList.add('loading');
 
-      const body = JSON.stringify({
+      var config = fetchConfig('javascript');
+      config.headers['X-Requested-With'] = 'XMLHttpRequest';
+      config.body = JSON.stringify({
         ...JSON.parse(serializeForm(this.form)),
         sections: this.cartNotification.getSectionsToRender().map((section) => section.id),
         sections_url: window.location.pathname
       });
 
-      fetch(`${routes.cart_add_url}`, { ...fetchConfig('javascript'), body })
+      fetch(`${routes.cart_add_url}`, config)
         .then((response) => response.json())
-        .then((parsedState) => {
-          this.cartNotification.renderContents(parsedState);
+        .then((response) => {
+          if (response.status) {
+            this.handleErrorMessage(response.description);
+            return;
+          }
+
+          this.cartNotification.renderContents(response);
         })
         .catch((e) => {
           console.error(e);
@@ -35,6 +42,17 @@ if (!customElements.get('product-form')) {
           submitButton.classList.remove('loading');
           submitButton.removeAttribute('disabled');
         });
+    }
+
+    handleErrorMessage(errorMessage = false) {
+      this.errorMessageWrapper = this.errorMessageWrapper || this.querySelector('.product-form__error-message-wrapper');
+      this.errorMessage = this.errorMessage || this.errorMessageWrapper.querySelector('.product-form__error-message');
+
+      this.errorMessageWrapper.toggleAttribute('hidden', !errorMessage);
+
+      if (errorMessage ) {
+        this.errorMessage.textContent = errorMessage;
+      }
     }
   });
 }

--- a/assets/section-main-product.css
+++ b/assets/section-main-product.css
@@ -110,6 +110,19 @@
   display: block;
 }
 
+.product-form__error-message-wrapper:not([hidden]) {
+  display: flex;
+  font-size: 1.2rem;
+  margin-bottom: 1.5rem;
+}
+
+.product-form__error-message-wrapper svg {
+  flex-shrink: 0;
+  width: 1.2rem;
+  margin-right: 0.7rem;
+  margin-top: 0.1rem;
+}
+
 /* Form Elements */
 .product-form__input {
   flex: 0 0 100%;

--- a/assets/section-main-product.css
+++ b/assets/section-main-product.css
@@ -112,6 +112,7 @@
 
 .product-form__error-message-wrapper:not([hidden]) {
   display: flex;
+  align-items: center;
   font-size: 1.2rem;
   margin-bottom: 1.5rem;
 }
@@ -119,6 +120,7 @@
 .product-form__error-message-wrapper svg {
   flex-shrink: 0;
   width: 1.2rem;
+  height: 1.2rem;
   margin-right: 0.7rem;
   margin-top: 0.1rem;
 }

--- a/sections/featured-product.liquid
+++ b/sections/featured-product.liquid
@@ -229,6 +229,17 @@
               <div {{ block.shopify_attributes }}>
                 {%- if product != blank -%}
                   <product-form class="product-form">
+                    <div class="product-form__error-message-wrapper" role="alert" hidden>
+                      <span class="visually-hidden">{{ 'accessibility.error' | t }} </span>
+                      <svg aria-hidden="true" focusable="false" role="presentation" class="icon icon-error" viewBox="0 0 13 13">
+                        <circle cx="6.5" cy="6.50049" r="5.5" stroke="white" stroke-width="2"/>
+                        <circle cx="6.5" cy="6.5" r="5.5" fill="#EB001B" stroke="#EB001B" stroke-width="0.7"/>
+                        <path d="M5.87413 3.52832L5.97439 7.57216H7.02713L7.12739 3.52832H5.87413ZM6.50076 9.66091C6.88091 9.66091 7.18169 9.37267 7.18169 9.00504C7.18169 8.63742 6.88091 8.34917 6.50076 8.34917C6.12061 8.34917 5.81982 8.63742 5.81982 9.00504C5.81982 9.37267 6.12061 9.66091 6.50076 9.66091Z" fill="white"/>
+                        <path d="M5.87413 3.17832H5.51535L5.52424 3.537L5.6245 7.58083L5.63296 7.92216H5.97439H7.02713H7.36856L7.37702 7.58083L7.47728 3.537L7.48617 3.17832H7.12739H5.87413ZM6.50076 10.0109C7.06121 10.0109 7.5317 9.57872 7.5317 9.00504C7.5317 8.43137 7.06121 7.99918 6.50076 7.99918C5.94031 7.99918 5.46982 8.43137 5.46982 9.00504C5.46982 9.57872 5.94031 10.0109 6.50076 10.0109Z" fill="white" stroke="#EB001B" stroke-width="0.7">
+                      </svg>
+                      <span class="product-form__error-message"></span>
+                    </div>
+    
                     {%- form 'product', product, id: product_form_id, class: 'form', novalidate: 'novalidate', data-type: 'add-to-cart-form' -%}
                       <input type="hidden" name="id" value="{{ product.selected_or_first_available_variant.id }}">
                       <div class="product-form__buttons">

--- a/sections/main-product.liquid
+++ b/sections/main-product.liquid
@@ -264,6 +264,17 @@
           {%- when 'buy_buttons' -%}
             <div {{ block.shopify_attributes }}>
               <product-form class="product-form">
+                <div class="product-form__error-message-wrapper" role="alert" hidden>
+                  <span class="visually-hidden">{{ 'accessibility.error' | t }} </span>
+                  <svg aria-hidden="true" focusable="false" role="presentation" class="icon icon-error" viewBox="0 0 13 13">
+                    <circle cx="6.5" cy="6.50049" r="5.5" stroke="white" stroke-width="2"/>
+                    <circle cx="6.5" cy="6.5" r="5.5" fill="#EB001B" stroke="#EB001B" stroke-width="0.7"/>
+                    <path d="M5.87413 3.52832L5.97439 7.57216H7.02713L7.12739 3.52832H5.87413ZM6.50076 9.66091C6.88091 9.66091 7.18169 9.37267 7.18169 9.00504C7.18169 8.63742 6.88091 8.34917 6.50076 8.34917C6.12061 8.34917 5.81982 8.63742 5.81982 9.00504C5.81982 9.37267 6.12061 9.66091 6.50076 9.66091Z" fill="white"/>
+                    <path d="M5.87413 3.17832H5.51535L5.52424 3.537L5.6245 7.58083L5.63296 7.92216H5.97439H7.02713H7.36856L7.37702 7.58083L7.47728 3.537L7.48617 3.17832H7.12739H5.87413ZM6.50076 10.0109C7.06121 10.0109 7.5317 9.57872 7.5317 9.00504C7.5317 8.43137 7.06121 7.99918 6.50076 7.99918C5.94031 7.99918 5.46982 8.43137 5.46982 9.00504C5.46982 9.57872 5.94031 10.0109 6.50076 10.0109Z" fill="white" stroke="#EB001B" stroke-width="0.7">
+                  </svg>
+                  <span class="product-form__error-message"></span>
+                </div>
+
                 {%- form 'product', product, id: product_form_id, class: 'form', novalidate: 'novalidate', data-type: 'add-to-cart-form' -%}
                   <input type="hidden" name="id" value="{{ product.selected_or_first_available_variant.id }}">
                   <div class="product-form__buttons">


### PR DESCRIPTION
**Why are these changes introduced?**
This PR adds error messaging to product pages. 
This will prevent buyers from adding more items to their cart, than are available.

Fixes #398.

**What approach did you take?**
Add the `X-Requested-With` header to allow error messages to be returned. 

```
config.headers['X-Requested-With'] = 'XMLHttpRequest';
```
The error message was added to products and featured products. 

Show error message if:
1. Variant has  insufficient stock - after Add to cart. 

If error message is visible. Hide the message if: 
1. Variant is changed 
2. Item is added to cart again

**Other considerations**
N/A 

**Demo links**

- [Store](https://os2-demo.myshopify.com/?preview_theme_id=126344298518)
- [Editor](https://os2-demo.myshopify.com/admin/themes/126344298518/editor)

**Testing** 
- [ ] If you change variants, the message disappears 
- [ ] If you add a quantity that is more than is available, show error message 
- [ ] Test featured product and product 
- [ ] If an error message is present and you submit form, hide error message 
- [ ] Test with dropdown and button variant types. 

**Checklist**
- [ ] Followed [theme code principles](https://github.com/Shopify/dawn/blob/main/.github/CONTRIBUTING.md#theme-code-principles)
- [ ] Linted with [Theme Check](https://github.com/Shopify/theme-check)
- [ ] Tested on [mobile](https://shopify.dev/themes/store/requirements#mobile-browser-requirements)
- [ ] Tested on [multiple browsers](https://shopify.dev/themes/store/requirements#desktop-browser-requirements)
- [ ] Tested for [accessibility](https://shopify.dev/themes/best-practices/accessibility)
