### PR TITLE
Fix predictive search product title margin

### DIFF
--- a/assets/component-predictive-search.css
+++ b/assets/component-predictive-search.css
@@ -128,6 +128,10 @@ predictive-search[loading] .predictive-search__results-list:first-child {
   font-size: 0.9rem;
 }
 
+.predictive-search__item-heading {
+  margin: 0;
+}
+
 .predictive-search__item .price {
   color: rgba(var(--color-foreground), 0.7);
   font-size: 1.2rem;


### PR DESCRIPTION
**Why are these changes introduced?**
I converted the `span` to an `h3` and didn't realize it added margin top and bottom.
This PR removes the margin top and bottom.

**What approach did you take?**
Removed margin on the product title element in the predictive search drop down. 

**Other considerations**
N/A

**Demo links**

- [Store](https://os2-demo.myshopify.com/?preview_theme_id=126345248790)
- [Editor](https://os2-demo.myshopify.com/admin/themes/126345248790/editor)

**Checklist**
- [x] Followed [theme code principles](https://github.com/Shopify/dawn/blob/main/.github/CONTRIBUTING.md#theme-code-principles)
- [x] Linted with [Theme Check](https://github.com/Shopify/theme-check)
- [x] Tested on [mobile](https://shopify.dev/themes/store/requirements#mobile-browser-requirements)
- [x] Tested on [multiple browsers](https://shopify.dev/themes/store/requirements#desktop-browser-requirements)
- [x] Tested for [accessibility](https://shopify.dev/themes/best-practices/accessibility)
