### PR TITLE
Add scroll margin for login and recover pages

### DIFF
--- a/assets/customer.css
+++ b/assets/customer.css
@@ -338,7 +338,7 @@
 }
 
 #recover:target {
-  display: inline;
+  display: block;
 }
 
 #recover:target + div {
@@ -348,6 +348,15 @@
 #recover:target ~ #login,
 #recover:target ~ #login + div {
   display: none;
+}
+
+#recover,
+#login {
+  scroll-margin-top: 20rem;
+}
+
+#recover {
+  margin-bottom: 0;
 }
 
 .activate button[name='decline'],


### PR DESCRIPTION
**Why are these changes introduced?**

Fixes #358 

**What approach did you take?**

The issue is caused by the no-js approach we're taking on this page. We're using the `:target` selector to hide/show the login and recover forms with anchor links/fragments. It is default browser behavior to snap the scroll to targeted element.

The easiest solution is to use `scroll-margin-top` property to offset where the browser snaps to.

**Other considerations**

The latest versions of all browsers support scroll-margin-top, but recent versions safari have a bug that prevent the prop from applying to fragment targets like we need. [See caniuse](https://caniuse.com/?search=scroll-margin-top). Given that the experience isn't necessarily "broken" without this fix I think current support is acceptable versus implementing some javascript to handle it more consistently.

**Demo links**

- [Store](https://os2-demo.myshopify.com/?preview_theme_id=126328537110)
- [Editor](https://os2-demo.myshopify.com/admin/themes/126328537110/editor)

**Checklist**
- [ ] Followed [theme code principles](https://github.com/Shopify/dawn/blob/main/.github/CONTRIBUTING.md#theme-code-principles)
- [ ] Linted with [Theme Check](https://github.com/Shopify/theme-check)
- [ ] Tested on [mobile](https://shopify.dev/themes/store/requirements#mobile-browser-requirements)
- [ ] Tested on [multiple browsers](https://shopify.dev/themes/store/requirements#desktop-browser-requirements)
- [ ] Tested for [accessibility](https://shopify.dev/themes/best-practices/accessibility)
