### PR TITLE
Fixed image quality in product modal

### DIFF
--- a/snippets/product-media.liquid
+++ b/snippets/product-media.liquid
@@ -18,11 +18,15 @@
   <img
     srcset="{%- if media.preview_image.width >= 550 -%}{{ media.preview_image | img_url: '550x' }} 550w,{%- endif -%}
             {%- if media.preview_image.width >= 1100 -%}{{ media.preview_image | img_url: '1100x' }} 1100w,{%- endif -%}
+            {%- if media.preview_image.width >= 1445 -%}{{ media.preview_image | img_url: '1445x' }} 1445w,{%- endif -%}
             {%- if media.preview_image.width >= 1680 -%}{{ media.preview_image | img_url: '1680x' }} 1680w,{%- endif -%}
             {%- if media.preview_image.width >= 2048 -%}{{ media.preview_image | img_url: '2048x' }} 2048w,{%- endif -%}
-            {%- if media.preview_image.width >= 4096 -%}{{ media.preview_image | img_url: '4096x' }} 4096w{%- endif -%}"
-    sizes="(min-width: 750px) calc(100vw - 12rem), 100vw"
-    src="{{ media.preview_image | img_url: '750x' }}"
+            {%- if media.preview_image.width >= 2200 -%}{{ media.preview_image | img_url: '2200x' }} 2200w,{%- endif -%}
+            {%- if media.preview_image.width >= 2890 -%}{{ media.preview_image | img_url: '2890x' }} 2890w,{%- endif -%}
+            {%- if media.preview_image.width >= 4096 -%}{{ media.preview_image | img_url: '4096x' }} 4096w,{%- endif -%}
+            {{ media.preview_image | img_url: 'master' }} {{ media.preview_image.width }}w"
+    sizes="(min-width: 750px) calc(100vw - 22rem), 1100px"
+    src="{{ media.preview_image | img_url: '1445x' }}"
     alt="{{ media.alt | escape }}"
     loading="lazy"
     width="1100"


### PR DESCRIPTION
**Why are these changes introduced?**

There was an issue with the image quality in the product modal.  It was being caused when an image that was uploaded was in between the smallest sizes in the `srcset` attribute- 550 and 1100.  So for example, if a merchant uploaded an image that was `938px` it would instead render a `550px` image.

Note: the solution was tested on the store on which the issue was originally reported and it did solve the quality issue.

**What approach did you take?**

To fix this, I've added the original image as the last element in the `srcset` attribute.  This guarantees that the highest possible quality image is an option as one of the `srcset` values regardless of the size that is uploaded and ensures that we output the best possible quality in cases where lower quality / smaller width images are being uploaded.

I also added a few sizes and fixed up the `sizes` attribute to better reflect the rendered image sizes.

**Other considerations**

I created an issue to do this to the rest of our `srcset` attributes throughout the theme.  I think this is a principled way to ensure the best possible quality outputs in all cases. https://github.com/Shopify/dawn/issues/615

**Checklist**
- [ ] Followed [theme code principles](https://github.com/Shopify/dawn/blob/main/.github/CONTRIBUTING.md#theme-code-principles)
- [ ] Linted with [Theme Check](https://github.com/Shopify/theme-check)
- [ ] Tested on [mobile](https://shopify.dev/themes/store/requirements#mobile-browser-requirements)
- [ ] Tested on [multiple browsers](https://shopify.dev/themes/store/requirements#desktop-browser-requirements)
- [ ] Tested for [accessibility](https://shopify.dev/themes/best-practices/accessibility)
