### PR TITLE
Fix cart image link accessibility pattern

### DIFF
--- a/assets/component-cart-items.css
+++ b/assets/component-cart-items.css
@@ -34,10 +34,6 @@
   }
 }
 
-.js .cart-item__image {
-  cursor: pointer;
-}
-
 .cart-item__details {
   font-size: 1.6rem;
   line-height: 1.4;
@@ -54,6 +50,17 @@
 
 .cart-item__media {
   position: relative;
+}
+
+.cart-item__link {
+  display: block;
+  bottom: 0;
+  left: 0;
+  position: absolute;
+  right: 0;
+  top: 0;
+  width: 100%;
+  height: 100%;
 }
 
 .cart-item__name {

--- a/sections/main-cart-items.liquid
+++ b/sections/main-cart-items.liquid
@@ -45,6 +45,7 @@
               {%- for item in cart.items -%}
                 <tr class="cart-item" id="CartItem-{{ item.index | plus: 1 }}">
                   <td class="cart-item__media">
+                    <a href="{{ item.url }}" class="cart-item__link" aria-hidden="true" tabindex="-1"> </a>
                     {% if item.image %}
                       <img class="cart-item__image"
                         src="{{ item.image | img_url: '300x' }}"
@@ -52,7 +53,6 @@
                         loading="lazy"
                         width="150"
                         height="{{ 150 | divided_by: item.image.aspect_ratio | ceil }}"
-                        onclick="window.location.href='{{ item.url }}'"
                       >
                     {% endif %}
                   </td>

--- a/sections/main-cart-items.liquid
+++ b/sections/main-cart-items.liquid
@@ -46,6 +46,7 @@
                 <tr class="cart-item" id="CartItem-{{ item.index | plus: 1 }}">
                   <td class="cart-item__media">
                     {% if item.image %}
+                      {% comment %} Leave empty space due to a:empty CSS display: none rule {% endcomment %}
                       <a href="{{ item.url }}" class="cart-item__link" aria-hidden="true" tabindex="-1"> </a>
                       <img class="cart-item__image"
                         src="{{ item.image | img_url: '300x' }}"

--- a/sections/main-cart-items.liquid
+++ b/sections/main-cart-items.liquid
@@ -45,8 +45,8 @@
               {%- for item in cart.items -%}
                 <tr class="cart-item" id="CartItem-{{ item.index | plus: 1 }}">
                   <td class="cart-item__media">
-                    <a href="{{ item.url }}" class="cart-item__link" aria-hidden="true" tabindex="-1"> </a>
                     {% if item.image %}
+                      <a href="{{ item.url }}" class="cart-item__link" aria-hidden="true" tabindex="-1"> </a>
                       <img class="cart-item__image"
                         src="{{ item.image | img_url: '300x' }}"
                         alt="{{ item.image.alt | escape }}"


### PR DESCRIPTION
**Why are these changes introduced?**

Related PR: https://github.com/Shopify/dawn/pull/605
The goal of this PR is the same as #605 , except that we want users to be able to right click to open a new tab. Currently, we use JS to trigger the link so it's not possible

**What approach did you take?**

Followed [Scott's approach](https://github.com/Shopify/dawn/issues/590#issuecomment-918428812):
- Add an `<a>` tag, and use position absolute to take full space
- Add `aria-hidden` and `tabindex=-1` so assistive technology can't detect the link, but only the image.

**Demo links**

- [Store](https://os2-demo.myshopify.com/cart?preview_theme_id=126374051862)
- [Editor](https://os2-demo.myshopify.com/admin/themes/126374051862/editor)

**Checklist**
- [x] Followed [theme code principles](https://github.com/Shopify/dawn/blob/main/.github/CONTRIBUTING.md#theme-code-principles)
- [x] Linted with [Theme Check](https://github.com/Shopify/theme-check)
- [x] Tested on [mobile](https://shopify.dev/themes/store/requirements#mobile-browser-requirements)
- [x] Tested on [multiple browsers](https://shopify.dev/themes/store/requirements#desktop-browser-requirements)
- [x] Tested for [accessibility](https://shopify.dev/themes/best-practices/accessibility)
