### PR TITLE
Fix details/summary accessibility pattern

### DIFF
--- a/assets/details-modal.js
+++ b/assets/details-modal.js
@@ -40,6 +40,7 @@ class DetailsModal extends HTMLElement {
     this.onBodyClickEvent =
       this.onBodyClickEvent || this.onBodyClick.bind(this);
     event.target.closest('details').setAttribute('open', true);
+    event.currentTarget.setAttribute('aria-expanded', 'true');
     document.body.addEventListener('click', this.onBodyClickEvent);
     document.body.classList.add('overflow-hidden');
 
@@ -52,6 +53,7 @@ class DetailsModal extends HTMLElement {
   close(focusToggle = true) {
     removeTrapFocus(focusToggle ? this.summaryToggle : null);
     this.detailsContainer.removeAttribute('open');
+    this.detailsContainer.querySelector('summary').setAttribute('aria-expanded', 'false');
     document.body.removeEventListener('click', this.onBodyClickEvent);
     document.body.classList.remove('overflow-hidden');
   }

--- a/assets/global.js
+++ b/assets/global.js
@@ -6,6 +6,20 @@ function getFocusableElements(container) {
   );
 }
 
+document.querySelectorAll('[id^="Details-"] summary').forEach((summary) => {
+  summary.addEventListener('click', (event) => {
+    const isOpen = event.currentTarget.closest('details').hasAttribute('open');
+    console.log(isOpen);
+    if(isOpen) {
+      event.currentTarget.setAttribute('aria-expanded', false);
+    } else {
+      event.currentTarget.setAttribute('aria-expanded', true);
+    }
+  });
+
+  summary.addEventListener('keyup', onKeyUpEscape);
+});
+
 const trapFocusHandlers = {};
 
 function trapFocus(container, elementToFocus = container) {
@@ -116,6 +130,7 @@ function onKeyUpEscape(event) {
 
   const summaryElement = openDetailsElement.querySelector('summary');
   openDetailsElement.removeAttribute('open');
+  summaryElement.setAttribute('aria-expanded', false);
   summaryElement.focus();
 }
 
@@ -374,6 +389,7 @@ class MenuDrawer extends HTMLElement {
 
   closeSubmenu(detailsElement) {
     detailsElement.classList.remove('menu-opening');
+    detailsElement.querySelector('summary').setAttribute('aria-expanded', false);
     removeTrapFocus();
     this.closeAnimation(detailsElement);
   }

--- a/assets/global.js
+++ b/assets/global.js
@@ -9,7 +9,7 @@ function getFocusableElements(container) {
 document.querySelectorAll('[id^="Details-"] summary').forEach((summary) => {
   summary.addEventListener('click', (event) => {
     const isOpen = event.currentTarget.closest('details').hasAttribute('open');
-    console.log(isOpen);
+    
     if(isOpen) {
       event.currentTarget.setAttribute('aria-expanded', false);
     } else {

--- a/assets/global.js
+++ b/assets/global.js
@@ -349,6 +349,7 @@ class MenuDrawer extends HTMLElement {
 
       setTimeout(() => {
         detailsElement.classList.add('menu-opening');
+        summaryElement.setAttribute('aria-expanded', true);
       });
     }
   }

--- a/sections/header.liquid
+++ b/sections/header.liquid
@@ -345,12 +345,12 @@
             <li>
               {%- if link.links != blank -%}
                 <details-disclosure>
-                  <details>
-                    <summary class="header__menu-item list-menu__item link focus-inset">
+                  <details id="Details-HeaderMenu">
+                    <summary class="header__menu-item list-menu__item link focus-inset" role="button" aria-expanded="false" aria-controls="HeaderMenu-MenuList">
                       <span {%- if link.child_active %} class="header__active-menu-item"{% endif %}>{{ link.title | escape }}</span>
                       {% render 'icon-caret' %}
                     </summary>
-                    <ul class="header__submenu list-menu list-menu--disclosure caption-large motion-reduce" role="list" tabindex="-1">
+                    <ul id="HeaderMenu-MenuList" class="header__submenu list-menu list-menu--disclosure caption-large motion-reduce" role="list" tabindex="-1">
                       {%- for childlink in link.links -%}
                         <li>
                           {%- if childlink.links == blank -%}
@@ -358,12 +358,12 @@
                               {{ childlink.title | escape }}
                             </a>
                           {%- else -%}
-                            <details>
-                              <summary class="header__menu-item link link--text list-menu__item focus-inset caption-large">
+                            <details id="Details-HeaderSubMenu-{{ forloop.index }}">
+                              <summary class="header__menu-item link link--text list-menu__item focus-inset caption-large" role="button" aria-expanded="false" aria-controls="HeaderMenu-SubMenuList-{{ forloop.index }}">
                                 {{ childlink.title | escape }}
                                 {% render 'icon-caret' %}
                               </summary>
-                              <ul class="header__submenu list-menu motion-reduce">
+                              <ul id="HeaderMenu-SubMenuList-{{ forloop.index }}" class="header__submenu list-menu motion-reduce">
                                 {%- for grandchildlink in childlink.links -%}
                                   <li>
                                     <a href="{{ grandchildlink.url }}" class="header__menu-item list-menu__item link link--text focus-inset caption-large{% if grandchildlink.current %} list-menu__item--active{% endif %}"{% if grandchildlink.current %} aria-current="page"{% endif %}>

--- a/sections/header.liquid
+++ b/sections/header.liquid
@@ -244,7 +244,7 @@
     {%- if section.settings.logo_position == 'top-center' or section.settings.menu == blank -%}
       <details-modal class="header__search">
         <details>
-          <summary class="header__icon header__icon--search header__icon--summary link link--text focus-inset modal__toggle" aria-haspopup="dialog" aria-label="{{ 'general.search.search' | t }}">
+          <summary class="header__icon header__icon--search header__icon--summary link link--text focus-inset modal__toggle" aria-haspopup="dialog" aria-label="{{ 'general.search.search' | t }}" aria-controls="SearchModal-TopCenter">
             <span>
               <svg class="modal__toggle-open icon icon-search" aria-hidden="true" focusable="false" role="presentation">
                 <use href="#icon-search">
@@ -254,7 +254,7 @@
               </svg>
             </span>
           </summary>
-          <div class="search-modal modal__content" role="dialog" aria-modal="true" aria-label="{{ 'general.search.search' | t }}">
+          <div id="SearchModal-TopCenter" class="search-modal modal__content" role="dialog" aria-modal="true" aria-label="{{ 'general.search.search' | t }}">
             <div class="modal-overlay"></div>
             <div class="search-modal__content" tabindex="-1">
               {%- if settings.predictive_search_enabled -%}
@@ -393,7 +393,7 @@
     <div class="header__icons">
       <details-modal class="header__search">
         <details>
-          <summary class="header__icon header__icon--search header__icon--summary link link--text focus-inset modal__toggle" aria-haspopup="dialog" aria-label="{{ 'general.search.search' | t }}">
+          <summary class="header__icon header__icon--search header__icon--summary link link--text focus-inset modal__toggle" aria-haspopup="dialog" aria-label="{{ 'general.search.search' | t }}" aria-controls="SearchModal">
             <span>
               <svg class="modal__toggle-open icon icon-search" aria-hidden="true" focusable="false" role="presentation">
                 <use href="#icon-search">
@@ -403,7 +403,7 @@
               </svg>
             </span>
           </summary>
-          <div class="search-modal modal__content" role="dialog" aria-modal="true" aria-label="{{ 'general.search.search' | t }}">
+          <div id="SearchModal" class="search-modal modal__content" role="dialog" aria-modal="true" aria-label="{{ 'general.search.search' | t }}">
             <div class="modal-overlay"></div>
             <div class="search-modal__content" tabindex="-1">
               {%- if settings.predictive_search_enabled -%}

--- a/sections/main-collection-product-grid.liquid
+++ b/sections/main-collection-product-grid.liquid
@@ -29,14 +29,14 @@
                 {%- assign total_active_values = total_active_values | plus: filter.active_values.size -%}
                 {% case filter.type %}
                 {% when 'list' %}
-                  <details class="disclosure-has-popup facets__disclosure js-filter" data-index="{{ forloop.index }}">
-                    <summary class="facets__summary caption-large focus-offset">
+                  <details id="Details-{{ forloop.index }}-{{ section.id }}" class="disclosure-has-popup facets__disclosure js-filter" data-index="{{ forloop.index }}">
+                    <summary class="facets__summary caption-large focus-offset" role="button" aria-expanded="false" aria-controls="Facet-{{ forloop.index }}-{{ section.id }}">
                       <div>
                         <span>{{ filter.label | escape }}</span>
                         {% render 'icon-caret' %}
                       </div>
                     </summary>
-                    <div class="facets__display">
+                    <div class="facets__display" id="Facet-{{ forloop.index }}-{{ section.id }}">
                       <div class="facets__header">
                         <span class="facets__selected no-js-hidden">{{ 'sections.collection_template.filters_selected' | t: count: filter.active_values.size }}</span>
                         <facet-remove>
@@ -92,14 +92,14 @@
                       assign uses_comma_decimals = true
                     endif
                   %}
-                  <details class="disclosure-has-popup facets__disclosure js-filter" data-index="{{ forloop.index }}">
-                    <summary class="facets__summary caption-large focus-offset">
+                  <details id="Details-{{ forloop.index }}-{{ section.id }}" class="disclosure-has-popup facets__disclosure js-filter" data-index="{{ forloop.index }}">
+                    <summary class="facets__summary caption-large focus-offset" role="button" aria-expanded="false" aria-controls="Facet-{{ forloop.index }}-{{ section.id }}">
                       <div>
                         <span>{{ filter.label | escape }}</span>
                         {% render 'icon-caret' %}
                       </div>
                     </summary>
-                    <div class="facets__display">
+                    <div class="facets__display" id="Facet-{{ forloop.index }}-{{ section.id }}">
                       <div class="facets__header">
                         {%- assign max_price_amount = filter.range_max | money | strip_html | escape -%}
                         <span class="facets__selected">{{ "sections.collection_template.max_price" | t: price: max_price_amount }}</span>
@@ -254,15 +254,15 @@
                 {%- for filter in collection.filters -%}
                   {% case filter.type %}
                   {% when 'list' %}
-                    <details class="mobile-facets__details js-filter" data-index="mobile-{{ forloop.index }}">
-                      <summary class="mobile-facets__summary focus-inset">
+                    <details id="Details-Mobile-{{ forloop.index }}-{{ section.id }}" class="mobile-facets__details js-filter" data-index="mobile-{{ forloop.index }}">
+                      <summary class="mobile-facets__summary focus-inset" role="button" aria-expanded="false" aria-controls="FacetMobile-{{ forloop.index }}-{{ section.id }}">
                         <div>
                           <span>{{ filter.label | escape }}</span>                        
                           <span class="mobile-facets__arrow no-js-hidden">{% render 'icon-arrow' %}</span>
                           <noscript>{% render 'icon-caret' %}</noscript>
                         </div>
                       </summary>
-                      <div class="mobile-facets__submenu">
+                      <div class="mobile-facets__submenu" id="FacetMobile-{{ forloop.index }}-{{ section.id }}">
                         <button class="mobile-facets__close-button link link--text focus-inset" aria-expanded="true" type="button">
                           {% render 'icon-arrow' %}
                           {{ filter.label | escape }}
@@ -302,15 +302,15 @@
                       </div>
                     </details>
                   {% when 'price_range' %}
-                    <details class="mobile-facets__details js-filter" data-index="mobile-{{ forloop.index }}">
-                      <summary class="mobile-facets__summary focus-inset">
+                    <details id="Details-Mobile-{{ forloop.index }}-{{ section.id }}" class="mobile-facets__details js-filter" data-index="mobile-{{ forloop.index }}">
+                      <summary class="mobile-facets__summary focus-inset" role="button" aria-expanded="false" aria-controls="FacetMobile-{{ forloop.index }}-{{ section.id }}">
                         <div>
                           <span>{{ filter.label | escape }}</span>
                           <span class="mobile-facets__arrow no-js-hidden">{% render 'icon-arrow' %}</span>
                           <noscript>{% render 'icon-caret' %}</noscript>
                         </div>
                       </summary>
-                      <div class="mobile-facets__submenu">
+                      <div class="mobile-facets__submenu" id="FacetMobile-{{ forloop.index }}-{{ section.id }}">
                         <button class="mobile-facets__close-button link link--text focus-inset" aria-expanded="true" type="button">
                           {% render 'icon-arrow' %}
                           {{ filter.label | escape }}

--- a/sections/main-product.liquid
+++ b/sections/main-product.liquid
@@ -102,8 +102,8 @@
             {{ block.settings.custom_liquid }}
           {%- when 'collapsible_tab' -%}
             <div class="product__accordion accordion" {{ block.shopify_attributes }}>
-              <details>
-                <summary>
+              <details id="Details-{{ block.id }}-{{ section.id }}">
+                <summary role="button" aria-expanded="false" aria-controls="ProductAccordion-{{ block.id }}-{{ section.id }}">
                   <div class="summary__title">
                     {% render 'icon-accordion', icon: block.settings.icon %}
                     <h2 class="h4 accordion__title">
@@ -112,7 +112,7 @@
                   </div>
                   {% render 'icon-caret' %}
                 </summary>
-                <div class="accordion__content rte">
+                <div class="accordion__content rte" id="ProductAccordion-{{ block.id }}-{{ section.id }}">
                   {{ block.settings.content }}
                   {{ block.settings.page.content }}
                 </div>


### PR DESCRIPTION
**Why are these changes introduced?**

Fixes https://github.com/Shopify/dawn/issues/78

The goal of this PR is to normalize `details` and `summary` regarding accessibility behavior. The affected components are:
- Collection filters
- Header search modal
- Header menu (mobile)
- Header menu (desktop)
- Product page: tab collapsible page content

**What approach did you take?**

- Added `role="button"` attribute to the `summary` control
- Added `aria-expanded` attribute to toggle `true` or `false` depending on the state (open/close)
- Added `aria-controls` attribute
- Add `Esc` key support to close the content and focus back to the "controller"

I created a global code snippet to loop through all instances that started with `#Details-"` (e.g. `<details id="Details-HeaderMenu">`) and added `click` event and `keyup` event.

Some components are already using their custom elements (`details-modal`, `menu-drawer`) so I added the logic there instead so leveraging the global code snippet so I can avoid potential conflicts.

I'm always open to improve the approach.

**Demo links**

- [Store](https://os2-demo.myshopify.com/?preview_theme_id=126384111638)
- [Editor](https://os2-demo.myshopify.com/admin/themes/126384111638/editor)

**Checklist**
- [x] Followed [theme code principles](https://github.com/Shopify/dawn/blob/main/.github/CONTRIBUTING.md#theme-code-principles)
- [x] Linted with [Theme Check](https://github.com/Shopify/theme-check)
- [x] Tested on [mobile](https://shopify.dev/themes/store/requirements#mobile-browser-requirements)
- [x] Tested on [multiple browsers](https://shopify.dev/themes/store/requirements#desktop-browser-requirements)
- [x] Tested for [accessibility](https://shopify.dev/themes/best-practices/accessibility)
