### PR TITLE
Fix long menu overlap

### DIFF
--- a/assets/base.css
+++ b/assets/base.css
@@ -2124,6 +2124,7 @@ details[open] > .header__icon--menu .icon-hamburger {
   opacity: 1;
   transform: translateY(0);
   animation: animateMenuOpen var(--duration-default) ease;
+  z-index: 1;
 }
 
 /* Header menu */


### PR DESCRIPTION
**Why are these changes introduced?**

Fixes #625 .

**What approach did you take?**

Updated the `z-index` of the menu that is open

You can test it with the `Wild menu that has way to much items`

**Other considerations**

**Demo links**

- [Editor](https://os2-demo.myshopify.com/admin/themes/126392958998/editor)

**Checklist**
- [ ] Followed [theme code principles](https://github.com/Shopify/dawn/blob/main/.github/CONTRIBUTING.md#theme-code-principles)
- [ ] Linted with [Theme Check](https://github.com/Shopify/theme-check)
- [ ] Tested on [mobile](https://shopify.dev/themes/store/requirements#mobile-browser-requirements)
- [ ] Tested on [multiple browsers](https://shopify.dev/themes/store/requirements#desktop-browser-requirements)
- [ ] Tested for [accessibility](https://shopify.dev/themes/best-practices/accessibility)
