### PR TITLE
Remove white space mobile view for product page

### DIFF
--- a/assets/component-product-model.css
+++ b/assets/component-product-model.css
@@ -3,6 +3,7 @@
   color: rgb(var(--color-foreground));
   margin: 1rem auto;
   box-shadow: none;
+  display: flex;
 }
 
 .button.product__xr-button:hover {

--- a/assets/component-product-model.css
+++ b/assets/component-product-model.css
@@ -3,7 +3,6 @@
   color: rgb(var(--color-foreground));
   margin: 1rem auto;
   box-shadow: none;
-  display: flex;
 }
 
 .button.product__xr-button:hover {

--- a/assets/component-product-model.css
+++ b/assets/component-product-model.css
@@ -11,6 +11,7 @@
 
 .product__xr-button[data-shopify-xr-hidden] {
   visibility: hidden;
+  display: none;
 }
 
 @media screen and (max-width: 749px) {

--- a/assets/component-product-model.css
+++ b/assets/component-product-model.css
@@ -1,8 +1,9 @@
-.button.product__xr-button {
+.product__xr-button {
   background: rgba(var(--color-foreground), 0.08);
   color: rgb(var(--color-foreground));
   margin: 1rem auto;
   box-shadow: none;
+  display: flex;
 }
 
 .button.product__xr-button:hover {

--- a/assets/component-product-model.css
+++ b/assets/component-product-model.css
@@ -14,7 +14,7 @@
 }
 
 @media screen and (max-width: 749px) {
-  slider-component .product__xr-button:not([data-shopify-xr-hidden]) {
+  slider-component .product__xr-button {
     display: none;
   }
 

--- a/assets/component-product-model.css
+++ b/assets/component-product-model.css
@@ -10,7 +10,7 @@
 }
 
 .product__xr-button[data-shopify-xr-hidden] {
-  display: none;
+  visibility: hidden;
 }
 
 @media screen and (max-width: 749px) {

--- a/assets/component-product-model.css
+++ b/assets/component-product-model.css
@@ -10,7 +10,6 @@
 }
 
 .product__xr-button[data-shopify-xr-hidden] {
-  visibility: hidden;
   display: none;
 }
 

--- a/assets/product-model.js
+++ b/assets/product-model.js
@@ -54,5 +54,8 @@ window.ProductModel = {
 };
 
 window.addEventListener('DOMContentLoaded', () => { 
+  if (Shopify.designMode) {
+    document.querySelectorAll("[data-shopify-xr-hidden]").forEach(element => element.classList.add('hidden'));
+  }
   if (window.ProductModel) window.ProductModel.loadShopifyXR();
 });


### PR DESCRIPTION
**Why are these changes introduced?**

Fixes #499 .

**What approach did you take?**

Added `display: none;` when the visibility is set to `hidden`

**Other considerations**

**Demo links**

Test it on the product `Pleated Heel Boot off white` on mobile (by resizing the screen or viewing it in the editor in the mobile view)

You should still see the `view in your space` when you are using a device: https://screenshot.click/20-03-zhf48-0umjv.png

- [Editor](https://os2-demo.myshopify.com/admin/themes/126411571222/editor)

**Checklist**
- [ ] Followed [theme code principles](https://github.com/Shopify/dawn/blob/main/.github/CONTRIBUTING.md#theme-code-principles)
- [ ] Linted with [Theme Check](https://github.com/Shopify/theme-check)
- [ ] Tested on [mobile](https://shopify.dev/themes/store/requirements#mobile-browser-requirements)
- [ ] Tested on [multiple browsers](https://shopify.dev/themes/store/requirements#desktop-browser-requirements)
- [ ] Tested for [accessibility](https://shopify.dev/themes/best-practices/accessibility)
