### PR TITLE
Fix loading spinner issue on variant change

### DIFF
--- a/assets/global.js
+++ b/assets/global.js
@@ -156,7 +156,7 @@ const serializeForm = form => {
   for (const key of formData.keys()) {
     const regex = /(?:^(properties\[))(.*?)(?:\]$)/;
 
-    if (regex.test(key)) { 
+    if (regex.test(key)) {
       obj.properties = obj.properties || {};
       obj.properties[regex.exec(key)[2]] = formData.get(key);
     } else {
@@ -675,6 +675,11 @@ class VariantSelects extends HTMLElement {
     const productForm = document.getElementById(`product-form-${this.dataset.section}`);
     if (!productForm) return;
     const addButton = productForm.querySelector('[name="add"]');
+    const spinner = `<div class="loading-overlay__spinner hidden">
+    <svg aria-hidden="true" focusable="false" role="presentation" class="spinner" viewBox="0 0 66 66" xmlns="http://www.w3.org/2000/svg">
+      <circle class="path" fill="none" stroke-width="6" cx="33" cy="33" r="30"></circle>
+    </svg>
+    </div>`;
 
     if (!addButton) return;
 
@@ -684,6 +689,7 @@ class VariantSelects extends HTMLElement {
     } else {
       addButton.removeAttribute('disabled');
       addButton.textContent = window.variantStrings.addToCart;
+      addButton.innerHTML += spinner;
     }
 
     if (!modifyClass) return;

--- a/assets/global.js
+++ b/assets/global.js
@@ -675,15 +675,16 @@ class VariantSelects extends HTMLElement {
     const productForm = document.getElementById(`product-form-${this.dataset.section}`);
     if (!productForm) return;
     const addButton = productForm.querySelector('[name="add"]');
+    const addButtonText = productForm.querySelector('[name="add"] > span');
 
     if (!addButton) return;
 
     if (disable) {
       addButton.setAttribute('disabled', true);
-      if (text) addButton.textContent = text;
+      if (text) addButtonText.textContent = text;
     } else {
       addButton.removeAttribute('disabled');
-      addButton.textContent = window.variantStrings.addToCart;
+      addButtonText.textContent = window.variantStrings.addToCart;
     }
 
     if (!modifyClass) return;
@@ -692,9 +693,10 @@ class VariantSelects extends HTMLElement {
   setUnavailable() {
     const button = document.getElementById(`product-form-${this.dataset.section}`);
     const addButton = button.querySelector('[name="add"]');
+    const addButtonText = button.querySelector('[name="add"] > span');
     const price = document.getElementById(`price-${this.dataset.section}`);
     if (!addButton) return;
-    addButton.textContent = window.variantStrings.unavailable;
+    addButtonText.textContent = window.variantStrings.unavailable;
     if (price) price.classList.add('visibility-hidden');
   }
 

--- a/assets/global.js
+++ b/assets/global.js
@@ -675,11 +675,6 @@ class VariantSelects extends HTMLElement {
     const productForm = document.getElementById(`product-form-${this.dataset.section}`);
     if (!productForm) return;
     const addButton = productForm.querySelector('[name="add"]');
-    const spinner = `<div class="loading-overlay__spinner hidden">
-    <svg aria-hidden="true" focusable="false" role="presentation" class="spinner" viewBox="0 0 66 66" xmlns="http://www.w3.org/2000/svg">
-      <circle class="path" fill="none" stroke-width="6" cx="33" cy="33" r="30"></circle>
-    </svg>
-    </div>`;
 
     if (!addButton) return;
 
@@ -689,7 +684,6 @@ class VariantSelects extends HTMLElement {
     } else {
       addButton.removeAttribute('disabled');
       addButton.textContent = window.variantStrings.addToCart;
-      addButton.innerHTML += spinner;
     }
 
     if (!modifyClass) return;

--- a/assets/section-main-product.css
+++ b/assets/section-main-product.css
@@ -230,7 +230,7 @@ fieldset.product-form__input .form__label {
 
 .product-form__buttons .loading-overlay__spinner {
   position: absolute;
-  top: 12px;
+  top: 1.2rem;
   left: 50%;
   transform: translateX(-50%);
 }

--- a/assets/section-main-product.css
+++ b/assets/section-main-product.css
@@ -224,6 +224,17 @@ fieldset.product-form__input .form__label {
   max-width: 25rem;
 }
 
+.product-form__buttons {
+  position: relative;
+}
+
+.product-form__buttons .loading-overlay__spinner {
+  position: absolute;
+  top: 12px;
+  left: 50%;
+  transform: translateX(-50%);
+}
+
 .product-form__submit {
   margin-bottom: 1rem;
 }

--- a/assets/section-main-product.css
+++ b/assets/section-main-product.css
@@ -224,17 +224,6 @@ fieldset.product-form__input .form__label {
   max-width: 25rem;
 }
 
-.product-form__buttons {
-  position: relative;
-}
-
-.product-form__buttons .loading-overlay__spinner {
-  position: absolute;
-  top: 1.2rem;
-  left: 50%;
-  transform: translateX(-50%);
-}
-
 .product-form__submit {
   margin-bottom: 1rem;
 }

--- a/sections/featured-product.liquid
+++ b/sections/featured-product.liquid
@@ -259,17 +259,19 @@
                           class="product-form__submit button button--full-width {% if block.settings.show_dynamic_checkout and product.selling_plan_groups == empty %}button--secondary{% else %}button--primary{% endif %}"
                         {% if product.selected_or_first_available_variant.available == false %}disabled{% endif %}
                         >
-                            {%- if product.selected_or_first_available_variant.available -%}
-                              {{ 'products.product.add_to_cart' | t }}
-                            {%- else -%}
-                              {{ 'products.product.sold_out' | t }}
-                            {%- endif -%}
+                            <span>
+                              {%- if product.selected_or_first_available_variant.available -%}
+                                {{ 'products.product.add_to_cart' | t }}
+                              {%- else -%}
+                                {{ 'products.product.sold_out' | t }}
+                              {%- endif -%}
+                            </span>
+                            <div class="loading-overlay__spinner hidden">
+                              <svg aria-hidden="true" focusable="false" role="presentation" class="spinner" viewBox="0 0 66 66" xmlns="http://www.w3.org/2000/svg">
+                                <circle class="path" fill="none" stroke-width="6" cx="33" cy="33" r="30"></circle>
+                              </svg>
+                            </div>
                         </button>
-                        <div class="loading-overlay__spinner hidden">
-                          <svg aria-hidden="true" focusable="false" role="presentation" class="spinner" viewBox="0 0 66 66" xmlns="http://www.w3.org/2000/svg">
-                            <circle class="path" fill="none" stroke-width="6" cx="33" cy="33" r="30"></circle>
-                          </svg>
-                        </div>
                         {%- if block.settings.show_dynamic_checkout -%}
                           {{ form | payment_button }}
                         {%- endif -%}

--- a/sections/featured-product.liquid
+++ b/sections/featured-product.liquid
@@ -249,7 +249,7 @@
                       </svg>
                       <span class="product-form__error-message"></span>
                     </div>
-    
+
                     {%- form 'product', product, id: product_form_id, class: 'form', novalidate: 'novalidate', data-type: 'add-to-cart-form' -%}
                       <input type="hidden" name="id" value="{{ product.selected_or_first_available_variant.id }}">
                       <div class="product-form__buttons">
@@ -264,12 +264,12 @@
                             {%- else -%}
                               {{ 'products.product.sold_out' | t }}
                             {%- endif -%}
-                            <div class="loading-overlay__spinner hidden">
-                              <svg aria-hidden="true" focusable="false" role="presentation" class="spinner" viewBox="0 0 66 66" xmlns="http://www.w3.org/2000/svg">
-                                <circle class="path" fill="none" stroke-width="6" cx="33" cy="33" r="30"></circle>
-                              </svg>
-                            </div>
                         </button>
+                        <div class="loading-overlay__spinner hidden">
+                          <svg aria-hidden="true" focusable="false" role="presentation" class="spinner" viewBox="0 0 66 66" xmlns="http://www.w3.org/2000/svg">
+                            <circle class="path" fill="none" stroke-width="6" cx="33" cy="33" r="30"></circle>
+                          </svg>
+                        </div>
                         {%- if block.settings.show_dynamic_checkout -%}
                           {{ form | payment_button }}
                         {%- endif -%}

--- a/sections/main-product.liquid
+++ b/sections/main-product.liquid
@@ -299,12 +299,12 @@
                         {%- else -%}
                           {{ 'products.product.sold_out' | t }}
                         {%- endif -%}
-                        <div class="loading-overlay__spinner hidden">
-                          <svg aria-hidden="true" focusable="false" role="presentation" class="spinner" viewBox="0 0 66 66" xmlns="http://www.w3.org/2000/svg">
-                            <circle class="path" fill="none" stroke-width="6" cx="33" cy="33" r="30"></circle>
-                          </svg>
-                        </div>
                     </button>
+                    <div class="loading-overlay__spinner hidden">
+                      <svg aria-hidden="true" focusable="false" role="presentation" class="spinner" viewBox="0 0 66 66" xmlns="http://www.w3.org/2000/svg">
+                        <circle class="path" fill="none" stroke-width="6" cx="33" cy="33" r="30"></circle>
+                      </svg>
+                    </div>
                     {%- if block.settings.show_dynamic_checkout -%}
                       {{ form | payment_button }}
                     {%- endif -%}

--- a/sections/main-product.liquid
+++ b/sections/main-product.liquid
@@ -294,17 +294,19 @@
                       class="product-form__submit button button--full-width {% if block.settings.show_dynamic_checkout and product.selling_plan_groups == empty %}button--secondary{% else %}button--primary{% endif %}"
                     {% if product.selected_or_first_available_variant.available == false %}disabled{% endif %}
                     >
-                        {%- if product.selected_or_first_available_variant.available -%}
-                          {{ 'products.product.add_to_cart' | t }}
-                        {%- else -%}
-                          {{ 'products.product.sold_out' | t }}
-                        {%- endif -%}
+                        <span>
+                          {%- if product.selected_or_first_available_variant.available -%}
+                            {{ 'products.product.add_to_cart' | t }}
+                          {%- else -%}
+                            {{ 'products.product.sold_out' | t }}
+                          {%- endif -%}
+                        </span>
+                        <div class="loading-overlay__spinner hidden">
+                          <svg aria-hidden="true" focusable="false" role="presentation" class="spinner" viewBox="0 0 66 66" xmlns="http://www.w3.org/2000/svg">
+                            <circle class="path" fill="none" stroke-width="6" cx="33" cy="33" r="30"></circle>
+                          </svg>
+                        </div>
                     </button>
-                    <div class="loading-overlay__spinner hidden">
-                      <svg aria-hidden="true" focusable="false" role="presentation" class="spinner" viewBox="0 0 66 66" xmlns="http://www.w3.org/2000/svg">
-                        <circle class="path" fill="none" stroke-width="6" cx="33" cy="33" r="30"></circle>
-                      </svg>
-                    </div>
                     {%- if block.settings.show_dynamic_checkout -%}
                       {{ form | payment_button }}
                     {%- endif -%}


### PR DESCRIPTION
**Why are these changes introduced?**

Fixes #636 

**What approach did you take?**

I moved the spinner outside of the button and added it as the next sibling element of the atc. This way the element isn't removed on variant changed (it was before as we update the `textContent` of the atc button).

Also added some product/feat. product specific styling to place the spinner relative to the button form. 

**Other considerations**

Some options I considered: 
- Using the svg file as a pseudo element. But I couldn't animate the path properly to match the animation like in the rest of the theme. 
- I could move the spinner outside of the `product-form__buttons` element and position it absolutely, relative to the form. I will give this a try and report back. Edit: looks good this way. 
- Use JS to re insert the spinner element on variant change. But more JS isn't ideal. 

**Demo links**

- [Store](https://os2-demo.myshopify.com/?preview_theme_id=126412357654)

**Checklist**
- [ ] Followed [theme code principles](https://github.com/Shopify/dawn/blob/main/.github/CONTRIBUTING.md#theme-code-principles)
- [ ] Linted with [Theme Check](https://github.com/Shopify/theme-check)
- [ ] Tested on [mobile](https://shopify.dev/themes/store/requirements#mobile-browser-requirements)
- [ ] Tested on [multiple browsers](https://shopify.dev/themes/store/requirements#desktop-browser-requirements)
- [ ] Tested for [accessibility](https://shopify.dev/themes/best-practices/accessibility)
