### PR TITLE
Predictive search result iOS fix 

### DIFF
--- a/assets/base.css
+++ b/assets/base.css
@@ -2051,6 +2051,8 @@ details[open] .modal-overlay::after {
   left: 0;
   right: 0;
   height: 100vh;
+  touch-action: none;
+
 }
 
 .no-js details[open] > .header__icon--search {

--- a/assets/base.css
+++ b/assets/base.css
@@ -2051,8 +2051,6 @@ details[open] .modal-overlay::after {
   left: 0;
   right: 0;
   height: 100vh;
-  touch-action: none;
-
 }
 
 .no-js details[open] > .header__icon--search {
@@ -2301,4 +2299,13 @@ details-disclosure > details {
   .icon-close-small path {
     stroke: CanvasText;
   }
+}
+
+.body-fixed {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  /* height: 100vh; */
 }

--- a/assets/predictive-search.js
+++ b/assets/predictive-search.js
@@ -5,6 +5,16 @@ class PredictiveSearch extends HTMLElement {
     this.input = this.querySelector('input[type="search"]');
     this.predictiveSearchResults = this.querySelector('[data-predictive-search]');
 
+    this.isIOS = /iPad|iPhone|iPod/.test(navigator.platform)
+    || (navigator.platform === 'MacIntel' && navigator.maxTouchPoints > 1);
+    if (this.isIOS) {
+      this.stickyHeader = this.stickyHeader || document.querySelector('sticky-header');
+      this.searchIcon = this.stickyHeader.querySelector('.header__icon--search');
+      this.scrollTopValue = null;
+    } else {
+      console.log('This is Not a IOS device');
+    }
+
     this.setupEventListeners();
   }
 
@@ -16,14 +26,21 @@ class PredictiveSearch extends HTMLElement {
       this.onChange(event);
     }, 300).bind(this));
     this.input.addEventListener('focus', this.onFocus.bind(this));
-
     this.addEventListener('focusout', this.onFocusOut.bind(this));
     this.addEventListener('keyup', this.onKeyup.bind(this));
     this.addEventListener('keydown', this.onKeydown.bind(this));
+    if (this.isIOS) this.searchIcon.addEventListener('click', this.onSearchOpen.bind(this));
   }
 
   getQuery() {
     return this.input.value.trim();
+  }
+
+  onSearchOpen() {
+    this.scrollTopValue = window.pageYOffset;
+    document.body.style.top = `-${this.scrollTopValue}px`;
+    document.body.classList.add('body-fixed');
+    this.stickyHeader.dispatchEvent(new Event('predictiveSearchOpen'));
   }
 
   onChange() {
@@ -51,7 +68,7 @@ class PredictiveSearch extends HTMLElement {
     } else {
       this.getSearchResults(searchTerm);
     }
-  } 
+  }
 
   onFocusOut() {
     setTimeout(() => {
@@ -88,7 +105,7 @@ class PredictiveSearch extends HTMLElement {
 
   switchOption(direction) {
     if (!this.getAttribute('open')) return;
-    
+
     const moveUp = direction === 'up';
     const selectedElement = this.querySelector('[aria-selected="true"]');
     const allElements = this.querySelectorAll('li');
@@ -96,7 +113,7 @@ class PredictiveSearch extends HTMLElement {
 
     if (moveUp && !selectedElement) return;
 
-    this.statusElement.textContent = ''; 
+    this.statusElement.textContent = '';
 
     if (!moveUp && selectedElement) {
       activeElement = selectedElement.nextElementSibling || allElements[0];
@@ -108,7 +125,7 @@ class PredictiveSearch extends HTMLElement {
 
     activeElement.setAttribute('aria-selected', true);
     if (selectedElement) selectedElement.setAttribute('aria-selected', false);
- 
+
     this.setLiveRegionText(activeElement.textContent);
     this.input.setAttribute('aria-activedescendant', activeElement.id);
   }
@@ -129,7 +146,7 @@ class PredictiveSearch extends HTMLElement {
     }
 
     fetch(`${routes.predictive_search_url}?q=${encodeURIComponent(searchTerm)}&${encodeURIComponent('resources[type]')}=product&${encodeURIComponent('resources[limit]')}=4&section_id=predictive-search`)
-      .then((response) => { 
+      .then((response) => {
         if (!response.ok) {
           var error = new Error(response.status);
           this.close();
@@ -146,7 +163,7 @@ class PredictiveSearch extends HTMLElement {
       .catch((error) => {
         this.close();
         throw error;
-      }); 
+      });
   }
 
   setLiveRegionLoadingState() {
@@ -160,7 +177,7 @@ class PredictiveSearch extends HTMLElement {
   setLiveRegionText(statusText) {
     this.statusElement.setAttribute('aria-hidden', 'false');
     this.statusElement.textContent = statusText;
-    
+
     setTimeout(() => {
       this.statusElement.setAttribute('aria-hidden', 'true');
     }, 1000);
@@ -168,16 +185,16 @@ class PredictiveSearch extends HTMLElement {
 
   renderSearchResults(resultsMarkup) {
     this.predictiveSearchResults.innerHTML = resultsMarkup;
-    this.setAttribute('results', true);  
+    this.setAttribute('results', true);
 
     this.setLiveRegionResults();
     this.open();
   }
 
-  setLiveRegionResults() { 
+  setLiveRegionResults() {
     this.removeAttribute('loading');
     this.setLiveRegionText(this.querySelector('[data-predictive-search-live-region-count-value]').textContent);
-  } 
+  }
 
   getResultsMaxHeight() {
     this.resultsMaxHeight = window.innerHeight - document.getElementById('shopify-section-header').getBoundingClientRect().bottom;
@@ -190,7 +207,7 @@ class PredictiveSearch extends HTMLElement {
     this.input.setAttribute('aria-expanded', true);
   }
 
-  close(clearSearchTerm = false) { 
+  close(clearSearchTerm = false) {
     if (clearSearchTerm) {
       this.input.value = '';
       this.removeAttribute('results');
@@ -205,6 +222,11 @@ class PredictiveSearch extends HTMLElement {
     this.input.setAttribute('aria-expanded', false);
     this.resultsMaxHeight = false
     this.predictiveSearchResults.removeAttribute('style');
+
+    if (!this.isIOS) return;
+    this.stickyHeader.dispatchEvent(new Event('predictiveSearchClosed'));
+    document.body.classList.remove('body-fixed');
+    window.scrollTo(0, this.scrollTopValue);
   }
 }
 

--- a/sections/header.liquid
+++ b/sections/header.liquid
@@ -262,7 +262,7 @@
               {%- endif -%}
                 <form action="{{ routes.search_url }}" method="get" role="search" class="search search-modal__form">
                   <div class="field">
-                    <input class="search__input field__input" 
+                    <input class="search__input field__input"
                       id="Search-In-Modal-1"
                       type="search"
                       name="q"
@@ -278,7 +278,7 @@
                         autocorrect="off"
                         autocomplete="off"
                         autocapitalize="off"
-                        spellcheck="false" 
+                        spellcheck="false"
                       {%- endif -%}
                     >
                     <label class="field__label" for="Search-In-Modal-1">{{ 'general.search.search' | t }}</label>
@@ -287,9 +287,9 @@
                       <svg class="icon icon-search" aria-hidden="true" focusable="false" role="presentation">
                         <use href="#icon-search">
                       </svg>
-                    </button> 
+                    </button>
                   </div>
-                  
+
                   {%- if settings.predictive_search_enabled -%}
                     <div class="predictive-search predictive-search--header" tabindex="-1" data-predictive-search>
                       <div class="predictive-search__loading-state">
@@ -304,7 +304,7 @@
                 </form>
               {%- if settings.predictive_search_enabled -%}
                 </predictive-search>
-              {%- endif -%} 
+              {%- endif -%}
               <button type="button" class="modal__close-button link link--text focus-inset" aria-label="{{ 'accessibility.close' | t }}">
                 <svg class="icon icon-close" aria-hidden="true" focusable="false" role="presentation">
                   <use href="#icon-close">
@@ -408,10 +408,10 @@
             <div class="search-modal__content" tabindex="-1">
               {%- if settings.predictive_search_enabled -%}
                 <predictive-search class="search-modal__form" data-loading-text="{{ 'accessibility.loading' | t }}">
-              {%- endif -%} 
+              {%- endif -%}
                 <form action="{{ routes.search_url }}" method="get" role="search" class="search search-modal__form">
                   <div class="field">
-                    <input class="search__input field__input" 
+                    <input class="search__input field__input"
                       id="Search-In-Modal"
                       type="search"
                       name="q"
@@ -427,7 +427,7 @@
                         autocorrect="off"
                         autocomplete="off"
                         autocapitalize="off"
-                        spellcheck="false" 
+                        spellcheck="false"
                       {%- endif -%}
                     >
                     <label class="field__label" for="Search-In-Modal">{{ 'general.search.search' | t }}</label>
@@ -436,9 +436,9 @@
                       <svg class="icon icon-search" aria-hidden="true" focusable="false" role="presentation">
                         <use href="#icon-search">
                       </svg>
-                    </button> 
+                    </button>
                   </div>
-                  
+
                   {%- if settings.predictive_search_enabled -%}
                     <div class="predictive-search predictive-search--header" tabindex="-1" data-predictive-search>
                       <div class="predictive-search__loading-state">
@@ -514,11 +514,17 @@
       this.headerBounds = {};
       this.currentScrollTop = 0;
       this.preventReveal = false;
+      this.predictiveSearchOpen = false;
 
       this.onScrollHandler = this.onScroll.bind(this);
       this.hideHeaderOnScrollUp = () => this.preventReveal = true;
+      this.setPredictiveSearchState = () => {
+        this.predictiveSearchOpen = !this.predictiveSearchOpen;
+      };
 
       this.addEventListener('preventHeaderReveal', this.hideHeaderOnScrollUp);
+      this.addEventListener('predictiveSearchOpen', this.setPredictiveSearchState);
+      this.addEventListener('predictiveSearchClosed', this.setPredictiveSearchState);
       window.addEventListener('scroll', this.onScrollHandler, false);
 
       this.createObserver();
@@ -540,6 +546,8 @@
 
     onScroll() {
       const scrollTop = window.pageYOffset || document.documentElement.scrollTop;
+
+      if (this.predictiveSearchOpen) return;
 
       if (scrollTop > this.currentScrollTop && scrollTop > this.headerBounds.bottom) {
         requestAnimationFrame(this.hide.bind(this));


### PR DESCRIPTION
**Why are these changes introduced?**

Fixes #546.

**What approach did you take?**

I looked at a few different approach and ended up using a JS one. 
- I check if it's iOS or not and then add an event listener to know when the search is open. 
- When it's opened I save the scroll value, apply it to the body, add a class to the body to fix its position and I dispatch a custom event to the sticky header. I also dispatch an event when closing the search.
- The sticky header has a listener for this event and won't do anything to the header (hide it) while it's open. 

This make it so I can scroll without triggering the `hide` function on the header. 

I was testing it on my iPad and it worked ok. Not as well as it does on Chrome by default but much better than what we currently have on `main`.

[Video demo](https://screenshot.click/21-09-we6h1-7jzrk.mp4)

**Other considerations**

**Demo links**

- [Store](url)
- [Editor](url)

**Checklist**
- [ ] Followed [theme code principles](https://github.com/Shopify/dawn/blob/main/.github/CONTRIBUTING.md#theme-code-principles)
- [ ] Linted with [Theme Check](https://github.com/Shopify/theme-check)
- [ ] Tested on [mobile](https://shopify.dev/themes/store/requirements#mobile-browser-requirements)
- [ ] Tested on [multiple browsers](https://shopify.dev/themes/store/requirements#desktop-browser-requirements)
- [ ] Tested for [accessibility](https://shopify.dev/themes/best-practices/accessibility)
