### PR TITLE
Update price.liquid HTML structure

### DIFF
--- a/assets/component-price.css
+++ b/assets/component-price.css
@@ -80,6 +80,7 @@
 }
 
 .unit-price {
+  display: block;
   font-size: 1.1rem;
   letter-spacing: 0.04rem;
   line-height: 1.2;

--- a/assets/component-price.css
+++ b/assets/component-price.css
@@ -17,17 +17,11 @@
   justify-content: flex-end;
 }
 
-.price dl {
-  margin: 0;
-  display: flex;
-  flex-direction: column;
-}
-
-.price dd {
+.price .price-item {
   margin: 0 1rem 0 0;
 }
 
-.price .price__last:last-of-type {
+.price:not(.price--show-badge) .price-item--last:last-of-type {
   margin: 0;
 }
 
@@ -59,8 +53,7 @@
 .price .price__badge-sale,
 .price .price__badge-sold-out,
 .price--on-sale .price__regular,
-.price--on-sale .price__availability,
-.price--no-compare .price__compare {
+.price--on-sale .price__availability {
   display: none;
 }
 

--- a/snippets/price.liquid
+++ b/snippets/price.liquid
@@ -34,49 +34,41 @@
   {%- if price_class %} {{ price_class }}{% endif -%}
   {%- if available == false %} price--sold-out {% endif -%}
   {%- if compare_at_price > price %} price--on-sale {% endif -%}
-  {%- if product.price_varies == false and product.compare_at_price_varies %} price--no-compare{% endif -%}">
-  <dl>
+  {%- if product.price_varies == false and product.compare_at_price_varies %} price--no-compare{% endif -%}
+  {%- if show_badges %} price--show-badge{% endif -%}">
+  <div>
     {%- comment -%}
       Explanation of description list:
         - div.price__regular: Displayed when there are no variants on sale
         - div.price__sale: Displayed when a variant is a sale
-        - div.price__availability: Displayed when the product is sold out
     {%- endcomment -%}
     <div class="price__regular">
-      <dt>
-        <span class="visually-hidden visually-hidden--inline">{{ 'products.product.price.regular_price' | t }}</span>
-      </dt>
-      <dd {% if show_badges == false %}class="price__last"{% endif %}>
-        <span class="price-item price-item--regular">
-          {{ money_price }}
-        </span>
-      </dd>
+      <span class="visually-hidden visually-hidden--inline">{{ 'products.product.price.regular_price' | t }}</span>
+      <span class="price-item price-item--regular">
+        {{ money_price }}
+      </span>
     </div>
     <div class="price__sale">
-      <dt class="price__compare">
+      {%- unless product.price_varies == false and product.compare_at_price_varies %}
         <span class="visually-hidden visually-hidden--inline">{{ 'products.product.price.regular_price' | t }}</span>
-      </dt>
-      <dd class="price__compare">
-        <s class="price-item price-item--regular">
-          {% if settings.currency_code_enabled %}
-            {{ compare_at_price | money_with_currency }}
-          {% else %}
-            {{ compare_at_price | money }}
-          {% endif %}
-        </s>
-      </dd>
-      <dt>
-        <span class="visually-hidden visually-hidden--inline">{{ 'products.product.price.sale_price' | t }}</span>
-      </dt>
-      <dd {% if show_badges == false %}class="price__last"{% endif %}>
-        <span class="price-item price-item--sale">
-          {{ money_price }}
+        <span>
+          <s class="price-item price-item--regular">
+            {% if settings.currency_code_enabled %}
+              {{ compare_at_price | money_with_currency }}
+            {% else %}
+              {{ compare_at_price | money }}
+            {% endif %}
+          </s>
         </span>
-      </dd>
+      {%- endunless -%}
+      <span class="visually-hidden visually-hidden--inline">{{ 'products.product.price.sale_price' | t }}</span>
+      <span class="price-item price-item--sale price-item--last">
+        {{ money_price }}
+      </span>
     </div>
     <small class="unit-price caption{% if product.selected_or_first_available_variant.unit_price_measurement == nil %} hidden{% endif %}">
-      <dt class="visually-hidden">{{ 'products.product.price.unit_price' | t }}</dt>
-      <dd {% if show_badges == false %}class="price__last"{% endif %}>
+      <span class="visually-hidden">{{ 'products.product.price.unit_price' | t }}</span>
+      <div class="price-item price-item--last">
         <span>{{- product.selected_or_first_available_variant.unit_price | money -}}</span>
         <span aria-hidden="true">/</span>
         <span class="visually-hidden">&nbsp;{{ 'accessibility.unit_price_separator' | t }}&nbsp;</span>
@@ -86,9 +78,9 @@
           {%- endif -%}
           {{ product.selected_or_first_available_variant.unit_price_measurement.reference_unit }}
         </span>
-      </dd>
+      </div>
     </small>
-  </dl>
+  </div>
   {%- if show_badges -%}
     <span class="badge price__badge-sale color-{{ settings.sale_badge_color_scheme }}" aria-hidden="true">
       {{ 'products.product.on_sale' | t }}

--- a/snippets/price.liquid
+++ b/snippets/price.liquid
@@ -68,7 +68,7 @@
     </div>
     <small class="unit-price caption{% if product.selected_or_first_available_variant.unit_price_measurement == nil %} hidden{% endif %}">
       <span class="visually-hidden">{{ 'products.product.price.unit_price' | t }}</span>
-      <div class="price-item price-item--last">
+      <span class="price-item price-item--last">
         <span>{{- product.selected_or_first_available_variant.unit_price | money -}}</span>
         <span aria-hidden="true">/</span>
         <span class="visually-hidden">&nbsp;{{ 'accessibility.unit_price_separator' | t }}&nbsp;</span>
@@ -78,7 +78,7 @@
           {%- endif -%}
           {{ product.selected_or_first_available_variant.unit_price_measurement.reference_unit }}
         </span>
-      </div>
+      </span>
     </small>
   </div>
   {%- if show_badges -%}


### PR DESCRIPTION
**Why are these changes introduced?**
Updates the markup for Product price to feature valid/accessible HTML structure.

Fixes #74.

**What approach did you take?**
Followed suggestions on #74:
> Due to rethinking on list heuristics from the accessibility community, and the fact that there are no visuals indicating list content, let's remove the dl semantic elements. This will provide valid HTML and remove extra announcements of list and list item count which is not required in this context.

**Demo links**
- [Store](https://os2-demo.myshopify.com/?preview_theme_id=126446993430)
- [Editor](https://os2-demo.myshopify.com/admin/themes/126446993430/editor)

**Checklist**
- [ ] Followed [theme code principles](https://github.com/Shopify/dawn/blob/main/.github/CONTRIBUTING.md#theme-code-principles)
- [ ] Linted with [Theme Check](https://github.com/Shopify/theme-check)
- [ ] Tested on [mobile](https://shopify.dev/themes/store/requirements#mobile-browser-requirements)
- [ ] Tested on [multiple browsers](https://shopify.dev/themes/store/requirements#desktop-browser-requirements)
- [ ] Tested for [accessibility](https://shopify.dev/themes/best-practices/accessibility)
