### PR TITLE
Add subscription label to cart notification

### DIFF
--- a/sections/cart-notification-product.liquid
+++ b/sections/cart-notification-product.liquid
@@ -22,6 +22,9 @@
             {%- endfor -%}
           </dl>
         {%- endunless -%}
+        {%- if item.selling_plan_allocation != nil -%}
+          <p class="cart-notification-product__option h4">{{ item.selling_plan_allocation.selling_plan.name }}</p>
+        {%- endif -%}
       </div>
     </div>
   {%- endfor -%}


### PR DESCRIPTION
**Why are these changes introduced?**
Fixes #673 

**What approach did you take?**
Same approach used on `main-cart-items.liquid`: output a `<p>{{ item.selling_plan_allocation.selling_plan.name }}</p>` element below the cart options.

<img src="https://user-images.githubusercontent.com/37168033/134572978-1f5ab1f9-3ce2-4dff-9e40-2ce7deebe7d6.png" width="280">


**Demo links**
- [Editor](https://os2-demo.myshopify.com/admin/themes/126428971030/editor)
- [Store](https://os2-demo.myshopify.com/?preview_theme_id=126428971030)

**Checklist**
- [x] Followed [theme code principles](https://github.com/Shopify/dawn/blob/main/.github/CONTRIBUTING.md#theme-code-principles)
- [x] Linted with [Theme Check](https://github.com/Shopify/theme-check)
- [x] Tested on [mobile](https://shopify.dev/themes/store/requirements#mobile-browser-requirements)
- [x] Tested on [multiple browsers](https://shopify.dev/themes/store/requirements#desktop-browser-requirements)
- [x] Tested for [accessibility](https://shopify.dev/themes/best-practices/accessibility)