### PR TITLE
Add missing lazy loading tag for theme-check

### DIFF
--- a/sections/predictive-search.liquid
+++ b/sections/predictive-search.liquid
@@ -19,6 +19,7 @@
                 alt="{{ product.featured_media.alt }}"
                 width="50"
                 height="{{ 50 | divided_by: product.featured_media.preview_image.aspect_ratio }}"
+                loading="lazy"
               >
             {%- endif -%}
             <div class="predictive-search__item-content{% unless settings.predictive_search_show_vendor or settings.predictive_search_show_price %} predictive-search__item-content--centered{% endunless %}">


### PR DESCRIPTION
**Why are these changes introduced?**

Upon using `theme-check` from main branch, I noticed that the linter considers the missing `loading='lazy'` tag on the predictive search images to be an offense.

<img width="1023" alt="Screenshot 2021-09-24 at 10 19 15 AM" src="https://user-images.githubusercontent.com/16366896/134651549-5061405c-4a7a-4fe5-8bec-9f06554225ae.png">

**What approach did you take?**

Adding the `loading='lazy'` tag to predictive search images

**Other considerations**

Perhaps this tag was intentionally omitted for this use case since the predictive search occurs higher up in the user's viewport? In which case, is there a good way to make the theme-check linter less strict about lazy loading?

**Demo links**

- [Store](url)
- [Editor](url)

**Checklist**
- [x] Followed [theme code principles](https://github.com/Shopify/dawn/blob/main/.github/CONTRIBUTING.md#theme-code-principles)
- [x] Linted with [Theme Check](https://github.com/Shopify/theme-check)
- [x] Tested on [mobile](https://shopify.dev/themes/store/requirements#mobile-browser-requirements)
- [x] Tested on [multiple browsers](https://shopify.dev/themes/store/requirements#desktop-browser-requirements)
- [x] Tested for [accessibility](https://shopify.dev/themes/best-practices/accessibility)
