### PR TITLE
Add image banner height settings

### DIFF
--- a/assets/section-image-banner.css
+++ b/assets/section-image-banner.css
@@ -7,29 +7,29 @@
 @media screen and (max-width: 749px) {
   .banner--small.banner--mobile-bottom:not(.banner--adapt) > .banner__media,
   .banner--small.banner--stacked:not(.banner--mobile-bottom):not(.banner--adapt) > .banner__media {
-    height: 42rem;
+    height: 28rem;
   }
 
   .banner--medium.banner--mobile-bottom:not(.banner--adapt) > .banner__media,
   .banner--medium.banner--stacked:not(.banner--mobile-bottom):not(.banner--adapt) > .banner__media {
-    height: 56rem;
+    height: 34rem;
   }
 
   .banner--large.banner--mobile-bottom:not(.banner--adapt) > .banner__media,
   .banner--large.banner--stacked:not(.banner--mobile-bottom):not(.banner--adapt) > .banner__media {
-    height: 72rem;
+    height: 39rem;
   }
 
   .banner--small:not(.banner--mobile-bottom):not(.banner--adapt) .banner__content {
-    min-height: 42rem;
+    min-height: 28rem;
   }
 
   .banner--medium:not(.banner--mobile-bottom):not(.banner--adapt) .banner__content {
-    min-height: 56rem;
+    min-height: 34rem;
   }
 
   .banner--large:not(.banner--mobile-bottom):not(.banner--adapt) .banner__content {
-    min-height: 72rem;
+    min-height: 39rem;
   }
 }
 

--- a/assets/section-image-banner.css
+++ b/assets/section-image-banner.css
@@ -18,7 +18,6 @@
 
 @media screen and (min-width: 750px) {
   .banner {
-    min-height: 72rem;
     flex-direction: row;
   }
 }
@@ -69,6 +68,18 @@
   .banner__media {
     height: 100%;
   }
+}
+
+.banner--small:not(.banner--adapt) {
+  min-height: 42rem;
+}
+
+.banner--medium:not(.banner--adapt) {
+  min-height: 56rem;
+}
+
+.banner--large:not(.banner--adapt) {
+  min-height: 72rem;
 }
 
 .banner--adapt {
@@ -161,10 +172,12 @@
 
   .banner__content--flex-start {
     align-items: flex-start;
+    padding-bottom: 15rem;
   }
 
   .banner__content--flex-end {
     align-items: flex-end;
+    padding-top: 15rem;
   }
 }
 

--- a/assets/section-image-banner.css
+++ b/assets/section-image-banner.css
@@ -5,14 +5,31 @@
 }
 
 @media screen and (max-width: 749px) {
-  .banner--mobile-bottom:not(.banner--stacked):not(.banner--adapt)
-    > .banner__media {
-    height: 39rem;
+  .banner--small.banner--mobile-bottom:not(.banner--adapt) > .banner__media,
+  .banner--small.banner--stacked:not(.banner--mobile-bottom):not(.banner--adapt) > .banner__media {
+    height: 42rem;
   }
 
-  .banner:not(.banner--stacked) {
-    flex-direction: row;
-    flex-wrap: wrap;
+  .banner--medium.banner--mobile-bottom:not(.banner--adapt) > .banner__media,
+  .banner--medium.banner--stacked:not(.banner--mobile-bottom):not(.banner--adapt) > .banner__media {
+    height: 56rem;
+  }
+
+  .banner--large.banner--mobile-bottom:not(.banner--adapt) > .banner__media,
+  .banner--large.banner--stacked:not(.banner--mobile-bottom):not(.banner--adapt) > .banner__media {
+    height: 72rem;
+  }
+
+  .banner--small:not(.banner--mobile-bottom):not(.banner--adapt) .banner__content {
+    min-height: 42rem;
+  }
+
+  .banner--medium:not(.banner--mobile-bottom):not(.banner--adapt) .banner__content {
+    min-height: 56rem;
+  }
+
+  .banner--large:not(.banner--mobile-bottom):not(.banner--adapt) .banner__content {
+    min-height: 72rem;
   }
 }
 
@@ -20,9 +37,26 @@
   .banner {
     flex-direction: row;
   }
+
+  .banner--small:not(.banner--adapt) {
+    min-height: 42rem;
+  }
+
+  .banner--medium:not(.banner--adapt) {
+    min-height: 56rem;
+  }
+
+  .banner--large:not(.banner--adapt) {
+    min-height: 72rem;
+  }
 }
 
 @media screen and (max-width: 749px) {
+  .banner:not(.banner--stacked) {
+    flex-direction: row;
+    flex-wrap: wrap;
+  }
+  
   .banner--stacked {
     height: auto;
   }
@@ -57,29 +91,12 @@
   .banner--stacked .banner__media-half + .banner__media-half {
     order: 1;
   }
-
-  .banner:not(.banner--adapt):not(.banner--stacked):not(.banner--mobile-bottom)
-    > .banner__content {
-    min-height: 39rem;
-  }
 }
 
 @media screen and (min-width: 750px) {
   .banner__media {
     height: 100%;
   }
-}
-
-.banner--small:not(.banner--adapt) {
-  min-height: 42rem;
-}
-
-.banner--medium:not(.banner--adapt) {
-  min-height: 56rem;
-}
-
-.banner--large:not(.banner--adapt) {
-  min-height: 72rem;
 }
 
 .banner--adapt {
@@ -112,7 +129,6 @@
   .banner--stacked:not(.banner--mobile-bottom):not(.banner--adapt)
     .banner__content {
     position: absolute;
-    min-height: 39rem;
     height: auto;
   }
 
@@ -124,7 +140,6 @@
 
   .banner--stacked:not(.banner--adapt) .banner__media {
     position: relative;
-    height: 39rem;
   }
 
   .banner::before {

--- a/assets/section-image-banner.css
+++ b/assets/section-image-banner.css
@@ -305,6 +305,12 @@
   }
 }
 
+@media screen and (min-width: 1400px) {
+  .banner__box {
+    max-width: 90rem;
+  }
+}
+
 .banner__heading > *,
 .banner__text > * {
   word-wrap: break-word;

--- a/locales/cs.schema.json
+++ b/locales/cs.schema.json
@@ -763,7 +763,8 @@
           "label": "Zobrazit obrázky na mobilním zařízení nad sebou"
         },
         "adapt_height_first_image": {
-          "label": "Přizpůsobit výšku sekce velikosti prvního obrázku"
+          "label": "Přizpůsobit výšku sekce velikosti prvního obrázku",
+          "info": "Pokud je tato možnost zaškrtnuta, přepíše nastavení výšky obrázkového banneru."
         },
         "show_text_box": {
           "label": "Zobrazit textové pole na počítači"
@@ -776,6 +777,19 @@
         },
         "show_text_below": {
           "label": "Zobrazit text pod obrázky"
+        },
+        "image_height": {
+          "label": "Výška obrázkového banneru",
+          "options__1": {
+            "label": "Malá"
+          },
+          "options__2": {
+            "label": "Střední"
+          },
+          "options__3": {
+            "label": "Velká"
+          },
+          "info": "Nejlepších výsledků dosáhnete pomocí obrázku s poměrem stran 2:3. [Zjistit více](https://help.shopify.com/en/manual/shopify-admin/productivity-tools/image-editor#understanding-image-aspect-ratio)"
         }
       },
       "blocks": {

--- a/locales/da.schema.json
+++ b/locales/da.schema.json
@@ -763,7 +763,8 @@
           "label": "Stabl billeder på mobilenheder"
         },
         "adapt_height_first_image": {
-          "label": "Tilpas afsnitshøjden til størrelsen af det første billede"
+          "label": "Tilpas afsnitshøjden til størrelsen af det første billede",
+          "info": "Overskriver indstillingerne for højden på billedbanneret, når det markeres."
         },
         "show_text_box": {
           "label": "Vis tekstfelt på skrivebord"
@@ -776,6 +777,19 @@
         },
         "show_text_below": {
           "label": "Vis tekster under billeder"
+        },
+        "image_height": {
+          "label": "Højde på billedbanner",
+          "options__1": {
+            "label": "Lille"
+          },
+          "options__2": {
+            "label": "Medium"
+          },
+          "options__3": {
+            "label": "Stor"
+          },
+          "info": "Brug et billede med et højde-bredde-forhold på 2:3 for at opnå det bedste resultat. [Få mere at vide](https://help.shopify.com/en/manual/shopify-admin/productivity-tools/image-editor#understanding-image-aspect-ratio)"
         }
       },
       "blocks": {

--- a/locales/de.schema.json
+++ b/locales/de.schema.json
@@ -763,7 +763,8 @@
           "label": "Gestapelte Bilder auf Mobilgeräten"
         },
         "adapt_height_first_image": {
-          "label": "Abschnittshöhe an Größe des ersten Bildes anpassen"
+          "label": "Abschnittshöhe an Größe des ersten Bildes anpassen",
+          "info": "Überschreibt bei Überprüfung die Einstellung für die Höhe des Bild-Banners."
         },
         "show_text_box": {
           "label": "Textfeld auf dem Desktop anzeigen"
@@ -776,6 +777,19 @@
         },
         "show_text_below": {
           "label": "Text unter Bildern anzeigen"
+        },
+        "image_height": {
+          "label": "Höhe des Bild-Banners",
+          "options__1": {
+            "label": "Klein"
+          },
+          "options__2": {
+            "label": "Mittel"
+          },
+          "options__3": {
+            "label": "Groß"
+          },
+          "info": "Verwende für Bilder ein Seitenverhältnis von 2:3 für optimale Ergebnisse. [Mehr Informationen](https://help.shopify.com/en/manual/shopify-admin/productivity-tools/image-editor#understanding-image-aspect-ratio)"
         }
       },
       "blocks": {

--- a/locales/en.default.schema.json
+++ b/locales/en.default.schema.json
@@ -816,6 +816,19 @@
         "image_2": {
           "label": "Second image"
         },
+        "image_height": {
+          "label": "Image banner height",
+          "options__1": {
+            "label": "Small"
+          },
+          "options__2": {
+            "label": "Medium"
+          },
+          "options__3": {
+            "label": "Large"
+          },
+          "info": "For best results, use an image with a 2:3 aspect ratio. [Learn more](https://help.shopify.com/en/manual/shopify-admin/productivity-tools/image-editor#understanding-image-aspect-ratio)"
+        },
         "desktop_text_box_position": {
           "options__1": {
             "label": "Top"
@@ -863,7 +876,8 @@
           "label": "Show text below images"
         },
         "adapt_height_first_image": {
-          "label": "Adapt section height to first image size"
+          "label": "Adapt section height to first image size",
+          "info": "Overwrites image banner height setting when checked."
         }
       },
       "blocks": {

--- a/locales/es.schema.json
+++ b/locales/es.schema.json
@@ -763,7 +763,8 @@
           "label": "Apilar imágenes en móviles"
         },
         "adapt_height_first_image": {
-          "label": "Adaptar altura de sección a tamaño de primera imagen"
+          "label": "Adaptar altura de sección a tamaño de primera imagen",
+          "info": "Sobrescribe la configuración de altura del banner de imagen cuando está seleccionada."
         },
         "show_text_box": {
           "label": "Mostrar el cuadro de texto en el escritorio"
@@ -776,6 +777,19 @@
         },
         "show_text_below": {
           "label": "Mostrar el texto debajo de las imágenes"
+        },
+        "image_height": {
+          "label": "Altura del banner de imagen",
+          "options__1": {
+            "label": "Pequeña"
+          },
+          "options__2": {
+            "label": "Mediana"
+          },
+          "options__3": {
+            "label": "Grande"
+          },
+          "info": "Para mejores resultados, utiliza una imagen con una relación de aspecto 2:3. [Más información](https://help.shopify.com/en/manual/shopify-admin/productivity-tools/image-editor#understanding-image-aspect-ratio)"
         }
       },
       "blocks": {

--- a/locales/fi.schema.json
+++ b/locales/fi.schema.json
@@ -763,7 +763,8 @@
           "label": "Pinoa kuvat mobiilissa"
         },
         "adapt_height_first_image": {
-          "label": "Mukauta osion korkeus ensimmäisen kuvan kokoon"
+          "label": "Mukauta osion korkeus ensimmäisen kuvan kokoon",
+          "info": "Korvaa kuvabannerin korkeusasetuksen"
         },
         "show_text_box": {
           "label": "Näytä tekstiruutu työpöydällä"
@@ -776,6 +777,19 @@
         },
         "show_text_below": {
           "label": "Näytä teksti kuvien alapuolella"
+        },
+        "image_height": {
+          "label": "Kuvabannerin korkeus",
+          "options__1": {
+            "label": "Pieni"
+          },
+          "options__2": {
+            "label": "Keskisuuri"
+          },
+          "options__3": {
+            "label": "Suuri"
+          },
+          "info": "Saat parhaat tulokset käyttämällä kuvaa, jonka kuvasuhde on 2:3. [Lisätietoja](https://help.shopify.com/en/manual/shopify-admin/productivity-tools/image-editor#understanding-image-aspect-ratio)"
         }
       },
       "blocks": {

--- a/locales/fr.schema.json
+++ b/locales/fr.schema.json
@@ -763,7 +763,8 @@
           "label": "Empiler des images sur un mobile"
         },
         "adapt_height_first_image": {
-          "label": "Adapter la hauteur de la section à la taille de la première image"
+          "label": "Adapter la hauteur de la section à la taille de la première image",
+          "info": "Remplace le paramètre de hauteur de la bannière d'image lorsqu'il est activé."
         },
         "show_text_box": {
           "label": "Afficher la zone de texte sur le bureau"
@@ -776,6 +777,19 @@
         },
         "show_text_below": {
           "label": "Afficher le texte sous les images"
+        },
+        "image_height": {
+          "label": "Hauteur de la bannière de l'image",
+          "options__1": {
+            "label": "Petit"
+          },
+          "options__2": {
+            "label": "Moyen"
+          },
+          "options__3": {
+            "label": "Grand"
+          },
+          "info": "Pour optimiser vos résultats, utilisez une image ayant un rapport d'aspect de 2:3. [En savoir plus](https://help.shopify.com/en/manual/shopify-admin/productivity-tools/image-editor#understanding-image-aspect-ratio)"
         }
       },
       "blocks": {

--- a/locales/it.schema.json
+++ b/locales/it.schema.json
@@ -763,7 +763,8 @@
           "label": "Elenca immagini su dispositivo mobile"
         },
         "adapt_height_first_image": {
-          "label": "Adatta l'altezza della sezione alle dimensioni della prima immagine"
+          "label": "Adatta l'altezza della sezione alle dimensioni della prima immagine",
+          "info": "Se si effettua la selezione, sovrascrive le impostazioni dell'altezza del banner immagine."
         },
         "show_text_box": {
           "label": "Mostra casella di testo sul desktop"
@@ -776,6 +777,19 @@
         },
         "show_text_below": {
           "label": "Mostra testo sotto le immagini"
+        },
+        "image_height": {
+          "label": "Altezza banner immagine",
+          "options__1": {
+            "label": "Piccola"
+          },
+          "options__2": {
+            "label": "Media"
+          },
+          "options__3": {
+            "label": "Grande"
+          },
+          "info": "Per un risultato ottimale, utilizza un'immagine con proporzioni 2:3. [Maggiori informazioni](https://help.shopify.com/en/manual/shopify-admin/productivity-tools/image-editor#understanding-image-aspect-ratio)"
         }
       },
       "blocks": {

--- a/locales/ja.schema.json
+++ b/locales/ja.schema.json
@@ -769,7 +769,8 @@
           "label": "モバイルで画像を重ねる"
         },
         "adapt_height_first_image": {
-          "label": "セクションの高さを最初の画像サイズに合わせる"
+          "label": "セクションの高さを最初の画像サイズに合わせる",
+          "info": "チェックすると、画像バナーの高さ設定が上書きされます。"
         },
         "show_text_box": {
           "label": "デスクトップ上にテキストボックスを表示する"
@@ -782,6 +783,19 @@
         },
         "show_text_below": {
           "label": "画像下にテキストを表示する"
+        },
+        "image_height": {
+          "label": "画像バナーの高さ",
+          "options__1": {
+            "label": "小"
+          },
+          "options__2": {
+            "label": "中"
+          },
+          "options__3": {
+            "label": "大"
+          },
+          "info": "画像のアスペクト比が2:3のものを使用すると最適です。[詳しくはこちら](https://help.shopify.com/en/manual/shopify-admin/productivity-tools/image-editor#understanding-image-aspect-ratio)"
         }
       },
       "blocks": {

--- a/locales/ko.schema.json
+++ b/locales/ko.schema.json
@@ -769,7 +769,8 @@
           "label": "모바일 스택 이미지"
         },
         "adapt_height_first_image": {
-          "label": "첫 번째 이미지에 섹션 높이 맞추기"
+          "label": "첫 번째 이미지에 섹션 높이 맞추기",
+          "info": "확인란을 선택하면 이미지 배너 높이 설정을 덮어씁니다."
         },
         "show_text_box": {
           "label": "바탕 화면에 텍스트 상자 표시"
@@ -782,6 +783,19 @@
         },
         "show_text_below": {
           "label": "텍스트를 이미지 아래에 표시"
+        },
+        "image_height": {
+          "label": "이미지 배너 높이",
+          "options__1": {
+            "label": "작게"
+          },
+          "options__2": {
+            "label": "보통"
+          },
+          "options__3": {
+            "label": "크게"
+          },
+          "info": "최고의 결과를 얻으려면 이미지의 가로 세로 비율을 2:3으로 사용하십시오. [자세히 알아보기](https://help.shopify.com/en/manual/shopify-admin/productivity-tools/image-editor#understanding-image-aspect-ratio)"
         }
       },
       "blocks": {

--- a/locales/nb.schema.json
+++ b/locales/nb.schema.json
@@ -763,7 +763,8 @@
           "label": "Stable bilder på mobil"
         },
         "adapt_height_first_image": {
-          "label": "Tilpass seksjonshøyden til den første bildestørrelsen"
+          "label": "Tilpass seksjonshøyden til den første bildestørrelsen",
+          "info": "Overskriver innstillingen for bildebannerhøyde når den er avmerket."
         },
         "show_text_box": {
           "label": "Vis tekstboks på datamaskiner"
@@ -776,6 +777,19 @@
         },
         "show_text_below": {
           "label": "Vis tekst under bilder"
+        },
+        "image_height": {
+          "label": "Høyde på bildebanner",
+          "options__1": {
+            "label": "Liten"
+          },
+          "options__2": {
+            "label": "Middels"
+          },
+          "options__3": {
+            "label": "Stor"
+          },
+          "info": "Bruk et bilde med størrelsesforhold 2:3 for best resultat. [Finn ut mer](https://help.shopify.com/en/manual/shopify-admin/productivity-tools/image-editor#understanding-image-aspect-ratio)"
         }
       },
       "blocks": {

--- a/locales/nl.schema.json
+++ b/locales/nl.schema.json
@@ -763,7 +763,8 @@
           "label": "Afbeeldingen stapelen op mobiel"
         },
         "adapt_height_first_image": {
-          "label": "Sectiehoogte aanpassen aan grootte eerste afbeelding"
+          "label": "Sectiehoogte aanpassen aan grootte eerste afbeelding",
+          "info": "Overschrijft de instelling voor de hoogte van de bannerafbeelding als je deze controleert."
         },
         "show_text_box": {
           "label": "Geef het tekstvak weer op het bureaublad"
@@ -776,6 +777,19 @@
         },
         "show_text_below": {
           "label": "Geef tekst weer onder afbeeldingen"
+        },
+        "image_height": {
+          "label": "Hoogte van de bannerafbeelding",
+          "options__1": {
+            "label": "Klein"
+          },
+          "options__2": {
+            "label": "Gemiddeld"
+          },
+          "options__3": {
+            "label": "Groot"
+          },
+          "info": "Gebruik voor de beste resultaten een afbeelding met een beeldverhouding van 2:3. [Meer informatie](https://help.shopify.com/en/manual/shopify-admin/productivity-tools/image-editor#understanding-image-aspect-ratio)"
         }
       },
       "blocks": {

--- a/locales/pl.schema.json
+++ b/locales/pl.schema.json
@@ -763,7 +763,8 @@
           "label": "Układaj obrazy w stosy na urządzeniu mobilnym"
         },
         "adapt_height_first_image": {
-          "label": "Dostosuj wysokość sekcji do rozmiaru pierwszego obrazu"
+          "label": "Dostosuj wysokość sekcji do rozmiaru pierwszego obrazu",
+          "info": "Nadpisuje ustawienie wysokości banera obrazu, jeżeli jest zaznaczone."
         },
         "show_text_box": {
           "label": "Pokaż pole tekstowe na pulpicie"
@@ -776,6 +777,19 @@
         },
         "show_text_below": {
           "label": "Pokaż tekst pod obrazami"
+        },
+        "image_height": {
+          "label": "Wysokość banera z obrazem",
+          "options__1": {
+            "label": "Mały"
+          },
+          "options__2": {
+            "label": "Średni"
+          },
+          "options__3": {
+            "label": "Duży"
+          },
+          "info": "Aby uzyskać najlepsze wyniki, użyj obrazu o współczynniku proporcji 2:3. [Dowiedz się więcej](https://help.shopify.com/en/manual/shopify-admin/productivity-tools/image-editor#understanding-image-aspect-ratio)"
         }
       },
       "blocks": {

--- a/locales/pt-BR.schema.json
+++ b/locales/pt-BR.schema.json
@@ -763,7 +763,8 @@
           "label": "Empilhar imagens em dispositivos móveis"
         },
         "adapt_height_first_image": {
-          "label": "Adaptar a altura da seção para o tamanho da primeira imagem"
+          "label": "Adaptar a altura da seção para o tamanho da primeira imagem",
+          "info": "Quando marcada, substitui a configuração de altura para o banner da imagem."
         },
         "show_text_box": {
           "label": "Exibir caixa de texto no computador"
@@ -776,6 +777,19 @@
         },
         "show_text_below": {
           "label": "Exibir texto abaixo de imagens"
+        },
+        "image_height": {
+          "label": "Altura do banner da imagem",
+          "options__1": {
+            "label": "Pequena"
+          },
+          "options__2": {
+            "label": "Média"
+          },
+          "options__3": {
+            "label": "Grande"
+          },
+          "info": "Use uma imagem com proporção 2:3 para ter os melhores resultados. [Saiba mais](https://help.shopify.com/en/manual/shopify-admin/productivity-tools/image-editor#understanding-image-aspect-ratio)"
         }
       },
       "blocks": {

--- a/locales/pt-PT.schema.json
+++ b/locales/pt-PT.schema.json
@@ -769,7 +769,8 @@
           "label": "Empilhar imagens em dispositivos móveis"
         },
         "adapt_height_first_image": {
-          "label": "Adaptar altura da secção ao tamanho da primeira imagem"
+          "label": "Adaptar altura da secção ao tamanho da primeira imagem",
+          "info": "Quando marcada, substitui a definição de altura do banner da imagem."
         },
         "show_text_box": {
           "label": "Mostrar caixa de texto no desktop"
@@ -782,6 +783,19 @@
         },
         "show_text_below": {
           "label": "Mostrar texto abaixo das imagens"
+        },
+        "image_height": {
+          "label": "Altura do banner da imagem",
+          "options__1": {
+            "label": "Pequeno"
+          },
+          "options__2": {
+            "label": "Médio"
+          },
+          "options__3": {
+            "label": "Grande"
+          },
+          "info": "Para obter os melhores resultados, utilize uma imagem com uma proporção de 2:3. [Saber mais](https://help.shopify.com/en/manual/shopify-admin/productivity-tools/image-editor#understanding-image-aspect-ratio)"
         }
       },
       "blocks": {

--- a/locales/sv.schema.json
+++ b/locales/sv.schema.json
@@ -769,7 +769,8 @@
           "label": "Stapla bilder på mobil"
         },
         "adapt_height_first_image": {
-          "label": "Anpassa avsnittets höjd till storleken på första bilden."
+          "label": "Anpassa avsnittets höjd till storleken på första bilden.",
+          "info": "Skriver över inställning för bildbanner-höjden när den markeras."
         },
         "show_text_box": {
           "label": "Visa textruta på dator"
@@ -782,6 +783,19 @@
         },
         "show_text_below": {
           "label": "Visa text under bilder"
+        },
+        "image_height": {
+          "label": "Höjd på bildbanner",
+          "options__1": {
+            "label": "Liten"
+          },
+          "options__2": {
+            "label": "Medel"
+          },
+          "options__3": {
+            "label": "Stor"
+          },
+          "info": "Använd en bild med bildformat 2:3, för bästa resultat. [Mer information](https://help.shopify.com/en/manual/shopify-admin/productivity-tools/image-editor#understanding-image-aspect-ratio)"
         }
       },
       "blocks": {

--- a/locales/th.schema.json
+++ b/locales/th.schema.json
@@ -769,7 +769,8 @@
           "label": "การรวมภาพบนมือถือ"
         },
         "adapt_height_first_image": {
-          "label": "ปรับความสูงของส่วนตามขนาดของรูปภาพแรก"
+          "label": "ปรับความสูงของส่วนตามขนาดของรูปภาพแรก",
+          "info": "เขียนทับการตั้งค่าความสูงของแบนเนอร์รูปภาพเมื่อทำเครื่องหมาย"
         },
         "show_text_box": {
           "label": "แสดงกล่องข้อความบนเดสก์ท็อป"
@@ -782,6 +783,19 @@
         },
         "show_text_below": {
           "label": "แสดงข้อความที่ด้านล่างของรูปภาพ"
+        },
+        "image_height": {
+          "label": "ความสูงของแบนเนอร์รูปภาพ",
+          "options__1": {
+            "label": "เล็ก"
+          },
+          "options__2": {
+            "label": "ปานกลาง"
+          },
+          "options__3": {
+            "label": "ใหญ่"
+          },
+          "info": "ใช้รูปภาพที่มีอัตราส่วนภาพ 2:3 เพื่อผลลัพธ์ที่ดีที่สุด [ดูข้อมูลเพิ่มเติม](https://help.shopify.com/en/manual/shopify-admin/productivity-tools/image-editor#understanding-image-aspect-ratio)"
         }
       },
       "blocks": {

--- a/locales/tr.schema.json
+++ b/locales/tr.schema.json
@@ -763,7 +763,8 @@
           "label": "Mobilde görselleri üst üste ekle"
         },
         "adapt_height_first_image": {
-          "label": "Bölüm yüksekliğini ilk görselin boyutuna uyarla"
+          "label": "Bölüm yüksekliğini ilk görselin boyutuna uyarla",
+          "info": "İşaretlendiğinde görüntü banner'ı yükseklik ayarının üzerine yazar."
         },
         "show_text_box": {
           "label": "Masaüstünde metin kutusunu göster"
@@ -776,6 +777,19 @@
         },
         "show_text_below": {
           "label": "Metni görsellerin altında göster"
+        },
+        "image_height": {
+          "label": "Görsel banner'ı yüksekliği",
+          "options__1": {
+            "label": "Küçük"
+          },
+          "options__2": {
+            "label": "Orta"
+          },
+          "options__3": {
+            "label": "Büyük"
+          },
+          "info": "En iyi sonuçlar için 2:3 en-boy oranına sahip bir görsel kullanın. [Daha fazla bilgi edinin](https://help.shopify.com/en/manual/shopify-admin/productivity-tools/image-editor#understanding-image-aspect-ratio)"
         }
       },
       "blocks": {

--- a/locales/vi.schema.json
+++ b/locales/vi.schema.json
@@ -763,7 +763,8 @@
           "label": "Xếp chồng hình ảnh trên điện thoại di động"
         },
         "adapt_height_first_image": {
-          "label": "Điều chỉnh độ cao mục theo cỡ hình ảnh thứ nhất"
+          "label": "Điều chỉnh độ cao mục theo cỡ hình ảnh thứ nhất",
+          "info": "Nếu chọn, cài đặt chiều cao biểu ngữ hình ảnh sẽ được ghi đè."
         },
         "show_text_box": {
           "label": "Hiển thị hộp văn bản trên máy tính để bàn"
@@ -776,6 +777,19 @@
         },
         "show_text_below": {
           "label": "Hiển thị văn bản bên dưới hình ảnh"
+        },
+        "image_height": {
+          "label": "Chiều cao biểu ngữ hình ảnh",
+          "options__1": {
+            "label": "Nhỏ"
+          },
+          "options__2": {
+            "label": "Vừa"
+          },
+          "options__3": {
+            "label": "Lớn"
+          },
+          "info": "Để có kết quả tốt nhất, hãy sử dụng hình ảnh có tỷ lệ khung hình 2:3. [Tìm hiểu thêm](https://help.shopify.com/en/manual/shopify-admin/productivity-tools/image-editor#understanding-image-aspect-ratio)"
         }
       },
       "blocks": {

--- a/locales/zh-CN.schema.json
+++ b/locales/zh-CN.schema.json
@@ -769,7 +769,8 @@
           "label": "在移动设备上堆叠图片"
         },
         "adapt_height_first_image": {
-          "label": "使分区高度适应第一张图片大小"
+          "label": "使分区高度适应第一张图片大小",
+          "info": "当勾选时，覆盖图像横幅高度设置。"
         },
         "show_text_box": {
           "label": "在桌面上显示文本框"
@@ -782,6 +783,19 @@
         },
         "show_text_below": {
           "label": "在图片下方显示文本"
+        },
+        "image_height": {
+          "label": "图像横幅高度",
+          "options__1": {
+            "label": "小"
+          },
+          "options__2": {
+            "label": "中"
+          },
+          "options__3": {
+            "label": "大"
+          },
+          "info": "若要获得最佳效果，请使用纵横比为 2:3 的图片。[了解详细信息](https://help.shopify.com/en/manual/shopify-admin/productivity-tools/image-editor#understanding-image-aspect-ratio)"
         }
       },
       "blocks": {

--- a/locales/zh-TW.schema.json
+++ b/locales/zh-TW.schema.json
@@ -769,7 +769,8 @@
           "label": "在行動裝置上堆疊圖片"
         },
         "adapt_height_first_image": {
-          "label": "配合的一張圖片尺寸的區段高度"
+          "label": "配合的一張圖片尺寸的區段高度",
+          "info": "檢查時覆寫圖片橫幅高度設定。"
         },
         "show_text_box": {
           "label": "在桌面顯示文字方塊"
@@ -782,6 +783,19 @@
         },
         "show_text_below": {
           "label": "將文字置於圖片下方"
+        },
+        "image_height": {
+          "label": "圖片橫幅高度",
+          "options__1": {
+            "label": "小"
+          },
+          "options__2": {
+            "label": "中等"
+          },
+          "options__3": {
+            "label": "大"
+          },
+          "info": "若想要獲得最佳結果，請使用寬高比為 2:3 的圖片。[瞭解詳情](https://help.shopify.com/en/manual/shopify-admin/productivity-tools/image-editor#understanding-image-aspect-ratio)"
         }
       },
       "blocks": {

--- a/sections/image-banner.liquid
+++ b/sections/image-banner.liquid
@@ -29,7 +29,7 @@
   }
 {%- endstyle -%}
 
-<div id="Banner-{{ section.id }}" class="banner{% if section.settings.stack_images_on_mobile and section.settings.image != blank and section.settings.image_2 != blank %} banner--stacked{% endif %}{% if section.settings.adapt_height_first_image and section.settings.image != blank %} banner--adapt{% endif %}{% if section.settings.show_text_below %} banner--mobile-bottom{%- endif -%}{% if section.settings.show_text_box == false %} banner--desktop-transparent{% endif %}">
+<div id="Banner-{{ section.id }}" class="banner banner--{{ section.settings.image_height }}{% if section.settings.stack_images_on_mobile and section.settings.image != blank and section.settings.image_2 != blank %} banner--stacked{% endif %}{% if section.settings.adapt_height_first_image and section.settings.image != blank %} banner--adapt{% endif %}{% if section.settings.show_text_below %} banner--mobile-bottom{%- endif -%}{% if section.settings.show_text_box == false %} banner--desktop-transparent{% endif %}">
   {%- if section.settings.image != blank -%}
     <div class="banner__media media{% if section.settings.image == blank and section.settings.image_2 == blank %} placeholder{% endif %}{% if section.settings.image_2 != blank %} banner__media-half{% endif %}">
       <img
@@ -120,10 +120,32 @@
       "label": "t:sections.image-banner.settings.image_2.label"
     },
     {
+      "type": "select",
+      "id": "image_height",
+      "options": [
+        {
+          "value": "small",
+          "label": "t:sections.image-banner.settings.image_height.options__1.label"
+        },
+        {
+          "value": "medium",
+          "label": "t:sections.image-banner.settings.image_height.options__2.label"
+        },
+        {
+          "value": "large",
+          "label": "t:sections.image-banner.settings.image_height.options__3.label"
+        }
+      ],
+      "default": "medium",
+      "label": "t:sections.image-banner.settings.image_height.label",
+      "info": "t:sections.image-banner.settings.image_height.info"
+    },
+    {
       "type": "checkbox",
       "id": "adapt_height_first_image",
       "default": false,
-      "label": "t:sections.image-banner.settings.adapt_height_first_image.label"
+      "label": "t:sections.image-banner.settings.adapt_height_first_image.label",
+      "info": "t:sections.image-banner.settings.adapt_height_first_image.info"
     },
     {
       "type": "select",


### PR DESCRIPTION
**Why are these changes introduced?**

Fixes #552 

**What approach did you take?**

Replaced fixed heights with setting specific values using a `banner--<size>` class.

Also included a banner box width update for widescreens.

**Demo links**

- [Editor](https://os2-demo.myshopify.com/admin/themes/126447321110/editor)

**Checklist**
- [ ] Followed [theme code principles](https://github.com/Shopify/dawn/blob/main/.github/CONTRIBUTING.md#theme-code-principles)
- [ ] Linted with [Theme Check](https://github.com/Shopify/theme-check)
- [ ] Tested on [mobile](https://shopify.dev/themes/store/requirements#mobile-browser-requirements)
- [ ] Tested on [multiple browsers](https://shopify.dev/themes/store/requirements#desktop-browser-requirements)
- [ ] Tested for [accessibility](https://shopify.dev/themes/best-practices/accessibility)
