### PR TITLE
Remove facet encoding

### DIFF
--- a/assets/facets.js
+++ b/assets/facets.js
@@ -164,7 +164,8 @@ class FacetFiltersForm extends HTMLElement {
   onActiveFilterClick(event) {
     event.preventDefault();
     FacetFiltersForm.toggleActiveFacets();
-    FacetFiltersForm.renderPage(event.currentTarget.href.slice(event.currentTarget.href.indexOf('?') + 1));
+    const url = event.currentTarget.href.indexOf('?') == -1 ? '' : event.currentTarget.href.slice(event.currentTarget.href.indexOf('?') + 1);
+    FacetFiltersForm.renderPage(url);
   }
 }
 

--- a/assets/facets.js
+++ b/assets/facets.js
@@ -8,7 +8,7 @@ class FacetFiltersForm extends HTMLElement {
     }, 500);
 
     this.querySelector('form').addEventListener('input', this.debouncedOnSubmit.bind(this));
-    
+
     const facetWrapper = this.querySelector('#FacetsWrapperDesktop');
     if (facetWrapper) facetWrapper.addEventListener('keyup', onKeyUpEscape);
   }
@@ -36,7 +36,7 @@ class FacetFiltersForm extends HTMLElement {
     document.getElementById('ProductGridContainer').querySelector('.collection').classList.add('loading');
     if (countContainer){
       countContainer.classList.add('loading');
-    }    
+    }
     if (countContainerDesktop){
       countContainerDesktop.classList.add('loading');
     }
@@ -93,9 +93,9 @@ class FacetFiltersForm extends HTMLElement {
 
     const facetDetailsElements =
       parsedHTML.querySelectorAll('#FacetFiltersForm .js-filter, #FacetFiltersFormMobile .js-filter');
-    const matchesIndex = (element) => { 
+    const matchesIndex = (element) => {
       const jsFilter = event ? event.target.closest('.js-filter') : undefined;
-      return jsFilter ? element.dataset.index === jsFilter.dataset.index : false; 
+      return jsFilter ? element.dataset.index === jsFilter.dataset.index : false;
     }
     const facetsToRender = Array.from(facetDetailsElements).filter(element => !matchesIndex(element));
     const countsToRender = Array.from(facetDetailsElements).find(matchesIndex);
@@ -164,7 +164,7 @@ class FacetFiltersForm extends HTMLElement {
   onActiveFilterClick(event) {
     event.preventDefault();
     FacetFiltersForm.toggleActiveFacets();
-    FacetFiltersForm.renderPage(new URL(event.currentTarget.href).searchParams.toString());
+    FacetFiltersForm.renderPage(event.currentTarget.href.slice(event.currentTarget.href.indexOf('?') + 1));
   }
 }
 


### PR DESCRIPTION
**Why are these changes introduced?**

Fix requested by @carolineschnapp to allow differentiation between encoded and unencoded `,` in search parameters.  This is particularly needed in the facet removal buttons.  @carolineschnapp has tested it for her use case.

**What approach did you take?**

Replaced the URL `toString()` approach with a `slice` to maintain the original string instead of converting it back and forth and letting `toString()` encode it.

**Other considerations**

**Demo links**

- [Store](https://os2-demo.myshopify.com/?_ab=0&_fd=0&_sc=1&preview_theme_id=126461280278)

**Checklist**

- [x] Followed [theme code principles](https://github.com/Shopify/dawn/blob/main/.github/CONTRIBUTING.md#theme-code-principles)
- [x] Linted with [Theme Check](https://github.com/Shopify/theme-check)
- [x] Tested on [mobile](https://shopify.dev/themes/store/requirements#mobile-browser-requirements)
- [x] Tested on [multiple browsers](https://shopify.dev/themes/store/requirements#desktop-browser-requirements)
- [x] Tested for [accessibility](https://shopify.dev/themes/best-practices/accessibility)
