### PR TITLE
Proposal: Use standard_product_type for schema.org Product category

### DIFF
--- a/sections/main-product.liquid
+++ b/sections/main-product.liquid
@@ -496,6 +496,9 @@
       "@type": "Thing",
       "name": {{ product.vendor | json }}
     },
+    {%- if product.standard_product_type -%}
+      "category": {{ product.standard_product_type.type_path | json }},
+    {%- endif -%}
     "offers": [
       {%- for variant in product.variants -%}
         {


### PR DESCRIPTION
[schema.org's Product model](https://schema.org/Product) has a `category` that could be populated by `standard_product_type`. This field is not yet available in Liquid but I'm putting together a proposal to add it, and wanted to demo what this could look like in Dawn.

Any thoughts on doing this?