### PR TITLE
Fix cart error translation

### DIFF
--- a/layout/theme.liquid
+++ b/layout/theme.liquid
@@ -148,7 +148,7 @@
 
       window.cartStrings = {
         error: `{{ 'sections.cart.cart_error' | t }}`,
-        quantityError: `{{ 'sections.cart.cart_quantity_error_html' | t }}`
+        quantityError: `{{ 'sections.cart.cart_quantity_error_html' | t: quantity: '[quantity]' }}`
       }
 
       window.variantStrings = {

--- a/locales/en.default.json
+++ b/locales/en.default.json
@@ -228,7 +228,7 @@
       "checkout": "Check out",
       "empty": "Your cart is empty",
       "cart_error": "There was an error while updating your cart. Please try again.",
-      "cart_quantity_error_html": "You can only add [quantity] of this item to your cart.",
+      "cart_quantity_error_html": "You can only add {{ quantity }} of this item to your cart.",
       "taxes_and_shipping_policy_at_checkout_html": "Taxes and <a href=\"{{ link }}\">shipping</a> calculated at checkout",
       "taxes_included_but_shipping_at_checkout": "Tax included and shipping calculated at checkout",
       "taxes_included_and_shipping_policy_html": "Tax included. <a href=\"{{ link }}\">Shipping</a> calculated at checkout.",
@@ -261,7 +261,7 @@
       "view_all": "View all"
     },
     "collection_template": {
-      "empty": "No products found", 
+      "empty": "No products found",
       "title": "Collection",
       "use_fewer_filters_html": "Use fewer filters or <a class=\"{{ class }}\" href=\"{{ link }}\">clear all</a>"
     },


### PR DESCRIPTION
**Why are these changes introduced?**

There is currently an issue where we're relying on a string to change the quantity amount of the error message in the cart. 

It's looking for a string `[quantity]` which only exists in the english language. It's translated in other languages so the JS won't find the string it's looking for. 

This is a follow up to [this PR](#702) by @onkbear. 

**What approach did you take?**

I've changed `[quantity]` to `{{ quantity }}` in the english translation so that in `theme.liquid` I can set `quantity` to be `[quantity]`. 

**Other considerations**

**Demo links**

- [Store](https://os2-demo.myshopify.com/?preview_theme_id=126478647318)
- [Editor](https://os2-demo.myshopify.com/admin/themes/126478647318/editor)

**Checklist**
- [ ] Followed [theme code principles](https://github.com/Shopify/dawn/blob/main/.github/CONTRIBUTING.md#theme-code-principles)
- [ ] Linted with [Theme Check](https://github.com/Shopify/theme-check)
- [ ] Tested on [mobile](https://shopify.dev/themes/store/requirements#mobile-browser-requirements)
- [ ] Tested on [multiple browsers](https://shopify.dev/themes/store/requirements#desktop-browser-requirements)
- [ ] Tested for [accessibility](https://shopify.dev/themes/best-practices/accessibility)
