### PR TITLE
Fix no-js variant select on Featured Product

### DIFF
--- a/sections/featured-product.liquid
+++ b/sections/featured-product.liquid
@@ -219,7 +219,7 @@
                 <div class="product-form__input{% if product.has_only_default_variant %} hidden{% endif %}">
                   <label class="form__label" for="Variants-{{ section.id }}">{{ 'products.product.product_variants' | t }}</label>
                   <div class="select">
-                    <select name="id" id="Variants-{{ section.id }}" class="select__select" form="product-form">
+                    <select name="id" id="Variants-{{ section.id }}" class="select__select" form="{{ product_form_id }}">
                       {%- for variant in product.variants -%}
                         <option
                           {% if variant == product.selected_or_first_available_variant %}selected="selected"{% endif %}
@@ -251,7 +251,7 @@
                     </div>
 
                     {%- form 'product', product, id: product_form_id, class: 'form', novalidate: 'novalidate', data-type: 'add-to-cart-form' -%}
-                      <input type="hidden" name="id" value="{{ product.selected_or_first_available_variant.id }}">
+                      <input type="hidden" name="id" value="{{ product.selected_or_first_available_variant.id }}" disabled>
                       <div class="product-form__buttons">
                         <button
                           type="submit"

--- a/sections/main-product.liquid
+++ b/sections/main-product.liquid
@@ -286,7 +286,7 @@
                 </div>
 
                 {%- form 'product', product, id: product_form_id, class: 'form', novalidate: 'novalidate', data-type: 'add-to-cart-form' -%}
-                  <input type="hidden" disabled name="id" value="{{ product.selected_or_first_available_variant.id }}">
+                  <input type="hidden" name="id" value="{{ product.selected_or_first_available_variant.id }}" disabled>
                   <div class="product-form__buttons">
                     <button
                       type="submit"


### PR DESCRIPTION
**Why are these changes introduced?**
When JavaScript is disabled, only initial variant could be added to cart, regardless of which variant was selected. This PR fixes this issue by replicating the same solution implemented by #210 on `main-product.liquid`

Fixes #179.

**What approach did you take?**
- Disabled the "master" input, only used by JS variants.
- Updated the no-js `<select>` element to use the correct Form ID.

**Demo links**
- [Store](https://os2-demo.myshopify.com/?preview_theme_id=126478843926)
- [Editor](https://os2-demo.myshopify.com/admin/themes/126478843926/editor)

**Testing 🎩 **
- [ ] Add a Featured Product section with a product that has multiple variants.
- [ ] Use Developer Tools to disable JavaScript
- [ ] Navigate to the Featured Product section and select a different variant. Click the `Add to Cart` button.
- [ ] The correct variant should be added to the cart page.

**Checklist**
- [x] Followed [theme code principles](https://github.com/Shopify/dawn/blob/main/.github/CONTRIBUTING.md#theme-code-principles)
- [x] Linted with [Theme Check](https://github.com/Shopify/theme-check)
- [x] Tested on [mobile](https://shopify.dev/themes/store/requirements#mobile-browser-requirements)
- [x] Tested on [multiple browsers](https://shopify.dev/themes/store/requirements#desktop-browser-requirements)
- [x] Tested for [accessibility](https://shopify.dev/themes/best-practices/accessibility)
