### PR TITLE
=Add a enable/disable notification for cart, like in Debut

### DIFF
--- a/config/settings_schema.json
+++ b/config/settings_schema.json
@@ -67,6 +67,17 @@
     ]
   },
   {
+    "name": "t:settings_schema.enable_ajax.name",
+    "settings": [
+      {
+        "type": "checkbox",
+        "id": "enable_ajax",
+        "default": true,
+        "label": "t:settings_schema.enable_ajax.settings.enable_checkbox.label"
+      }
+    ]
+  },
+  {
     "name": "t:settings_schema.typography.name",
     "settings": [
       {

--- a/locales/en.default.schema.json
+++ b/locales/en.default.schema.json
@@ -36,6 +36,14 @@
         }
       }
     },
+    "enable_ajax": {
+      "name": "Add to cart notification",
+      "settings": {
+        "enable_checkbox": {
+          "label": "Show notification when item is added to cart"
+        }
+      }
+    },
     "typography": {
       "name": "Typography",
       "settings": {

--- a/locales/es.schema.json
+++ b/locales/es.schema.json
@@ -36,6 +36,14 @@
         }
       }
     },
+    "enable_ajax": {
+      "name": "Notificación de Agregar al carrito",
+      "settings": {
+        "enable_checkbox": {
+          "label": "Mostrar notificación cuando se agrega un artículo al carrito"
+        }
+      }
+    },
     "typography": {
       "name": "Tipografía",
       "settings": {

--- a/sections/main-product.liquid
+++ b/sections/main-product.liquid
@@ -440,7 +440,10 @@
 
   customElements.define('product-modal', ProductModal);
 {% endjavascript %}
+
+{% if settings.enable_ajax == true %}
 <script src="{{ 'product-form.js' | asset_url }}" defer="defer"></script>
+{% endif %}
 
 {%- if first_3d_model -%}
   <script type="application/json" id="ProductJSON-{{ product.id }}">


### PR DESCRIPTION
**Why are these changes introduced?**
If need add a file field for a product need disable the ajax option, like in Debut

**What approach did you take?**

**Other considerations**
I add English and Spanish languague

**Checklist**
- [ ] Followed [theme code principles](https://github.com/Shopify/dawn/blob/main/.github/CONTRIBUTING.md#theme-code-principles)
- [ ] Linted with [Theme Check](https://github.com/Shopify/theme-check)
- [ ] Tested on [mobile](https://shopify.dev/themes/store/requirements#mobile-browser-requirements)
- [] Tested on [multiple browsers](https://shopify.dev/themes/store/requirements#desktop-browser-requirements)
- [ ] Tested for [accessibility](https://shopify.dev/themes/best-practices/accessibility)
