### PR TITLE
Hackdays/social image previews

### DIFF
--- a/assets/open-graph-product.css
+++ b/assets/open-graph-product.css
@@ -1,0 +1,83 @@
+:root {
+
+  --font-body-scale: 1.7;
+  --font-heading-scale: 0.8;
+}
+
+.open-graph {
+  width: 1200px;
+  height: 630px;
+  overflow: hidden;
+  display: flex;
+  padding: 1rem;
+}
+
+.open-graph__meta {
+  flex: 1 0 auto;
+  display: flex;
+  flex-direction: column;
+}
+
+.open-graph__price {
+  margin: 0 0 1rem 0;
+}
+
+.open-graph__variant-label {
+  font-size: 1.3rem;
+  line-height: calc(1 + .5 / var(--font-body-scale));
+  letter-spacing: .04rem;
+}
+
+.open-graph__variants {
+  padding: 0;
+  margin: 0 0 1rem 0;
+  list-style-type: none;
+  display: flex;
+  color: black;
+}
+
+.open-graph__variant-item {
+  border: 0.1rem solid rgba(var(--color-foreground), 0.55);
+  border-radius: 4rem;
+  color: rgb(var(--color-foreground));
+  display: inline-block;
+  margin: 0.7rem 0.5rem 0.2rem 0;
+  padding: 1rem 2rem;
+  font-size: 1.4rem;
+  letter-spacing: 0.1rem;
+  line-height: 1;
+  text-align: center;
+}
+
+.open-graph__variant-item--unavailable {
+  border-color: rgba(var(--color-foreground), 0.1);
+  color: rgba(var(--color-foreground), 0.4);
+  text-decoration: line-through;
+}
+
+.open-graph__title {
+  margin: 1.5rem 0;
+}
+
+.open-graph__variant-item--unavailable {
+  color: rgba(var(--color-base-text), 0.5);
+}
+
+.open-graph__featured-image {
+  display: flex;
+  margin-right: 1rem;
+}
+
+.open-graph__image-list {
+  margin: 1rem 0 0 0;
+  flex: 1 0 auto;
+  padding: 0;
+  list-style-type: none;
+  display: flex;
+  align-items: flex-end;
+}
+
+.open-graph__image-item {
+  display: flex;
+  margin-right: 1rem;
+} 

--- a/layout/open-graph.liquid
+++ b/layout/open-graph.liquid
@@ -1,0 +1,168 @@
+<!doctype html>
+<html class="no-js" lang="{{ request.locale.iso_code }}">
+  <head>
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="viewport" content="width=device-width,initial-scale=1">
+    <meta name="theme-color" content="">
+    <link rel="canonical" href="{{ canonical_url }}">
+    <link rel="preconnect" href="https://cdn.shopify.com" crossorigin>
+
+    {%- if settings.favicon != blank -%}
+      <link rel="icon" type="image/png" href="{{ settings.favicon | img_url: '32x32' }}">
+    {%- endif -%}
+
+    {%- unless settings.type_header_font.system? and settings.type_body_font.system? -%}
+      <link rel="preconnect" href="https://fonts.shopifyc{ dn.com" crossorigin>
+    {%- endunless -%}
+
+    <title>
+      {{ page_title }}
+      {%- if current_tags %} &ndash; tagged "{{ current_tags | join: ', ' }}"{% endif -%}
+      {%- if current_page != 1 %} &ndash; Page {{ current_page }}{% endif -%}
+      {%- unless page_title contains shop.name %} &ndash; {{ shop.name }}{% endunless -%}
+    </title>
+
+    {% if page_description %}
+      <meta name="description" content="{{ page_description | escape }}">
+    {% endif %}
+
+    {% render 'meta-tags' %}
+
+    <script src="{{ 'global.js' | asset_url }}" defer="defer"></script>
+    {{ content_for_header }}
+
+    {%- liquid
+      assign body_font_bold = settings.type_body_font | font_modify: 'weight', 'bold'
+      assign body_font_italic = settings.type_body_font | font_modify: 'style', 'italic'
+      assign body_font_bold_italic = body_font_bold | font_modify: 'style', 'italic'
+    %}
+
+    {% style %}
+      {{ settings.type_body_font | font_face: font_display: 'swap' }}
+      {{ body_font_bold | font_face: font_display: 'swap' }}
+      {{ body_font_italic | font_face: font_display: 'swap' }}
+      {{ body_font_bold_italic | font_face: font_display: 'swap' }}
+      {{ settings.type_header_font | font_face: font_display: 'swap' }}
+
+      :root {
+        --font-body-family: {{ settings.type_body_font.family }}, {{ settings.type_body_font.fallback_families }};
+        --font-body-style: {{ settings.type_body_font.style }};
+        --font-body-weight: {{ settings.type_body_font.weight }};
+
+        --font-heading-family: {{ settings.type_header_font.family }}, {{ settings.type_header_font.fallback_families }};
+        --font-heading-style: {{ settings.type_header_font.style }};
+        --font-heading-weight: {{ settings.type_header_font.weight }};
+
+        --font-body-scale: {{ settings.body_scale | divided_by: 100.0 }};
+        --font-heading-scale: {{ settings.heading_scale | times: 1.0 | divided_by: settings.body_scale }};
+
+        --color-base-text: {{ settings.colors_text.red }}, {{ settings.colors_text.green }}, {{ settings.colors_text.blue }};
+        --color-base-background-1: {{ settings.colors_background_1.red }}, {{ settings.colors_background_1.green }}, {{ settings.colors_background_1.blue }};
+        --color-base-background-2: {{ settings.colors_background_2.red }}, {{ settings.colors_background_2.green }}, {{ settings.colors_background_2.blue }};
+        --color-base-solid-button-labels: {{ settings.colors_solid_button_labels.red }}, {{ settings.colors_solid_button_labels.green }}, {{ settings.colors_solid_button_labels.blue }};
+        --color-base-outline-button-labels: {{ settings.colors_outline_button_labels.red }}, {{ settings.colors_outline_button_labels.green }}, {{ settings.colors_outline_button_labels.blue }};
+        --color-base-accent-1: {{ settings.colors_accent_1.red }}, {{ settings.colors_accent_1.green }}, {{ settings.colors_accent_1.blue }};
+        --color-base-accent-2: {{ settings.colors_accent_2.red }}, {{ settings.colors_accent_2.green }}, {{ settings.colors_accent_2.blue }};
+        --payment-terms-background-color: {{ settings.colors_background_1 }};
+
+        --gradient-base-background-1: {% if settings.gradient_background_1 != blank %}{{ settings.gradient_background_1 }}{% else %}{{ settings.colors_background_1 }}{% endif %};
+        --gradient-base-background-2: {% if settings.gradient_background_2 != blank %}{{ settings.gradient_background_2 }}{% else %}{{ settings.colors_background_2 }}{% endif %};
+        --gradient-base-accent-1: {% if settings.gradient_accent_1 != blank %}{{ settings.gradient_accent_1 }}{% else %}{{ settings.colors_accent_1 }}{% endif %};
+        --gradient-base-accent-2: {% if settings.gradient_accent_2 != blank %}{{ settings.gradient_accent_2 }}{% else %}{{ settings.colors_accent_2 }}{% endif %};
+
+        --page-width: {{ settings.page_width | divided_by: 10 }}rem;
+        --page-width-margin: {% if settings.page_width == '1600' %}2{% else %}0{% endif %}rem;
+      }
+
+      *,
+      *::before,
+      *::after {
+        box-sizing: inherit;
+      }
+
+      html {
+        box-sizing: border-box;
+        font-size: calc(var(--font-body-scale) * 62.5%);
+        height: 100%;
+      }
+
+      body {
+        display: grid;
+        grid-template-rows: auto auto 1fr auto;
+        grid-template-columns: 100%;
+        min-height: 100%;
+        margin: 0;
+        font-size: 1.5rem;
+        letter-spacing: 0.06rem;
+        line-height: calc(1 + 0.8 / var(--font-body-scale));
+        font-family: var(--font-body-family);
+        font-style: var(--font-body-style);
+        font-weight: var(--font-body-weight);
+      }
+
+      @media screen and (min-width: 750px) {
+        body {
+          font-size: 1.6rem;
+        }
+      }
+    {% endstyle %}
+
+    {{ 'base.css' | asset_url | stylesheet_tag }}
+
+    {%- unless settings.type_body_font.system? -%}
+      <link rel="preload" as="font" href="{{ settings.type_body_font | font_url }}" type="font/woff2" crossorigin>
+    {%- endunless -%}
+    {%- unless settings.type_header_font.system? -%}
+      <link rel="preload" as="font" href="{{ settings.type_header_font | font_url }}" type="font/woff2" crossorigin>
+    {%- endunless -%}
+
+    {%- if settings.predictive_search_enabled -%}
+      <link rel="stylesheet" href="{{ 'component-predictive-search.css' | asset_url }}" media="print" onload="this.media='all'">
+    {%- endif -%}
+
+    <script>document.documentElement.className = document.documentElement.className.replace('no-js', 'js');</script>
+  </head>
+
+  <body class="gradient">
+    <a class="skip-to-content-link button visually-hidden" href="#MainContent">
+      {{ "accessibility.skip_to_text" | t }}
+    </a>
+
+    <main id="MainContent" class="content-for-layout open-graph-preview" role="main" tabindex="-1">
+      {{ content_for_layout }}
+    </main>
+
+    <ul hidden>
+      <li id="a11y-refresh-page-message">{{ 'accessibility.refresh_page' | t }}</li>
+    </ul>
+
+    <script>
+      window.routes = {
+        cart_add_url: '{{ routes.cart_add_url }}',
+        cart_change_url: '{{ routes.cart_change_url }}',
+        cart_update_url: '{{ routes.cart_update_url }}',
+        predictive_search_url: '{{ routes.predictive_search_url }}'
+      };
+
+      window.cartStrings = {
+        error: `{{ 'sections.cart.cart_error' | t }}`,
+        quantityError: `{{ 'sections.cart.cart_quantity_error_html' | t }}`
+      }
+
+      window.variantStrings = {
+        addToCart: `{{ 'products.product.add_to_cart' | t }}`,
+        soldOut: `{{ 'products.product.sold_out' | t }}`,
+        unavailable: `{{ 'products.product.unavailable' | t }}`,
+      }
+
+      window.accessibilityStrings = {
+        shareSuccess: `{{ 'general.share.success_message' | t }}`,
+      }
+    </script>
+
+    {%- if settings.predictive_search_enabled -%}
+      <script src="{{ 'predictive-search.js' | asset_url }}" defer="defer"></script>
+    {%- endif -%}
+  </body>
+</html>

--- a/sections/open-graph-product.liquid
+++ b/sections/open-graph-product.liquid
@@ -1,0 +1,56 @@
+{{ 'open-graph-product.css' | asset_url | stylesheet_tag }}
+{{ 'component-price.css' | asset_url | stylesheet_tag }}
+
+
+<div class="open-graph color-background-1">
+  <div class="open-graph__featured-image">
+    <img src="{{ product.featured_image | img_url: '580x580' }}">
+  </div>
+  <div class="open-graph__meta">
+    <h1 class="open-graph__title">{{ product.title }}</h1>
+    <div class="open-graph__price">
+      {%- render 'price', product: product, use_variant: true, show_badges: true, price_class: 'price--large' -%}
+      {%- if shop.taxes_included or shop.shipping_policy.body != blank -%}
+      <div class="product__tax caption rte">
+        {%- if shop.taxes_included -%}
+          {{ 'products.product.include_taxes' | t }}
+        {%- endif -%}
+      </div>
+    {%- endif -%}
+    </div>
+
+    {%- unless product.has_only_default_variant -%}
+      {%- for option in product.options_with_values -%}
+        <span class="open-graph__variant-label">{{option.name}}</span>
+        <ul class="open-graph__variants">
+          {%- for value in option.values -%}
+            <li class="open-graph__variant-item {% if variant.available == false %} open-graph__variant-item--unavailable{% endif %}">
+              {{ value }}
+            </li>
+          {%- endfor -%}
+        </ul>
+        {%- endfor -%}
+      </ul>
+    {%- endunless -%}
+
+    <ul class="open-graph__image-list">
+      {% for image in product.images %}
+        {% if image.src != product.featured_image %}
+          <li class="open-graph__image-item">
+            <img src="{{ image.src | img_url: '170x170' }}">
+          </li>
+        {% endif %}
+      {% endfor %}
+    </ul>
+  </div>
+</div>
+
+
+{% schema %}
+{
+  "name": "t:sections.open-graph-product.name",
+  "tag": "section",
+  "class": "open-graph-product",
+  "settings": []
+}
+{% endschema %}

--- a/snippets/meta-tags.liquid
+++ b/snippets/meta-tags.liquid
@@ -42,7 +42,7 @@
     assign width = "1200"
     assign cache_buster = product.price
     assign permanent_subdomain = shop.permanent_domain | replace: ".myshopify.com", ""
-    assign og_image = "//cdn.shopify.com/screenshots/social/" | append: permanent_subdomain | append: product.url | append: "?height=" | append: height | append: "&width=" | append: width | append: "&cb=" | append: cache_buster | append: "&view=open_graph"
+    assign og_image = "//cdn.shopify.com/screenshots/social/" | append: permanent_subdomain | append: product.url | append: "?height=" | append: height | append: "&width=" | append: width | append: "&cb=" | append: cache_buster | append: "&view=open-graph"
   %}
 
   <meta property="og:image" content="http:{{ og_image }}">

--- a/snippets/meta-tags.liquid
+++ b/snippets/meta-tags.liquid
@@ -42,7 +42,7 @@
     assign width = "1200"
     assign cache_buster = product.price
     assign permanent_subdomain = shop.permanent_domain | replace: ".myshopify.com", ""
-    assign og_image = "//cdn.shopify.com/screenshots/social/" | append: permanent_subdomain | append: product.url | append: "?height=" | append: height | append: "&width=" | append: width | append: "&cb=" | append: cache_buster
+    assign og_image = "//cdn.shopify.com/screenshots/social/" | append: permanent_subdomain | append: product.url | append: "?height=" | append: height | append: "&width=" | append: width | append: "&cb=" | append: cache_buster | append: "&view=open_graph"
   %}
 
   <meta property="og:image" content="http:{{ og_image }}">

--- a/snippets/meta-tags.liquid
+++ b/snippets/meta-tags.liquid
@@ -21,7 +21,7 @@
 <meta property="og:type" content="{{ og_type }}">
 <meta property="og:description" content="{{ og_description | escape }}">
 
-{%- if page_image -%}
+{%- if page_image and request.page_type != 'product' -%}
   <meta property="og:image" content="http:{{ page_image | img_url: 'master' }}">
   <meta property="og:image:secure_url" content="https:{{ page_image | img_url: 'master' }}">
   <meta property="og:image:width" content="{{ page_image.width }}">
@@ -29,6 +29,26 @@
 {%- endif -%}
 
 {%- if request.page_type == 'product' -%}
+  {% comment %}
+    TODO: The following should eventually go into a new drop `social_image`
+    https://github.com/Shopify/hackdays-social-image-previews/issues/2
+
+    The cache_buster is currently set by price, update_at doesn't seem to
+    be exposed in the drip. Changing the price will invalidate the cache.
+    However social media platforms do have their own caching.
+  {% endcomment %}
+  {% liquid
+    assign height = "630"
+    assign width = "1200"
+    assign cache_buster = product.price
+    assign permanent_subdomain = shop.permanent_domain | replace: ".myshopify.com", ""
+    assign og_image = "//cdn.shopify.com/screenshots/social/" | append: permanent_subdomain | append: product.url | append: "?height=" | append: height | append: "&width=" | append: width | append: "&cb=" | append: cache_buster
+  %}
+
+  <meta property="og:image" content="http:{{ og_image }}">
+  <meta property="og:image:secure_url" content="https:{{ og_image }}">
+  <meta property="og:image:width" content="{{ width }}">
+  <meta property="og:image:height" content="{{ height }}">
   <meta property="og:price:amount" content="{{ product.price | money_without_currency | strip_html }}">
   <meta property="og:price:currency" content="{{ cart.currency.iso_code }}">
 {%- endif -%}

--- a/templates/product.open-graph.json
+++ b/templates/product.open-graph.json
@@ -1,0 +1,13 @@
+{
+  "layout": "open-graph",
+  "name": "Open Graph Preview",
+  "sections": {
+    "main": {
+      "type": "open-graph-product"
+    }
+  },
+  "order": [
+    "main"
+  ]
+}
+


### PR DESCRIPTION
**Why are these changes introduced?**

We are working on a hack day [project](https://hackdays.shopify.io/projects/14631) to improve images that are shared on social media.


<img width="599" alt="new-tweet" src="https://user-images.githubusercontent.com/2196085/137299693-d2dcb31e-ff4a-4fb0-8824-21c357e106d0.png">

**What approach did you take?**

The approach is not currently production ready, but is the following.

1. Themes are modified to have a new Social Preview version of a Product. This view allows the merchant to configure how their product will appear when shared on social media.
2. The `og:image` for products is altered to point to a service which takes an image of the new view created above, it then returns that image as the one that is show on social media.

**Demo links**

- [Store](https://andy-polhill-bridge-the-gap.myshopify.com/products/checkerboard-vans)

**Checklist**
- [ ] Followed [theme code principles](https://github.com/Shopify/dawn/blob/main/.github/CONTRIBUTING.md#theme-code-principles)
- [ ] Linted with [Theme Check](https://github.com/Shopify/theme-check)
- [ ] Tested on [mobile](https://shopify.dev/themes/store/requirements#mobile-browser-requirements)
- [ ] Tested on [multiple browsers](https://shopify.dev/themes/store/requirements#desktop-browser-requirements)
- [ ] Tested for [accessibility](https://shopify.dev/themes/best-practices/accessibility)

This code is not tested and should not be merged, it should provide a useful reference point.