### PR TITLE
Removing media query around no-heading class, fixes issue #785

### DIFF
--- a/assets/base.css
+++ b/assets/base.css
@@ -912,10 +912,8 @@ summary::-webkit-details-marker {
   flex-shrink: 0;
 }
 
-@media screen and (min-width: 990px) {
-  .title-wrapper-with-link.title-wrapper-with-link--no-heading {
-    display: none;
-  }
+.title-wrapper-with-link.title-wrapper-with-link--no-heading {
+  display: none;
 }
 
 .subtitle {
@@ -2330,4 +2328,3 @@ details-disclosure > details {
     stroke: CanvasText;
   }
 }
-


### PR DESCRIPTION
**Why are these changes introduced?**

Fixes #785. Spacing was still reserved for titles that don't exist under 990px

**What approach did you take?**

Removed media query holding the min-query so that mobile devices would mimic the desktop device spacing.

**Demo links**
[Mobile Image](https://i.imgur.com/yU86CGC.png)

**Checklist**
- [✅  ] Followed [theme code principles](https://github.com/Shopify/dawn/blob/main/.github/CONTRIBUTING.md#theme-code-principles)
- [✅ ] Linted with [Theme Check](https://github.com/Shopify/theme-check)
- [✅  ] Tested on [mobile](https://shopify.dev/themes/store/requirements#mobile-browser-requirements)
- [✅  ] Tested on [multiple browsers](https://shopify.dev/themes/store/requirements#desktop-browser-requirements)
- [✅  ] Tested for [accessibility](https://shopify.dev/themes/best-practices/accessibility)
