### PR TITLE
Mobile navigation focus issue

### DIFF
--- a/assets/global.js
+++ b/assets/global.js
@@ -323,7 +323,7 @@ class MenuDrawer extends HTMLElement {
 
     if (detailsElement === this.mainDetailsToggle) {
       if(isOpen) event.preventDefault();
-      isOpen ? this.closeMenuDrawer(summaryElement) : this.openMenuDrawer(summaryElement);
+      isOpen ? this.closeMenuDrawer(event, summaryElement) : this.openMenuDrawer(summaryElement);
     } else {
       setTimeout(() => {
         detailsElement.classList.add('menu-opening');


### PR DESCRIPTION
**Why are these changes introduced?**

Fixes #76 

**What approach did you take?**

The code in placed looked good. What I found is that the issue was related to the transition of the submenu appearing. So I had to move the `trapFocus()` into a `setTimeout()` function as well. 

It seemed to work with `50`ms but I used `100`ms as I thought it gave us a safe gap. I tried with no value mentioned but it wasn't working sill. I tried on slow 3g and it worked fine. 

**Other considerations**

Open to other suggestions. 

**Demo links**

- [Store](https://os2-demo.myshopify.com/?preview_theme_id=126531829782)
- [Editor](https://os2-demo.myshopify.com/admin/themes/126531829782/editor)

**Checklist**
- [ ] Followed [theme code principles](https://github.com/Shopify/dawn/blob/main/.github/CONTRIBUTING.md#theme-code-principles)
- [ ] Linted with [Theme Check](https://github.com/Shopify/theme-check)
- [ ] Tested on [mobile](https://shopify.dev/themes/store/requirements#mobile-browser-requirements)
- [ ] Tested on [multiple browsers](https://shopify.dev/themes/store/requirements#desktop-browser-requirements)
- [ ] Tested for [accessibility](https://shopify.dev/themes/best-practices/accessibility)
