### PR TITLE
Image Banner Section - Keeping multiple buttons center aligned when long titles are present.

### DIFF
--- a/assets/section-image-banner.css
+++ b/assets/section-image-banner.css
@@ -6,35 +6,29 @@
 
 @media screen and (max-width: 749px) {
   .banner--small.banner--mobile-bottom:not(.banner--adapt) > .banner__media,
-  .banner--small.banner--stacked:not(.banner--mobile-bottom):not(.banner--adapt)
-    > .banner__media {
+  .banner--small.banner--stacked:not(.banner--mobile-bottom):not(.banner--adapt) > .banner__media {
     height: 28rem;
   }
 
   .banner--medium.banner--mobile-bottom:not(.banner--adapt) > .banner__media,
-  .banner--medium.banner--stacked:not(.banner--mobile-bottom):not(.banner--adapt)
-    > .banner__media {
+  .banner--medium.banner--stacked:not(.banner--mobile-bottom):not(.banner--adapt) > .banner__media {
     height: 34rem;
   }
 
   .banner--large.banner--mobile-bottom:not(.banner--adapt) > .banner__media,
-  .banner--large.banner--stacked:not(.banner--mobile-bottom):not(.banner--adapt)
-    > .banner__media {
+  .banner--large.banner--stacked:not(.banner--mobile-bottom):not(.banner--adapt) > .banner__media {
     height: 39rem;
   }
 
-  .banner--small:not(.banner--mobile-bottom):not(.banner--adapt)
-    .banner__content {
+  .banner--small:not(.banner--mobile-bottom):not(.banner--adapt) .banner__content {
     min-height: 28rem;
   }
 
-  .banner--medium:not(.banner--mobile-bottom):not(.banner--adapt)
-    .banner__content {
+  .banner--medium:not(.banner--mobile-bottom):not(.banner--adapt) .banner__content {
     min-height: 34rem;
   }
 
-  .banner--large:not(.banner--mobile-bottom):not(.banner--adapt)
-    .banner__content {
+  .banner--large:not(.banner--mobile-bottom):not(.banner--adapt) .banner__content {
     min-height: 39rem;
   }
 }
@@ -62,7 +56,7 @@
     flex-direction: row;
     flex-wrap: wrap;
   }
-
+  
   .banner--stacked {
     height: auto;
   }


### PR DESCRIPTION
**Why are these changes introduced?**
When using multiple buttons in the image banner in conjunction with long titles the max-width on the multiple button container is aligning itself left.

Fixes #783.

**What approach did you take?**

Adding `margin: 2rem auto 0;`

**Demo links**
Issue Example: 
![Screen Recording 2021-10-19 at 8 42 30 AM](https://user-images.githubusercontent.com/12848057/137914154-eaea483a-53e1-4761-a083-e5e5104f3c8f.gif)

**Checklist**
- [✅  ] Followed [theme code principles](https://github.com/Shopify/dawn/blob/main/.github/CONTRIBUTING.md#theme-code-principles)
- [✅  ] Linted with [Theme Check](https://github.com/Shopify/theme-check)
- [✅  ] Tested on [mobile](https://shopify.dev/themes/store/requirements#mobile-browser-requirements)
- [✅  ] Tested on [multiple browsers](https://shopify.dev/themes/store/requirements#desktop-browser-requirements)
- [✅  ] Tested for [accessibility](https://shopify.dev/themes/best-practices/accessibility)
