### PR TITLE
Fix product slider on mobile

### DIFF
--- a/assets/global.js
+++ b/assets/global.js
@@ -601,7 +601,7 @@ class VariantSelects extends HTMLElement {
     }
     window.setTimeout(() => {
       parent.scrollLeft = 0;
-      parent.querySelector('li.product__media-item').scrollIntoView({behavior: "smooth"});
+      parent.querySelector('li.product__media-item').scrollIntoView({behavior: 'smooth'});
     });
   }
 


### PR DESCRIPTION
**Why are these changes introduced?**

Fixes #665 

**What approach did you take?**

There is some inconsistency for whatever reason when you're clicking a variant with an attached image on android devices. It's supposed to scroll it into the view, right after the image is pushed to the beginning of the product media list.

So i added another scrolling action: `parent.scrollLeft = 0;`. 

I kept `scrollIntoView` as I still need it on desktop and it's working fine there. My guess is that there is a hiccup when we're doing `parent.prepend(newMedia);` and then trying to scroll that element into the view. Some of the timing might be off and it's messing the functionality of the slider. 

**Other considerations**

I tried to see if using `parent.firstChild` instead of `parent.querySelector(...` would help but it didn't change anything. 

**Demo links**

- [Store](https://os2-demo.myshopify.com/?preview_theme_id=126536024086)

**Testing**

In order to test you'll need to check the preview from an android device. The issue wasn't happening using only the inspect tools. 

You can search for the `sandal` product and click the different variant colours to see if there is any issue when it's supposed to scroll you to the variant image associated to the colour. 

**Checklist**
- [ ] Followed [theme code principles](https://github.com/Shopify/dawn/blob/main/.github/CONTRIBUTING.md#theme-code-principles)
- [ ] Linted with [Theme Check](https://github.com/Shopify/theme-check)
- [ ] Tested on [mobile](https://shopify.dev/themes/store/requirements#mobile-browser-requirements)
- [ ] Tested on [multiple browsers](https://shopify.dev/themes/store/requirements#desktop-browser-requirements)
- [ ] Tested for [accessibility](https://shopify.dev/themes/best-practices/accessibility)
