### PR TITLE
Faceted filters - Add `h2` to heading structure

### DIFF
--- a/assets/base.css
+++ b/assets/base.css
@@ -483,11 +483,6 @@ blockquote {
   letter-spacing: 0.04rem;
 }
 
-h2.caption-large,
-h3.caption-large {
-  font-size: calc(var(--font-heading-scale) * 1.3rem);
-}
-
 .color-foreground {
   color: rgb(var(--color-foreground));
 }

--- a/assets/component-cart-notification.css
+++ b/assets/component-cart-notification.css
@@ -58,8 +58,8 @@
 
 .cart-notification__heading .icon-checkmark {
   color: rgb(var(--color-foreground));
-  margin-right: calc(var(--font-heading-scale) * 1rem);
-  width: calc(var(--font-heading-scale) * 1.3rem);
+  margin-right: 1rem;
+  width: 1.3rem;
 }
 
 .cart-notification__close {

--- a/assets/component-facets.css
+++ b/assets/component-facets.css
@@ -80,6 +80,7 @@
 }
 
 .facet-filters__sort {
+  border: 0;
   font-size: 1.4rem;
   height: auto;
   line-height: calc(1 + 0.5 / var(--font-body-scale));

--- a/assets/component-facets.css
+++ b/assets/component-facets.css
@@ -44,7 +44,7 @@
   display: block;
   color: var(--color-foreground-85);
   font-size: 1.4rem;
-  margin-right: 2rem;
+  margin: 0 2rem 0 0;
 }
 
 .facet-filters__summary {

--- a/assets/component-facets.css
+++ b/assets/component-facets.css
@@ -849,10 +849,6 @@ input.mobile-facets__checkbox {
   margin: 0;
 }
 
-.product-count__text p {
-  margin: 0;
-}
-
 .product-count__text.loading {
   visibility: hidden;
 }

--- a/assets/component-facets.css
+++ b/assets/component-facets.css
@@ -849,6 +849,10 @@ input.mobile-facets__checkbox {
   margin: 0;
 }
 
+.product-count__text p {
+  margin: 0;
+}
+
 .product-count__text.loading {
   visibility: hidden;
 }

--- a/sections/contact-form.liquid
+++ b/sections/contact-form.liquid
@@ -7,7 +7,7 @@
       <div class="form-status form-status-list form__message" tabindex="-1" autofocus>{% render 'icon-success' %} {{ 'templates.contact.form.post_success' | t }}</div>
     {%- elsif form.errors -%}
       <div class="form__message">
-        <h2 class="form-status caption-large" role="alert" tabindex="-1" autofocus>{% render 'icon-error' %} {{ 'templates.contact.form.error_heading' | t }}</h2>
+        <h2 class="form-status caption-large text-body" role="alert" tabindex="-1" autofocus>{% render 'icon-error' %} {{ 'templates.contact.form.error_heading' | t }}</h2>
       </div>
       <ul class="form-status-list caption-large" role="list">
         <li>

--- a/sections/footer.liquid
+++ b/sections/footer.liquid
@@ -225,7 +225,7 @@
           <localization-form>
             {%- form 'localization', id: 'FooterCountryForm', class: 'localization-form' -%}
               <div class="no-js-hidden">
-                <h2 class="caption-large" id="FooterCountryLabel">{{ 'localization.country_label' | t }}</h2>
+                <h2 class="caption-large text-body" id="FooterCountryLabel">{{ 'localization.country_label' | t }}</h2>
                 <div class="disclosure">
                   <button type="button" class="disclosure__button localization-form__select localization-selector link link--text caption-large" aria-expanded="false" aria-controls="FooterCountryList" aria-describedby="FooterCountryLabel">
                     {{ localization.country.name }} ({{ localization.country.currency.iso_code }} {{ localization.country.currency.symbol }})
@@ -268,7 +268,7 @@
           <localization-form>
             {%- form 'localization', id: 'FooterLanguageForm', class: 'localization-form' -%}
               <div class="no-js-hidden">
-                <h2 class="caption-large" id="FooterLanguageLabel">{{ 'localization.language_label' | t }}</h2>
+                <h2 class="caption-large text-body" id="FooterLanguageLabel">{{ 'localization.language_label' | t }}</h2>
                 <div class="disclosure">
                   <button type="button" class="disclosure__button localization-form__select localization-selector link link--text caption-large" aria-expanded="false" aria-controls="FooterLanguageList" aria-describedby="FooterLanguageLabel">
                     {{ localization.language.endonym_name | capitalize }}

--- a/sections/main-article.liquid
+++ b/sections/main-article.liquid
@@ -138,7 +138,7 @@
           <h2>{{ 'blogs.article.comment_form_title' | t }}</h2>
           {%- if form.errors -%}
             <div class="form__message" role="alert">
-              <h3 class="form-status caption-large" tabindex="-1" autofocus>
+              <h3 class="form-status caption-large text-body" tabindex="-1" autofocus>
                 {% render 'icon-error' %} {{ 'templates.contact.form.error_heading' | t }}
               </h3>
             </div>

--- a/snippets/cart-notification.liquid
+++ b/snippets/cart-notification.liquid
@@ -12,7 +12,7 @@
   <div class="cart-notification-wrapper page-width{% if color_scheme %} color-{{ color_scheme }}{% endif %}">
     <div id="cart-notification" class="cart-notification focus-inset" aria-modal="true" aria-label="{{ 'general.cart.item_added' | t }}" role="dialog" tabindex="-1">
       <div class="cart-notification__header">
-        <h2 class="cart-notification__heading caption-large">{%- render 'icon-checkmark' -%} {{ 'general.cart.item_added' | t }}</h2>
+        <h2 class="cart-notification__heading caption-large text-body">{%- render 'icon-checkmark' -%} {{ 'general.cart.item_added' | t }}</h2>
         <button type="button" class="cart-notification__close modal__close-button link link--text focus-inset" aria-label="{{ 'accessibility.close' | t }}">
           <svg class="icon icon-close" aria-hidden="true" focusable="false"><use href="#icon-close"></svg>
         </button>

--- a/snippets/facets.liquid
+++ b/snippets/facets.liquid
@@ -488,8 +488,8 @@
     </facet-remove>
   </div>
   <div class="product-count light{% unless collapse_on_larger_devices %} medium-hide large-up-hide{% endunless %}" role="status">
-    <h2 class="text-body">
-      <p id="ProductCount" class="product-count__text">
+    <h2 class="product-count__text text-body">
+      <p id="ProductCount">
         {%- if results.results_count -%}
           {{ 'templates.search.results_with_count' | t: terms: results.terms, count: results.results_count }}
         {%- elsif results.products_count == results.all_products_count -%}

--- a/snippets/facets.liquid
+++ b/snippets/facets.liquid
@@ -35,7 +35,7 @@
         {% if enable_filtering %}
           <div id="FacetsWrapperDesktop" class="facets__wrapper">
             {%- unless results.filters == empty -%}
-              <p class="facets__heading caption-large">{{ 'products.facets.filter_by_label' | t }}</p>
+              <h2 class="facets__heading caption-large text-body">{{ 'products.facets.filter_by_label' | t }}</h2>
             {%- endunless -%}
 
             {%- for filter in results.filters -%}
@@ -208,7 +208,9 @@
         {%- if enable_sorting -%}
           <div class="facet-filters sorting caption">
             <div class="facet-filters__field">
-              <label class="facet-filters__label caption-large" for="SortBy">{{ 'products.facets.sort_by_label' | t }}</label>
+              <h2 class="facet-filters__label caption-large text-body">
+                <label for="SortBy">{{ 'products.facets.sort_by_label' | t }}</label>
+              </h2>
               <div class="select">
                 {%- assign sort_by = results.sort_by | default: results.default_sort_by -%}
                 <select name="sort_by" class="facet-filters__sort select__select caption-large" id="SortBy" aria-describedby="a11y-refresh-page-message">
@@ -227,15 +229,17 @@
         {%- endif -%}
 
         <div class="product-count light" role="status">
-          <p id="ProductCountDesktop" class="product-count__text">
-            {%- if results.results_count -%}
-              {{ 'templates.search.results_with_count' | t: terms: results.terms, count: results.results_count }}
-            {%- elsif results.products_count == results.all_products_count -%}
-              {{ 'products.facets.product_count_simple' | t: count: results.products_count }}
-            {%- else -%}
-              {{ 'products.facets.product_count' | t: product_count: results.products_count, count: results.all_products_count }}
-            {%- endif -%}
-          </p>
+          <h2 class="product-count__text text-body">
+            <span id="ProductCountDesktop">
+              {%- if results.results_count -%}
+                {{ 'templates.search.results_with_count' | t: terms: results.terms, count: results.results_count }}
+              {%- elsif results.products_count == results.all_products_count -%}
+                {{ 'products.facets.product_count_simple' | t: count: results.products_count }}
+              {%- else -%}
+                {{ 'products.facets.product_count' | t: product_count: results.products_count, count: results.all_products_count }}
+              {%- endif -%}
+            </span>
+          </h2>
           <div class="loading-overlay__spinner">
             <svg aria-hidden="true" focusable="false" role="presentation" class="spinner" viewBox="0 0 66 66" xmlns="http://www.w3.org/2000/svg">
               <circle class="path" fill="none" stroke-width="6" cx="33" cy="33" r="30"></circle>
@@ -484,15 +488,17 @@
     </facet-remove>
   </div>
   <div class="product-count light{% unless collapse_on_larger_devices %} medium-hide large-up-hide{% endunless %}" role="status">
-    <p id="ProductCount" class="product-count__text">
-      {%- if results.results_count -%}
-        {{ 'templates.search.results_with_count' | t: terms: results.terms, count: results.results_count }}
-      {%- elsif results.products_count == results.all_products_count -%}
-        {{ 'products.facets.product_count_simple' | t: count: results.products_count }}
-      {%- else -%}
-        {{ 'products.facets.product_count' | t: product_count: results.products_count, count: results.all_products_count }}
-      {%- endif -%}
-    </p>
+    <h2 class="text-body">
+      <p id="ProductCount" class="product-count__text">
+        {%- if results.results_count -%}
+          {{ 'templates.search.results_with_count' | t: terms: results.terms, count: results.results_count }}
+        {%- elsif results.products_count == results.all_products_count -%}
+          {{ 'products.facets.product_count_simple' | t: count: results.products_count }}
+        {%- else -%}
+          {{ 'products.facets.product_count' | t: product_count: results.products_count, count: results.all_products_count }}
+        {%- endif -%}
+      </p>
+    </h2>
     <div class="loading-overlay__spinner">
       <svg aria-hidden="true" focusable="false" role="presentation" class="spinner" viewBox="0 0 66 66" xmlns="http://www.w3.org/2000/svg">
         <circle class="path" fill="none" stroke-width="6" cx="33" cy="33" r="30"></circle>

--- a/snippets/facets.liquid
+++ b/snippets/facets.liquid
@@ -489,7 +489,7 @@
   </div>
   <div class="product-count light{% unless collapse_on_larger_devices %} medium-hide large-up-hide{% endunless %}" role="status">
     <h2 class="product-count__text text-body">
-      <p id="ProductCount">
+      <span id="ProductCount">
         {%- if results.results_count -%}
           {{ 'templates.search.results_with_count' | t: terms: results.terms, count: results.results_count }}
         {%- elsif results.products_count == results.all_products_count -%}
@@ -497,7 +497,7 @@
         {%- else -%}
           {{ 'products.facets.product_count' | t: product_count: results.products_count, count: results.all_products_count }}
         {%- endif -%}
-      </p>
+      </span>
     </h2>
     <div class="loading-overlay__spinner">
       <svg aria-hidden="true" focusable="false" role="presentation" class="spinner" viewBox="0 0 66 66" xmlns="http://www.w3.org/2000/svg">


### PR DESCRIPTION
**Why are these changes introduced?**

Fixes #111 

**What approach did you take?**

##### 1 - Add `h2` tag for facet filtering labels and product count

Use techniques described [in the issue](https://github.com/Shopify/dawn/issues/111#issue-937890812) and [in w3 docs](https://www.w3.org/WAI/WCAG21/Techniques/html/H69) to provide page hierarchy and allow quick navigation to:
- filtering
- sorting
- product count (heading for the product grid)

##### 2 - Ensure `caption-large` is using body font and text size for visual consistency

Facet filtering labels use `caption-large` styling. Opportunity to refactor headings used across the theme with `caption-large` styling.

**Other considerations**

n/a

**Demo links**

- [Store](https://os2-demo.myshopify.com/?preview_theme_id=126537105430)
- [Editor](https://os2-demo.myshopify.com/admin/themes/126537105430/editor)

**Checklist**
- [ ] Followed [theme code principles](https://github.com/Shopify/dawn/blob/main/.github/CONTRIBUTING.md#theme-code-principles)
- [ ] Linted with [Theme Check](https://github.com/Shopify/theme-check)
- [ ] Tested on [mobile](https://shopify.dev/themes/store/requirements#mobile-browser-requirements)
- [ ] Tested on [multiple browsers](https://shopify.dev/themes/store/requirements#desktop-browser-requirements)
- [ ] Tested for [accessibility](https://shopify.dev/themes/best-practices/accessibility)
