### PR TITLE
Product A11Y: Fix invalid HTML and announce price when updating variants

### DIFF
--- a/assets/global.js
+++ b/assets/global.js
@@ -527,13 +527,13 @@ class SliderComponent extends HTMLElement {
     this.currentPage = Math.round(this.slider.scrollLeft / this.sliderLastItem.clientWidth) + 1;
 
     if (this.currentPage === 1) {
-      this.prevButton.setAttribute('disabled', true);
+      this.prevButton.setAttribute('disabled', 'disabled');
     } else {
       this.prevButton.removeAttribute('disabled');
     }
 
     if (this.currentPage === this.totalPages) {
-      this.nextButton.setAttribute('disabled', true);
+      this.nextButton.setAttribute('disabled', 'disabled');
     } else {
       this.nextButton.removeAttribute('disabled');
     }
@@ -671,7 +671,7 @@ class VariantSelects extends HTMLElement {
     if (!addButton) return;
 
     if (disable) {
-      addButton.setAttribute('disabled', true);
+      addButton.setAttribute('disabled', 'disabled');
       if (text) addButtonText.textContent = text;
     } else {
       addButton.removeAttribute('disabled');

--- a/sections/featured-product.liquid
+++ b/sections/featured-product.liquid
@@ -195,7 +195,7 @@
                           <select id="Option-{{ section.id }}-{{ forloop.index0 }}"
                             class="select__select"
                             name="options[{{ option.name | escape }}]"
-                            form="product-form-{{ section.id }}"
+                            form="{{ product_form_id }}"
                           >
                             {%- for value in option.values -%}
                               <option value="{{ value | escape }}" {% if option.selected_value == value %}selected="selected"{% endif %}>

--- a/sections/featured-product.liquid
+++ b/sections/featured-product.liquid
@@ -78,7 +78,7 @@
                 {%- endif -%}
               </h2>
             {%- when 'price' -%}
-              <div class="no-js-hidden" id="price-{{ section.id }}" {{ block.shopify_attributes }}>
+              <div class="no-js-hidden" id="price-{{ section.id }}" role="status" {{ block.shopify_attributes }}>
                 {%- render 'price', product: product, use_variant: true, show_badges: true, price_class: 'price--large' -%}
               </div>
               {%- if shop.taxes_included or shop.shipping_policy.body != blank -%}
@@ -115,7 +115,7 @@
                       id="Quantity-{{ section.id }}"
                       min="1"
                       value="1"
-                      form="product-form-{{ section.id }}"
+                      form="{{ product_form_id }}"
                     >
                   <button class="quantity__button no-js-hidden" name="plus" type="button">
                     <span class="visually-hidden">{{ 'products.product.quantity.increase' | t: product: product.title | escape }}</span>
@@ -168,13 +168,13 @@
                         <fieldset class="js product-form__input">
                           <legend class="form__label">{{ option.name }}</legend>
                           {%- for value in option.values -%}
-                            <input type="radio" id="{{ section.id }}-{{ option.name }}-{{ forloop.index0 }}"
+                            <input type="radio" id="{{ section.id }}-{{ option.position }}-{{ forloop.index0 }}"
                                   name="{{ option.name }}"
                                   value="{{ value | escape }}"
-                                  form="product-form-{{ section.id }}"
+                                  form="{{ product_form_id }}"
                                   {% if option.selected_value == value %}checked{% endif %}
                             >
-                            <label for="{{ section.id }}-{{ option.name }}-{{ forloop.index0 }}">
+                            <label for="{{ section.id }}-{{ option.position }}-{{ forloop.index0 }}">
                               {{ value }}
                             </label>
                           {%- endfor -%}

--- a/sections/main-product.liquid
+++ b/sections/main-product.liquid
@@ -146,7 +146,7 @@
                     id="Quantity-{{ section.id }}"
                     min="1"
                     value="1"
-                    form="product-form-{{ section.id }}"
+                    form="{{ product_form_id }}"
                   >
                 <button class="quantity__button no-js-hidden" name="plus" type="button">
                   <span class="visually-hidden">{{ 'products.product.quantity.increase' | t: product: product.title | escape }}</span>
@@ -204,13 +204,13 @@
                       <fieldset class="js product-form__input">
                         <legend class="form__label">{{ option.name }}</legend>
                         {%- for value in option.values -%}
-                          <input type="radio" id="{{ section.id }}-{{ option.name }}-{{ forloop.index0 }}"
+                          <input type="radio" id="{{ section.id }}-{{ option.position }}-{{ forloop.index0 }}"
                                 name="{{ option.name }}"
                                 value="{{ value | escape }}"
-                                form="product-form-{{ section.id }}"
+                                form="{{ product_form_id }}"
                                 {% if option.selected_value == value %}checked{% endif %}
                           >
-                          <label for="{{ section.id }}-{{ option.name }}-{{ forloop.index0 }}">
+                          <label for="{{ section.id }}-{{ option.position }}-{{ forloop.index0 }}">
                             {{ value }}
                           </label>
                         {%- endfor -%}
@@ -231,7 +231,7 @@
                         <select id="Option-{{ section.id }}-{{ forloop.index0 }}"
                           class="select__select"
                           name="options[{{ option.name | escape }}]"
-                          form="product-form-{{ section.id }}"
+                          form="{{ product_form_id }}"
                         >
                           {%- for value in option.values -%}
                             <option value="{{ value | escape }}" {% if option.selected_value == value %}selected="selected"{% endif %}>

--- a/sections/main-product.liquid
+++ b/sections/main-product.liquid
@@ -84,7 +84,7 @@
               {{ product.title | escape }}
             </h1>
           {%- when 'price' -%}
-            <div class="no-js-hidden" id="price-{{ section.id }}" {{ block.shopify_attributes }}>
+            <div class="no-js-hidden" id="price-{{ section.id }}" role="status" {{ block.shopify_attributes }}>
               {%- render 'price', product: product, use_variant: true, show_badges: true, price_class: 'price--large' -%}
             </div>
             {%- if shop.taxes_included or shop.shipping_policy.body != blank -%}

--- a/snippets/price.liquid
+++ b/snippets/price.liquid
@@ -82,11 +82,11 @@
     </small>
   </div>
   {%- if show_badges -%}
-    <span class="badge price__badge-sale color-{{ settings.sale_badge_color_scheme }}" aria-hidden="true">
+    <span class="badge price__badge-sale color-{{ settings.sale_badge_color_scheme }}">
       {{ 'products.product.on_sale' | t }}
     </span>
 
-    <span class="badge price__badge-sold-out color-{{ settings.sold_out_badge_color_scheme }}" aria-hidden="true">
+    <span class="badge price__badge-sold-out color-{{ settings.sold_out_badge_color_scheme }}">
       {{ 'products.product.sold_out' | t }}
     </span>
   {%- endif -%}


### PR DESCRIPTION
**Why are these changes introduced?**
Accessibility fixes for Product page and Featured Product sections:
- Fix invalid HTML markup
- Add `role="status"` to price container so the price is announced when variants are updated

Fixes #126 
Fixes #463

**What approach did you take?**
Followed suggestions on the issues.

To fix invalid HTML:
- Replaced `option.name` with `option.position` on the radio button `id`s. `option.name` can have spaces, resulting in a space separated (invalid) `id` attribute.
- Updated all `form` attributes to use the same `{{ product_form_id }}` to keep consistency.
- Updated `disabled="true"` (invalid) to `disabled="disabled"` (valid) in all JS files that are using this property

To announce price variants:
- Removed `aria-hidden` from badges in `price.liquid`.
- Added `role="status"` to the price region.

**Demo links**
- [Store](https://os2-demo.myshopify.com/?preview_theme_id=126539268118)
- [Editor](https://os2-demo.myshopify.com/admin/themes/126539268118/editor)

**Suggested Tests**
Accessibility
- [ ] Use a Screen Reader to test if prices are announced when the variant price or availability changes. [Suggested product](https://os2-demo.myshopify.com/products/brick-apple).

Functionality
- [ ] Check if Product form still works as expected in products with multiple variants on the product page and featured product section.

**Checklist**
- [x] Followed [theme code principles](https://github.com/Shopify/dawn/blob/main/.github/CONTRIBUTING.md#theme-code-principles)
- [x] Linted with [Theme Check](https://github.com/Shopify/theme-check)
- [x] Tested on [mobile](https://shopify.dev/themes/store/requirements#mobile-browser-requirements)
- [x] Tested on [multiple browsers](https://shopify.dev/themes/store/requirements#desktop-browser-requirements)
- [x] Tested for [accessibility](https://shopify.dev/themes/best-practices/accessibility)
