### PR TITLE
Fix password.json setting id

### DIFF
--- a/templates/password.json
+++ b/templates/password.json
@@ -16,7 +16,7 @@
         "paragraph": {
           "type": "paragraph",
           "settings": {
-            "paragraph": "<p>Be the first to know when we launch.</p>"
+            "text": "<p>Be the first to know when we launch.</p>"
           }
         },
         "email_form": {


### PR DESCRIPTION
**Why are these changes introduced?**

An issue with the github integration. When forking Dawn, your `password.json` file will be out of sync as it will be different from the one on Github due to the ID being used that isn't matching the schema settings. 

**What approach did you take?**

Fix the ID used in `password.json` to match the right one from the Email signup section. 

**Other considerations**

**Demo links**

- [Store](https://os2-demo.myshopify.com/?preview_theme_id=126539726870)
- [Editor](https://os2-demo.myshopify.com/admin/themes/126539726870/editor)

**Checklist**
- [ ] Followed [theme code principles](https://github.com/Shopify/dawn/blob/main/.github/CONTRIBUTING.md#theme-code-principles)
- [ ] Linted with [Theme Check](https://github.com/Shopify/theme-check)
- [ ] Tested on [mobile](https://shopify.dev/themes/store/requirements#mobile-browser-requirements)
- [ ] Tested on [multiple browsers](https://shopify.dev/themes/store/requirements#desktop-browser-requirements)
- [ ] Tested for [accessibility](https://shopify.dev/themes/best-practices/accessibility)
