### PR TITLE
Fix focus management on blog pagination 

### DIFF
--- a/sections/main-article.liquid
+++ b/sections/main-article.liquid
@@ -104,7 +104,7 @@
         {%- if article.comments_count > 0 -%}
           {%- assign anchorId = '#Comments-' | append: article.id -%}
 
-          <h2 id="Comments-{{ article.id }}">{{ 'blogs.article.comments' | t: count: article.comments_count }}</h2>
+          <h2 id="Comments-{{ article.id }}" tabindex="-1">{{ 'blogs.article.comments' | t: count: article.comments_count }}</h2>
           {% paginate article.comments by 5 %}
             <div class="article-template__comments">
               {%- if comment.status == 'pending' and comment.content -%}


### PR DESCRIPTION
**Why are these changes introduced?**
Fixes #694

**What approach did you take?**
Adds missing `tabindex="-1"` to the `<h2>` element that is used as anchor by `pagination.liquid`.

**Demo links**
- [Store](https://os2-demo.myshopify.com/?preview_theme_id=126542413846)
- [Blog Post](https://os2-demo.myshopify.com/blogs/news/attention-to-detail-is-of-utmost-importance?preview_theme_id=126542413846)
- [Editor](https://os2-demo.myshopify.com/admin/themes/126542413846/editor)

**Checklist**
- [x] Followed [theme code principles](https://github.com/Shopify/dawn/blob/main/.github/CONTRIBUTING.md#theme-code-principles)
- [x] Linted with [Theme Check](https://github.com/Shopify/theme-check)
- [x] Tested on [mobile](https://shopify.dev/themes/store/requirements#mobile-browser-requirements)
- [x] Tested on [multiple browsers](https://shopify.dev/themes/store/requirements#desktop-browser-requirements)
- [x] Tested for [accessibility](https://shopify.dev/themes/best-practices/accessibility)
