### PR TITLE
Fix variant spacing on product page

### DIFF
--- a/assets/section-main-product.css
+++ b/assets/section-main-product.css
@@ -463,7 +463,6 @@ a.product__text {
 
 .product__media-item--variant:first-child {
   display: block;
-  padding-right: 1.5rem;
 }
 
 @media screen and (max-width: 749px) {

--- a/assets/section-main-product.css
+++ b/assets/section-main-product.css
@@ -466,6 +466,13 @@ a.product__text {
   padding-right: 1.5rem;
 }
 
+@media screen and (max-width: 749px) {
+  .product__media-item--variant:first-child {
+    padding-right: 1.5rem;
+  }
+
+}
+
 @media screen and (min-width: 750px) and (max-width: 989px) {
   .product__media-list .product__media-item:first-child {
     padding-left: 0;

--- a/assets/section-main-product.css
+++ b/assets/section-main-product.css
@@ -463,6 +463,7 @@ a.product__text {
 
 .product__media-item--variant:first-child {
   display: block;
+  padding-right: 1.5rem;
 }
 
 @media screen and (min-width: 750px) and (max-width: 989px) {

--- a/sections/main-product.liquid
+++ b/sections/main-product.liquid
@@ -47,10 +47,8 @@
           if product.media.size < 2 
             assign should_hide = true
           endif
-          if section.settings.hide_variants 
-            if media_size < 2
-              assign should_hide = true
-            endif
+          if section.settings.hide_variants and media_size < 2
+            assign should_hide = true
           endif
         -%}
         <div class="slider-buttons no-js-hidden{% if should_hide == true %} small-hide{% endif %}">

--- a/sections/main-product.liquid
+++ b/sections/main-product.liquid
@@ -41,14 +41,8 @@
             {%- endunless -%}
           {%- endfor -%}
         </ul>
-        {%-liquid
-          assign should_hide_slider = false
-          assign media_size = product.media.size | minus: variant_images.size | plus: 1
-          if product.media.size < 2 or section.settings.hide_variants and media_size < 2
-            assign should_hide_slider = true
-          endif
-        -%}
-        <div class="slider-buttons no-js-hidden{% if should_hide_slider %} small-hide{% endif %}">
+        {%- assign filtered_media_size = product.media.size | minus: variant_images.size | plus: 1 -%}
+        <div class="slider-buttons no-js-hidden{% if product.media.size < 2 or section.settings.hide_variants and filtered_media_size < 2 %} small-hide{% endif %}">
           <button type="button" class="slider-button slider-button--prev" name="previous" aria-label="{{ 'accessibility.previous_slide' | t }}">{% render 'icon-caret' %}</button>
           <div class="slider-counter caption">
             <span class="slider-counter--current">1</span>

--- a/sections/main-product.liquid
+++ b/sections/main-product.liquid
@@ -41,7 +41,7 @@
             {%- endunless -%}
           {%- endfor -%}
         </ul>
-        <div class="slider-buttons no-js-hidden{% if product.media.size < 2 %} small-hide{% endif %}">
+        <div class="slider-buttons no-js-hidden{% if product.media.size < 2 or section.settings.hide_variants %} small-hide{% endif %}">
           <button type="button" class="slider-button slider-button--prev" name="previous" aria-label="{{ 'accessibility.previous_slide' | t }}">{% render 'icon-caret' %}</button>
           <div class="slider-counter caption">
             <span class="slider-counter--current">1</span>

--- a/sections/main-product.liquid
+++ b/sections/main-product.liquid
@@ -41,13 +41,25 @@
             {%- endunless -%}
           {%- endfor -%}
         </ul>
-        <div class="slider-buttons no-js-hidden{% if product.media.size < 2 or section.settings.hide_variants %} small-hide{% endif %}">
+        {%-liquid
+          assign should_hide = false
+          assign media_size = product.media.size | minus: variant_images.size | plus: 1
+          if product.media.size < 2 
+            assign should_hide = true
+          endif
+          if section.settings.hide_variants 
+            if media_size < 2
+              assign should_hide = true
+            endif
+          endif
+        -%}
+        <div class="slider-buttons no-js-hidden{% if should_hide == true %} small-hide{% endif %}">
           <button type="button" class="slider-button slider-button--prev" name="previous" aria-label="{{ 'accessibility.previous_slide' | t }}">{% render 'icon-caret' %}</button>
           <div class="slider-counter caption">
             <span class="slider-counter--current">1</span>
             <span aria-hidden="true"> / </span>
             <span class="visually-hidden">{{ 'accessibility.of' | t }}</span>
-            <span class="slider-counter--total">{% if section.settings.hide_variants %}{{ product.media.size | minus: variant_images.size | plus: 1 }}{% else %}{{ product.media.size }}{% endif %}</span>
+            <span class="slider-counter--total">{% if section.settings.hide_variants %}{{ media_size }}{% else %}{{ product.media.size }}{% endif %}</span>
           </div>
           <button type="button" class="slider-button slider-button--next" name="next" aria-label="{{ 'accessibility.next_slide' | t }}">{% render 'icon-caret' %}</button>
         </div>

--- a/sections/main-product.liquid
+++ b/sections/main-product.liquid
@@ -48,7 +48,7 @@
             <span class="slider-counter--current">1</span>
             <span aria-hidden="true"> / </span>
             <span class="visually-hidden">{{ 'accessibility.of' | t }}</span>
-            <span class="slider-counter--total">{% if section.settings.hide_variants %}{{ media_size }}{% else %}{{ product.media.size }}{% endif %}</span>
+            <span class="slider-counter--total">{% if section.settings.hide_variants %}{{ filtered_media_size }}{% else %}{{ product.media.size }}{% endif %}</span>
           </div>
           <button type="button" class="slider-button slider-button--next" name="next" aria-label="{{ 'accessibility.next_slide' | t }}">{% render 'icon-caret' %}</button>
         </div>

--- a/sections/main-product.liquid
+++ b/sections/main-product.liquid
@@ -42,16 +42,13 @@
           {%- endfor -%}
         </ul>
         {%-liquid
-          assign should_hide = false
+          assign should_hide_slider = false
           assign media_size = product.media.size | minus: variant_images.size | plus: 1
-          if product.media.size < 2 
-            assign should_hide = true
-          endif
-          if section.settings.hide_variants and media_size < 2
-            assign should_hide = true
+          if product.media.size < 2 or section.settings.hide_variants and media_size < 2
+            assign should_hide_slider = true
           endif
         -%}
-        <div class="slider-buttons no-js-hidden{% if should_hide == true %} small-hide{% endif %}">
+        <div class="slider-buttons no-js-hidden{% if should_hide_slider %} small-hide{% endif %}">
           <button type="button" class="slider-button slider-button--prev" name="previous" aria-label="{{ 'accessibility.previous_slide' | t }}">{% render 'icon-caret' %}</button>
           <div class="slider-counter caption">
             <span class="slider-counter--current">1</span>


### PR DESCRIPTION
**Why are these changes introduced?**

Fixes #677 .

**What approach did you take?**

Add spacing to the right on mobile. Details on how to reproduce: https://github.com/Shopify/dawn/issues/677

**Demo links**

- [Editor](https://os2-demo.myshopify.com/admin/themes/126542675990/editor)

You can test it with the product `Shoe Test variant product`

Before: https://screenshot.click/21-09-895ce-bpi4d.png
After: https://screenshot.click/20-44-jd5ry-qvyq1.png

**Checklist**
- [ ] Followed [theme code principles](https://github.com/Shopify/dawn/blob/main/.github/CONTRIBUTING.md#theme-code-principles)
- [ ] Linted with [Theme Check](https://github.com/Shopify/theme-check)
- [ ] Tested on [mobile](https://shopify.dev/themes/store/requirements#mobile-browser-requirements)
- [ ] Tested on [multiple browsers](https://shopify.dev/themes/store/requirements#desktop-browser-requirements)
- [ ] Tested for [accessibility](https://shopify.dev/themes/best-practices/accessibility)
