### PR TITLE
Add unit price to cart

### DIFF
--- a/assets/component-cart-items.css
+++ b/assets/component-cart-items.css
@@ -45,7 +45,7 @@
 }
 
 .cart-item__details > * + * {
-  margin-top: 0.8rem;
+  margin-top: 0.6rem;
 }
 
 .cart-item__media {

--- a/assets/component-cart-items.css
+++ b/assets/component-cart-items.css
@@ -93,6 +93,10 @@
   opacity: 0.7;
 }
 
+.cart-item__final-price {
+  font-weight: 400;
+}
+
 .product-option {
   font-size: 1.4rem;
   word-break: break-all;

--- a/sections/main-cart-items.liquid
+++ b/sections/main-cart-items.liquid
@@ -111,7 +111,7 @@
                           {{ 'products.product.price.regular_price' | t }}
                         </dt>
                         <dd>
-                          <s class="cart-item__old-price">
+                          <s class="cart-item__old-price product-option">
                             {{ item.original_price | money }}
                           </s>
                         </dd>

--- a/sections/main-cart-items.liquid
+++ b/sections/main-cart-items.liquid
@@ -70,14 +70,14 @@
                           {{ 'products.product.price.regular_price' | t }}
                         </span>
                         <s class="cart-item__old-price product-option">
-                          {{ item.original_price | money }}
+                          {{- item.original_price | money -}}
                         </s>
                         <span class="visually-hidden">
                           {{ 'products.product.price.sale_price' | t }}
                         </span>
-                        <strong class="product-option">
+                        <span class="product-option">
                           {{ item.final_price | money }}
-                        </strong>
+                        </span>
                       </div>
                     {%- else -%}
                       <div class="product-option">

--- a/sections/main-cart-items.liquid
+++ b/sections/main-cart-items.liquid
@@ -65,26 +65,24 @@
                     <a href="{{ item.url }}" class="cart-item__name h4 break">{{ item.product.title | escape }}</a>
 
                     {%- if item.original_price != item.final_price -%}
-                      <span class="cart-item__discounted-prices">
+                      <div class="cart-item__discounted-prices">
                         <span class="visually-hidden">
                           {{ 'products.product.price.regular_price' | t }}
                         </span>
-                        <span>
-                          <s class="cart-item__old-price product-option">
-                            {{ item.original_price | money }}
-                          </s>
-                        </dd>
+                        <s class="cart-item__old-price product-option">
+                          {{ item.original_price | money }}
+                        </s>
                         <span class="visually-hidden">
                           {{ 'products.product.price.sale_price' | t }}
                         </span>
-                        <span class="product-option">
+                        <strong class="product-option">
                           {{ item.final_price | money }}
-                        </span>
-                      </span>
+                        </strong>
+                      </div>
                     {%- else -%}
-                      <span class="product-option">
+                      <div class="product-option">
                         {{ item.original_price | money }}
-                      </span>
+                      </div>
                     {%- endif -%}
 
                     {%- if item.product.has_only_default_variant == false or item.properties.size != 0 or item.selling_plan_allocation != nil -%}

--- a/sections/main-cart-items.liquid
+++ b/sections/main-cart-items.liquid
@@ -64,6 +64,29 @@
 
                     <a href="{{ item.url }}" class="cart-item__name h4 break">{{ item.product.title | escape }}</a>
 
+                    {%- if item.original_price != item.final_price -%}
+                      <dl class="cart-item__discounted-prices">
+                        <dt class="visually-hidden">
+                          {{ 'products.product.price.regular_price' | t }}
+                        </dt>
+                        <dd>
+                          <s class="cart-item__old-price product-option">
+                            {{ item.original_price | money }}
+                          </s>
+                        </dd>
+                        <dt class="visually-hidden">
+                          {{ 'products.product.price.sale_price' | t }}
+                        </dt>
+                        <dd class="product-option">
+                          {{ item.final_price | money }}
+                        </dd>
+                      </dl>
+                    {%- else -%}
+                      <span class="product-option">
+                        {{ item.original_price | money }}
+                      </span>
+                    {%- endif -%}
+
                     {%- if item.product.has_only_default_variant == false or item.properties.size != 0 or item.selling_plan_allocation != nil -%}
                       <dl>
                         {%- if item.product.has_only_default_variant == false -%}
@@ -105,28 +128,6 @@
                         </li>
                       {%- endfor -%}
                     </ul>
-                    {%- if item.original_price != item.final_price -%}
-                      <dl class="cart-item__discounted-prices">
-                        <dt class="visually-hidden">
-                          {{ 'products.product.price.regular_price' | t }}
-                        </dt>
-                        <dd>
-                          <s class="cart-item__old-price product-option">
-                            {{ item.original_price | money }}
-                          </s>
-                        </dd>
-                        <dt class="visually-hidden">
-                          {{ 'products.product.price.sale_price' | t }}
-                        </dt>
-                        <dd class="product-option">
-                          {{ item.final_price | money }}
-                        </dd>
-                      </dl>
-                    {%- else -%}
-                      <span class="product-option">
-                        {{ item.original_price | money }}
-                      </span>
-                    {%- endif -%}
                   </td>
 
                   <td class="cart-item__totals right medium-hide large-up-hide">

--- a/sections/main-cart-items.liquid
+++ b/sections/main-cart-items.liquid
@@ -65,22 +65,22 @@
                     <a href="{{ item.url }}" class="cart-item__name h4 break">{{ item.product.title | escape }}</a>
 
                     {%- if item.original_price != item.final_price -%}
-                      <dl class="cart-item__discounted-prices">
-                        <dt class="visually-hidden">
+                      <span class="cart-item__discounted-prices">
+                        <span class="visually-hidden">
                           {{ 'products.product.price.regular_price' | t }}
-                        </dt>
-                        <dd>
+                        </span>
+                        <span>
                           <s class="cart-item__old-price product-option">
                             {{ item.original_price | money }}
                           </s>
                         </dd>
-                        <dt class="visually-hidden">
+                        <span class="visually-hidden">
                           {{ 'products.product.price.sale_price' | t }}
-                        </dt>
-                        <dd class="product-option">
+                        </span>
+                        <span class="product-option">
                           {{ item.final_price | money }}
-                        </dd>
-                      </dl>
+                        </span>
+                      </span>
                     {%- else -%}
                       <span class="product-option">
                         {{ item.original_price | money }}

--- a/sections/main-cart-items.liquid
+++ b/sections/main-cart-items.liquid
@@ -75,9 +75,9 @@
                         <span class="visually-hidden">
                           {{ 'products.product.price.sale_price' | t }}
                         </span>
-                        <span class="product-option">
+                        <strong class="cart-item__final-price product-option">
                           {{ item.final_price | money }}
-                        </span>
+                        </strong>
                       </div>
                     {%- else -%}
                       <div class="product-option">

--- a/sections/main-cart-items.liquid
+++ b/sections/main-cart-items.liquid
@@ -105,6 +105,28 @@
                         </li>
                       {%- endfor -%}
                     </ul>
+                    {%- if item.original_price != item.final_price -%}
+                      <dl class="cart-item__discounted-prices">
+                        <dt class="visually-hidden">
+                          {{ 'products.product.price.regular_price' | t }}
+                        </dt>
+                        <dd>
+                          <s class="cart-item__old-price">
+                            {{ item.original_price | money }}
+                          </s>
+                        </dd>
+                        <dt class="visually-hidden">
+                          {{ 'products.product.price.sale_price' | t }}
+                        </dt>
+                        <dd class="product-option">
+                          {{ item.final_price | money }}
+                        </dd>
+                      </dl>
+                    {%- else -%}
+                      <span class="product-option">
+                        {{ item.original_price | money }}
+                      </span>
+                    {%- endif -%}
                   </td>
 
                   <td class="cart-item__totals right medium-hide large-up-hide">


### PR DESCRIPTION
**Why are these changes introduced?**

Fixes #497 .

**What approach did you take?**

Followed what we use for the total column, but used `original_price` and `final_price` instead of `final_line_price` and `original_line_price`


**Other considerations**

Unit was already living under the total, so I kept it there

**Demo links**

- [Store](https://os2-demo.myshopify.com/?_ab=0&_fd=0&_sc=1&preview_theme_id=126548672534)

**Checklist**
- [ ] Followed [theme code principles](https://github.com/Shopify/dawn/blob/main/.github/CONTRIBUTING.md#theme-code-principles)
- [ ] Linted with [Theme Check](https://github.com/Shopify/theme-check)
- [ ] Tested on [mobile](https://shopify.dev/themes/store/requirements#mobile-browser-requirements)
- [ ] Tested on [multiple browsers](https://shopify.dev/themes/store/requirements#desktop-browser-requirements)
- [ ] Tested for [accessibility](https://shopify.dev/themes/best-practices/accessibility)
