### PR TITLE
Product image seo

### DIFF
--- a/sections/featured-product.liquid
+++ b/sections/featured-product.liquid
@@ -416,16 +416,16 @@
     "@type": "Product",
     "name": {{ product.title | json }},
     "url": {{ shop.url | append: product.url | json }},
-    {%- if seo_media -%}
+    {% if seo_media -%}
       {%- assign media_size = seo_media.preview_image.width | append: 'x' -%}
       "image": [
         {{ seo_media | img_url: media_size | prepend: "https:" | json }}
       ],
-    {%- endif -%}
+    {%- endif %}
     "description": {{ product.description | strip_html | json }},
-    {%- if product.selected_or_first_available_variant.sku != blank -%}
+    {% if product.selected_or_first_available_variant.sku != blank -%}
       "sku": {{ product.selected_or_first_available_variant.sku | json }},
-    {%- endif -%}
+    {%- endif %}
     "brand": {
       "@type": "Thing",
       "name": {{ product.vendor | json }}

--- a/sections/featured-product.liquid
+++ b/sections/featured-product.liquid
@@ -404,9 +404,9 @@
 
 {%- liquid
   if product.selected_or_first_available_variant.featured_media
-    assign seoMedia = product.selected_or_first_available_variant.featured_media
+    assign seo_media = product.selected_or_first_available_variant.featured_media
   else
-    assign seoMedia = product.featured_media
+    assign seo_media = product.featured_media
   endif
 -%}
 
@@ -416,10 +416,10 @@
     "@type": "Product",
     "name": {{ product.title | json }},
     "url": {{ shop.url | append: product.url | json }},
-    {%- if seoMedia -%}
-      {%- assign media_size = seoMedia.preview_image.width | append: 'x' -%}
+    {%- if seo_media -%}
+      {%- assign media_size = seo_media.preview_image.width | append: 'x' -%}
       "image": [
-        {{ seoMedia | img_url: media_size | prepend: "https:" | json }}
+        {{ seo_media | img_url: media_size | prepend: "https:" | json }}
       ],
     {%- endif -%}
     "description": {{ product.description | strip_html | json }},

--- a/sections/featured-product.liquid
+++ b/sections/featured-product.liquid
@@ -411,6 +411,11 @@
     {%- if product.selected_or_first_available_variant.featured_media -%}
       {%- assign media_size = product.selected_or_first_available_variant.featured_media.preview_image.width | append: 'x' -%}
       "image": [
+        {{ product.selected_or_first_available_variant.featured_media | img_url: media_size | prepend: "https:" | json }}
+      ],
+    {%- elsif product.featured_media -%}
+      {%- assign media_size = product.featured_media.preview_image.width | append: 'x' -%}
+      "image": [
         {{ product.featured_media | img_url: media_size | prepend: "https:" | json }}
       ],
     {%- endif -%}

--- a/sections/featured-product.liquid
+++ b/sections/featured-product.liquid
@@ -402,21 +402,24 @@
   <script src="{{ 'product-model.js' | asset_url }}" defer></script>
 {%- endif -%}
 
+{%- liquid
+  if product.selected_or_first_available_variant.featured_media
+    assign seoMedia = product.selected_or_first_available_variant.featured_media
+  else
+    assign seoMedia = product.featured_media
+  endif
+-%}
+
 <script type="application/ld+json">
   {
     "@context": "http://schema.org/",
     "@type": "Product",
     "name": {{ product.title | json }},
     "url": {{ shop.url | append: product.url | json }},
-    {%- if product.selected_or_first_available_variant.featured_media -%}
-      {%- assign media_size = product.selected_or_first_available_variant.featured_media.preview_image.width | append: 'x' -%}
+    {%- if seoMedia -%}
+      {%- assign media_size = seoMedia.preview_image.width | append: 'x' -%}
       "image": [
-        {{ product.selected_or_first_available_variant.featured_media | img_url: media_size | prepend: "https:" | json }}
-      ],
-    {%- elsif product.featured_media -%}
-      {%- assign media_size = product.featured_media.preview_image.width | append: 'x' -%}
-      "image": [
-        {{ product.featured_media | img_url: media_size | prepend: "https:" | json }}
+        {{ seoMedia | img_url: media_size | prepend: "https:" | json }}
       ],
     {%- endif -%}
     "description": {{ product.description | strip_html | json }},

--- a/sections/main-product.liquid
+++ b/sections/main-product.liquid
@@ -478,9 +478,9 @@
 
 {%- liquid
   if product.selected_or_first_available_variant.featured_media
-    assign seoMedia = product.selected_or_first_available_variant.featured_media
+    assign seo_media = product.selected_or_first_available_variant.featured_media
   else
-    assign seoMedia = product.featured_media
+    assign seo_media = product.featured_media
   endif
 -%}
 
@@ -490,10 +490,10 @@
     "@type": "Product",
     "name": {{ product.title | json }},
     "url": {{ shop.url | append: product.url | json }},
-    {%- if seoMedia -%}
-      {%- assign media_size = seoMedia.preview_image.width | append: 'x' -%}
+    {%- if seo_media -%}
+      {%- assign media_size = seo_media.preview_image.width | append: 'x' -%}
       "image": [
-        {{ seoMedia | img_url: media_size | prepend: "https:" | json }}
+        {{ seo_media | img_url: media_size | prepend: "https:" | json }}
       ],
     {%- endif -%}
     "description": {{ product.description | strip_html | json }},

--- a/sections/main-product.liquid
+++ b/sections/main-product.liquid
@@ -490,16 +490,16 @@
     "@type": "Product",
     "name": {{ product.title | json }},
     "url": {{ shop.url | append: product.url | json }},
-    {%- if seo_media -%}
+    {% if seo_media -%}
       {%- assign media_size = seo_media.preview_image.width | append: 'x' -%}
       "image": [
         {{ seo_media | img_url: media_size | prepend: "https:" | json }}
       ],
-    {%- endif -%}
+    {%- endif %}
     "description": {{ product.description | strip_html | json }},
-    {%- if product.selected_or_first_available_variant.sku != blank -%}
+    {% if product.selected_or_first_available_variant.sku != blank -%}
       "sku": {{ product.selected_or_first_available_variant.sku | json }},
-    {%- endif -%}
+    {%- endif %}
     "brand": {
       "@type": "Thing",
       "name": {{ product.vendor | json }}

--- a/sections/main-product.liquid
+++ b/sections/main-product.liquid
@@ -475,7 +475,7 @@
 
   <script src="{{ 'product-model.js' | asset_url }}" defer></script>
 {%- endif -%}
-<p>TESTING: {{ product.featured_media.preview_image.width }}</p>
+
 <script type="application/ld+json">
   {
     "@context": "http://schema.org/",
@@ -490,7 +490,7 @@
     {%- elsif product.featured_media -%}
       {%- assign media_size = product.featured_media.preview_image.width | append: 'x' -%}
       "image": [
-        {{ product.featured_media.preview_image | img_url: media_size | prepend: "https:" | json }}
+        {{ product.featured_media | img_url: media_size | prepend: "https:" | json }}
       ],
     {%- endif -%}
     "description": {{ product.description | strip_html | json }},

--- a/sections/main-product.liquid
+++ b/sections/main-product.liquid
@@ -475,7 +475,7 @@
 
   <script src="{{ 'product-model.js' | asset_url }}" defer></script>
 {%- endif -%}
-
+<p>TESTING: {{ product.featured_media.preview_image.width }}</p>
 <script type="application/ld+json">
   {
     "@context": "http://schema.org/",
@@ -486,6 +486,11 @@
       {%- assign media_size = product.selected_or_first_available_variant.featured_media.preview_image.width | append: 'x' -%}
       "image": [
         {{ product.selected_or_first_available_variant.featured_media | img_url: media_size | prepend: "https:" | json }}
+      ],
+    {%- elsif product.featured_media -%}
+      {%- assign media_size = product.featured_media.preview_image.width | append: 'x' -%}
+      "image": [
+        {{ product.featured_media.preview_image | img_url: media_size | prepend: "https:" | json }}
       ],
     {%- endif -%}
     "description": {{ product.description | strip_html | json }},

--- a/sections/main-product.liquid
+++ b/sections/main-product.liquid
@@ -476,21 +476,24 @@
   <script src="{{ 'product-model.js' | asset_url }}" defer></script>
 {%- endif -%}
 
+{%- liquid
+  if product.selected_or_first_available_variant.featured_media
+    assign seoMedia = product.selected_or_first_available_variant.featured_media
+  else
+    assign seoMedia = product.featured_media
+  endif
+-%}
+
 <script type="application/ld+json">
   {
     "@context": "http://schema.org/",
     "@type": "Product",
     "name": {{ product.title | json }},
     "url": {{ shop.url | append: product.url | json }},
-    {%- if product.selected_or_first_available_variant.featured_media -%}
-      {%- assign media_size = product.selected_or_first_available_variant.featured_media.preview_image.width | append: 'x' -%}
+    {%- if seoMedia -%}
+      {%- assign media_size = seoMedia.preview_image.width | append: 'x' -%}
       "image": [
-        {{ product.selected_or_first_available_variant.featured_media | img_url: media_size | prepend: "https:" | json }}
-      ],
-    {%- elsif product.featured_media -%}
-      {%- assign media_size = product.featured_media.preview_image.width | append: 'x' -%}
-      "image": [
-        {{ product.featured_media | img_url: media_size | prepend: "https:" | json }}
+        {{ seoMedia | img_url: media_size | prepend: "https:" | json }}
       ],
     {%- endif -%}
     "description": {{ product.description | strip_html | json }},


### PR DESCRIPTION
**Why are these changes introduced?**

Fixes #713 

**What approach did you take?**

I added another option for when the product as a featured image but no variant image.

**Other considerations**

I wonder if we should have those two options or only use the `featured_media` one. 

As a user/merchant, my featured image for the product might be the one I'd like to use/show for general information while the variant image not as much.  

So I think using only `featured_media` would be best 🤔  Curious to hear reviewers' thoughts (cc: @bredowmax)

**Demo links**

- ~Store~
- In order to test you can copy the changes on your/a test store that isn't password protected. Edit the code of the theme (on `main-product.liquid` and/or `featured-product.liquid`), then grab the url of the home page if you're testing the feat. product or the product page if you're testing the main product and paste it in [google's rich results test](https://search.google.com/test/rich-results). 

**Checklist**
- [ ] Followed [theme code principles](https://github.com/Shopify/dawn/blob/main/.github/CONTRIBUTING.md#theme-code-principles)
- [ ] Linted with [Theme Check](https://github.com/Shopify/theme-check)
- [ ] Tested on [mobile](https://shopify.dev/themes/store/requirements#mobile-browser-requirements)
- [ ] Tested on [multiple browsers](https://shopify.dev/themes/store/requirements#desktop-browser-requirements)
- [ ] Tested for [accessibility](https://shopify.dev/themes/best-practices/accessibility)
