### PR TITLE
Show 4 entries in a single row for a collection list

### DIFF
--- a/assets/section-collection-list.css
+++ b/assets/section-collection-list.css
@@ -98,14 +98,16 @@
     box-shadow: none;
   }
 
+  .collection-list.grid--2-col-tablet .grid__item {
+    max-width: 50%;
+  }
+
   .collection-list.grid--3-col-tablet .grid__item {
     max-width: 33.33%;
   }
 
-  .collection-list--4-items .grid__item,
-  .collection-list--7-items .grid__item:nth-child(n + 4),
-  .collection-list--10-items .grid__item:nth-child(n + 7) {
-    width: 50%;
+  .collection-list.grid--4-col-tablet .grid__item {
+    max-width: 25%;
   }
 }
 


### PR DESCRIPTION
**Why are these changes introduced?**

Fixes #781. The issue contains a very detailed description and screenshots.

**What approach did you take?**

Identify the problem that setting grid positions should be done on the parent (grid) level, not on the individual item level. Verified this is aligned with the original intent of the CSS class name.

**Other considerations**

I initially tried to set `.grid__item:nth-child(n)` (to avoid the gaps with `n + 4`, but quickly figured out that's the wrong part to fix this.

**Demo links**

See https://thesmallbatchproject.ch/en/collections (you'll need to use the developer consoles to delete a few <li> items to get exactly 4 items).

**Checklist**
- [x] Followed [theme code principles](https://github.com/Shopify/dawn/blob/main/.github/CONTRIBUTING.md#theme-code-principles)
- [x] Linted with [Theme Check](https://github.com/Shopify/theme-check)
- [x] Tested on [mobile](https://shopify.dev/themes/store/requirements#mobile-browser-requirements)
- [x] Tested on [multiple browsers](https://shopify.dev/themes/store/requirements#desktop-browser-requirements)
- [x] Tested for [accessibility](https://shopify.dev/themes/best-practices/accessibility)
