### PR TITLE
Fix counter for swipe on mobile section when section has html in the…

### DIFF
--- a/assets/global.js
+++ b/assets/global.js
@@ -497,7 +497,7 @@ class SliderComponent extends HTMLElement {
   constructor() {
     super();
     this.slider = this.querySelector('ul');
-    this.sliderItems = this.querySelectorAll('li');
+    this.sliderItems = this.querySelectorAll('li.slider__slide');
     this.pageCount = this.querySelector('.slider-counter--current');
     this.pageTotal = this.querySelector('.slider-counter--total');
     this.prevButton = this.querySelector('button[name="previous"]');


### PR DESCRIPTION
**Why are these changes introduced?**

Within the customizer, for multiple sections (multi-column for example), if a user creates an HTML list within the text field (description field in multi-column) and has the "Enable swipe on mobile" setting enabled, the counter for the slider on mobile will show incorrect current/total slide numbers. 

You can see here in this multi column I have 3 columns added:
<img width="284" alt="Screen Shot 2021-10-27 at 7 50 40 PM" src="https://user-images.githubusercontent.com/20651001/139163395-f336a78a-1b75-4580-a0d6-c301f0ddc5fd.png">

But if I add lists in the body text like so, you'll notice the counter is now reading 17 despite 3 actual slides. The current slide counter eg 1/3, 2/3, 3/3 will also be incorrect but only on the last side.

<img width="1030" alt="Screen Shot 2021-10-27 at 7 47 56 PM" src="https://user-images.githubusercontent.com/20651001/139163241-70367a35-c839-46ee-928b-80c46f788629.png">


I understand inputting html into the text fields isn't optimal to do but it is possible and as such users will use it, hence how I stumbled upon this.

Fixes #0.

**What approach did you take?**

I simply added the parent class for the slide element into the logic for the counter so other child `<li>` elements won't be included in the count:

```
// global.js

// before
this.sliderItems = this.querySelectorAll('li');

// after
this.sliderItems = this.querySelectorAll('li.slider__slide');
```

**Other considerations**

The collection-list, featured-blog, featured-collection, and multicolumn sections all seem to be affected by this.


**Checklist**
- [x] Followed [theme code principles](https://github.com/Shopify/dawn/blob/main/.github/CONTRIBUTING.md#theme-code-principles)
- [X] Linted with [Theme Check](https://github.com/Shopify/theme-check)
- [X] Tested on [mobile](https://shopify.dev/themes/store/requirements#mobile-browser-requirements)
- [X] Tested on [multiple browsers](https://shopify.dev/themes/store/requirements#desktop-browser-requirements)
- [X] Tested for [accessibility](https://shopify.dev/themes/best-practices/accessibility)
