### PR TITLE
Fixed RGB color format on 404 template

### DIFF
--- a/layout/password.liquid
+++ b/layout/password.liquid
@@ -49,13 +49,13 @@
         --font-body-scale: {{ settings.body_scale | divided_by: 100.0 }};
         --font-heading-scale: {{ settings.heading_scale | times: 1.0 | divided_by: settings.body_scale }};
 
-        --color-base-text: {{ settings.colors_text.red }}, {{ settings.colors_text.green }}, {{ settings.colors_text.blue }};
-        --color-base-background-1: {{ settings.colors_background_1.red }}, {{ settings.colors_background_1.green }}, {{ settings.colors_background_1.blue }};
-        --color-base-background-2: {{ settings.colors_background_2.red }}, {{ settings.colors_background_2.green }}, {{ settings.colors_background_2.blue }};
-        --color-base-solid-button-labels: {{ settings.colors_solid_button_labels.red }}, {{ settings.colors_solid_button_labels.green }}, {{ settings.colors_solid_button_labels.blue }};
-        --color-base-outline-button-labels: {{ settings.colors_outline_button_labels.red }}, {{ settings.colors_outline_button_labels.green }}, {{ settings.colors_outline_button_labels.blue }};
-        --color-base-accent-1: {{ settings.colors_accent_1.red }}, {{ settings.colors_accent_1.green }}, {{ settings.colors_accent_1.blue }};
-        --color-base-accent-2: {{ settings.colors_accent_2.red }}, {{ settings.colors_accent_2.green }}, {{ settings.colors_accent_2.blue }};
+        --color-base-text: {{ settings.colors_text | color_extract: 'red' }}, {{ settings.colors_text | color_extract: 'green' }}, {{ settings.colors_text | color_extract: 'blue' }};
+        --color-base-background-1: {{ settings.colors_background_1 | color_extract: 'red' }}, {{ settings.colors_background_1 | color_extract: 'green' }}, {{ settings.colors_background_1 | color_extract: 'blue' }};
+        --color-base-background-2: {{ settings.colors_background_2 | color_extract: 'red' }}, {{ settings.colors_background_2 | color_extract: 'green' }}, {{ settings.colors_background_2 | color_extract: 'blue' }};
+        --color-base-solid-button-labels: {{ settings.colors_solid_button_labels | color_extract: 'red' }}, {{ settings.colors_solid_button_labels | color_extract: 'green' }}, {{ settings.colors_solid_button_labels | color_extract: 'blue' }};
+        --color-base-outline-button-labels: {{ settings.colors_outline_button_labels | color_extract: 'red' }}, {{ settings.colors_outline_button_labels | color_extract: 'green' }}, {{ settings.colors_outline_button_labels | color_extract: 'blue' }};
+        --color-base-accent-1: {{ settings.colors_accent_1 | color_extract: 'red' }}, {{ settings.colors_accent_1 | color_extract: 'green' }}, {{ settings.colors_accent_1 | color_extract: 'blue' }};
+        --color-base-accent-2: {{ settings.colors_accent_2 | color_extract: 'red' }}, {{ settings.colors_accent_2 | color_extract: 'green' }}, {{ settings.colors_accent_2 | color_extract: 'blue' }};
         --payment-terms-background-color: {{ settings.colors_background_1 }};
 
         --gradient-base-background-1: {% if settings.gradient_background_1 != blank %}{{ settings.gradient_background_1 }}{% else %}{{ settings.colors_background_1 }}{% endif %};

--- a/layout/theme.liquid
+++ b/layout/theme.liquid
@@ -57,13 +57,13 @@
         --font-body-scale: {{ settings.body_scale | divided_by: 100.0 }};
         --font-heading-scale: {{ settings.heading_scale | times: 1.0 | divided_by: settings.body_scale }};
 
-        --color-base-text: {{ settings.colors_text.red }}, {{ settings.colors_text.green }}, {{ settings.colors_text.blue }};
-        --color-base-background-1: {{ settings.colors_background_1.red }}, {{ settings.colors_background_1.green }}, {{ settings.colors_background_1.blue }};
-        --color-base-background-2: {{ settings.colors_background_2.red }}, {{ settings.colors_background_2.green }}, {{ settings.colors_background_2.blue }};
-        --color-base-solid-button-labels: {{ settings.colors_solid_button_labels.red }}, {{ settings.colors_solid_button_labels.green }}, {{ settings.colors_solid_button_labels.blue }};
-        --color-base-outline-button-labels: {{ settings.colors_outline_button_labels.red }}, {{ settings.colors_outline_button_labels.green }}, {{ settings.colors_outline_button_labels.blue }};
-        --color-base-accent-1: {{ settings.colors_accent_1.red }}, {{ settings.colors_accent_1.green }}, {{ settings.colors_accent_1.blue }};
-        --color-base-accent-2: {{ settings.colors_accent_2.red }}, {{ settings.colors_accent_2.green }}, {{ settings.colors_accent_2.blue }};
+        --color-base-text: {{ settings.colors_text | color_extract: 'red' }}, {{ settings.colors_text | color_extract: 'green' }}, {{ settings.colors_text | color_extract: 'blue' }};
+        --color-base-background-1: {{ settings.colors_background_1 | color_extract: 'red' }}, {{ settings.colors_background_1 | color_extract: 'green' }}, {{ settings.colors_background_1 | color_extract: 'blue' }};
+        --color-base-background-2: {{ settings.colors_background_2 | color_extract: 'red' }}, {{ settings.colors_background_2 | color_extract: 'green' }}, {{ settings.colors_background_2 | color_extract: 'blue' }};
+        --color-base-solid-button-labels: {{ settings.colors_solid_button_labels | color_extract: 'red' }}, {{ settings.colors_solid_button_labels | color_extract: 'green' }}, {{ settings.colors_solid_button_labels | color_extract: 'blue' }};
+        --color-base-outline-button-labels: {{ settings.colors_outline_button_labels | color_extract: 'red' }}, {{ settings.colors_outline_button_labels | color_extract: 'green' }}, {{ settings.colors_outline_button_labels | color_extract: 'blue' }};
+        --color-base-accent-1: {{ settings.colors_accent_1 | color_extract: 'red' }}, {{ settings.colors_accent_1 | color_extract: 'green' }}, {{ settings.colors_accent_1 | color_extract: 'blue' }};
+        --color-base-accent-2: {{ settings.colors_accent_2 | color_extract: 'red' }}, {{ settings.colors_accent_2 | color_extract: 'green' }}, {{ settings.colors_accent_2 | color_extract: 'blue' }};
         --payment-terms-background-color: {{ settings.colors_background_1 }};
 
         --gradient-base-background-1: {% if settings.gradient_background_1 != blank %}{{ settings.gradient_background_1 }}{% else %}{{ settings.colors_background_1 }}{% endif %};

--- a/templates/gift_card.liquid
+++ b/templates/gift_card.liquid
@@ -52,13 +52,13 @@
         --font-body-scale: {{ settings.body_scale | divided_by: 100.0 }};
         --font-heading-scale: {{ settings.heading_scale | times: 1.0 | divided_by: settings.body_scale }};
 
-        --color-base-text: {{ settings.colors_text.red }}, {{ settings.colors_text.green }}, {{ settings.colors_text.blue }};
-        --color-base-background-1: {{ settings.colors_background_1.red }}, {{ settings.colors_background_1.green }}, {{ settings.colors_background_1.blue }};
-        --color-base-background-2: {{ settings.colors_background_2.red }}, {{ settings.colors_background_2.green }}, {{ settings.colors_background_2.blue }};
-        --color-base-solid-button-labels: {{ settings.colors_solid_button_labels.red }}, {{ settings.colors_solid_button_labels.green }}, {{ settings.colors_solid_button_labels.blue }};
-        --color-base-outline-button-labels: {{ settings.colors_outline_button_labels.red }}, {{ settings.colors_outline_button_labels.green }}, {{ settings.colors_outline_button_labels.blue }};
-        --color-base-accent-1: {{ settings.colors_accent_1.red }}, {{ settings.colors_accent_1.green }}, {{ settings.colors_accent_1.blue }};
-        --color-base-accent-2: {{ settings.colors_accent_2.red }}, {{ settings.colors_accent_2.green }}, {{ settings.colors_accent_2.blue }};
+        --color-base-text: {{ settings.colors_text | color_extract: 'red' }}, {{ settings.colors_text | color_extract: 'green' }}, {{ settings.colors_text | color_extract: 'blue' }};
+        --color-base-background-1: {{ settings.colors_background_1 | color_extract: 'red' }}, {{ settings.colors_background_1 | color_extract: 'green' }}, {{ settings.colors_background_1 | color_extract: 'blue' }};
+        --color-base-background-2: {{ settings.colors_background_2 | color_extract: 'red' }}, {{ settings.colors_background_2 | color_extract: 'green' }}, {{ settings.colors_background_2 | color_extract: 'blue' }};
+        --color-base-solid-button-labels: {{ settings.colors_solid_button_labels | color_extract: 'red' }}, {{ settings.colors_solid_button_labels | color_extract: 'green' }}, {{ settings.colors_solid_button_labels | color_extract: 'blue' }};
+        --color-base-outline-button-labels: {{ settings.colors_outline_button_labels | color_extract: 'red' }}, {{ settings.colors_outline_button_labels | color_extract: 'green' }}, {{ settings.colors_outline_button_labels | color_extract: 'blue' }};
+        --color-base-accent-1: {{ settings.colors_accent_1 | color_extract: 'red' }}, {{ settings.colors_accent_1 | color_extract: 'green' }}, {{ settings.colors_accent_1 | color_extract: 'blue' }};
+        --color-base-accent-2: {{ settings.colors_accent_2 | color_extract: 'red' }}, {{ settings.colors_accent_2 | color_extract: 'green' }}, {{ settings.colors_accent_2 | color_extract: 'blue' }};
 
         --gradient-base-background-1: {% if settings.gradient_background_1 != blank %}{{ settings.gradient_background_1 }}{% else %}{{ settings.colors_background_1 }}{% endif %};
 


### PR DESCRIPTION
**Why are these changes introduced?**

Fixes #846.

**What approach did you take?**

On the 404 template page, the traditional way of RGB color format is not working so replaced with `color_extract` color filter.

**Other considerations**

**Demo links**

- [Store](https://cloverlane.com/404)

**Checklist**
- [x] Followed [theme code principles](https://github.com/Shopify/dawn/blob/main/.github/CONTRIBUTING.md#theme-code-principles)
- [x] Linted with [Theme Check](https://github.com/Shopify/theme-check)
- [x] Tested on [mobile](https://shopify.dev/themes/store/requirements#mobile-browser-requirements)
- [x] Tested on [multiple browsers](https://shopify.dev/themes/store/requirements#desktop-browser-requirements)
- [x] Tested for [accessibility](https://shopify.dev/themes/best-practices/accessibility)
