### PR TITLE
Fix pickup-in-store international domains and multi-language support

### DIFF
--- a/assets/pickup-availability.js
+++ b/assets/pickup-availability.js
@@ -11,7 +11,11 @@ if (!customElements.get('pickup-availability')) {
     }
 
     fetchAvailability(variantId) {
-      const variantSectionUrl = `${this.dataset.baseUrl}variants/${variantId}/?section_id=pickup-availability`;
+      let rootUrl = this.dataset.rootUrl;
+      if (!rootUrl.endsWith("/")) {
+        rootUrl = rootUrl + "/";
+      }
+      const variantSectionUrl = `${rootUrl}variants/${variantId}/?section_id=pickup-availability`;
 
       fetch(variantSectionUrl)
         .then(response => response.text())

--- a/sections/main-product.liquid
+++ b/sections/main-product.liquid
@@ -320,7 +320,7 @@
 
               <pickup-availability class="product__pickup-availabilities no-js-hidden"
                 {% if product.selected_or_first_available_variant.available and pick_up_availabilities.size > 0 %} available{% endif %}
-                data-base-url="{{ shop.url }}{{ routes.root_url }}"
+                data-root-url="{{ routes.root_url }}"
                 data-variant-id="{{ product.selected_or_first_available_variant.id }}"
                 data-has-only-default-variant="{{ product.has_only_default_variant }}"
               >


### PR DESCRIPTION
**Why are these changes introduced?**

Fixes https://github.com/Shopify/dawn/issues/548

As per the issue description, we must always use the current domain to issue an ajax call or otherwise a CORS issue will occur.

Additionally, the concatenation was not valid for multi-language use cases where the resulting url was not valid. 

**Demo links**
URL: https://jp.defaultglobal.com/products/blue-silk-tuxedo
Generated XHR: https://defaultglobal.com/variants/31362180874262/?section_id=pickup-availability
Result: 
```
Access to fetch at 'https://defaultglobal.com/variants/31362180874262/?section_id=pickup-availability' from origin 'https://jp.defaultglobal.com' has been blocked by CORS policy: No 'Access-Control-Allow-Origin' header is present on the requested resource. If an opaque response serves your needs, set the request's mode to 'no-cors' to fetch the resource with CORS disabled.
```
<img width="565" alt="Screen Shot 2021-11-03 at 7 01 31 PM" src="https://user-images.githubusercontent.com/207902/140232465-5ca2b8b4-f4c0-45b0-99af-8390fc28eaf4.png">



URL: https://defaultglobal.com/en-fr/products/blue-silk-tuxedo
Generated XHR: https://defaultglobal.com/en-fr/en-frvariants/31362180874262/?section_id=pickup-availability
Result: 
```
<div id="shopify-section-pickup-availability" class="shopify-section">
</div>
```

**Checklist**
- [x] Followed [theme code principles](https://github.com/Shopify/dawn/blob/main/.github/CONTRIBUTING.md#theme-code-principles)
- [ ] Linted with [Theme Check](https://github.com/Shopify/theme-check)
- [ ] Tested on [mobile](https://shopify.dev/themes/store/requirements#mobile-browser-requirements)
- [ ] Tested on [multiple browsers](https://shopify.dev/themes/store/requirements#desktop-browser-requirements)
- [ ] Tested for [accessibility](https://shopify.dev/themes/best-practices/accessibility)
