### PR TITLE
Fix pick up availability 'Unavailable'

### DIFF
--- a/assets/pickup-availability.js
+++ b/assets/pickup-availability.js
@@ -57,8 +57,8 @@ if (!customElements.get('pickup-availability')) {
 
       document.body.appendChild(sectionInnerHTML.querySelector('pickup-availability-drawer'));
 
-      if (!this.querySelector('button')) return;
-      this.querySelector('button').addEventListener('click', (evt) => {
+      const button = this.querySelector('button');
+      if (button) button.addEventListener('click', (evt) => {
         document.querySelector('pickup-availability-drawer').show(evt.target);
       });
     }

--- a/assets/pickup-availability.js
+++ b/assets/pickup-availability.js
@@ -57,6 +57,7 @@ if (!customElements.get('pickup-availability')) {
 
       document.body.appendChild(sectionInnerHTML.querySelector('pickup-availability-drawer'));
 
+      if (!this.querySelector('button')) return;
       this.querySelector('button').addEventListener('click', (evt) => {
         document.querySelector('pickup-availability-drawer').show(evt.target);
       });


### PR DESCRIPTION
**Why are these changes introduced?**

While testing out [this PR](https://github.com/Shopify/dawn/pull/848) I noticed an issue where the product was unavailable at a pick up location. But it wasn't showing the proper message/html due to an error coming up from `renderPreview()` where the event listener being added to the button was failing since there was no button in this scenario. 

**What approach did you take?**
Added a check/early return if no button is present in the HTML being rendered. 

![](https://screenshot.click/21-11-zt36f-839fh.png)

**Other considerations**

**Demo links**
I've been testing on this store/page: https://ca.catleaves.com/products/invisible-cat-leaf

I went into the code in the admin and added the check that I'm adding in this PR to confirmed it fixed the issue.

I will try and recreate the same setup in our test store but I can't atm. 

**Checklist**
- [ ] Followed [theme code principles](https://github.com/Shopify/dawn/blob/main/.github/CONTRIBUTING.md#theme-code-principles)
- [ ] Linted with [Theme Check](https://github.com/Shopify/theme-check)
- [ ] Tested on [mobile](https://shopify.dev/themes/store/requirements#mobile-browser-requirements)
- [ ] Tested on [multiple browsers](https://shopify.dev/themes/store/requirements#desktop-browser-requirements)
- [ ] Tested for [accessibility](https://shopify.dev/themes/best-practices/accessibility)
