### PR TITLE
Update predictive-search image to lazy load

### DIFF
--- a/sections/predictive-search.liquid
+++ b/sections/predictive-search.liquid
@@ -19,6 +19,7 @@
                 alt="{{ product.featured_media.alt }}"
                 width="50"
                 height="{{ 50 | divided_by: product.featured_media.preview_image.aspect_ratio }}"
+                loading="lazy"
               >
             {%- endif -%}
             <div class="predictive-search__item-content{% unless settings.predictive_search_show_vendor or settings.predictive_search_show_price %} predictive-search__item-content--centered{% endunless %}">


### PR DESCRIPTION
Updated to fix theme check suggestion.

Before

```
shopify theme check
Checking . ...
sections/predictive-search.liquid:17: suggestion: ImgLazyLoading: Add a loading="lazy" attribute to defer loading of images.
	<img class="predictive-search__image"

226 files inspected, 1 offenses detected, 0 offenses auto-correctable
```

After
```
dgitman@Davids-MacBook-Pro-2 dawn % shopify theme check
Checking . ...
226 files inspected, 0 offenses detected, 0 offenses auto-correctable
```