### PR TITLE
Fix image tag for a product's schema.org

### DIFF
--- a/sections/featured-product.liquid
+++ b/sections/featured-product.liquid
@@ -410,9 +410,10 @@
     "url": {{ shop.url | append: product.url | json }},
     {%- if product.selected_or_first_available_variant.featured_media -%}
       {%- assign media_size = product.selected_or_first_available_variant.featured_media.preview_image.width | append: 'x' -%}
-      "image": [
-        {{ product.featured_media | img_url: media_size | prepend: "https:" | json }}
-      ],
+      "image": {{ product.selected_or_first_available_variant.featured_media | img_url: media_size | prepend: "https:" | json }},
+    {% elsif product.featured_media %}
+      {%- assign media_size = product.featured_media.preview_image.width | append: 'x' -%}
+      "image": {{ product.featured_media | img_url: media_size | prepend: "https:" | json }},
     {%- endif -%}
     "description": {{ product.description | strip_html | json }},
     {%- if product.selected_or_first_available_variant.sku != blank -%}

--- a/sections/main-product.liquid
+++ b/sections/main-product.liquid
@@ -485,9 +485,10 @@
     "url": {{ shop.url | append: product.url | json }},
     {%- if product.selected_or_first_available_variant.featured_media -%}
       {%- assign media_size = product.selected_or_first_available_variant.featured_media.preview_image.width | append: 'x' -%}
-      "image": [
-        {{ product.selected_or_first_available_variant.featured_media | img_url: media_size | prepend: "https:" | json }}
-      ],
+      "image": {{ product.selected_or_first_available_variant.featured_media | img_url: media_size | prepend: "https:" | json }},
+    {% elsif product.featured_media %}
+      {%- assign media_size = product.featured_media.preview_image.width | append: 'x' -%}
+      "image": {{ product.featured_media | img_url: media_size | prepend: "https:" | json }},
     {%- endif -%}
     "description": {{ product.description | strip_html | json }},
     {%- if product.selected_or_first_available_variant.sku != blank -%}


### PR DESCRIPTION
**Why are these changes introduced?**

Google Search Console warned me that the products don't have an image tag. This is true for all products that don't have a variant, but only a default option.

**What approach did you take?**

I left the variant-specific image tag in place and added an else condition for the main image.

Additionally, I changed the image array to a simple string, following the guidelines at https://schema.org/image. (I'm happy to pull this out of this change if I misinterpreted that.)

**Other considerations**

**Demo links**

- [Example product on live store](https://thesmallbatchproject.ch/en/products/garcoa-curimana-76)

**Checklist**
- [x] Followed [theme code principles](https://github.com/Shopify/dawn/blob/main/.github/CONTRIBUTING.md#theme-code-principles)
- [x] Linted with [Theme Check](https://github.com/Shopify/theme-check)
- [x] Tested on [mobile](https://shopify.dev/themes/store/requirements#mobile-browser-requirements)
- [x] Tested on [multiple browsers](https://shopify.dev/themes/store/requirements#desktop-browser-requirements)
- [x] Tested for [accessibility](https://shopify.dev/themes/best-practices/accessibility)
