### PR TITLE
Fix 404 menu nav not showing

### DIFF
--- a/sections/header.liquid
+++ b/sections/header.liquid
@@ -95,7 +95,7 @@
               <div class="menu-drawer__navigation-container">
                 <nav class="menu-drawer__navigation">
                   <ul class="menu-drawer__menu list-menu" role="list">
-                    {%- for link in section.settings.menu.links -%}
+                    {%- for link in linklists[section.settings.menu].links -%}
                       <li>
                         {%- if link.links != blank -%}
                           <details id="Details-menu-drawer-menu-item-{{ forloop.index }}">
@@ -351,7 +351,7 @@
     {%- if section.settings.menu != blank -%}
       <nav class="header__inline-menu">
         <ul class="list-menu list-menu--inline" role="list">
-          {%- for link in section.settings.menu.links -%}
+          {%- for link in linklists[section.settings.menu].links -%}
             <li>
               {%- if link.links != blank -%}
                 <details-disclosure>


### PR DESCRIPTION
**Why are these changes introduced?**

Fixes #873 

**What approach did you take?**

Changed the way we're checking for links within the menu chosen in the header.

**Other considerations**

Seems to be more related to an issue in the way we render the 404 template but in the mean time, let's ship this fix. 
Also the original approach seem to be working in the footer but not the header... 🤔 

**Demo links**

- [Store](https://os2-demo.myshopify.com/?preview_theme_id=126765563926)
- [Editor](https://os2-demo.myshopify.com/admin/themes/126765563926/editor)

**Checklist**
- [ ] Followed [theme code principles](https://github.com/Shopify/dawn/blob/main/.github/CONTRIBUTING.md#theme-code-principles)
- [ ] Linted with [Theme Check](https://github.com/Shopify/theme-check)
- [ ] Tested on [mobile](https://shopify.dev/themes/store/requirements#mobile-browser-requirements)
- [ ] Tested on [multiple browsers](https://shopify.dev/themes/store/requirements#desktop-browser-requirements)
- [ ] Tested for [accessibility](https://shopify.dev/themes/best-practices/accessibility)
