### PR TITLE
Add theme level grid setting

### DIFF
--- a/assets/base.css
+++ b/assets/base.css
@@ -929,20 +929,20 @@ summary::-webkit-details-marker {
   display: flex;
   flex-wrap: wrap;
   margin-bottom: 2rem;
-  margin-left: -0.5rem;
+  margin-left: calc(-1 * var(--grid-mobile-horizontal-spacing));;
   padding: 0;
   list-style: none;
 }
 
 @media screen and (min-width: 750px) {
   .grid {
-    margin-left: -1rem;
+    margin-left: calc(-1 * var(--grid-desktop-horizontal-spacing));
   }
 }
 
 .grid__item {
-  padding-left: 0.5rem;
-  padding-bottom: 0.5rem;
+  padding-left: var(--grid-mobile-horizontal-spacing);
+  padding-bottom: var(--grid-mobile-vertical-spacing);
   width: calc(25% - 0.5rem * 3 / 4);
   max-width: 50%;
   flex-grow: 1;
@@ -951,9 +951,9 @@ summary::-webkit-details-marker {
 
 @media screen and (min-width: 750px) {
   .grid__item {
-    padding-left: 1rem;
-    padding-bottom: 1rem;
-    width: calc(25% - 1rem * 3 / 4);
+    padding-left: var(--grid-desktop-horizontal-spacing);
+    padding-bottom: var(--grid-desktop-vertical-spacing);
+    width: calc(25% - var(--grid-desktop-horizontal-spacing) * 3 / 4);
     max-width: 50%;
   }
 }
@@ -988,48 +988,48 @@ summary::-webkit-details-marker {
 }
 
 .grid--3-col .grid__item {
-  width: calc(33.33% - 0.5rem * 2 / 3);
+  width: calc(33.33% - var(--grid-mobile-horizontal-spacing) * 2 / 3);
 }
 
 @media screen and (min-width: 750px) {
   .grid--3-col .grid__item {
-    width: calc(33.33% - 1rem * 2 / 3);
+    width: calc(33.33% - var(--grid-desktop-horizontal-spacing) * 2 / 3);
   }
 }
 
 .grid--2-col .grid__item {
-  width: calc(50% - 0.5rem / 2);
+  width: calc(50% - var(--grid-mobile-horizontal-spacing) / 2);
 }
 
 @media screen and (min-width: 750px) {
   .grid--2-col .grid__item {
-    width: calc(50% - 1rem / 2);
+    width: calc(50% - var(--grid-desktop-horizontal-spacing) / 2);
   }
 
   .grid--4-col-tablet .grid__item {
-    width: calc(25% - 1rem * 3 / 4);
+    width: calc(25% - var(--grid-desktop-horizontal-spacing) * 3 / 4);
   }
 
   .grid--3-col-tablet .grid__item {
-    width: calc(33.33% - 1rem * 2 / 3);
+    width: calc(33.33% - var(--grid-desktop-horizontal-spacing) * 2 / 3);
   }
 
   .grid--2-col-tablet .grid__item {
-    width: calc(50% - 1rem / 2);
+    width: calc(50% - var(--grid-desktop-horizontal-spacing) / 2);
   }
 }
 
 @media screen and (min-width: 990px) {
   .grid--4-col-desktop .grid__item {
-    width: calc(25% - 1rem * 3 / 4);
+    width: calc(25% - var(--grid-desktop-horizontal-spacing) * 3 / 4);
   }
 
   .grid--3-col-desktop .grid__item {
-    width: calc(33.33% - 1rem * 2 / 3);
+    width: calc(33.33% - var(--grid-desktop-horizontal-spacing) * 2 / 3);
   }
 
   .grid--2-col-desktop .grid__item {
-    width: calc(50% - 1rem / 2);
+    width: calc(50% - var(--grid-desktop-horizontal-spacing) / 2);
   }
 }
 
@@ -1055,6 +1055,10 @@ summary::-webkit-details-marker {
 
   .grid--peek .grid__item {
     width: calc(50% - 3.75rem / 2);
+  }
+
+  .grid--peek .grid__item {
+    padding-left: 0.5rem;
   }
 
   .grid--peek .grid__item:first-of-type {

--- a/assets/collage.css
+++ b/assets/collage.css
@@ -24,7 +24,8 @@
 
 .collage {
   display: grid;
-  gap: 1rem;
+  row-gap: var(--grid-mobile-vertical-spacing);
+  column-gap: var(--grid-mobile-horizontal-spacing);
 }
 
 .collage--mobile {
@@ -34,6 +35,8 @@
 @media screen and (min-width: 750px) {
   .collage {
     grid-template-columns: 1fr 1fr 1fr;
+    row-gap: var(--grid-desktop-vertical-spacing);
+    column-gap: var(--grid-desktop-horizontal-spacing);
   }
 }
 

--- a/assets/component-card.css
+++ b/assets/component-card.css
@@ -199,6 +199,7 @@
   flex-direction: column;
   position: relative;
   text-decoration: none;
+  padding-bottom: 0.5rem;
 }
 
 .card-wrapper .card-information {

--- a/assets/component-product-grid.css
+++ b/assets/component-product-grid.css
@@ -1,5 +1,5 @@
 .product-grid .grid__item {
-  padding-bottom: 2rem;
+  padding-bottom: var(--grid-mobile-vertical-spacing);
 }
 
 .product-grid.negative-margin {
@@ -8,6 +8,10 @@
 
 @media screen and (min-width: 750px) {
   .product-grid .grid__item {
+    padding-bottom: var(--grid-desktop-vertical-spacing);
+  }
+
+  .product-grid {
     padding-bottom: calc(5rem + var(--page-width-margin));
   }
 

--- a/assets/section-collection-list.css
+++ b/assets/section-collection-list.css
@@ -63,10 +63,6 @@
     width: calc(100% - 3rem);
   }
 
-  .collection-list__item.grid__item {
-    padding-bottom: 1rem;
-  }
-
   .slider.collection-list--1-items {
     padding-bottom: 0;
   }

--- a/assets/section-featured-blog.css
+++ b/assets/section-featured-blog.css
@@ -92,14 +92,14 @@
 
 @media screen and (min-width: 750px) {
   .blog__posts .article + .article {
-    margin-left: 1rem;
+    margin-left: var(--grid-desktop-horizontal-spacing);
   }
 }
 
 @media screen and (max-width: 749px) {
   .blog__post.article {
     width: calc(100% - 3rem);
-    padding-left: 0.5rem;
+    padding-left: var(--grid-mobile-horizontal-spacing);
   }
 }
 

--- a/assets/section-main-blog.css
+++ b/assets/section-main-blog.css
@@ -1,11 +1,15 @@
 .blog-articles {
   display: grid;
   grid-gap: 1rem;
+  column-gap: var(--grid-mobile-horizontal-spacing);
+  row-gap: var(--grid-mobile-vertical-spacing);
 }
 
 @media screen and (min-width: 750px) {
   .blog-articles {
     grid-template-columns: 1fr 1fr;
+    column-gap: var(--grid-desktop-horizontal-spacing);
+    row-gap: var(--grid-desktop-vertical-spacing); 
   }
 
   .blog-articles--collage > *:nth-child(3n + 1),

--- a/config/settings_schema.json
+++ b/config/settings_schema.json
@@ -134,6 +134,63 @@
     ]
   },
   {
+    "name": "Grid",
+    "settings": [
+      {
+        "type": "paragraph",
+        "content": "Affects collection, search and blog pages. Also affects collage, collection, collection list, multicolumn and blog sections"
+      },
+      {
+        "type": "header",
+        "content": "Desktop"
+      },
+      {
+        "type": "range",
+        "id": "grid_desktop_vertical_spacing",
+        "min": 0,
+        "max": 40,
+        "step": 5,
+        "default": 10,
+        "unit": "px",
+        "label": "Vertical spacing"
+      },
+      {
+        "type": "range",
+        "id": "grid_desktop_horizontal_spacing",
+        "min": 0,
+        "max": 40,
+        "step": 5,
+        "default": 10,
+        "unit": "px",
+        "label": "Horizontal spacing"
+      },
+      {
+        "type": "header",
+        "content": "Mobile"
+      },
+      {
+        "type": "range",
+        "id": "grid_mobile_vertical_spacing",
+        "min": 0,
+        "max": 30,
+        "step": 5,
+        "default": 5,
+        "unit": "px",
+        "label": "Vertical spacing"
+      },
+      {
+        "type": "range",
+        "id": "grid_mobile_horizontal_spacing",
+        "min": 0,
+        "max": 30,
+        "step": 5,
+        "default": 5,
+        "unit": "px",
+        "label": "Horizontal spacing"
+      }
+    ]
+  },
+  {
     "name": "t:settings_schema.styles.name",
     "settings": [
       {

--- a/layout/theme.liquid
+++ b/layout/theme.liquid
@@ -73,6 +73,12 @@
 
         --page-width: {{ settings.page_width | divided_by: 10 }}rem;
         --page-width-margin: {% if settings.page_width == '1600' %}2{% else %}0{% endif %}rem;
+
+        {% comment %} Grid styles {% endcomment %}
+        --grid-desktop-vertical-spacing: {{ settings.grid_desktop_vertical_spacing | divided_by: 10.0 }}rem;
+        --grid-desktop-horizontal-spacing: {{ settings.grid_desktop_horizontal_spacing | divided_by: 10.0 }}rem;
+        --grid-mobile-vertical-spacing: {{ settings.grid_mobile_vertical_spacing | divided_by: 10.0 }}rem;
+        --grid-mobile-horizontal-spacing: {{ settings.grid_mobile_horizontal_spacing | divided_by: 10.0 }}rem;
       }
 
       *,


### PR DESCRIPTION
**Why are these changes introduced?**
Adds theme level settings for Grid. 

Fixes #820 

**What approach did you take?**
Made an initial update to the existing grid to change row/column gap with theme level settings. 
I will continue to iterate to use flex gap now that it's supported in the latest two versions of our supported browsers, and/or convert flex grids to css grid. Wanted to get a prototype set up for Meli to look at today. 

Affected sections: 
- [x] Featured blog
- [x] Featured collections
- [x] Collection list 
- [x] Multi-column

Affected templates 
- [x] Product page media grid
- [x] Collection list 
- [x] Collection product grid
- [x] Blog page         

**Other considerations**
I did not apply Horizontal spacing to the mobile slider. The slider is set up in a specific way that allows the "peek" effect of the previous/next slide. I feel that adding grid gap to the slider would add complexity. I also feel that this doesn't really represent a "Grid" and I feel comfortable excluding it from these settings on mobile. cc. @melissaperreault 
For example: Collection list with the "swipe on mobile" enabled. 

**Demo links**

**Checklist**
- [ ] Followed [theme code principles](https://github.com/Shopify/dawn/blob/main/.github/CONTRIBUTING.md#theme-code-principles)
- [ ] Linted with [Theme Check](https://github.com/Shopify/theme-check)
- [ ] Tested on [mobile](https://shopify.dev/themes/store/requirements#mobile-browser-requirements)
- [ ] Tested on [multiple browsers](https://shopify.dev/themes/store/requirements#desktop-browser-requirements)
- [ ] Tested for [accessibility](https://shopify.dev/themes/best-practices/accessibility)
