### PR TITLE
Remove text box padding setting

### DIFF
--- a/assets/section-image-banner.css
+++ b/assets/section-image-banner.css
@@ -198,7 +198,7 @@
 
 .banner__box {
   border: var(--text-boxes-border-width) solid rgba(var(--color-foreground), var(--text-boxes-border-opacity));
-  padding: var(--text-boxes-padding);
+  padding: 4rem 3.5rem;
   border-radius: var(--text-boxes-radius);
   box-shadow: var(--text-boxes-shadow-horizontal-offset)
     var(--text-boxes-shadow-vertical-offset)

--- a/assets/section-multicolumn.css
+++ b/assets/section-multicolumn.css
@@ -261,7 +261,6 @@
 
 .multicolumn-card {
   border: var(--text-boxes-border-width) solid rgba(var(--color-foreground), var(--text-boxes-border-opacity));
-  padding: var(--text-boxes-padding);
   border-radius: var(--text-boxes-radius);
   box-shadow: var(--text-boxes-shadow-horizontal-offset)
     var(--text-boxes-shadow-vertical-offset)

--- a/config/settings_schema.json
+++ b/config/settings_schema.json
@@ -297,20 +297,6 @@
       },
       {
         "type": "header",
-        "content": "Spacing"
-      },
-      {
-        "type": "range",
-        "id": "text_boxes_padding",
-        "min": 0,
-        "max": 20,
-        "step": 1,
-        "unit": "px",
-        "label": "Padding",
-        "default": 10
-      },
-      {
-        "type": "header",
         "content": "Borders"
       },
       {

--- a/layout/password.liquid
+++ b/layout/password.liquid
@@ -66,7 +66,6 @@
         --page-width: {{ settings.page_width | divided_by: 10 }}rem;
         --page-width-margin: {% if settings.page_width == '1600' %}2{% else %}0{% endif %}rem;
 
-        --text-boxes-padding: {{ settings.text_boxes_padding }}px;
         --text-boxes-border-opacity: {{ settings.text_boxes_border_opacity | divided_by: 100.0 }};
         --text-boxes-border-width: {{ settings.text_boxes_border_width }}px;
         --text-boxes-radius: {{ settings.text_boxes_radius }}px;

--- a/layout/theme.liquid
+++ b/layout/theme.liquid
@@ -105,7 +105,6 @@
         --grid-mobile-vertical-spacing: {{ settings.grid_mobile_vertical_spacing | divided_by: 10.0 }}rem;
         --grid-mobile-horizontal-spacing: {{ settings.grid_mobile_horizontal_spacing | divided_by: 10.0 }}rem;
 
-        --text-boxes-padding: {{ settings.text_boxes_padding }}px;
         --text-boxes-border-opacity: {{ settings.text_boxes_border_opacity | divided_by: 100.0 }};
         --text-boxes-border-width: {{ settings.text_boxes_border_width }}px;
         --text-boxes-radius: {{ settings.text_boxes_radius }}px;


### PR DESCRIPTION
**Why are these changes introduced?**

Removes the `Padding` setting from the global `Text Boxes` settings and replaces the original padding values in multicolumn and image banner.

**What approach did you take?**

Reverts changes added in https://github.com/Shopify/dawn/pull/889

**Other considerations**

**Demo links**

- [Store](url)
- [Editor](url)

**Checklist**
- [ ] Followed [theme code principles](https://github.com/Shopify/dawn/blob/main/.github/CONTRIBUTING.md#theme-code-principles)
- [ ] Linted with [Theme Check](https://github.com/Shopify/theme-check)
- [ ] Tested on [mobile](https://shopify.dev/themes/store/requirements#mobile-browser-requirements)
- [ ] Tested on [multiple browsers](https://shopify.dev/themes/store/requirements#desktop-browser-requirements)
- [ ] Tested for [accessibility](https://shopify.dev/themes/best-practices/accessibility)
