### PR TITLE
Split popup and drawer settings

### DIFF
--- a/assets/base.css
+++ b/assets/base.css
@@ -2285,15 +2285,15 @@ details[open] > .header__icon--menu .icon-hamburger {
 }
 
 .header__submenu.list-menu--disclosure {
-  border-radius: var(--popup-drawer-corner-radius);
-  border-color: rgba(var(--color-foreground), var(--popup-drawer-border-opacity));
+  border-radius: var(--popup-corner-radius);
+  border-color: rgba(var(--color-foreground), var(--popup-border-opacity));
   border-style: solid;
-  border-width: var(--popup-drawer-border-width);
+  border-width: var(--popup-border-width);
   filter: drop-shadow(
-    var(--popup-drawer-shadow-horizontal-offset)
-    var(--popup-drawer-shadow-vertical-offset)
-    var(--popup-drawer-shadow-blur-radius)
-    rgba(var(--color-foreground), var(--popup-drawer-shadow-opacity))
+    var(--popup-shadow-horizontal-offset)
+    var(--popup-shadow-vertical-offset)
+    var(--popup-shadow-blur-radius)
+    rgba(var(--color-foreground), var(--popup-shadow-opacity))
   );
 }
 

--- a/assets/component-cart-notification.css
+++ b/assets/component-cart-notification.css
@@ -7,12 +7,12 @@
 }
 
 .cart-notification {
-  border-bottom-right-radius: var(--popup-drawer-corner-radius);
-  border-bottom-left-radius: var(--popup-drawer-corner-radius);
+  border-bottom-right-radius: var(--popup-corner-radius);
+  border-bottom-left-radius: var(--popup-corner-radius);
   background-color: rgb(var(--color-background));
-  border-color: rgba(var(--color-foreground), var(--popup-drawer-border-opacity));
+  border-color: rgba(var(--color-foreground), var(--popup-border-opacity));
   border-style: solid;
-  border-width: 0 0 var(--popup-drawer-border-width);
+  border-width: 0 0 var(--popup-border-width);
   padding: 2.5rem 3.5rem;
   position: absolute;
   right: 0;
@@ -21,10 +21,10 @@
   width: 100%;
   z-index: -1;
   filter: drop-shadow(
-    var(--popup-drawer-shadow-horizontal-offset)
-    var(--popup-drawer-shadow-vertical-offset)
-    var(--popup-drawer-shadow-blur-radius)
-    rgba(var(--color-foreground), var(--popup-drawer-shadow-opacity))
+    var(--popup-shadow-horizontal-offset)
+    var(--popup-shadow-vertical-offset)
+    var(--popup-shadow-blur-radius)
+    rgba(var(--color-foreground), var(--popup-shadow-opacity))
   );
 }
 
@@ -34,7 +34,7 @@
   }
 
   .cart-notification {
-    border-width: 0 var(--popup-drawer-border-width) var(--popup-drawer-border-width);
+    border-width: 0 var(--popup-border-width) var(--popup-border-width);
     max-width: 36.8rem;
     right: 4rem;
   }

--- a/assets/component-facets.css
+++ b/assets/component-facets.css
@@ -211,15 +211,15 @@
 }
 
 .facets__display {
-  border-width: var(--popup-drawer-border-width);
+  border-width: var(--popup-border-width);
   border-style: solid;
-  border-color: rgba(var(--color-foreground), var(--popup-drawer-border-opacity));
-  border-radius: var(--popup-drawer-corner-radius);
+  border-color: rgba(var(--color-foreground), var(--popup-border-opacity));
+  border-radius: var(--popup-corner-radius);
   filter: drop-shadow(
-    var(--popup-drawer-shadow-horizontal-offset)
-    var(--popup-drawer-shadow-vertical-offset)
-    var(--popup-drawer-shadow-blur-radius)
-    rgba(var(--color-foreground), var(--popup-drawer-shadow-opacity))
+    var(--popup-shadow-horizontal-offset)
+    var(--popup-shadow-vertical-offset)
+    var(--popup-shadow-blur-radius)
+    rgba(var(--color-foreground), var(--popup-shadow-opacity))
   );
   background-color: rgb(var(--color-background));
   position: absolute;
@@ -524,14 +524,14 @@ a.active-facets__button.focused .active-facets__button-inner,
   max-width: 37.5rem;
   display: flex;
   flex-direction: column;
-  border-color: rgba(var(--color-foreground), var(--popup-drawer-border-opacity));
+  border-color: rgba(var(--color-foreground), var(--drawer-border-opacity));
   border-style: solid;
-  border-width: 0 0 0 var(--popup-drawer-border-width);
+  border-width: 0 0 0 var(--drawer-border-width);
   filter: drop-shadow(
-    var(--popup-drawer-shadow-horizontal-offset)
-    var(--popup-drawer-shadow-vertical-offset)
-    var(--popup-drawer-shadow-blur-radius)
-    rgba(var(--color-foreground), var(--popup-drawer-shadow-opacity))
+    var(--drawer-shadow-horizontal-offset)
+    var(--drawer-shadow-vertical-offset)
+    var(--drawer-shadow-blur-radius)
+    rgba(var(--color-foreground), var(--drawer-shadow-opacity))
   );
 }
 

--- a/assets/component-menu-drawer.css
+++ b/assets/component-menu-drawer.css
@@ -37,16 +37,16 @@ menu-drawer > details[open] > summary::before {
   top: 100%;
   width: calc(100vw - 4rem);
   padding: 0;
-  border-width: 0 var(--popup-drawer-border-width) 0 0;
+  border-width: 0 var(--drawer-border-width) 0 0;
   background-color: rgb(var(--color-background));
   overflow-x: hidden;
   border-style: solid;
-  border-color: rgba(var(--color-foreground), var(--popup-drawer-border-opacity));
+  border-color: rgba(var(--color-foreground), var(--drawer-border-opacity));
   filter: drop-shadow(
-    var(--popup-drawer-shadow-horizontal-offset)
-    var(--popup-drawer-shadow-vertical-offset)
-    var(--popup-drawer-shadow-blur-radius)
-    rgba(var(--color-foreground), var(--popup-drawer-shadow-opacity))
+    var(--drawer-shadow-horizontal-offset)
+    var(--drawer-shadow-vertical-offset)
+    var(--drawer-shadow-blur-radius)
+    rgba(var(--color-foreground), var(--drawer-shadow-opacity))
   );
 }
 

--- a/assets/component-pickup-availability.css
+++ b/assets/component-pickup-availability.css
@@ -54,14 +54,14 @@ pickup-availability-drawer {
     transform var(--duration-default) ease;
   transform: translateX(100%);
   width: 100%;
-  border-width: 0 0 0 var(--popup-drawer-border-width);
-  border-color: rgba(var(--color-foreground), var(--popup-drawer-border-opacity));
+  border-width: 0 0 0 var(--drawer-border-width);
+  border-color: rgba(var(--color-foreground), var(--drawer-border-opacity));
   border-style: solid;
   filter: drop-shadow(
-    var(--popup-drawer-shadow-horizontal-offset)
-    var(--popup-drawer-shadow-vertical-offset)
-    var(--popup-drawer-shadow-blur-radius)
-    rgba(var(--color-foreground), var(--popup-drawer-shadow-opacity))
+    var(--drawer-shadow-horizontal-offset)
+    var(--drawer-shadow-vertical-offset)
+    var(--drawer-shadow-blur-radius)
+    rgba(var(--color-foreground), var(--drawer-shadow-opacity))
   );
 }
 

--- a/assets/component-predictive-search.css
+++ b/assets/component-predictive-search.css
@@ -3,18 +3,18 @@
   position: absolute;
   top: calc(100% + 0.1rem);
   left: -0.1rem;
-  border-width: var(--popup-drawer-border-width);
+  border-width: var(--popup-border-width);
   border-style: solid;
-  border-color: rgba(var(--color-foreground), var(--popup-drawer-border-opacity));
+  border-color: rgba(var(--color-foreground), var(--popup-border-opacity));
   background-color: rgb(var(--color-background));
   z-index: 3;
-  border-bottom-right-radius: var(--popup-drawer-corner-radius);
-  border-bottom-left-radius: var(--popup-drawer-corner-radius);
+  border-bottom-right-radius: var(--popup-corner-radius);
+  border-bottom-left-radius: var(--popup-corner-radius);
   filter: drop-shadow(
-    var(--popup-drawer-shadow-horizontal-offset)
-    var(--popup-drawer-shadow-vertical-offset)
-    var(--popup-drawer-shadow-blur-radius)
-    rgba(var(--color-foreground), var(--popup-drawer-shadow-opacity))
+    var(--popup-shadow-horizontal-offset)
+    var(--popup-shadow-vertical-offset)
+    var(--popup-shadow-blur-radius)
+    rgba(var(--color-foreground), var(--popup-shadow-opacity))
   );
 }
 

--- a/assets/disclosure.css
+++ b/assets/disclosure.css
@@ -13,9 +13,9 @@
 }
 
 .disclosure__list {
-  border-width: var(--popup-drawer-border-width);
+  border-width: var(--popup-border-width);
   border-style: solid;
-  border-color: rgba(var(--color-foreground), var(--popup-drawer-border-opacity));
+  border-color: rgba(var(--color-foreground), var(--popup-border-opacity));
   font-size: 1.4rem;
   margin-top: -0.5rem;
   min-height: 8.2rem;
@@ -31,12 +31,12 @@
   transform: translateY(-1rem);
   z-index: 2;
   background-color: rgb(var(--color-background));
-  border-radius: var(--popup-drawer-corner-radius);
+  border-radius: var(--popup-corner-radius);
   filter: drop-shadow(
-    var(--popup-drawer-shadow-horizontal-offset)
-    var(--popup-drawer-shadow-vertical-offset)
-    var(--popup-drawer-shadow-blur-radius)
-    rgba(var(--color-foreground), var(--popup-drawer-shadow-opacity))
+    var(--popup-shadow-horizontal-offset)
+    var(--popup-shadow-vertical-offset)
+    var(--popup-shadow-blur-radius)
+    rgba(var(--color-foreground), var(--popup-shadow-opacity))
   );
 }
 

--- a/assets/section-main-product.css
+++ b/assets/section-main-product.css
@@ -726,7 +726,7 @@ a.product__text {
 }
 
 .product-popup-modal__content {
-  border-radius: var(--popup-drawer-corner-radius);
+  border-radius: var(--popup-corner-radius);
   background-color: rgb(var(--color-background));
   overflow: auto;
   height: 80%;
@@ -738,14 +738,14 @@ a.product__text {
   position: absolute;
   top: 0;
   padding: 0 1.5rem 0 3rem;
-  border-color: rgba(var(--color-foreground), var(--popup-drawer-border-opacity));
+  border-color: rgba(var(--color-foreground), var(--popup-border-opacity));
   border-style: solid;
-  border-width: var(--popup-drawer-border-width);
+  border-width: var(--popup-border-width);
   filter: drop-shadow(
-    var(--popup-drawer-shadow-horizontal-offset)
-    var(--popup-drawer-shadow-vertical-offset)
-    var(--popup-drawer-shadow-blur-radius)
-    rgba(var(--color-foreground), var(--popup-drawer-shadow-opacity))
+    var(--popup-shadow-horizontal-offset)
+    var(--popup-shadow-vertical-offset)
+    var(--popup-shadow-blur-radius)
+    rgba(var(--color-foreground), var(--popup-shadow-opacity))
   );
 }
 

--- a/config/settings_schema.json
+++ b/config/settings_schema.json
@@ -723,12 +723,12 @@
       },
       {
         "type": "range",
-        "id": "popup_blur_radius",
+        "id": "popup_shadow_blur_radius",
         "min": 0,
         "max": 20,
         "step": 2,
         "unit": "px",
-        "label": "t:settings_schema.popups.settings.popup_blur_radius.label",
+        "label": "t:settings_schema.popups.settings.popup_shadow_blur_radius.label",
         "default": 0
       }
     ]
@@ -788,12 +788,12 @@
       },
       {
         "type": "range",
-        "id": "drawer_blur_radius",
+        "id": "drawer_shadow_blur_radius",
         "min": 0,
         "max": 20,
         "step": 2,
         "unit": "px",
-        "label": "t:settings_schema.drawers.settings.drawer_blur_radius.label",
+        "label": "t:settings_schema.drawers.settings.drawer_shadow_blur_radius.label",
         "default": 0
       }
     ]

--- a/config/settings_schema.json
+++ b/config/settings_schema.json
@@ -659,77 +659,141 @@
     ]
   },
   {
-    "name": "t:settings_schema.popup_drawer.name",
+    "name": "t:settings_schema.popups.name",
     "settings": [
       {
         "type": "range",
-        "id": "popup_drawer_border_width",
+        "id": "popup_border_width",
         "min": 0,
         "max": 10,
         "step": 1,
         "unit": "px",
-        "label": "t:settings_schema.popup_drawer.settings.popup_drawer_border_width.label",
+        "label": "t:settings_schema.popups.settings.popup_border_width.label",
         "default": 1
       },
       {
         "type": "range",
-        "id": "popup_drawer_border_opacity",
+        "id": "popup_border_opacity",
         "min": 0,
         "max": 100,
         "step": 5,
         "unit": "%",
-        "label": "t:settings_schema.popup_drawer.settings.popup_drawer_border_opacity.label",
+        "label": "t:settings_schema.popups.settings.popup_border_opacity.label",
         "default": 10
       },
       {
         "type": "range",
-        "id": "popup_drawer_corner_radius",
+        "id": "popup_corner_radius",
         "min": 0,
         "max": 30,
         "step": 3,
         "unit": "px",
-        "label": "t:settings_schema.popup_drawer.settings.popup_drawer_corner_radius.label",
-        "info": "t:settings_schema.popup_drawer.settings.popup_drawer_corner_radius.info",
+        "label": "t:settings_schema.popups.settings.popup_corner_radius.label",
         "default": 0
       },
       {
         "type": "range",
-        "id": "popup_drawer_shadow_opacity",
+        "id": "popup_shadow_opacity",
         "min": 0,
         "max": 100,
         "step": 5,
         "unit": "%",
-        "label": "t:settings_schema.popup_drawer.settings.popup_drawer_shadow_opacity.label",
+        "label": "t:settings_schema.popups.settings.popup_shadow_opacity.label",
         "default": 0
       },
       {
         "type": "range",
-        "id": "popup_drawer_shadow_horizontal_offset",
+        "id": "popup_shadow_horizontal_offset",
         "min": -20,
         "max": 20,
         "step": 2,
         "unit": "px",
-        "label": "t:settings_schema.popup_drawer.settings.popup_drawer_shadow_horizontal_offset.label",
+        "label": "t:settings_schema.popups.settings.popup_shadow_horizontal_offset.label",
         "default": 0
       },
       {
         "type": "range",
-        "id": "popup_drawer_shadow_vertical_offset",
+        "id": "popup_shadow_vertical_offset",
         "min": -20,
         "max": 20,
         "step": 2,
         "unit": "px",
-        "label": "t:settings_schema.popup_drawer.settings.popup_drawer_shadow_vertical_offset.label",
+        "label": "t:settings_schema.popups.settings.popup_shadow_vertical_offset.label",
         "default": 0
       },
       {
         "type": "range",
-        "id": "popup_drawer_blur_radius",
+        "id": "popup_blur_radius",
         "min": 0,
         "max": 20,
         "step": 2,
         "unit": "px",
-        "label": "t:settings_schema.popup_drawer.settings.popup_drawer_blur_radius.label",
+        "label": "t:settings_schema.popups.settings.popup_blur_radius.label",
+        "default": 0
+      }
+    ]
+  },
+  {
+    "name": "t:settings_schema.drawers.name",
+    "settings": [
+      {
+        "type": "range",
+        "id": "drawer_border_width",
+        "min": 0,
+        "max": 10,
+        "step": 1,
+        "unit": "px",
+        "label": "t:settings_schema.drawers.settings.drawer_border_width.label",
+        "default": 1
+      },
+      {
+        "type": "range",
+        "id": "drawer_border_opacity",
+        "min": 0,
+        "max": 100,
+        "step": 5,
+        "unit": "%",
+        "label": "t:settings_schema.drawers.settings.drawer_border_opacity.label",
+        "default": 10
+      },
+      {
+        "type": "range",
+        "id": "drawer_shadow_opacity",
+        "min": 0,
+        "max": 100,
+        "step": 5,
+        "unit": "%",
+        "label": "t:settings_schema.drawers.settings.drawer_shadow_opacity.label",
+        "default": 0
+      },
+      {
+        "type": "range",
+        "id": "drawer_shadow_horizontal_offset",
+        "min": -20,
+        "max": 20,
+        "step": 2,
+        "unit": "px",
+        "label": "t:settings_schema.drawers.settings.drawer_shadow_horizontal_offset.label",
+        "default": 0
+      },
+      {
+        "type": "range",
+        "id": "drawer_shadow_vertical_offset",
+        "min": -20,
+        "max": 20,
+        "step": 2,
+        "unit": "px",
+        "label": "t:settings_schema.drawers.settings.drawer_shadow_vertical_offset.label",
+        "default": 0
+      },
+      {
+        "type": "range",
+        "id": "drawer_blur_radius",
+        "min": 0,
+        "max": 20,
+        "step": 2,
+        "unit": "px",
+        "label": "t:settings_schema.drawers.settings.drawer_blur_radius.label",
         "default": 0
       }
     ]

--- a/layout/theme.liquid
+++ b/layout/theme.liquid
@@ -104,14 +104,14 @@
         --popup-shadow-opacity: {{ settings.popup_shadow_opacity | divided_by: 100.0 }};
         --popup-shadow-horizontal-offset: {{ settings.popup_shadow_horizontal_offset }}px;
         --popup-shadow-vertical-offset: {{ settings.popup_shadow_vertical_offset }}px;
-        --popup-shadow-blur-radius: {{ settings.popup_blur_radius }}px;
+        --popup-shadow-blur-radius: {{ settings.popup_shadow_blur_radius }}px;
 
         --drawer-border-width: {{ settings.drawer_border_width }}px;
         --drawer-border-opacity: {{ settings.drawer_border_opacity | divided_by: 100.0 }};
         --drawer-shadow-opacity: {{ settings.drawer_shadow_opacity | divided_by: 100.0 }};
         --drawer-shadow-horizontal-offset: {{ settings.drawer_shadow_horizontal_offset }}px;
         --drawer-shadow-vertical-offset: {{ settings.drawer_shadow_vertical_offset }}px;
-        --drawer-shadow-blur-radius: {{ settings.drawer_blur_radius }}px;
+        --drawer-shadow-blur-radius: {{ settings.drawer_shadow_blur_radius }}px;
 
         {% comment %} Grid styles {% endcomment %}
         --grid-desktop-vertical-spacing: {{ settings.grid_desktop_vertical_spacing | divided_by: 10.0 }}rem;

--- a/layout/theme.liquid
+++ b/layout/theme.liquid
@@ -98,13 +98,20 @@
         --sections-spacing: {{ settings.sections_spacing }}px;
         --sections-safe-spacing: {% if settings.sections_spacing < 15 %}15{% else %}{{settings.sections_spacing}}{% endif %}px;
 
-        --popup-drawer-border-width: {{ settings.popup_drawer_border_width }}px;
-        --popup-drawer-border-opacity: {{ settings.popup_drawer_border_opacity | divided_by: 100.0 }};
-        --popup-drawer-corner-radius: {{ settings.popup_drawer_corner_radius }}px;
-        --popup-drawer-shadow-opacity: {{ settings.popup_drawer_shadow_opacity | divided_by: 100.0 }};
-        --popup-drawer-shadow-horizontal-offset: {{ settings.popup_drawer_shadow_horizontal_offset }}px;
-        --popup-drawer-shadow-vertical-offset: {{ settings.popup_drawer_shadow_vertical_offset }}px;
-        --popup-drawer-shadow-blur-radius: {{ settings.popup_drawer_blur_radius }}px;
+        --popup-border-width: {{ settings.popup_border_width }}px;
+        --popup-border-opacity: {{ settings.popup_border_opacity | divided_by: 100.0 }};
+        --popup-corner-radius: {{ settings.popup_corner_radius }}px;
+        --popup-shadow-opacity: {{ settings.popup_shadow_opacity | divided_by: 100.0 }};
+        --popup-shadow-horizontal-offset: {{ settings.popup_shadow_horizontal_offset }}px;
+        --popup-shadow-vertical-offset: {{ settings.popup_shadow_vertical_offset }}px;
+        --popup-shadow-blur-radius: {{ settings.popup_blur_radius }}px;
+
+        --drawer-border-width: {{ settings.drawer_border_width }}px;
+        --drawer-border-opacity: {{ settings.drawer_border_opacity | divided_by: 100.0 }};
+        --drawer-shadow-opacity: {{ settings.drawer_shadow_opacity | divided_by: 100.0 }};
+        --drawer-shadow-horizontal-offset: {{ settings.drawer_shadow_horizontal_offset }}px;
+        --drawer-shadow-vertical-offset: {{ settings.drawer_shadow_vertical_offset }}px;
+        --drawer-shadow-blur-radius: {{ settings.drawer_blur_radius }}px;
 
         {% comment %} Grid styles {% endcomment %}
         --grid-desktop-vertical-spacing: {{ settings.grid_desktop_vertical_spacing | divided_by: 10.0 }}rem;

--- a/locales/en.default.schema.json
+++ b/locales/en.default.schema.json
@@ -180,29 +180,51 @@
         }
       }
     },
-    "popup_drawer": {
-      "name": "Popups and drawers",
+    "popups": {
+      "name": "Popups",
       "settings": {
-        "popup_drawer_border_width": {
+        "popup_border_width": {
           "label": "Border width"
         },
-        "popup_drawer_border_opacity": {
+        "popup_border_opacity": {
           "label": "Border opacity"
         },
-        "popup_drawer_corner_radius": {
-          "label": "Border corner radius",
-          "info": "Applies to popups only."
+        "popup_corner_radius": {
+          "label": "Border corner radius"
         },
-        "popup_drawer_shadow_opacity": {
+        "popup_shadow_opacity": {
           "label": "Shadow opacity"
         },
-        "popup_drawer_shadow_horizontal_offset": {
+        "popup_shadow_horizontal_offset": {
           "label": "Shadow horizontal offset"
         },
-        "popup_drawer_shadow_vertical_offset": {
+        "popup_shadow_vertical_offset": {
           "label": "Shadow vertical offset"
         },
-        "popup_drawer_blur_radius": {
+        "popup_blur_radius": {
+          "label": "Shadow blur radius"
+        }
+      }
+    },
+    "drawers": {
+      "name": "Drawers",
+      "settings": {
+        "drawer_border_width": {
+          "label": "Border width"
+        },
+        "drawer_border_opacity": {
+          "label": "Border opacity"
+        },
+        "drawer_shadow_opacity": {
+          "label": "Shadow opacity"
+        },
+        "drawer_shadow_horizontal_offset": {
+          "label": "Shadow horizontal offset"
+        },
+        "drawer_shadow_vertical_offset": {
+          "label": "Shadow vertical offset"
+        },
+        "drawer_blur_radius": {
           "label": "Shadow blur radius"
         }
       }

--- a/locales/en.default.schema.json
+++ b/locales/en.default.schema.json
@@ -201,7 +201,7 @@
         "popup_shadow_vertical_offset": {
           "label": "Shadow vertical offset"
         },
-        "popup_blur_radius": {
+        "popup_shadow_blur_radius": {
           "label": "Shadow blur radius"
         }
       }
@@ -224,7 +224,7 @@
         "drawer_shadow_vertical_offset": {
           "label": "Shadow vertical offset"
         },
-        "drawer_blur_radius": {
+        "drawer_shadow_blur_radius": {
           "label": "Shadow blur radius"
         }
       }


### PR DESCRIPTION
**Why are these changes introduced?**

Splits the popup drawer settings into separate categories. This PR does not add any additional settings or fix any bugs. Nor _should_ it add any new bugs. The only difference between both categories now is `Corner radius` has been excluded from `Drawers` and the associated info note has been removed.

**What approach did you take?**

Below is how I've applied the respective settings.

Drawers
- Hamburger menu (mobile)
- Facet filters (mobile)
- Pickup availability

Popups
- Main nav submenu (desktop)
- Facet filters (desktop)
- Localization selects
- Cart notification
- Predictive search results
- Main product popup modal

**Other considerations**

For additional context, if needed..

Original popup drawer settings commit https://github.com/Shopify/dawn/pull/865
Follow up to popup drawer settings https://github.com/Shopify/dawn/pull/902


**Demo links**

- [Editor](https://os2-demo.myshopify.com/admin/themes/126921637910/editor)

**Checklist**
- [ ] Followed [theme code principles](https://github.com/Shopify/dawn/blob/main/.github/CONTRIBUTING.md#theme-code-principles)
- [ ] Linted with [Theme Check](https://github.com/Shopify/theme-check)
- [ ] Tested on [mobile](https://shopify.dev/themes/store/requirements#mobile-browser-requirements)
- [ ] Tested on [multiple browsers](https://shopify.dev/themes/store/requirements#desktop-browser-requirements)
- [ ] Tested for [accessibility](https://shopify.dev/themes/best-practices/accessibility)
