### PR TITLE
Use standar REM units

### DIFF
--- a/assets/base.css
+++ b/assets/base.css
@@ -174,7 +174,7 @@ html.no-js .no-js-hidden {
 .page-width {
   max-width: var(--page-width);
   margin: 0 auto;
-  padding: 0 1.5rem;
+  padding: 0 0.95rem;
 }
 
 .page-width-desktop {
@@ -184,11 +184,11 @@ html.no-js .no-js-hidden {
 
 @media screen and (min-width: 750px) {
   .page-width {
-    padding: 0 5rem;
+    padding: 0 3.15rem;
   }
 
   .page-width--narrow {
-    padding: 0 9rem;
+    padding: 0 5.5rem;
   }
 
   .page-width-desktop {
@@ -196,45 +196,45 @@ html.no-js .no-js-hidden {
   }
 
   .page-width-tablet {
-    padding: 0 5rem;
+    padding: 0 3.15rem;
   }
 }
 
 @media screen and (min-width: 990px) {
   .page-width--narrow {
-    max-width: 72.6rem;
+    max-width: 45.5rem;
     padding: 0;
   }
 
   .page-width-desktop {
     max-width: var(--page-width);
-    padding: 0 5rem;
+    padding: 0 3.15rem;
   }
 }
 
 .element-margin {
-  margin-top: 5rem;
+  margin-top: 3.15rem;
 }
 
 .spaced-section {
-  margin-top: 5rem;
+  margin-top: 3.15rem;
 }
 
 .spaced-section:last-child {
-  margin-bottom: 5rem;
+  margin-bottom: 3.15rem;
 }
 
 @media screen and (min-width: 750px) {
   .element-margin {
-    margin-top: calc(5rem + var(--page-width-margin));
+    margin-top: calc(3.15rem + var(--page-width-margin));
   }
 
   .spaced-section {
-    margin-top: calc(5rem + var(--page-width-margin));
+    margin-top: calc(3.15rem + var(--page-width-margin));
   }
 
   .spaced-section:last-child {
-    margin-bottom: calc(5rem + var(--page-width-margin));
+    margin-bottom: calc(3.15rem + var(--page-width-margin));
   }
 }
 
@@ -262,13 +262,13 @@ body,
 
 .background-secondary {
   background-color: rgba(var(--color-foreground), 0.04);
-  padding: 4rem 0 5rem;
+  padding: 2.5rem 0 3.15rem;
 }
 
 @media screen and (min-width: 750px) {
   .background-secondary {
-    padding: calc(6rem + var(--page-width-margin)) 0
-      calc(5rem + var(--page-width-margin));
+    padding: calc(3.75rem + var(--page-width-margin)) 0
+      calc(3.15rem + var(--page-width-margin));
   }
 }
 
@@ -279,12 +279,12 @@ body,
 
 .page-margin,
 .shopify-challenge__container {
-  margin: 7rem auto;
+  margin: 4.4rem auto;
 }
 
 .rte-width {
-  max-width: 82rem;
-  margin: 0 auto 2rem;
+  max-width: 50.0rem;
+  margin: 0 auto 1.25rem;
 }
 
 .list-unstyled {
@@ -341,8 +341,8 @@ body,
 }
 
 .text-body {
-  font-size: 1.5rem;
-  letter-spacing: 0.06rem;
+  font-size: 0.95rem;
+  letter-spacing: 0.0375rem;
   line-height: calc(1 + 0.8 / var(--font-body-scale));
   font-family: var(--font-body-family);
   font-style: var(--font-body-style);
@@ -363,54 +363,54 @@ h5,
   font-family: var(--font-heading-family);
   font-style: var(--font-heading-style);
   font-weight: var(--font-heading-weight);
-  letter-spacing: calc(var(--font-heading-scale) * 0.06rem);
+  letter-spacing: calc(var(--font-heading-scale) * 0.0375rem);
   color: rgb(var(--color-foreground));
   line-height: calc(1 + 0.3 / max(1, var(--font-heading-scale)));
 }
 
 .h0 {
-  font-size: calc(var(--font-heading-scale) * 4rem);
+  font-size: calc(var(--font-heading-scale) * 2.5rem);
 }
 
 @media only screen and (min-width: 750px) {
   .h0 {
-    font-size: calc(var(--font-heading-scale) * 5.2rem);
+    font-size: calc(var(--font-heading-scale) * 3.25rem);
   }
 }
 
 h1,
 .h1 {
-  font-size: calc(var(--font-heading-scale) * 3rem);
+  font-size: calc(var(--font-heading-scale) * 1.9rem);
 }
 
 @media only screen and (min-width: 750px) {
   h1,
   .h1 {
-    font-size: calc(var(--font-heading-scale) * 4rem);
+    font-size: calc(var(--font-heading-scale) * 2.5rem);
   }
 }
 
 h2,
 .h2 {
-  font-size: calc(var(--font-heading-scale) * 2rem);
+  font-size: calc(var(--font-heading-scale) * 1.25rem);
 }
 
 @media only screen and (min-width: 750px) {
   h2,
   .h2 {
-    font-size: calc(var(--font-heading-scale) * 2.4rem);
+    font-size: calc(var(--font-heading-scale) * 1.5rem);
   }
 }
 
 h3,
 .h3 {
-  font-size: calc(var(--font-heading-scale) * 1.7rem);
+  font-size: calc(var(--font-heading-scale) * 1.05rem);
 }
 
 @media only screen and (min-width: 750px) {
   h3,
   .h3 {
-    font-size: calc(var(--font-heading-scale) * 1.8rem);
+    font-size: calc(var(--font-heading-scale) * 1.15rem);
   }
 }
 
@@ -418,18 +418,18 @@ h4,
 .h4 {
   font-family: var(--font-heading-family);
   font-style: var(--font-heading-style);
-  font-size: calc(var(--font-heading-scale) * 1.5rem);
+  font-size: calc(var(--font-heading-scale) * 0.95rem);
 }
 
 h5,
 .h5 {
-  font-size: calc(var(--font-heading-scale) * 1.2rem);
+  font-size: calc(var(--font-heading-scale) * 0.75rem);
 }
 
 @media only screen and (min-width: 750px) {
   h5,
   .h5 {
-    font-size: calc(var(--font-heading-scale) * 1.3rem);
+    font-size: calc(var(--font-heading-scale) * 0.8rem);
   }
 }
 
@@ -443,31 +443,31 @@ h6,
 blockquote {
   font-style: italic;
   color: rgba(var(--color-foreground), 0.75);
-  border-left: 0.2rem solid rgba(var(--color-foreground), 0.2);
-  padding-left: 1rem;
+  border-left: 0.125rem solid rgba(var(--color-foreground), 0.2);
+  padding-left: 0.65rem;
 }
 
 @media screen and (min-width: 750px) {
   blockquote {
-    padding-left: 1.5rem;
+    padding-left: 0.95rem;
   }
 }
 
 .caption {
-  font-size: 1rem;
-  letter-spacing: 0.07rem;
+  font-size: 0.65rem;
+  letter-spacing: 0.044rem;
   line-height: calc(1 + 0.7 / var(--font-body-scale));
 }
 
 @media screen and (min-width: 750px) {
   .caption {
-    font-size: 1.2rem;
+    font-size: 0.75rem;
   }
 }
 
 .caption-with-letter-spacing {
-  font-size: 1rem;
-  letter-spacing: 0.13rem;
+  font-size: 0.65rem;
+  letter-spacing: 0.08rem;
   line-height: calc(1 + 0.2 / var(--font-body-scale));
   text-transform: uppercase;
 }
@@ -478,9 +478,9 @@ blockquote {
 .field__input,
 .form__label,
 .select__select {
-  font-size: 1.3rem;
+  font-size: 0.8rem;
   line-height: calc(1 + 0.5 / var(--font-body-scale));
-  letter-spacing: 0.04rem;
+  letter-spacing: 0.025rem;
 }
 
 .color-foreground {
@@ -490,16 +490,16 @@ blockquote {
 table:not([class]) {
   table-layout: fixed;
   border-collapse: collapse;
-  font-size: 1.4rem;
+  font-size: 0.9rem;
   border-style: hidden;
-  box-shadow: 0 0 0 0.1rem rgba(var(--color-foreground), 0.2);
+  box-shadow: 0 0 0 0.065rem rgba(var(--color-foreground), 0.2);
   /* draws the table border  */
 }
 
 table:not([class]) td,
 table:not([class]) th {
   padding: 1em;
-  border: 0.1rem solid rgba(var(--color-foreground), 0.2);
+  border: 0.065rem solid rgba(var(--color-foreground), 0.2);
 }
 
 .hidden {
@@ -563,10 +563,10 @@ h6:empty {
   border: none;
   box-shadow: none;
   text-decoration: underline;
-  text-underline-offset: 0.3rem;
+  text-underline-offset: 0.19rem;
   color: rgb(var(--color-link));
   background-color: transparent;
-  font-size: 1.4rem;
+  font-size: 0.9rem;
   font-family: inherit;
 }
 
@@ -580,17 +580,17 @@ h6:empty {
 
 .link-with-icon {
   display: inline-flex;
-  font-size: 1.4rem;
+  font-size: 0.9rem;
   font-weight: 600;
-  letter-spacing: 0.1rem;
+  letter-spacing: 0.065rem;
   text-decoration: none;
-  margin-bottom: 4.5rem;
+  margin-bottom: 2.8rem;
   white-space: nowrap;
 }
 
 .link-with-icon .icon {
-  width: 1.5rem;
-  margin-left: 1rem;
+  width: 0.95rem;
+  margin-left: 0.65rem;
 }
 
 .link[role="link"]:not([href]) {
@@ -599,7 +599,7 @@ h6:empty {
 
 .circle-divider::after {
   content: '\2022';
-  margin: 0 1.3rem 0 1.5rem;
+  margin: 0 0.8rem 0 0.95rem;
 }
 
 .circle-divider:last-of-type::after {
@@ -608,15 +608,15 @@ h6:empty {
 
 hr {
   border: none;
-  height: 0.1rem;
+  height: 0.065rem;
   background-color: rgba(var(--color-foreground), 0.2);
   display: block;
-  margin: 5rem 0;
+  margin: 3.15rem 0;
 }
 
 @media screen and (min-width: 750px) {
   hr {
-    margin: 7rem 0;
+    margin: 4.4rem 0;
   }
 }
 
@@ -659,34 +659,34 @@ details > * {
 .underlined-link,
 .customer a {
   color: rgba(var(--color-link), var(--alpha-link));
-  text-underline-offset: 0.3rem;
-  text-decoration-thickness: 0.1rem;
+  text-underline-offset: 0.19rem;
+  text-decoration-thickness: 0.065rem;
   transition: text-decoration-thickness ease 100ms;
 }
 
 .underlined-link:hover,
 .customer a:hover {
   color: rgb(var(--color-link));
-  text-decoration-thickness: 0.2rem;
+  text-decoration-thickness: 0.125rem;
 }
 
 .icon-arrow {
-  width: 1.5rem;
+  width: 0.95rem;
 }
 
 h3 .icon-arrow,
 .h3 .icon-arrow {
-  width: calc(var(--font-heading-scale) * 1.5rem);
+  width: calc(var(--font-heading-scale) * 0.95rem);
 }
 
 /* arrow animation */
 .animate-arrow .icon-arrow path {
-  transform: translateX(-0.25rem);
+  transform: translateX(-0.155rem);
   transition: transform var(--duration-short) ease;
 }
 
 .animate-arrow:hover .icon-arrow path {
-  transform: translateX(-0.05rem);
+  transform: translateX(-0.0315rem);
 }
 
 /* base-details-summary */
@@ -698,9 +698,9 @@ summary {
 
 summary .icon-caret {
   position: absolute;
-  height: 0.6rem;
-  right: 1.5rem;
-  top: calc(50% - 0.2rem);
+  height: 0.375rem;
+  right: 0.95rem;
+  top: calc(50% - 0.125rem);
 }
 
 summary::-webkit-details-marker {
@@ -753,19 +753,19 @@ summary::-webkit-details-marker {
 }
 
 *:focus-visible {
-  outline: 0.2rem solid rgba(var(--color-foreground), 0.5);
-  outline-offset: 0.3rem;
-  box-shadow: 0 0 0 0.3rem rgb(var(--color-background)),
-    0 0 0.5rem 0.4rem rgba(var(--color-foreground), 0.3);
+  outline: 0.125rem solid rgba(var(--color-foreground), 0.5);
+  outline-offset: 0.19rem;
+  box-shadow: 0 0 0 0.19rem rgb(var(--color-background)),
+    0 0 0.315rem 0.25rem rgba(var(--color-foreground), 0.3);
 }
 
 /* Fallback - for browsers that don't support :focus-visible, a fallback is set for :focus */
 .focused,
 .no-js *:focus {
-  outline: 0.2rem solid rgba(var(--color-foreground), 0.5);
-  outline-offset: 0.3rem;
-  box-shadow: 0 0 0 0.3rem rgb(var(--color-background)),
-    0 0 0.5rem 0.4rem rgba(var(--color-foreground), 0.3);
+  outline: 0.125rem solid rgba(var(--color-foreground), 0.5);
+  outline-offset: 0.19rem;
+  box-shadow: 0 0 0 0.19rem rgb(var(--color-background)),
+    0 0 0.315rem 0.25rem rgba(var(--color-foreground), 0.3);
 }
 
 /* Negate the fallback side-effect for browsers that support :focus-visible */
@@ -779,16 +779,16 @@ summary::-webkit-details-marker {
 */
 
 .focus-inset:focus-visible {
-  outline: 0.2rem solid rgba(var(--color-foreground), 0.5);
-  outline-offset: -0.2rem;
-  box-shadow: 0 0 0.2rem 0 rgba(var(--color-foreground), 0.3);
+  outline: 0.125rem solid rgba(var(--color-foreground), 0.5);
+  outline-offset: -0.125rem;
+  box-shadow: 0 0 0.125rem 0 rgba(var(--color-foreground), 0.3);
 }
 
 .focused.focus-inset,
 .no-js .focus-inset:focus {
-  outline: 0.2rem solid rgba(var(--color-foreground), 0.5);
-  outline-offset: -0.2rem;
-  box-shadow: 0 0 0.2rem 0 rgba(var(--color-foreground), 0.3);
+  outline: 0.125rem solid rgba(var(--color-foreground), 0.5);
+  outline-offset: -0.125rem;
+  box-shadow: 0 0 0.125rem 0 rgba(var(--color-foreground), 0.3);
 }
 
 .no-js .focus-inset:focus:not(:focus-visible) {
@@ -807,18 +807,18 @@ summary::-webkit-details-marker {
 }
 
 .focus-offset:focus-visible {
-  outline: 0.2rem solid rgba(var(--color-foreground), 0.5);
-  outline-offset: 1rem;
-  box-shadow: 0 0 0 1rem rgb(var(--color-background)),
-    0 0 0.2rem 1.2rem rgba(var(--color-foreground), 0.3);
+  outline: 0.125rem solid rgba(var(--color-foreground), 0.5);
+  outline-offset: 0.65rem;
+  box-shadow: 0 0 0 0.65rem rgb(var(--color-background)),
+    0 0 0.125rem 0.75rem rgba(var(--color-foreground), 0.3);
 }
 
 .focus-offset.focused,
 .no-js .focus-offset:focus {
-  outline: 0.2rem solid rgba(var(--color-foreground), 0.5);
-  outline-offset: 1rem;
-  box-shadow: 0 0 0 1rem rgb(var(--color-background)),
-    0 0 0.2rem 1.2rem rgba(var(--color-foreground), 0.3);
+  outline: 0.125rem solid rgba(var(--color-foreground), 0.5);
+  outline-offset: 0.65rem;
+  box-shadow: 0 0 0 0.65rem rgb(var(--color-background)),
+    0 0 0.125rem 0.75rem rgba(var(--color-foreground), 0.3);
 }
 
 .no-js .focus-offset:focus:not(:focus-visible) {
@@ -829,7 +829,7 @@ summary::-webkit-details-marker {
 /* component-title */
 .title,
 .title-wrapper-with-link {
-  margin: 3rem 0 2rem;
+  margin: 1.9rem 0 1.25rem;
 }
 
 .title-wrapper-with-link .title {
@@ -841,26 +841,26 @@ summary::-webkit-details-marker {
 }
 
 .title-wrapper {
-  margin-bottom: 3rem;
+  margin-bottom: 1.9rem;
 }
 
 .title-wrapper-with-link {
   display: flex;
   justify-content: space-between;
   align-items: flex-end;
-  gap: 1rem;
-  margin: 4rem 0 3rem;
+  gap: 0.65rem;
+  margin: 2.5rem 0 1.9rem;
   flex-wrap: wrap;
 }
 
 .title--primary {
-  margin: 4rem 0;
+  margin: 2.5rem 0;
 }
 
 .title-wrapper--self-padded-tablet-down,
 .title-wrapper--self-padded-mobile {
-  padding-left: 1.5rem;
-  padding-right: 1.5rem;
+  padding-left: 0.95rem;
+  padding-right: 0.95rem;
 }
 
 @media screen and (min-width: 750px) {
@@ -873,11 +873,11 @@ summary::-webkit-details-marker {
 @media screen and (min-width: 990px) {
   .title,
   .title-wrapper-with-link {
-    margin: 5rem 0 3rem;
+    margin: 3.15rem 0 1.9rem;
   }
 
   .title--primary {
-    margin: 2rem 0;
+    margin: 1.25rem 0;
   }
 
   .title-wrapper-with-link {
@@ -902,7 +902,7 @@ summary::-webkit-details-marker {
 }
 
 .title-wrapper-with-link .link-with-icon svg {
-  width: 1.5rem;
+  width: 0.95rem;
 }
 
 .title-wrapper-with-link a {
@@ -918,9 +918,9 @@ summary::-webkit-details-marker {
 }
 
 .subtitle {
-  font-size: 1.8rem;
+  font-size: 1.15rem;
   line-height: calc(1 + 0.8 / var(--font-body-scale));
-  letter-spacing: 0.05rem;
+  letter-spacing: 0.0315rem;
   color: rgba(var(--color-foreground), 0.7);
 }
 
@@ -928,22 +928,22 @@ summary::-webkit-details-marker {
 .grid {
   display: flex;
   flex-wrap: wrap;
-  margin-bottom: 2rem;
-  margin-left: -0.5rem;
+  margin-bottom: 1.25rem;
+  margin-left: -0.315rem;
   padding: 0;
   list-style: none;
 }
 
 @media screen and (min-width: 750px) {
   .grid {
-    margin-left: -1rem;
+    margin-left: -0.65rem;
   }
 }
 
 .grid__item {
-  padding-left: 0.5rem;
-  padding-bottom: 0.5rem;
-  width: calc(25% - 0.5rem * 3 / 4);
+  padding-left: 0.315rem;
+  padding-bottom: 0.315rem;
+  width: calc(25% - 0.315rem * 3 / 4);
   max-width: 50%;
   flex-grow: 1;
   flex-shrink: 0;
@@ -951,9 +951,9 @@ summary::-webkit-details-marker {
 
 @media screen and (min-width: 750px) {
   .grid__item {
-    padding-left: 1rem;
-    padding-bottom: 1rem;
-    width: calc(25% - 1rem * 3 / 4);
+    padding-left: 0.65rem;
+    padding-bottom: 0.65rem;
+    width: calc(25% - 0.65rem * 3 / 4);
     max-width: 50%;
   }
 }
@@ -988,48 +988,48 @@ summary::-webkit-details-marker {
 }
 
 .grid--3-col .grid__item {
-  width: calc(33.33% - 0.5rem * 2 / 3);
+  width: calc(33.33% - 0.315rem * 2 / 3);
 }
 
 @media screen and (min-width: 750px) {
   .grid--3-col .grid__item {
-    width: calc(33.33% - 1rem * 2 / 3);
+    width: calc(33.33% - 0.65rem * 2 / 3);
   }
 }
 
 .grid--2-col .grid__item {
-  width: calc(50% - 0.5rem / 2);
+  width: calc(50% - 0.315rem / 2);
 }
 
 @media screen and (min-width: 750px) {
   .grid--2-col .grid__item {
-    width: calc(50% - 1rem / 2);
+    width: calc(50% - 0.65rem / 2);
   }
 
   .grid--4-col-tablet .grid__item {
-    width: calc(25% - 1rem * 3 / 4);
+    width: calc(25% - 0.65rem * 3 / 4);
   }
 
   .grid--3-col-tablet .grid__item {
-    width: calc(33.33% - 1rem * 2 / 3);
+    width: calc(33.33% - 0.65rem * 2 / 3);
   }
 
   .grid--2-col-tablet .grid__item {
-    width: calc(50% - 1rem / 2);
+    width: calc(50% - 0.65rem / 2);
   }
 }
 
 @media screen and (min-width: 990px) {
   .grid--4-col-desktop .grid__item {
-    width: calc(25% - 1rem * 3 / 4);
+    width: calc(25% - 0.65rem * 3 / 4);
   }
 
   .grid--3-col-desktop .grid__item {
-    width: calc(33.33% - 1rem * 2 / 3);
+    width: calc(33.33% - 0.65rem * 2 / 3);
   }
 
   .grid--2-col-desktop .grid__item {
-    width: calc(50% - 1rem / 2);
+    width: calc(50% - 0.65rem / 2);
   }
 }
 
@@ -1054,37 +1054,37 @@ summary::-webkit-details-marker {
   }
 
   .grid--peek .grid__item {
-    width: calc(50% - 3.75rem / 2);
+    width: calc(50% - 2.35rem / 2);
   }
 
   .grid--peek .grid__item:first-of-type {
-    padding-left: 1.5rem;
+    padding-left: 0.95rem;
   }
 
   .grid--peek .grid__item:last-of-type {
-    padding-right: 1.5rem;
+    padding-right: 0.95rem;
   }
 }
 
 @media screen and (min-width: 750px) and (max-width: 989px) {
   .slider--tablet.grid--peek .grid__item {
-    width: calc(25% - 4rem * 3 / 4);
+    width: calc(25% - 2.5rem * 3 / 4);
   }
 
   .slider--tablet.grid--peek.grid--3-col-tablet .grid__item {
-    width: calc(33.33% - 4rem * 2 / 3);
+    width: calc(33.33% - 2.5rem * 2 / 3);
   }
 
   .slider--tablet.grid--peek.grid--2-col-tablet .grid__item {
-    width: calc(50% - 4rem / 2);
+    width: calc(50% - 2.5rem / 2);
   }
 
   .slider--tablet.grid--peek .grid__item:first-of-type {
-    padding-left: 1.5rem;
+    padding-left: 0.95rem;
   }
 
   .slider--tablet.grid--peek .grid__item:last-of-type {
-    padding-right: 1.5rem;
+    padding-right: 0.95rem;
   }
 }
 
@@ -1180,34 +1180,34 @@ deferred-media {
   align-items: center;
   box-sizing: border-box;
   font: inherit;
-  padding: 0.9rem 3rem 1.1rem;
+  padding: 0.55rem 1.9rem 0.7rem;
   text-decoration: none;
-  border: 0.1rem solid transparent;
+  border: 0.065rem solid transparent;
   border-radius: 0;
   background-color: rgba(var(--color-button), var(--alpha-button-background));
-  box-shadow: 0 0 0 0.1rem rgba(var(--color-button), var(--alpha-button-border));
+  box-shadow: 0 0 0 0.065rem rgba(var(--color-button), var(--alpha-button-border));
   color: rgb(var(--color-button-text));
-  min-width: 12rem;
-  min-height: 4.5rem;
+  min-width: 7.5rem;
+  min-height: 2.8rem;
   transition: box-shadow var(--duration-short) ease;
   -webkit-appearance: none;
   appearance: none;
 }
 
 .button:focus-visible {
-  box-shadow: 0 0 0 0.1rem rgba(var(--color-button), var(--alpha-button-border)),
-    0 0 0 0.3rem rgb(var(--color-background)),
-    0 0 0.5rem 0.4rem rgba(var(--color-foreground), 0.3);
+  box-shadow: 0 0 0 0.065rem rgba(var(--color-button), var(--alpha-button-border)),
+    0 0 0 0.19rem rgb(var(--color-background)),
+    0 0 0.315rem 0.25rem rgba(var(--color-foreground), 0.3);
 }
 
 .button:focus {
-  box-shadow: 0 0 0 0.1rem rgba(var(--color-button), var(--alpha-button-border)),
-    0 0 0 0.3rem rgb(var(--color-background)),
-    0 0 0.5rem 0.4rem rgba(var(--color-foreground), 0.3);
+  box-shadow: 0 0 0 0.065rem rgba(var(--color-button), var(--alpha-button-border)),
+    0 0 0 0.19rem rgb(var(--color-background)),
+    0 0 0.315rem 0.25rem rgba(var(--color-foreground), 0.3);
 }
 
 .button:focus:not(:focus-visible) {
-  box-shadow: 0 0 0 0.1rem rgba(var(--color-button), var(--alpha-button-border));
+  box-shadow: 0 0 0 0.065rem rgba(var(--color-button), var(--alpha-button-border));
 }
 
 .button::selection,
@@ -1220,20 +1220,20 @@ deferred-media {
 .button-label,
 .shopify-challenge__button,
 .customer button {
-  font-size: 1.5rem;
-  letter-spacing: 0.1rem;
+  font-size: 0.95rem;
+  letter-spacing: 0.065rem;
   line-height: calc(1 + 0.2 / var(--font-body-scale));
 }
 
 .button--tertiary {
-  font-size: 1.2rem;
-  padding: 1rem 1.5rem;
-  min-width: 9rem;
-  min-height: 3.5rem;
+  font-size: 0.75rem;
+  padding: 0.65rem 0.95rem;
+  min-width: 5.5rem;
+  min-height: 2.2rem;
 }
 
 .button--small {
-  padding: 1.2rem 2.6rem;
+  padding: 0.75rem 1.65rem;
 }
 
 /* Button - hover */
@@ -1241,7 +1241,7 @@ deferred-media {
 .button:not([disabled]):hover,
 .shopify-challenge__button:hover,
 .customer button:hover {
-  box-shadow: 0 0 0 0.2rem rgba(var(--color-button), var(--alpha-button-border));
+  box-shadow: 0 0 0 0.125rem rgba(var(--color-button), var(--alpha-button-border));
 }
 
 /* Button - other */
@@ -1293,9 +1293,9 @@ deferred-media {
 }
 
 .share-button__button {
-  font-size: 1.4rem;
+  font-size: 0.9rem;
   display: flex;
-  min-height: 2.4rem;
+  min-height: 1.5rem;
   align-items: center;
   color: rgb(var(--color-link));
   margin-left: 0;
@@ -1308,7 +1308,7 @@ details[open] > .share-button__fallback {
 
 .share-button__button:hover {
   text-decoration: underline;
-  text-underline-offset: 0.3rem;
+  text-underline-offset: 0.19rem;
 }
 
 .share-button__button,
@@ -1319,9 +1319,9 @@ details[open] > .share-button__fallback {
 }
 
 .share-button__button .icon-share {
-  height: 1.2rem;
-  margin-right: 1rem;
-  width: 1.3rem;
+  height: 0.75rem;
+  margin-right: 0.65rem;
+  width: 0.8rem;
 }
 
 .share-button__fallback {
@@ -1329,17 +1329,17 @@ details[open] > .share-button__fallback {
   display: flex;
   align-items: center;
   position: absolute;
-  top: 3rem;
-  left: 0.1rem;
+  top: 1.9rem;
+  left: 0.065rem;
   z-index: 3;
   width: 100%;
   min-width: max-content;
-  box-shadow: 0 0 0 0.1rem rgba(var(--color-foreground), 0.55);
+  box-shadow: 0 0 0 0.065rem rgba(var(--color-foreground), 0.55);
 }
 
 .share-button__fallback button {
-  width: 4.4rem;
-  height: 4.4rem;
+  width: 2.75rem;
+  height: 2.75rem;
   padding: 0;
   flex-shrink: 0;
   display: flex;
@@ -1373,8 +1373,8 @@ details[open] > .share-button__fallback {
 }
 
 .share-button__fallback .icon {
-  width: 1.5rem;
-  height: 1.5rem;
+  width: 0.95rem;
+  height: 0.95rem;
 }
 
 .share-button__message:not(:empty) {
@@ -1383,7 +1383,7 @@ details[open] > .share-button__fallback {
   width: 100%;
   height: 100%;
   margin-top: 0;
-  padding: 0.8rem 0 0.8rem 1.5rem;
+  padding: 0.5rem 0 0.5rem 0.95rem;
 }
 
 .share-button__message:not(:empty):not(.hidden) ~ * {
@@ -1398,13 +1398,13 @@ details[open] > .share-button__fallback {
   -webkit-appearance: none;
   appearance: none;
   background-color: transparent;
-  border: 0.1rem solid transparent;
+  border: 0.065rem solid transparent;
   border-radius: 0;
   color: rgb(var(--color-foreground));
-  font-size: 1.6rem;
+  font-size: 1.0rem;
   width: 100%;
-  box-shadow: 0 0 0 0.1rem rgba(var(--color-foreground), 0.55);
-  height: 4.5rem;
+  box-shadow: 0 0 0 0.065rem rgba(var(--color-foreground), 0.55);
+  height: 2.8rem;
   box-sizing: border-box;
   transition: box-shadow var(--duration-short) ease;
 }
@@ -1413,7 +1413,7 @@ details[open] > .share-button__fallback {
   font-family: var(--font-body-family);
   font-style: var(--font-body-style);
   font-weight: var(--font-body-weight);
-  font-size: 1.2rem;
+  font-size: 0.75rem;
   color: rgba(var(--color-foreground), 0.75);
 }
 
@@ -1422,7 +1422,7 @@ details[open] > .share-button__fallback {
 .customer .field input:hover,
 .customer select:hover,
 .localization-form__select:hover {
-  box-shadow: 0 0 0 0.2rem rgba(var(--color-foreground), 0.55);
+  box-shadow: 0 0 0 0.125rem rgba(var(--color-foreground), 0.55);
 }
 
 .field__input:focus,
@@ -1430,7 +1430,7 @@ details[open] > .share-button__fallback {
 .customer .field input:focus,
 .customer select:focus,
 .localization-form__select:focus {
-  box-shadow: 0 0 0 0.2rem rgba(var(--color-foreground), 0.75);
+  box-shadow: 0 0 0 0.125rem rgba(var(--color-foreground), 0.75);
   outline: transparent;
 }
 
@@ -1445,18 +1445,18 @@ details[open] > .share-button__fallback {
 
 .select .icon-caret,
 .customer select + svg {
-  height: 0.6rem;
+  height: 0.375rem;
   pointer-events: none;
   position: absolute;
-  top: calc(50% - 0.2rem);
-  right: 1.5rem;
+  top: calc(50% - 0.125rem);
+  right: 0.95rem;
 }
 
 .select__select,
 .customer select {
   cursor: pointer;
   line-height: calc(1 + 0.6 / var(--font-body-scale));
-  padding: 0 4rem 0 1.5rem;
+  padding: 0 2.5rem 0 0.95rem;
 }
 
 /* Field */
@@ -1479,21 +1479,21 @@ details[open] > .share-button__fallback {
 .customer .field input {
   flex-grow: 1;
   text-align: left;
-  padding: 1.5rem;
+  padding: 0.95rem;
 }
 
 .field__label,
 .customer .field label {
-  font-size: 1.6rem;
-  left: 1.5rem;
-  top: 1rem;
+  font-size: 1.0rem;
+  left: 0.95rem;
+  top: 0.65rem;
   margin-bottom: 0;
   pointer-events: none;
   position: absolute;
   transition: top var(--duration-short) ease,
     font-size var(--duration-short) ease;
   color: rgba(var(--color-foreground), 0.75);
-  letter-spacing: 0.1rem;
+  letter-spacing: 0.065rem;
   line-height: 1.5;
 }
 
@@ -1503,9 +1503,9 @@ details[open] > .share-button__fallback {
 .customer .field input:focus ~ label,
 .customer .field input:not(:placeholder-shown) ~ label,
 .customer .field input:-webkit-autofill ~ label {
-  font-size: 1rem;
+  font-size: 0.65rem;
   top: 0.3em;
-  letter-spacing: 0.04rem;
+  letter-spacing: 0.025rem;
 }
 
 .field__input:focus,
@@ -1514,7 +1514,7 @@ details[open] > .share-button__fallback {
 .customer .field input:focus,
 .customer .field input:not(:placeholder-shown),
 .customer .field input:-webkit-autofill {
-  padding: 2.2rem 1.5rem 0.8rem;
+  padding: 1.4rem 0.95rem 0.5rem;
 }
 
 .field__input::-webkit-search-cancel-button,
@@ -1534,19 +1534,19 @@ details[open] > .share-button__fallback {
   color: currentColor;
   cursor: pointer;
   display: flex;
-  height: 4.4rem;
+  height: 2.75rem;
   justify-content: center;
   overflow: hidden;
   padding: 0;
   position: absolute;
   right: 0;
   top: 0;
-  width: 4.4rem;
+  width: 2.75rem;
 }
 
 .field__button > svg {
-  height: 2.5rem;
-  width: 2.5rem;
+  height: 1.55rem;
+  width: 1.55rem;
 }
 
 .field__input:-webkit-autofill ~ .field__button,
@@ -1561,8 +1561,8 @@ details[open] > .share-button__fallback {
   font-family: var(--font-body-family);
   font-style: var(--font-body-style);
   font-weight: var(--font-body-weight);
-  padding: 1.2rem;
-  min-height: 10rem;
+  padding: 0.75rem;
+  min-height: 6.5rem;
   resize: none;
 }
 
@@ -1573,46 +1573,46 @@ details[open] > .share-button__fallback {
 input[type='checkbox'] {
   display: inline-block;
   width: auto;
-  margin-right: 0.5rem;
+  margin-right: 0.315rem;
 }
 
 /* Form global */
 
 .form__label {
   display: block;
-  margin-bottom: 0.6rem;
+  margin-bottom: 0.375rem;
 }
 
 .form__message {
   align-items: center;
   display: flex;
-  font-size: 1.4rem;
+  font-size: 0.9rem;
   line-height: 1;
-  margin-top: 1rem;
+  margin-top: 0.65rem;
 }
 
 .form__message--large {
-  font-size: 1.6rem;
+  font-size: 1.0rem;
 }
 
 .customer .field .form__message {
-  font-size: 1.4rem;
+  font-size: 0.9rem;
   text-align: left;
 }
 
 .form__message .icon,
 .customer .form__message svg {
   flex-shrink: 0;
-  height: 1.3rem;
-  margin-right: 0.5rem;
-  width: 1.3rem;
+  height: 0.8rem;
+  margin-right: 0.315rem;
+  width: 0.8rem;
 }
 
 .form__message--large .icon,
 .customer .form__message svg {
-  height: 1.5rem;
-  width: 1.5rem;
-  margin-right: 1rem;
+  height: 0.95rem;
+  width: 0.95rem;
+  margin-right: 0.65rem;
 }
 
 .customer .field .form__message svg {
@@ -1621,12 +1621,12 @@ input[type='checkbox'] {
 
 .form-status {
   margin: 0;
-  font-size: 1.6rem;
+  font-size: 1.0rem;
 }
 
 .form-status-list {
   padding: 0;
-  margin: 2rem 0 4rem;
+  margin: 1.25rem 0 2.5rem;
 }
 
 .form-status-list li {
@@ -1639,22 +1639,22 @@ input[type='checkbox'] {
 
 /* component-quantity */
 .quantity {
-  border: 0.1rem solid rgba(var(--color-base-text), 0.08);
+  border: 0.065rem solid rgba(var(--color-base-text), 0.08);
   position: relative;
-  height: 4.5rem;
-  width: calc(14rem / var(--font-body-scale));
+  height: 2.8rem;
+  width: calc(9.0rem / var(--font-body-scale));
   display: flex;
 }
 
 .quantity__input {
   color: currentColor;
-  font-size: 1.4rem;
+  font-size: 0.9rem;
   font-weight: 500;
   opacity: 0.85;
   text-align: center;
   background-color: transparent;
   border: 0;
-  padding: 0 0.5rem;
+  padding: 0 0.315rem;
   width: 100%;
   flex-grow: 1;
   -webkit-appearance: none;
@@ -1662,9 +1662,9 @@ input[type='checkbox'] {
 }
 
 .quantity__button {
-  width: calc(4.5rem / var(--font-body-scale));
+  width: calc(2.8rem / var(--font-body-scale));
   flex-shrink: 0;
-  font-size: 1.8rem;
+  font-size: 1.15rem;
   border: 0;
   background-color: transparent;
   cursor: pointer;
@@ -1676,15 +1676,15 @@ input[type='checkbox'] {
 }
 
 .quantity__button svg {
-  width: 1rem;
+  width: 0.65rem;
   pointer-events: none;
 }
 
 .quantity__input:-webkit-autofill,
 .quantity__input:-webkit-autofill:hover,
 .quantity__input:-webkit-autofill:active {
-  box-shadow: 0 0 0 10rem rgb(var(--color-background)) inset !important;
-  -webkit-box-shadow: 0 0 0 10rem rgb(var(--color-background)) inset !important;
+  box-shadow: 0 0 0 6.5rem rgb(var(--color-background)) inset !important;
+  -webkit-box-shadow: 0 0 0 6.5rem rgb(var(--color-background)) inset !important;
 }
 
 .quantity__input::-webkit-outer-spin-button,
@@ -1714,8 +1714,8 @@ input[type='checkbox'] {
 .no-js details[open] svg.modal__toggle-close {
   display: flex;
   z-index: 1;
-  height: 1.7rem;
-  width: 1.7rem;
+  height: 1.05rem;
+  width: 1.05rem;
 }
 
 .modal__toggle-open {
@@ -1734,15 +1734,15 @@ input[type='checkbox'] {
   display: flex;
   justify-content: center;
   align-items: center;
-  padding: 0rem;
-  height: 4.4rem;
-  width: 4.4rem;
+  padding: 0.0rem;
+  height: 2.75rem;
+  width: 2.75rem;
   background-color: transparent;
 }
 
 .modal__close-button .icon {
-  width: 1.7rem;
-  height: 1.7rem;
+  width: 1.05rem;
+  height: 1.05rem;
 }
 
 .modal__content {
@@ -1775,15 +1775,15 @@ input[type='checkbox'] {
   position: absolute;
   background-color: rgb(var(--color-button));
   color: rgb(var(--color-button-text));
-  height: 1.7rem;
-  width: 1.7rem;
+  height: 1.05rem;
+  width: 1.05rem;
   border-radius: 100%;
   display: flex;
   justify-content: center;
   align-items: center;
-  font-size: 0.9rem;
-  bottom: 0.8rem;
-  left: 2.2rem;
+  font-size: 0.55rem;
+  bottom: 0.5rem;
+  left: 1.4rem;
   line-height: calc(1 + 0.1 / var(--font-body-scale));
 }
 
@@ -1793,14 +1793,14 @@ input[type='checkbox'] {
 }
 
 .announcement-bar {
-  border-bottom: 0.1rem solid rgba(var(--color-foreground), 0.08);
+  border-bottom: 0.065rem solid rgba(var(--color-foreground), 0.08);
   color: rgb(var(--color-foreground));
 }
 
 .announcement-bar__link {
   display: block;
   width: 100%;
-  padding: 1rem 2rem;
+  padding: 0.65rem 1.25rem;
   text-decoration: none;
 }
 
@@ -1812,9 +1812,9 @@ input[type='checkbox'] {
 .announcement-bar__link .icon-arrow {
   display: inline-block;
   pointer-events: none;
-  margin-left: 0.8rem;
+  margin-left: 0.5rem;
   vertical-align: middle;
-  margin-bottom: 0.2rem;
+  margin-bottom: 0.125rem;
 }
 
 .announcement-bar__link .announcement-bar__message {
@@ -1823,9 +1823,9 @@ input[type='checkbox'] {
 
 .announcement-bar__message {
   text-align: center;
-  padding: 1rem 2rem;
+  padding: 0.65rem 1.25rem;
   margin: 0;
-  letter-spacing: 0.1rem;
+  letter-spacing: 0.065rem;
 }
 
 /* section-header */
@@ -1854,7 +1854,7 @@ input[type='checkbox'] {
 }
 
 .header-wrapper--border-bottom {
-  border-bottom: 0.1rem solid rgba(var(--color-foreground), 0.08);
+  border-bottom: 0.065rem solid rgba(var(--color-foreground), 0.08);
 }
 
 .header {
@@ -1862,14 +1862,14 @@ input[type='checkbox'] {
   grid-template-areas: 'left-icon heading icons';
   grid-template-columns: 1fr 2fr 1fr;
   align-items: center;
-  padding-top: 1rem;
-  padding-bottom: 1rem;
+  padding-top: 0.65rem;
+  padding-bottom: 0.65rem;
 }
 
 @media screen and (min-width: 990px) {
   .header {
-    padding-top: 2rem;
-    padding-bottom: 2rem;
+    padding-top: 1.25rem;
+    padding-bottom: 1.25rem;
   }
 
   .header--has-menu:not(.header--middle-left) {
@@ -1887,7 +1887,7 @@ input[type='checkbox'] {
   .header--middle-left {
     grid-template-areas: 'heading navigation icons';
     grid-template-columns: auto auto 1fr;
-    column-gap: 2rem;
+    column-gap: 1.25rem;
   }
 
   .header--top-center {
@@ -1897,7 +1897,7 @@ input[type='checkbox'] {
   }
 
   .header:not(.header--middle-left) .header__inline-menu {
-    margin-top: 1.05rem;
+    margin-top: 0.65rem;
   }
 }
 
@@ -1922,7 +1922,7 @@ input[type='checkbox'] {
 
 .header__heading-link {
   display: inline-block;
-  padding: 0.75rem;
+  padding: 0.47rem;
   text-decoration: none;
   word-break: break-word;
 }
@@ -1950,7 +1950,7 @@ input[type='checkbox'] {
 
 @media screen and (min-width: 990px) {
   .header__heading-link {
-    margin-left: -0.75rem;
+    margin-left: -0.47rem;
   }
 
   .header__heading,
@@ -1997,21 +1997,21 @@ input[type='checkbox'] {
 }
 
 .header__icon .icon {
-  height: 2rem;
-  width: 2rem;
+  height: 1.25rem;
+  width: 1.25rem;
   fill: none;
   vertical-align: middle;
 }
 
 .header__icon,
 .header__icon--cart .icon {
-  height: 4.4rem;
-  width: 4.4rem;
+  height: 2.75rem;
+  width: 2.75rem;
 }
 
 .header__icon--cart {
   position: relative;
-  margin-right: -1.2rem;
+  margin-right: -0.75rem;
 }
 
 @media screen and (max-width: 989px) {
@@ -2083,13 +2083,13 @@ details[open] .modal-overlay::after {
 }
 
 .no-js details[open] > .header__icon--search {
-  top: 1rem;
-  right: 0.5rem;
+  top: 0.65rem;
+  right: 0.315rem;
 }
 
 .search-modal {
   opacity: 0;
-  border-bottom: 0.1rem solid rgba(var(--color-foreground), 0.08);
+  border-bottom: 0.065rem solid rgba(var(--color-foreground), 0.08);
   height: 100%;
 }
 
@@ -2099,7 +2099,7 @@ details[open] .modal-overlay::after {
   justify-content: center;
   width: 100%;
   height: 100%;
-  padding: 0 5rem 0 1rem;
+  padding: 0 3.15rem 0 0.65rem;
   line-height: calc(1 + 0.8 / var(--font-body-scale));
 }
 
@@ -2109,27 +2109,27 @@ details[open] .modal-overlay::after {
 
 .search-modal__close-button {
   position: absolute;
-  right: 0.3rem;
+  right: 0.19rem;
 }
 
 @media screen and (min-width: 750px) {
   .search-modal__close-button {
-    right: 1rem;
+    right: 0.65rem;
   }
 
   .search-modal__content {
-    padding: 0 6rem;
+    padding: 0 3.75rem;
   }
 }
 
 @media screen and (min-width: 990px) {
   .search-modal__form {
-    max-width: 47.8rem;
+    max-width: 30.0rem;
   }
 
   .search-modal__close-button {
     position: initial;
-    margin-left: 0.5rem;
+    margin-left: 0.315rem;
   }
 }
 
@@ -2168,7 +2168,7 @@ details[open] > .header__icon--menu .icon-hamburger {
 
 /* Header menu */
 .header__inline-menu {
-  margin-left: -1.2rem;
+  margin-left: -0.75rem;
   grid-area: navigation;
   display: none;
 }
@@ -2197,11 +2197,11 @@ details[open] > .header__icon--menu .icon-hamburger {
 }
 
 .header__menu {
-  padding: 0 1rem;
+  padding: 0 0.65rem;
 }
 
 .header__menu-item {
-  padding: 1.2rem;
+  padding: 0.75rem;
   text-decoration: none;
   color: rgba(var(--color-foreground), 0.75);
 }
@@ -2216,18 +2216,18 @@ details[open] > .header__icon--menu .icon-hamburger {
 
 .header__menu-item:hover span {
   text-decoration: underline;
-  text-underline-offset: 0.3rem;
+  text-underline-offset: 0.19rem;
 }
 
 .header__active-menu-item {
   transition: text-decoration-thickness var(--duration-short) ease;
   color: rgb(var(--color-foreground));
   text-decoration: underline;
-  text-underline-offset: 0.3rem;
+  text-underline-offset: 0.19rem;
 }
 
 .header__menu-item:hover .header__active-menu-item {
-  text-decoration-thickness: 0.2rem;
+  text-decoration-thickness: 0.125rem;
 }
 
 .header__submenu {
@@ -2236,33 +2236,33 @@ details[open] > .header__icon--menu .icon-hamburger {
 }
 
 .header__submenu.list-menu {
-  padding: 2rem 0;
+  padding: 1.25rem 0;
 }
 
 .header__submenu .header__submenu {
   background-color: rgba(var(--color-foreground), 0.03);
-  padding: 0.5rem 0;
-  margin: 0.5rem 0;
+  padding: 0.315rem 0;
+  margin: 0.315rem 0;
 }
 
 .header__submenu .header__menu-item:after {
-  right: 2rem;
+  right: 1.25rem;
 }
 
 .header__submenu .header__menu-item {
-  padding: 0.95rem 3.5rem 0.95rem 2rem;
+  padding: 0.6rem 2.2rem 0.6rem 1.25rem;
 }
 
 .header__submenu .header__submenu .header__menu-item {
-  padding-left: 3rem;
+  padding-left: 1.9rem;
 }
 
 .header__menu-item .icon-caret {
-  right: 0.8rem;
+  right: 0.5rem;
 }
 
 .header__submenu .icon-caret {
-  right: 2rem;
+  right: 1.25rem;
 }
 
 details-disclosure > details {
@@ -2272,7 +2272,7 @@ details-disclosure > details {
 @keyframes animateMenuOpen {
   0% {
     opacity: 0;
-    transform: translateY(-1.5rem);
+    transform: translateY(-0.95rem);
   }
 
   100% {
@@ -2300,12 +2300,12 @@ details-disclosure > details {
 
 .badge {
   border: 1px solid transparent;
-  border-radius: 4rem;
+  border-radius: 2.5rem;
   display: inline-block;
-  font-size: 1.2rem;
-  letter-spacing: 0.1rem;
+  font-size: 0.75rem;
+  letter-spacing: 0.065rem;
   line-height: 1;
-  padding: 0.6rem 1.3rem;
+  padding: 0.375rem 0.8rem;
   text-align: center;
   background-color: rgb(var(--color-badge-background));
   border-color: rgba(var(--color-badge-border), var(--alpha-badge-border));

--- a/assets/collage.css
+++ b/assets/collage.css
@@ -1,30 +1,30 @@
 .collage-section + .collage-section .no-heading {
-  margin-top: -4rem;
+  margin-top: -2.5rem;
 }
 
 @media screen and (max-width: 749px) {
   .collage-wrapper-title {
-    margin-top: -1rem;
+    margin-top: -0.65rem;
   }
 }
 
 @media screen and (min-width: 750px) {
   .collage-wrapper.no-heading {
-    margin-top: calc(6rem + var(--page-width-margin));
+    margin-top: calc(3.75rem + var(--page-width-margin));
   }
 
   .collage-section + .collage-section .no-heading {
-    margin-top: calc(-4rem - var(--page-width-margin));
+    margin-top: calc(-2.5rem - var(--page-width-margin));
   }
 }
 
 .collage-wrapper-title {
-  margin-bottom: 3rem;
+  margin-bottom: 1.9rem;
 }
 
 .collage {
   display: grid;
-  gap: 1rem;
+  gap: 0.65rem;
 }
 
 .collage--mobile {
@@ -39,7 +39,7 @@
 
 .collage-card {
   position: relative;
-  border: 0.1rem solid rgba(var(--color-foreground), 0.08);
+  border: 0.065rem solid rgba(var(--color-foreground), 0.08);
 }
 
 .collage-card.collage-collection {
@@ -69,7 +69,7 @@
 @media screen and (min-width: 750px) {
   .collage-card--left:not(:only-child),
   .collage-card--right:not(:only-child) {
-    min-height: 40rem;
+    min-height: 25.0rem;
   }
 
   .collage-card--left:nth-last-child(3),
@@ -109,7 +109,7 @@
 }
 
 .collage-content.deferred-media__poster:focus {
-  outline-offset: 0.3rem;
+  outline-offset: 0.19rem;
 }
 
 .collage-video.collage-card--left .collage-content,
@@ -131,7 +131,7 @@
   .collage-card--left .deferred-media--placeholder,
   .collage-card--right .deferred-media--placeholder,
   .collage-video-placeholder {
-    padding-bottom: 25rem;
+    padding-bottom: 15.5rem;
   }
 }
 
@@ -167,7 +167,7 @@
 }
 
 .collage-card.collage-product:only-child {
-  max-width: 73rem;
+  max-width: 45.5rem;
   justify-self: center;
 }
 
@@ -193,16 +193,16 @@
 
 @media screen and (max-width: 749px) {
   .collage:not(.collage--mobile) .collage-card__no-image {
-    min-height: 25rem;
+    min-height: 15.5rem;
   }
 
   .collage-card__no-image.card__text-spacing {
-    padding: 2rem;
+    padding: 1.25rem;
   }
 
   .collage-card--left .collage-card__no-image h3,
   .collage-card--right .collage-card__no-image h3 {
-    font-size: calc(var(--font-heading-scale) * 3rem);
+    font-size: calc(var(--font-heading-scale) * 1.9rem);
   }
 
   .collage-card:not(.collage-card--left):not(.collage-card--right)
@@ -220,7 +220,7 @@
 .collage-card--right .collage-card__no-image,
 .collage-card--left .placeholder-svg,
 .collage-card--right .placeholder-svg {
-  min-height: 25rem;
+  min-height: 15.5rem;
 }
 
 @media screen and (min-width: 750px) {
@@ -228,11 +228,11 @@
   .collage-card--right .collage-card__no-image,
   .collage-card--left .placeholder-svg,
   .collage-card--right .placeholder-svg {
-    min-height: 40rem;
+    min-height: 25.0rem;
   }
 
   .collage-card__no-image h3 {
-    font-size: calc(var(--font-heading-scale) * 3rem);
+    font-size: calc(var(--font-heading-scale) * 1.9rem);
   }
 }
 
@@ -327,14 +327,14 @@
 
 .collage-card-spacing:not(.collage-card__image-wrapper),
 .collage-card-spacing > img {
-  padding: 2rem;
+  padding: 1.25rem;
 }
 
 .collage-card-spacing iframe,
 .collage-video.collage-card--left .collage-card-spacing .collage-content,
 .collage-video.collage-card--right .collage-card-spacing .collage-content {
-  width: calc(100% - 4rem);
-  height: calc(100% - 4rem);
+  width: calc(100% - 2.5rem);
+  height: calc(100% - 2.5rem);
 }
 
 .collage-card-spacing .card__text-spacing {
@@ -342,24 +342,24 @@
 }
 
 .collage-card-spacing .collage-content__info {
-  margin: 1.5rem 0 0;
+  margin: 0.95rem 0 0;
 }
 
 @media screen and (min-width: 750px) {
   .collage-card-spacing:not(.collage-card__image-wrapper),
   .collage-card-spacing > img {
-    padding: 3rem;
+    padding: 1.9rem;
   }
 
   .collage-card-spacing iframe,
   .collage-video.collage-card--left .collage-card-spacing .collage-content,
   .collage-video.collage-card--right .collage-card-spacing .collage-content {
-    width: calc(100% - 6rem);
-    height: calc(100% - 6rem);
+    width: calc(100% - 3.75rem);
+    height: calc(100% - 3.75rem);
   }
 
   .collage-card-spacing .collage-content__info {
-    margin: 1.8rem 0 0;
+    margin: 1.15rem 0 0;
   }
 
   .collage-card:not(.collage-card--left):not(.collage-card--right)
@@ -374,21 +374,21 @@
 }
 
 .collage-content__info {
-  margin: 1.5rem 2rem;
+  margin: 0.95rem 1.25rem;
 }
 
 .card-information__wrapper.collage-content__info {
   margin: 0;
-  padding: 1.5rem 2rem;
+  padding: 0.95rem 1.25rem;
 }
 
 @media screen and (min-width: 750px) {
   .collage-content__info {
-    margin: 2rem 3.5rem;
+    margin: 1.25rem 2.2rem;
   }
 
   .card-information__wrapper.collage-content__info {
-    padding: 2rem 3.5rem;
+    padding: 1.25rem 2.2rem;
   }
 }
 
@@ -426,7 +426,7 @@
 
 .collage-video__modal-toggle {
   background-color: rgb(var(--color-background));
-  border: 0.1rem solid rgba(var(--color-foreground), 0.1);
+  border: 0.065rem solid rgba(var(--color-foreground), 0.1);
   border-radius: 50%;
   color: rgba(var(--color-foreground), 0.55);
   display: flex;
@@ -434,54 +434,54 @@
   justify-content: center;
   cursor: pointer;
   position: fixed;
-  padding: 1.2rem;
+  padding: 0.75rem;
   z-index: 2;
-  top: 2rem;
-  right: 0.5rem;
-  width: 4rem;
+  top: 1.25rem;
+  right: 0.315rem;
+  width: 2.5rem;
   margin: 0 0 0 auto;
 }
 
 @media screen and (min-width: 750px) {
   .collage-video__modal-toggle {
-    right: 4.8rem;
-    top: 3.5rem;
+    right: 3.0rem;
+    top: 2.2rem;
   }
 }
 
 @media screen and (min-width: 990px) {
   .collage-video__modal-toggle {
-    right: 4.3rem;
-    top: 3rem;
+    right: 2.7rem;
+    top: 1.9rem;
   }
 }
 
 .collage-video__modal-toggle .icon {
   height: auto;
   margin: 0;
-  width: 2.2rem;
+  width: 1.4rem;
 }
 
 .collage-video__modal-content-info {
-  width: calc(100% - 1rem);
-  height: calc(100% - 6rem);
+  width: calc(100% - 0.65rem);
+  height: calc(100% - 3.75rem);
   margin: 0 auto;
-  padding-top: 8rem;
+  padding-top: 5.0rem;
 }
 
 @media screen and (min-width: 750px) {
   .collage-video__modal-content-info {
-    width: calc(100% - 9.6rem);
-    height: calc(100% - 7.5rem);
-    padding-top: 9.5rem;
+    width: calc(100% - 6.0rem);
+    height: calc(100% - 4.7rem);
+    padding-top: 6.0rem;
   }
 }
 
 @media screen and (min-width: 990px) {
   .collage-video__modal-content-info {
-    width: calc(100% - 8.6rem);
-    height: calc(100% - 7rem);
-    padding-top: 9rem;
+    width: calc(100% - 5.5rem);
+    height: calc(100% - 4.4rem);
+    padding-top: 5.5rem;
   }
 }
 

--- a/assets/component-accordion.css
+++ b/assets/component-accordion.css
@@ -2,7 +2,7 @@
   display: flex;
   position: relative;
   line-height: 1;
-  padding: 1.5rem 0;
+  padding: 0.95rem 0;
 }
 
 .accordion .summary__title {
@@ -11,7 +11,7 @@
 }
 
 .accordion .summary__title + .icon-caret {
-  height: calc(var(--font-heading-scale) * 0.6rem);
+  height: calc(var(--font-heading-scale) * 0.375rem);
 }
 
 .accordion + .accordion {
@@ -20,16 +20,16 @@
 }
 
 .accordion {
-  margin-top: 2.5rem;
+  margin-top: 1.55rem;
   margin-bottom: 0;
-  border-top: 0.1rem solid rgba(var(--color-foreground), 0.08);
-  border-bottom: 0.1rem solid rgba(var(--color-foreground), 0.08);
+  border-top: 0.065rem solid rgba(var(--color-foreground), 0.08);
+  border-bottom: 0.065rem solid rgba(var(--color-foreground), 0.08);
 }
 
 .accordion__title {
   display: inline-block;
-  max-width: calc(100% - 6rem);
-  min-height: 1.6rem;
+  max-width: calc(100% - 3.75rem);
+  min-height: 1.0rem;
   margin: 0;
   word-break: break-word;
 }
@@ -37,9 +37,9 @@
 .accordion .icon-accordion {
   align-self: center;
   fill: rgb(var(--color-foreground));
-  height: calc(var(--font-heading-scale) * 1.6rem);
-  margin-right: calc(var(--font-heading-scale) * 1rem);
-  width: calc(var(--font-heading-scale) * 1.6rem);
+  height: calc(var(--font-heading-scale) * 1.0rem);
+  margin-right: calc(var(--font-heading-scale) * 0.65rem);
+  width: calc(var(--font-heading-scale) * 1.0rem);
 }
 
 .accordion details[open] > summary .icon-caret {
@@ -47,7 +47,7 @@
 }
 
 .accordion__content {
-  margin-bottom: 1.5rem;
+  margin-bottom: 0.95rem;
   word-break: break-word;
 }
 

--- a/assets/component-article-card.css
+++ b/assets/component-article-card.css
@@ -1,10 +1,10 @@
 .articles-wrapper.grid {
-  margin: 0 0 5rem 0;
+  margin: 0 0 3.15rem 0;
 }
 
 @media screen and (min-width: 750px) {
   .articles-wrapper.grid {
-    margin-bottom: 7rem;
+    margin-bottom: 4.4rem;
   }
 }
 
@@ -37,7 +37,7 @@
 }
 
 .article-card__info {
-  padding: 3rem;
+  padding: 1.9rem;
   display: flex;
   flex-direction: column;
   flex-grow: 1;
@@ -54,7 +54,7 @@
 
 .article-content:hover .article-card__title {
   text-decoration: underline;
-  text-underline-offset: 0.3rem;
+  text-underline-offset: 0.19rem;
 }
 
 .article-card__image {
@@ -83,20 +83,20 @@
 }
 
 .article-card__link {
-  text-underline-offset: 0.3rem;
+  text-underline-offset: 0.19rem;
 }
 
 .article-content:hover .article-card__link {
-  text-decoration-thickness: 0.2rem;
+  text-decoration-thickness: 0.125rem;
 }
 
 .article-card__header {
   line-height: calc(0.8 / var(--font-body-scale));
-  margin-bottom: 1.2rem;
+  margin-bottom: 0.75rem;
 }
 
 .article-card__header h2 {
-  margin: 0 0 0.6rem;
+  margin: 0 0 0.375rem;
 }
 
 .article-card__header h2:only-child {
@@ -104,21 +104,21 @@
 }
 
 .article-card__header h2:not(:first-child) {
-  margin-top: 1rem;
+  margin-top: 0.65rem;
 }
 
 .article-card__header h2 + span {
   display: inline-block;
-  margin-top: 0.4rem;
+  margin-top: 0.25rem;
 }
 
 .article-card__footer {
-  letter-spacing: 0.1rem;
-  font-size: 1.4rem;
+  letter-spacing: 0.065rem;
+  font-size: 0.9rem;
 }
 
 .article-card__footer:not(:last-child) {
-  margin-bottom: 1rem;
+  margin-bottom: 0.65rem;
 }
 
 .article-card__footer:last-child {
@@ -130,51 +130,51 @@
 }
 
 .article-card__link:not(:only-child) {
-  margin-right: 3rem;
+  margin-right: 1.9rem;
 }
 
 @media screen and (min-width: 990px) {
   .article-card__link:not(:only-child) {
-    margin-right: 4rem;
+    margin-right: 2.5rem;
   }
 }
 
 .article-card__image--small {
-  padding-bottom: 11rem;
+  padding-bottom: 7.0rem;
 }
 
 .article-card__image--medium {
-  padding-bottom: 22rem;
+  padding-bottom: 14.0rem;
 }
 
 .article-card__image--large {
-  padding-bottom: 33rem;
+  padding-bottom: 20.5rem;
 }
 
 @media screen and (min-width: 750px) {
   .article-card__image--small {
-    padding-bottom: 14.3rem;
+    padding-bottom: 9.0rem;
   }
 
   .article-card__image--medium {
-    padding-bottom: 21.9rem;
+    padding-bottom: 13.5rem;
   }
 
   .article-card__image--large {
-    padding-bottom: 27.5rem;
+    padding-bottom: 17.0rem;
   }
 }
 
 @media screen and (min-width: 990px) {
   .article-card__image--small {
-    padding-bottom: 17.7rem;
+    padding-bottom: 11.0rem;
   }
 
   .article-card__image--medium {
-    padding-bottom: 30.7rem;
+    padding-bottom: 19.0rem;
   }
 
   .article-card__image--large {
-    padding-bottom: 40.7rem;
+    padding-bottom: 25.5rem;
   }
 }

--- a/assets/component-card.css
+++ b/assets/component-card.css
@@ -5,12 +5,12 @@
 }
 
 .card-information + .card {
-  margin-bottom: 1.3rem;
+  margin-bottom: 0.8rem;
 }
 
 @media screen and (min-width: 750px) {
   .card-information + .card {
-    margin-bottom: 1.7rem;
+    margin-bottom: 1.05rem;
   }
 }
 
@@ -20,7 +20,7 @@
 }
 
 .card .icon-wrap {
-  margin-left: 0.8rem;
+  margin-left: 0.5rem;
   white-space: nowrap;
   transition: transform var(--duration-short) ease;
   overflow: hidden;
@@ -55,20 +55,20 @@
 }
 
 .card--outline:not(.card--soft) {
-  border: calc(0.1rem / var(--font-body-scale)) solid rgba(var(--color-foreground), 0.04);
+  border: calc(0.065rem / var(--font-body-scale)) solid rgba(var(--color-foreground), 0.04);
 }
 
 .card--light-border {
-  border: 0.1rem solid rgba(var(--color-foreground), 0.04);
+  border: 0.065rem solid rgba(var(--color-foreground), 0.04);
 }
 
 .card--light-border:hover {
-  border: 0.1rem solid rgba(var(--color-foreground), 0.3);
+  border: 0.065rem solid rgba(var(--color-foreground), 0.3);
   box-shadow: none;
 }
 
 .card__text-spacing {
-  padding: 3rem;
+  padding: 1.9rem;
 }
 
 .card-colored.color-background-1 {
@@ -76,18 +76,18 @@
 }
 
 .card--media .card__text-spacing {
-  padding: 2rem;
+  padding: 1.25rem;
 }
 
 @media screen and (min-width: 750px) {
   .card--media .card__text-spacing {
-    padding-left: 3rem;
-    padding-right: 3rem;
+    padding-left: 1.9rem;
+    padding-right: 1.9rem;
   }
 }
 
 .card-information > * + * {
-  margin-top: 0.5rem;
+  margin-top: 0.315rem;
 }
 
 .card--text-only .card__inner {
@@ -97,8 +97,8 @@
 }
 
 .card__content {
-  margin-left: 2.5rem;
-  margin-right: 2.5rem;
+  margin-left: 1.55rem;
+  margin-right: 1.55rem;
 }
 
 .card__content > * {
@@ -108,8 +108,8 @@
 .card--text-only .card__content {
   grid-row: 2;
   justify-self: flex-start;
-  margin-bottom: 6rem;
-  margin-top: 5rem;
+  margin-bottom: 3.75rem;
+  margin-top: 3.15rem;
 }
 
 .card--text-only .card__badge {
@@ -119,7 +119,7 @@
 
 .card--search .card__badge > *,
 .card--text-only .card__badge > * {
-  margin: 0 1.2rem 1.2rem;
+  margin: 0 0.75rem 0.75rem;
 }
 
 .card--search .card__badge,
@@ -128,22 +128,22 @@
 }
 
 .card--text-only .card__content + .card__badge {
-  margin-top: -5rem;
+  margin-top: -3.15rem;
 }
 
 .media + .card__content {
-  margin-top: 2rem;
-  margin-bottom: 1.5rem;
+  margin-top: 1.25rem;
+  margin-bottom: 0.95rem;
 }
 
 @media screen and (min-width: 750px) {
   .card--text-only .card__content {
-    margin-top: 7rem;
-    margin-bottom: 7rem;
+    margin-top: 4.4rem;
+    margin-bottom: 4.4rem;
   }
 
   .card--text-only .card__content + .card__badge {
-    margin-top: -7rem;
+    margin-top: -4.4rem;
   }
 }
 
@@ -152,7 +152,7 @@
 }
 
 .card__text-spacing > *:not(.overlay-card) + * {
-  margin-top: 1.5rem;
+  margin-top: 0.95rem;
 }
 
 .card__text {
@@ -163,7 +163,7 @@
 .card-information__text {
   display: block;
   margin: 0;
-  padding-right: 1.2rem;
+  padding-right: 0.75rem;
 }
 
 .card-information__wrapper {
@@ -180,17 +180,17 @@
 }
 
 .card-information__wrapper > .rating {
-  margin-top: 0.4rem;
+  margin-top: 0.25rem;
 }
 
 .card-information__wrapper
   > *:not(.visually-hidden:first-child)
   + *:not(.rating) {
-  margin-top: 0.7rem;
+  margin-top: 0.44rem;
 }
 
 .card-information__wrapper .caption {
-  letter-spacing: 0.07rem;
+  letter-spacing: 0.044rem;
 }
 
 .card-wrapper {
@@ -223,9 +223,9 @@
 }
 
 .card-wrapper .full-unstyled-link:focus-visible::after {
-  outline: .2rem solid rgba(var(--color-foreground),.5);
-  outline-offset: 0.3rem;
-  box-shadow: 0 0 0 .3rem rgb(var(--color-background)),0 0 .5rem .4rem rgba(var(--color-foreground),.3);
+  outline: 0.125rem solid rgba(var(--color-foreground),.5);
+  outline-offset: 0.19rem;
+  box-shadow: 0 0 0 0.19rem rgb(var(--color-background)),0 0 0.315rem 0.25rem rgba(var(--color-foreground),.3);
 }
 
 .card-wrapper:focus-within .card {
@@ -233,36 +233,36 @@
 }
 
 .card__media-spacer {
-  padding: 2rem 2rem 0;
+  padding: 1.25rem 1.25rem 0;
 }
 
 @media screen and (min-width: 750px) {
   .card__media-spacer {
-    padding: 3rem 3rem 0;
+    padding: 1.9rem 1.9rem 0;
   }
 }
 
 .card__media-full-spacer {
-  padding: 2rem;
+  padding: 1.25rem;
 }
 
 .card-article-info {
-  margin-top: 1rem;
+  margin-top: 0.65rem;
   display: flex;
   flex-wrap: wrap;
 }
 
 .card__badge {
-  bottom: 1rem;
+  bottom: 0.65rem;
   display: flex;
   flex-wrap: wrap;
-  left: 1rem;
+  left: 0.65rem;
   position: absolute;
 }
 
 .card__badge > * {
-  margin-right: 1rem;
-  margin-top: 0.5rem;
+  margin-right: 0.65rem;
+  margin-top: 0.315rem;
 }
 
 .overlay-card {
@@ -306,7 +306,7 @@
 
   .card-wrapper:hover .card-information__text {
     text-decoration: underline;
-    text-underline-offset: 0.3rem;
+    text-underline-offset: 0.19rem;
   }
 
   .card-wrapper:hover .card--search img {
@@ -315,7 +315,7 @@
 
   .card-wrapper:hover .card__text {
     text-decoration: underline;
-    text-underline-offset: 0.3rem;
+    text-underline-offset: 0.19rem;
   }
 
   .card-wrapper:hover .card--soft {

--- a/assets/component-cart-items.css
+++ b/assets/component-cart-items.css
@@ -6,7 +6,7 @@
 
 .cart-items th {
   text-align: left;
-  padding-bottom: 1.8rem;
+  padding-bottom: 1.15rem;
   opacity: 0.85;
   font-weight: normal;
 }
@@ -25,7 +25,7 @@
 
 .cart-item__image {
   height: auto;
-  max-width: calc(10rem / var(--font-body-scale));
+  max-width: calc(6.5rem / var(--font-body-scale));
 }
 
 @media screen and (min-width: 750px) {
@@ -35,17 +35,17 @@
 }
 
 .cart-item__details {
-  font-size: 1.6rem;
+  font-size: 1.0rem;
   line-height: calc(1 + 0.4 / var(--font-body-scale));
 }
 
 .cart-item__details > * {
   margin: 0;
-  max-width: 30rem;
+  max-width: 19.0rem;
 }
 
 .cart-item__details > * + * {
-  margin-top: 0.6rem;
+  margin-top: 0.375rem;
 }
 
 .cart-item__media {
@@ -71,8 +71,8 @@
 
 .cart-item__name:hover {
   text-decoration: underline;
-  text-underline-offset: 0.3rem;
-  text-decoration-thickness: 0.2rem;
+  text-underline-offset: 0.19rem;
+  text-decoration-thickness: 0.125rem;
 }
 
 .cart-item__price-wrapper > * {
@@ -86,7 +86,7 @@
 }
 
 .cart-item__discounted-prices .cart-item__old-price {
-  font-size: 1.4rem;
+  font-size: 0.9rem;
 }
 
 .cart-item__old-price {
@@ -98,30 +98,30 @@
 }
 
 .product-option {
-  font-size: 1.4rem;
+  font-size: 0.9rem;
   word-break: break-all;
   line-height: calc(1 + 0.5 / var(--font-body-scale));
 }
 
 .cart-item cart-remove-button {
   display: inline-block;
-  margin-left: 1rem;
+  margin-left: 0.65rem;
 }
 
 @media screen and (min-width: 750px) and (max-width: 989px) {
   .cart-item cart-remove-button {
-    width: 4.5rem;
-    height: 4.5rem;
+    width: 2.8rem;
+    height: 2.8rem;
   }
 }
 
 cart-remove-button .button {
   box-shadow: none;
   color: rgba(var(--color-base-text), 0.75);
-  min-width: calc(4.5rem / var(--font-body-scale));
-  min-height: 4.5rem;
+  min-width: calc(2.8rem / var(--font-body-scale));
+  min-height: 2.8rem;
   padding: 0;
-  margin: 0 0.1rem 0.1rem 0;
+  margin: 0 0.065rem 0.065rem 0;
 }
 
 cart-remove-button .button:not([disabled]):hover {
@@ -135,14 +135,14 @@ cart-remove-button .button:not([disabled]):focus-visible {
 
 @media screen and (min-width: 750px) {
   cart-remove-button .button {
-    min-width: 3.5rem;
-    min-height: 3.5rem;
+    min-width: 2.2rem;
+    min-height: 2.2rem;
   }
 }
 
 cart-remove-button .icon-remove {
-  height: 1.5rem;
-  width: 1.5rem;
+  height: 0.95rem;
+  width: 0.95rem;
 }
 
 .cart-item .loading-overlay {
@@ -156,7 +156,7 @@ cart-remove-button .icon-remove {
 @media screen and (min-width: 750px) {
   .cart-item .loading-overlay {
     right: 0;
-    padding-top: 4.5rem;
+    padding-top: 2.8rem;
     bottom: auto;
   }
 }
@@ -168,18 +168,18 @@ cart-remove-button .icon-remove {
 .cart-item__error {
   display: flex;
   align-items: flex-start;
-  margin-top: 1rem;
+  margin-top: 0.65rem;
 }
 
 .cart-item__error-text {
-  font-size: 1.2rem;
+  font-size: 0.75rem;
   order: 1;
 }
 
 .cart-item__error-text + svg {
   flex-shrink: 0;
-  width: 1.2rem;
-  margin-right: 0.7rem;
+  width: 0.75rem;
+  margin-right: 0.44rem;
 }
 
 .cart-item__error-text:empty + svg {
@@ -191,7 +191,7 @@ cart-remove-button .icon-remove {
 }
 
 .product-option + .product-option {
-  margin-top: 0.4rem;
+  margin-top: 0.25rem;
 }
 
 .product-option * {
@@ -214,15 +214,15 @@ cart-remove-button .icon-remove {
   .cart-items thead tr {
     display: flex;
     justify-content: space-between;
-    border-bottom: 0.1rem solid rgba(var(--color-foreground), 0.2);
-    margin-bottom: 4rem;
+    border-bottom: 0.065rem solid rgba(var(--color-foreground), 0.2);
+    margin-bottom: 2.5rem;
   }
 
   .cart-item {
     display: grid;
     grid-template: repeat(2, auto) / repeat(4, 1fr);
-    gap: 1.5rem;
-    margin-bottom: 3.5rem;
+    gap: 0.95rem;
+    margin-bottom: 2.2rem;
   }
 
   .cart-item:last-child {
@@ -253,7 +253,7 @@ cart-remove-button .icon-remove {
 }
 
 .cart-item__error-text + svg {
-  margin-top: 0.4rem;
+  margin-top: 0.25rem;
 }
 
 @media screen and (min-width: 750px) {
@@ -266,7 +266,7 @@ cart-remove-button .icon-remove {
   }
 
   .cart-items th {
-    border-bottom: 0.1rem solid rgba(var(--color-foreground), 0.08);
+    border-bottom: 0.065rem solid rgba(var(--color-foreground), 0.08);
   }
 
   .cart-items thead th:first-child {
@@ -274,12 +274,12 @@ cart-remove-button .icon-remove {
   }
 
   .cart-items th + th {
-    padding-left: 4rem;
+    padding-left: 2.5rem;
   }
 
   .cart-items td {
     vertical-align: top;
-    padding-top: 4rem;
+    padding-top: 2.5rem;
   }
 
   .cart-item {
@@ -287,34 +287,34 @@ cart-remove-button .icon-remove {
   }
 
   .cart-item > td + td {
-    padding-left: 4rem;
+    padding-left: 2.5rem;
   }
 
   .cart-item__details {
-    width: 35rem;
+    width: 22.0rem;
   }
 
   .cart-item__media {
-    width: 10rem;
+    width: 6.5rem;
   }
 
   .cart-item cart-remove-button {
-    margin: 0.5rem 0 0 1.5rem;
+    margin: 0.315rem 0 0 0.95rem;
   }
 
   .cart-item__price-wrapper > *:only-child:not(.cart-item__discounted-prices) {
-    margin-top: 1rem;
+    margin-top: 0.65rem;
   }
 }
 
 @media screen and (min-width: 990px) {
   .cart-item .cart-item__quantity,
   .cart-items .cart-items__heading--wide {
-    padding-left: 6rem;
+    padding-left: 3.75rem;
   }
 
   .cart-item__details {
-    width: 50rem;
+    width: 31.5rem;
   }
 
   .cart-items thead th:first-child {

--- a/assets/component-cart-notification.css
+++ b/assets/component-cart-notification.css
@@ -10,8 +10,8 @@
   background-color: rgb(var(--color-background));
   border-color: rgba(var(--color-foreground), 0.2);
   border-style: solid;
-  border-width: 0 0 0.1rem;
-  padding: 2.5rem 3.5rem;
+  border-width: 0 0 0.065rem;
+  padding: 1.55rem 2.2rem;
   position: absolute;
   right: 0;
   transform: translateY(-100%);
@@ -22,13 +22,13 @@
 
 @media screen and (min-width: 750px) {
   .header-wrapper:not(.header-wrapper--border-bottom) + cart-notification .cart-notification {
-    border-top-width: 0.1rem;
+    border-top-width: 0.065rem;
   }
 
   .cart-notification {
-    border-width: 0 0.1rem 0.1rem;
-    max-width: 36.8rem;
-    right: 4rem;
+    border-width: 0 0.065rem 0.065rem;
+    max-width: 23.0rem;
+    right: 2.5rem;
   }
 }
 
@@ -58,13 +58,13 @@
 
 .cart-notification__heading .icon-checkmark {
   color: rgb(var(--color-foreground));
-  margin-right: 1rem;
-  width: 1.3rem;
+  margin-right: 0.65rem;
+  width: 0.8rem;
 }
 
 .cart-notification__close {
-  margin-top: -2rem;
-  margin-right: -3rem;
+  margin-top: -1.25rem;
+  margin-right: -1.9rem;
 }
 
 .cart-notification__links {
@@ -72,14 +72,14 @@
 }
 
 .cart-notification__links > * {
-  margin-top: 1rem;
+  margin-top: 0.65rem;
 }
 
 .cart-notification-product {
   align-items: flex-start;
   display: flex;
-  padding-bottom: 3rem;
-  padding-top: 2rem;
+  padding-bottom: 1.9rem;
+  padding-top: 1.25rem;
 }
 
 .cart-notification-product dl {
@@ -88,12 +88,12 @@
 }
 
 .cart-notification-product__image {
-  border: 0.1rem solid rgba(var(--color-foreground), 0.03);
-  margin-right: 1.5rem;
-  margin-top: 0.5rem;
+  border: 0.065rem solid rgba(var(--color-foreground), 0.03);
+  margin-right: 0.95rem;
+  margin-top: 0.315rem;
 }
 
 .cart-notification-product__name {
-  margin-bottom: 0.5rem;
+  margin-bottom: 0.315rem;
   margin-top: 0;
 }

--- a/assets/component-cart.css
+++ b/assets/component-cart.css
@@ -18,23 +18,23 @@ cart-items.is-empty .title-wrapper-with-link,
 .cart__warnings {
   display: none;
   text-align: center;
-  padding: 3rem 0 1rem;
+  padding: 1.9rem 0 0.65rem;
 }
 
 .cart__empty-text {
-  margin: 4.5rem 0 2rem;
+  margin: 2.8rem 0 1.25rem;
 }
 
 .cart__contents > * + * {
-  margin-top: 2.5rem;
+  margin-top: 1.55rem;
 }
 
 .cart__login-title {
-  margin: 5.5rem 0 0.5rem;
+  margin: 3.45rem 0 0.315rem;
 }
 
 .cart__login-paragraph {
-  margin-top: 0.8rem;
+  margin-top: 0.5rem;
 }
 
 .cart__login-paragraph a {
@@ -43,11 +43,11 @@ cart-items.is-empty .title-wrapper-with-link,
 
 @media screen and (min-width: 990px) {
   .cart__warnings {
-    padding: 7rem 0 1rem;
+    padding: 4.4rem 0 0.65rem;
   }
 
   .cart__empty-text {
-    margin: 0 0 3rem;
+    margin: 0 0 1.9rem;
   }
 }
 
@@ -57,8 +57,8 @@ cart-items {
 
 .cart__items {
   position: relative;
-  padding-bottom: 3rem;
-  border-bottom: 0.1rem solid rgba(var(--color-foreground), 0.08);
+  padding-bottom: 1.9rem;
+  border-bottom: 0.065rem solid rgba(var(--color-foreground), 0.08);
 }
 
 .cart__items--disabled {
@@ -66,11 +66,11 @@ cart-items {
 }
 
 .cart__footer {
-  padding: 4rem 0 0;
+  padding: 2.5rem 0 0;
 }
 
 .cart__footer-wrapper:last-child .cart__footer {
-  padding-bottom: 5rem;
+  padding-bottom: 3.15rem;
 }
 
 .cart__footer > div:only-child {
@@ -78,11 +78,11 @@ cart-items {
 }
 
 .cart__footer > * + * {
-  margin-top: 4rem;
+  margin-top: 2.5rem;
 }
 
 .cart__footer .discounts {
-  margin-top: 1rem;
+  margin-top: 0.65rem;
 }
 
 .cart__note {
@@ -93,20 +93,20 @@ cart-items {
   display: flex;
   align-items: flex-end;
   line-height: 1;
-  height: 1.8rem;
-  margin-bottom: 2rem;
+  height: 1.15rem;
+  margin-bottom: 1.25rem;
   color: rgba(var(--color-foreground), 0.75);
 }
 
 .cart__note .field__input {
-  padding: 1rem;
+  padding: 0.65rem;
 }
 
 @media screen and (min-width: 750px) {
   .cart__items {
     grid-column-start: 1;
     grid-column-end: 3;
-    padding-bottom: 4rem;
+    padding-bottom: 2.5rem;
   }
 
   .cart__contents > * + * {
@@ -128,11 +128,11 @@ cart-items {
   }
 
   .cart__footer > * {
-    width: 35rem;
+    width: 22.0rem;
   }
 
   .cart__footer > * + * {
-    margin-left: 4rem;
+    margin-left: 2.5rem;
     margin-top: 0;
   }
 }
@@ -142,20 +142,20 @@ cart-items {
 }
 
 .cart__ctas > *:not(noscript:first-child) + * {
-  margin-top: 1rem;
+  margin-top: 0.65rem;
 }
 
 .cart__update-button {
-  margin-bottom: 1rem;
+  margin-bottom: 0.65rem;
 }
 
 .cart__dynamic-checkout-buttons {
-  max-width: 36rem;
+  max-width: 22.5rem;
   margin: 0 auto;
 }
 
 .cart__blocks > * + * {
-  margin-top: 1rem;
+  margin-top: 0.65rem;
 }
 
 .cart__dynamic-checkout-buttons div[role='button'] {
@@ -164,18 +164,18 @@ cart-items {
 
 .cart-note__label {
   display: inline-block;
-  margin-bottom: 1rem;
+  margin-bottom: 0.65rem;
   line-height: calc(1 + 1 / var(--font-body-scale));
 }
 
 .tax-note {
-  margin: 2.2rem 0 1.6rem auto;
+  margin: 1.4rem 0 1.0rem auto;
   text-align: center;
   display: block;
 }
 
 .cart__checkout-button {
-  max-width: 36rem;
+  max-width: 22.5rem;
 }
 
 .cart__ctas {
@@ -184,16 +184,16 @@ cart-items {
 
 @media screen and (min-width: 750px) {
   .cart-note {
-    max-width: 35rem;
+    max-width: 22.0rem;
   }
 
   .cart__update-button {
     margin-bottom: 0;
-    margin-right: 0.8rem;
+    margin-right: 0.5rem;
   }
 
   .tax-note {
-    margin-bottom: 2.2rem;
+    margin-bottom: 1.4rem;
     text-align: right;
   }
 
@@ -203,6 +203,6 @@ cart-items {
 
   .cart__ctas {
     display: flex;
-    gap: 1rem;
+    gap: 0.65rem;
   }
 }

--- a/assets/component-collection-hero.css
+++ b/assets/component-collection-hero.css
@@ -5,18 +5,18 @@
 .collection-hero__inner {
   display: flex;
   flex-direction: column;
-  margin-bottom: 2rem;
+  margin-bottom: 1.25rem;
 }
 
 .collection-hero--with-image .collection-hero__inner {
   margin-bottom: 0;
-  padding-bottom: 2rem;
+  padding-bottom: 1.25rem;
 }
 
 @media screen and (min-width: 750px) {
   .collection-hero.collection-hero--with-image {
-    padding: calc(4rem + var(--page-width-margin)) 0
-      calc(4rem + var(--page-width-margin));
+    padding: calc(2.5rem + var(--page-width-margin)) 0
+      calc(2.5rem + var(--page-width-margin));
   }
 
   .collection-hero--with-image .collection-hero__inner {
@@ -41,19 +41,19 @@
 }
 
 .collection-hero__title {
-  margin: 5rem 0 0;
+  margin: 3.15rem 0 0;
 }
 
 .collection-hero__title + .collection-hero__description {
-  margin-top: 1.5rem;
-  font-size: 1.6rem;
+  margin-top: 0.95rem;
+  font-size: 1.0rem;
   line-height: calc(1 + 0.5 / var(--font-body-scale));
 }
 
 @media screen and (min-width: 750px) {
   .collection-hero__title + .collection-hero__description {
-    font-size: 1.8rem;
-    margin-top: 2rem;
+    font-size: 1.15rem;
+    margin-top: 1.25rem;
   }
 
   .collection-hero__description {
@@ -70,25 +70,25 @@
 }
 
 .collection-hero--with-image .collection-hero__text-wrapper {
-  padding: 5rem 0 4rem;
+  padding: 3.15rem 0 2.5rem;
 }
 
 @media screen and (max-width: 749px) {
   .collection-hero__image-container {
-    height: 20rem;
+    height: 12.5rem;
   }
 }
 
 @media screen and (min-width: 750px) {
   .collection-hero--with-image .collection-hero__text-wrapper {
-    padding: 4rem 2rem 4rem 0;
+    padding: 2.5rem 1.25rem 2.5rem 0;
     flex-basis: 50%;
   }
 
   .collection-hero__image-container {
     align-self: stretch;
     flex: 1 0 50%;
-    margin-left: 3rem;
-    min-height: 20rem;
+    margin-left: 1.9rem;
+    min-height: 12.5rem;
   }
 }

--- a/assets/component-deferred-media.css
+++ b/assets/component-deferred-media.css
@@ -32,19 +32,19 @@
 }
 
 .deferred-media__poster:focus {
-  outline-offset: -0.3rem;
+  outline-offset: -0.19rem;
 }
 
 .deferred-media__poster-button {
   background-color: rgb(var(--color-background));
-  border: 0.1rem solid rgba(var(--color-foreground), 0.1);
+  border: 0.065rem solid rgba(var(--color-foreground), 0.1);
   border-radius: 50%;
   color: rgb(var(--color-foreground));
   display: flex;
   align-items: center;
   justify-content: center;
-  height: 6.2rem;
-  width: 6.2rem;
+  height: 3.9rem;
+  width: 3.9rem;
   position: absolute;
   left: 50%;
   top: 50%;
@@ -58,11 +58,11 @@
 }
 
 .deferred-media__poster-button .icon {
-  width: 2rem;
-  height: 2rem;
+  width: 1.25rem;
+  height: 1.25rem;
 }
 
 .deferred-media__poster-button .icon-play {
-  margin-left: 0.2rem;
+  margin-left: 0.125rem;
 }
 

--- a/assets/component-discounts.css
+++ b/assets/component-discounts.css
@@ -1,5 +1,5 @@
 .discounts {
-  font-size: 1.2rem;
+  font-size: 0.75rem;
 }
 
 .discounts__discount {
@@ -18,7 +18,7 @@
 
 .discounts__discount > .icon {
   color: rgb(var(--color-foreground));
-  width: 1.2rem;
-  height: 1.2rem;
-  margin-right: 0.7rem;
+  width: 0.75rem;
+  height: 0.75rem;
+  margin-right: 0.44rem;
 }

--- a/assets/component-facets.css
+++ b/assets/component-facets.css
@@ -5,7 +5,7 @@
 }
 
 .active-facets-mobile {
-  margin-bottom: 0.5rem;
+  margin-bottom: 0.315rem;
 }
 
 @media screen and (min-width: 750px) {
@@ -22,7 +22,7 @@
 @media screen and (max-width: 989px) {
   .facets-container {
     grid-template-columns: auto minmax(0, max-content);
-    column-gap: 2rem;
+    column-gap: 1.25rem;
   }
 }
 
@@ -31,33 +31,33 @@
   display: flex;
   grid-column: 2;
   grid-row: 1;
-  padding-left: 2.5rem;
+  padding-left: 1.55rem;
 }
 
 @media screen and (min-width: 990px) {
   .facet-filters {
-    padding-left: 3rem;
+    padding-left: 1.9rem;
   }
 }
 
 .facet-filters__label {
   display: block;
   color: var(--color-foreground-85);
-  font-size: 1.4rem;
-  margin: 0 2rem 0 0;
+  font-size: 0.9rem;
+  margin: 0 1.25rem 0 0;
 }
 
 .facet-filters__summary {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  font-size: 1.4rem;
+  font-size: 0.9rem;
   cursor: pointer;
-  height: 4.5rem;
-  padding: 0 1.5rem;
-  min-width: 25rem;
-  margin-top: 2.4rem;
-  border: 0.1rem solid rgba(var(--color-foreground), 0.55);
+  height: 2.8rem;
+  padding: 0 0.95rem;
+  min-width: 15.5rem;
+  margin-top: 1.5rem;
+  border: 0.065rem solid rgba(var(--color-foreground), 0.55);
 }
 
 .facet-filters__summary::after {
@@ -76,17 +76,17 @@
 }
 
 .facet-filters button {
-  margin-left: 2.5rem;
+  margin-left: 1.55rem;
 }
 
 .facet-filters__sort {
   border: 0;
-  font-size: 1.4rem;
+  font-size: 0.9rem;
   height: auto;
   line-height: calc(1 + 0.5 / var(--font-body-scale));
   margin: 0;
   padding-left: 0;
-  padding-right: 1.75rem;
+  padding-right: 1.1rem;
 }
 
 @media screen and (forced-colors: active) {
@@ -101,33 +101,33 @@
 }
 
 .mobile-facets__sort .select__select:focus-visible {
-  outline: 0.2rem solid rgba(var(--color-foreground), 0.5);
-  outline-offset: 0.3rem;
-  box-shadow: 0 0 0 0.3rem rgb(var(--color-background)),
-    0 0 0.5rem 0.4rem rgba(var(--color-foreground), 0.3);
+  outline: 0.125rem solid rgba(var(--color-foreground), 0.5);
+  outline-offset: 0.19rem;
+  box-shadow: 0 0 0 0.19rem rgb(var(--color-background)),
+    0 0 0.315rem 0.25rem rgba(var(--color-foreground), 0.3);
 }
 
 .mobile-facets__sort .select__select.focused,
 .no-js .mobile-facets__sort .select__select:focus {
-  outline: 0.2rem solid rgba(var(--color-foreground), 0.5);
-  outline-offset: 0.3rem;
-  box-shadow: 0 0 0 0.3rem rgb(var(--color-background)),
-    0 0 0.5rem 0.4rem rgba(var(--color-foreground), 0.3);
+  outline: 0.125rem solid rgba(var(--color-foreground), 0.5);
+  outline-offset: 0.19rem;
+  box-shadow: 0 0 0 0.19rem rgb(var(--color-background)),
+    0 0 0.315rem 0.25rem rgba(var(--color-foreground), 0.3);
 }
 
 .facet-filters__sort:focus-visible {
-  outline: 0.2rem solid rgba(var(--color-foreground), 0.5);
-  outline-offset: 1rem;
-  box-shadow: 0 0 0 1rem rgb(var(--color-background)),
-    0 0 0.2rem 1.2rem rgba(var(--color-foreground), 0.3);
+  outline: 0.125rem solid rgba(var(--color-foreground), 0.5);
+  outline-offset: 0.65rem;
+  box-shadow: 0 0 0 0.65rem rgb(var(--color-background)),
+    0 0 0.125rem 0.75rem rgba(var(--color-foreground), 0.3);
 }
 
 .facet-filters__sort.focused,
 .no-js .facet-filters__sort:focus {
-  outline: 0.2rem solid rgba(var(--color-foreground), 0.5);
-  outline-offset: 1rem;
-  box-shadow: 0 0 0 1rem rgb(var(--color-background)),
-    0 0 0.2rem 1.2rem rgba(var(--color-foreground), 0.3);
+  outline: 0.125rem solid rgba(var(--color-foreground), 0.5);
+  outline-offset: 0.65rem;
+  box-shadow: 0 0 0 0.65rem rgb(var(--color-background)),
+    0 0 0.125rem 0.75rem rgba(var(--color-foreground), 0.3);
 }
 
 .no-js .facet-filters__sort:focus:not(:focus-visible),
@@ -147,9 +147,9 @@
 
 .facets__form {
   display: grid;
-  gap: 0 3.5rem;
+  gap: 0 2.2rem;
   grid-template-columns: 1fr max-content max-content;
-  margin-bottom: 0.5rem;
+  margin-bottom: 0.315rem;
 }
 
 .facets__wrapper {
@@ -164,8 +164,8 @@
 .facets__heading {
   display: block;
   color: rgba(var(--color-foreground), 0.85);
-  font-size: 1.4rem;
-  margin: -1.5rem 2rem 0 0;
+  font-size: 0.9rem;
+  margin: -0.95rem 1.25rem 0 0;
 }
 
 .facets__reset {
@@ -173,14 +173,14 @@
 }
 
 .facets__disclosure {
-  margin-right: 3.5rem;
+  margin-right: 2.2rem;
 }
 
 .facets__summary {
   color: rgba(var(--color-foreground), 0.75);
-  font-size: 1.4rem;
-  margin-bottom: 1.5rem;
-  padding: 0 1.75rem 0 0;
+  font-size: 0.9rem;
+  margin-bottom: 0.95rem;
+  padding: 0 1.1rem 0 0;
 }
 
 .facets__disclosure[open] .facets__summary,
@@ -198,7 +198,7 @@
 
 .facets__summary:hover span {
   text-decoration: underline;
-  text-underline-offset: 0.3rem;
+  text-underline-offset: 0.19rem;
 }
 
 .disclosure-has-popup[open] > .facets__summary::before {
@@ -217,19 +217,19 @@
   background-color: rgb(var(--color-background));
   position: absolute;
   border: 1px solid rgba(var(--color-foreground), 0.2);
-  top: calc(100% + 0.5rem);
-  left: -1.2rem;
-  width: 35rem;
-  max-height: 55rem;
+  top: calc(100% + 0.315rem);
+  left: -0.75rem;
+  width: 22.0rem;
+  max-height: 34.5rem;
   overflow-y: auto;
 }
 
 .facets__header {
   border-bottom: 1px solid rgba(var(--color-foreground), 0.2);
-  padding: 1.5rem 2rem;
+  padding: 0.95rem 1.25rem;
   display: flex;
   justify-content: space-between;
-  font-size: 1.4rem;
+  font-size: 0.9rem;
   position: sticky;
   top: 0;
   background-color: rgb(var(--color-background));
@@ -237,7 +237,7 @@
 }
 
 .facets__list {
-  padding: 0.5rem 2rem;
+  padding: 0.315rem 1.25rem;
 }
 
 .facets__item {
@@ -251,10 +251,10 @@
 }
 
 .facet-checkbox {
-  padding: 1rem 2rem 1rem 0;
+  padding: 0.65rem 1.25rem 0.65rem 0;
   flex-grow: 1;
   position: relative;
-  font-size: 1.4rem;
+  font-size: 0.9rem;
   display: flex;
   word-break: break-word;
 }
@@ -262,10 +262,10 @@
 .facet-checkbox input[type='checkbox'] {
   position: absolute;
   opacity: 1;
-  width: 1.6rem;
-  height: 1.6rem;
-  top: 0.7rem;
-  left: -0.4rem;
+  width: 1.0rem;
+  height: 1.0rem;
+  top: 0.44rem;
+  left: -0.25rem;
   z-index: -1;
   appearance: none;
   -webkit-appearance: none;
@@ -273,16 +273,16 @@
 
 .facet-checkbox > svg {
   background-color: rgb(var(--color-background));
-  margin-right: 1.2rem;
+  margin-right: 0.75rem;
   flex-shrink: 0;
 }
 
 .facet-checkbox .icon-checkmark {
   visibility: hidden;
   position: absolute;
-  left: 0.3rem;
+  left: 0.19rem;
   z-index: 5;
-  top: 1.4rem;
+  top: 0.9rem;
 }
 
 .facet-checkbox > input[type='checkbox']:checked ~ .icon-checkmark {
@@ -292,7 +292,7 @@
 @media screen and (forced-colors: active) {
   .facet-checkbox > svg {
     background-color: inherit;
-    border: 0.1rem solid rgb(var(--color-background));
+    border: 0.065rem solid rgb(var(--color-background));
   }
 
   .facet-checkbox > input[type='checkbox']:checked ~ .icon-checkmark {
@@ -306,11 +306,11 @@
 
 .facets__price {
   display: flex;
-  padding: 2rem;
+  padding: 1.25rem;
 }
 
 .facets__price .field + .field-currency {
-  margin-left: 2rem;
+  margin-left: 1.25rem;
 }
 
 .facets__price .field {
@@ -319,24 +319,24 @@
 
 .facets__price .field-currency {
   align-self: center;
-  margin-right: 0.6rem;
+  margin-right: 0.375rem;
 }
 
 .facets__price .field__label {
-  left: 1.5rem;
+  left: 0.95rem;
 }
 
 button.facets__button {
   min-height: 0;
-  margin: 0 0 0 0.5rem;
+  margin: 0 0 0 0.315rem;
   box-shadow: none;
-  padding-top: 1.4rem;
-  padding-bottom: 1.4rem;
+  padding-top: 0.9rem;
+  padding-bottom: 0.9rem;
 }
 
 .facets__button-no-js {
   min-width: auto;
-  transform: translateY(-0.6rem);
+  transform: translateY(-0.375rem);
 }
 
 .active-facets {
@@ -345,26 +345,26 @@ button.facets__button {
   width: 100%;
   grid-column: 1 / -1;
   grid-row: 2;
-  margin-top: -0.5rem;
+  margin-top: -0.315rem;
 }
 
 .active-facets__button {
   display: block;
-  margin-right: 1.5rem;
-  margin-top: 1.5rem;
-  padding-left: 0.2rem;
-  padding-right: 0.2rem;
+  margin-right: 0.95rem;
+  margin-top: 0.95rem;
+  padding-left: 0.125rem;
+  padding-right: 0.125rem;
   text-decoration: none;
 }
 
 span.active-facets__button-inner {
   color: rgb(var(--color-foreground));
-  box-shadow: 0 0 0 0.1rem rgb(var(--color-foreground));
-  border-radius: 2.6rem;
-  font-size: 1rem;
+  box-shadow: 0 0 0 0.065rem rgb(var(--color-foreground));
+  border-radius: 1.65rem;
+  font-size: 0.65rem;
   min-height: 0;
   min-width: 0;
-  padding: 0.5rem 1rem;
+  padding: 0.315rem 0.65rem;
   display: flex;
   align-items: stretch;
 }
@@ -373,38 +373,38 @@ span.active-facets__button-inner {
   align-items: center;
   display: flex;
   justify-content: center;
-  padding-top: 1.5rem;
+  padding-top: 0.95rem;
 }
 
 .active-facets__button-wrapper * {
-  font-size: 1rem;
+  font-size: 0.65rem;
 }
 
 @media screen and (min-width: 990px) {
   .active-facets__button {
-    margin-right: 1.5rem;
+    margin-right: 0.95rem;
   }
 
   .active-facets__button-wrapper *,
   span.active-facets__button-inner {
-    font-size: 1.2rem;
+    font-size: 0.75rem;
   }
 }
 
 @media screen and (max-width: 989px) {
   .active-facets {
-    margin: 0 -1.2rem -1.2rem;
+    margin: 0 -0.75rem -0.75rem;
   }
 
   .active-facets__button,
   .active-facets__button-remove {
     margin: 0;
-    padding: 1.2rem;
+    padding: 0.75rem;
   }
 
   span.active-facets__button-inner {
-    padding-bottom: 0.3rem;
-    padding-top: 0.3rem;
+    padding-bottom: 0.19rem;
+    padding-top: 0.19rem;
   }
 
   .active-facets__button-wrapper {
@@ -413,15 +413,15 @@ span.active-facets__button-inner {
 }
 
 .active-facets__button:hover .active-facets__button-inner {
-  box-shadow: 0 0 0 0.2rem rgb(var(--color-foreground));
+  box-shadow: 0 0 0 0.125rem rgb(var(--color-foreground));
 }
 
 .active-facets__button--light .active-facets__button-inner {
-  box-shadow: 0 0 0 0.1rem rgba(var(--color-foreground), 0.2);
+  box-shadow: 0 0 0 0.065rem rgba(var(--color-foreground), 0.2);
 }
 
 .active-facets__button--light:hover .active-facets__button-inner {
-  box-shadow: 0 0 0 0.2rem rgba(var(--color-foreground), 0.4);
+  box-shadow: 0 0 0 0.125rem rgba(var(--color-foreground), 0.4);
 }
 
 a.active-facets__button:focus-visible {
@@ -436,34 +436,34 @@ a.active-facets__button.focused,
 }
 
 a.active-facets__button:focus-visible .active-facets__button-inner {
-  box-shadow: 0 0 0 0.1rem rgba(var(--color-foreground), 0.2),
-    0 0 0 0.2rem rgb(var(--color-background)),
-    0 0 0 0.4rem rgb(var(--color-foreground));
+  box-shadow: 0 0 0 0.065rem rgba(var(--color-foreground), 0.2),
+    0 0 0 0.125rem rgb(var(--color-background)),
+    0 0 0 0.25rem rgb(var(--color-foreground));
   outline: none;
 }
 
 a.active-facets__button.focused .active-facets__button-inner,
 .no-js a.active-facets__button:focus .active-facets__button-inner {
-  box-shadow: 0 0 0 0.1rem rgba(var(--color-foreground), 0.2),
-    0 0 0 0.2rem rgb(var(--color-background)),
-    0 0 0 0.4rem rgb(var(--color-foreground));
+  box-shadow: 0 0 0 0.065rem rgba(var(--color-foreground), 0.2),
+    0 0 0 0.125rem rgb(var(--color-background)),
+    0 0 0 0.25rem rgb(var(--color-foreground));
   outline: none;
 }
 
 .active-facets__button svg {
   align-self: center;
   flex-shrink: 0;
-  margin-left: 0.6rem;
-  margin-right: -0.2rem;
+  margin-left: 0.375rem;
+  margin-right: -0.125rem;
   pointer-events: none;
-  width: 1.2rem;
+  width: 0.75rem;
 }
 
 @media all and (min-width: 990px) {
   .active-facets__button svg {
-    margin-right: -0.4rem;
-    margin-top: 0.1rem;
-    width: 1.4rem;
+    margin-right: -0.25rem;
+    margin-top: 0.065rem;
+    width: 0.9rem;
   }
 }
 
@@ -509,13 +509,13 @@ a.active-facets__button.focused .active-facets__button-inner,
 
 .mobile-facets__inner {
   background-color: rgb(var(--color-background));
-  width: calc(100% - 5rem);
+  width: calc(100% - 3.15rem);
   margin-left: auto;
   height: 100%;
   overflow-y: auto;
   pointer-events: all;
   transition: transform var(--duration-short) ease;
-  max-width: 37.5rem;
+  max-width: 23.5rem;
   display: flex;
   flex-direction: column;
 }
@@ -530,8 +530,8 @@ a.active-facets__button.focused .active-facets__button-inner,
 
 .mobile-facets__header {
   background-color: rgb(var(--color-background));
-  border-bottom: 0.1rem solid rgba(var(--color-foreground), 0.08);
-  padding: 1rem 2.5rem;
+  border-bottom: 0.065rem solid rgba(var(--color-foreground), 0.08);
+  padding: 0.65rem 1.55rem;
   text-align: center;
   display: flex;
   position: sticky;
@@ -545,17 +545,17 @@ a.active-facets__button.focused .active-facets__button-inner,
 }
 
 .mobile-facets__info {
-  padding: 0 2.6rem;
+  padding: 0 1.65rem;
 }
 
 .mobile-facets__heading {
-  font-size: calc(var(--font-heading-scale) * 1.4rem);
+  font-size: calc(var(--font-heading-scale) * 0.9rem);
   margin: 0;
 }
 
 .mobile-facets__count {
   color: rgba(var(--color-foreground), 0.7);
-  font-size: 1.3rem;
+  font-size: 0.8rem;
   margin: 0;
   flex-grow: 1;
 }
@@ -567,8 +567,8 @@ a.active-facets__button.focused .active-facets__button-inner,
 .mobile-facets__open {
   text-align: left;
   width: 100%;
-  padding-top: 0.5rem;
-  padding-bottom: 0.5rem;
+  padding-top: 0.315rem;
+  padding-bottom: 0.315rem;
   display: flex;
   align-items: center;
   color: rgba(var(--color-link), var(--alpha-link));
@@ -589,15 +589,15 @@ a.active-facets__button.focused .active-facets__button-inner,
 
 .mobile-facets__open:hover .mobile-facets__open-label {
   text-decoration: underline;
-  text-underline-offset: 0.3rem;
+  text-underline-offset: 0.19rem;
 }
 
 .mobile-facets__open > * + * {
-  margin-left: 1rem;
+  margin-left: 0.65rem;
 }
 
 .mobile-facets__open svg {
-  width: 2rem;
+  width: 1.25rem;
 }
 
 .mobile-facets__open line,
@@ -610,17 +610,17 @@ a.active-facets__button.focused .active-facets__button-inner,
   align-items: center;
   justify-content: center;
   position: fixed;
-  top: 0.7rem;
-  right: 1rem;
-  width: 4.4rem;
-  height: 4.4rem;
+  top: 0.44rem;
+  right: 0.65rem;
+  width: 2.75rem;
+  height: 2.75rem;
   z-index: 101;
   opacity: 0;
   transition: opacity var(--duration-short) ease;
 }
 
 .mobile-facets__close svg {
-  width: 2.2rem;
+  width: 1.4rem;
 }
 
 details.menu-opening .mobile-facets__close {
@@ -636,13 +636,13 @@ details.menu-opening .mobile-facets__close svg {
   align-items: center;
   background-color: transparent;
   display: flex;
-  font-size: 1.4rem;
+  font-size: 0.9rem;
   font: inherit;
   letter-spacing: inherit;
-  margin-top: 1.5rem;
-  padding: 1.2rem 2.6rem;
+  margin-top: 0.95rem;
+  padding: 0.75rem 1.65rem;
   text-decoration: none;
-  width: calc(100% - 5.2rem);
+  width: calc(100% - 3.25rem);
 }
 
 .no-js .mobile-facets__close-button {
@@ -651,11 +651,11 @@ details.menu-opening .mobile-facets__close svg {
 
 .mobile-facets__close-button .icon-arrow {
   transform: rotate(180deg);
-  margin-right: 1rem;
+  margin-right: 0.65rem;
 }
 
 .mobile-facets__main {
-  padding: 2.7rem 0 0;
+  padding: 1.7rem 0 0;
   position: relative;
   z-index: 1;
   flex-grow: 1;
@@ -689,7 +689,7 @@ details.menu-opening .mobile-facets__close svg {
 }
 
 .mobile-facets__summary {
-  padding: 1.3rem 2.5rem;
+  padding: 0.8rem 1.55rem;
 }
 
 .mobile-facets__summary svg {
@@ -737,18 +737,18 @@ details.menu-opening .mobile-facets__close svg {
 input.mobile-facets__checkbox {
   border: 0;
   position: absolute;
-  width: 1.6rem;
-  height: 1.6rem;
+  width: 1.0rem;
+  height: 1.0rem;
   position: absolute;
-  left: 2.1rem;
-  top: 1.2rem;
+  left: 1.3rem;
+  top: 0.75rem;
   z-index: 0;
   appearance: none;
   -webkit-appearance: none;
 }
 
 .mobile-facets__label {
-  padding: 1.5rem 2rem 1.5rem 2.5rem;
+  padding: 0.95rem 1.25rem 0.95rem 1.55rem;
   width: 100%;
   background-color: rgb(var(--color-background));
   transition: background-color 0.2s ease;
@@ -760,14 +760,14 @@ input.mobile-facets__checkbox {
   background-color: rgb(var(--color-background));
   position: relative;
   z-index: 2;
-  margin-right: 1.2rem;
+  margin-right: 0.75rem;
   flex-shrink: 0;
 }
 
 .mobile-facets__label .icon-checkmark {
   position: absolute;
-  top: 1.9rem;
-  left: 2.8rem;
+  top: 1.2rem;
+  left: 1.75rem;
   visibility: hidden;
 }
 
@@ -787,8 +787,8 @@ input.mobile-facets__checkbox {
 
 .mobile-facets__footer {
   background-color: rgb(var(--color-background));
-  border-top: 0.1rem solid rgba(var(--color-foreground), 0.08);
-  padding: 2rem;
+  border-top: 0.065rem solid rgba(var(--color-foreground), 0.08);
+  padding: 1.25rem;
   bottom: 0;
   position: sticky;
   display: flex;
@@ -797,7 +797,7 @@ input.mobile-facets__checkbox {
 }
 
 .mobile-facets__footer > * + * {
-  margin-left: 1rem;
+  margin-left: 0.65rem;
 }
 
 .mobile-facets__footer > * {
@@ -823,7 +823,7 @@ input.mobile-facets__checkbox {
 
 .no-js .mobile-facets__sort .select {
   position: relative;
-  right: -1rem;
+  right: -0.65rem;
 }
 
 .mobile-facets__sort .select .icon-caret {
@@ -832,10 +832,10 @@ input.mobile-facets__checkbox {
 
 .mobile-facets__sort .select__select {
   box-shadow: none;
-  margin-left: 0.5rem;
-  margin-right: 0.5rem;
-  padding-left: 0.5rem;
-  padding-right: 1.5rem;
+  margin-left: 0.315rem;
+  margin-right: 0.315rem;
+  padding-left: 0.315rem;
+  padding-right: 0.95rem;
 }
 
 .product-count {
@@ -845,7 +845,7 @@ input.mobile-facets__checkbox {
 }
 
 .product-count__text {
-  font-size: 1.4rem;
+  font-size: 0.9rem;
   line-height: calc(1 + 0.5 / var(--font-body-scale));
   margin: 0;
 }
@@ -860,7 +860,7 @@ input.mobile-facets__checkbox {
   right: 0;
   top: 50%;
   transform: translateY(-50%);
-  width: 1.8rem;
+  width: 1.15rem;
 }
 
 .product-count__text.loading + .loading-overlay__spinner {

--- a/assets/component-image-with-text.css
+++ b/assets/component-image-with-text.css
@@ -1,14 +1,14 @@
 .image-with-text {
-  margin-top: 5rem;
+  margin-top: 3.15rem;
 }
 
 .image-with-text:not(.color-scheme-background-1) {
-  margin-bottom: 5rem;
+  margin-bottom: 3.15rem;
 }
 
 @media screen and (min-width: 750px) {
   .image-with-text {
-    margin-bottom: calc(5rem + var(--page-width-margin));
+    margin-bottom: calc(3.15rem + var(--page-width-margin));
   }
 }
 
@@ -33,20 +33,20 @@
 }
 
 .image-with-text__media--small {
-  height: 19.4rem;
+  height: 12.0rem;
 }
 
 .image-with-text__media--large {
-  height: 43.5rem;
+  height: 27.0rem;
 }
 
 @media screen and (min-width: 750px) {
   .image-with-text__media--small {
-    height: 31.4rem;
+    height: 19.5rem;
   }
 
   .image-with-text__media--large {
-    height: 69.5rem;
+    height: 43.5rem;
   }
 }
 
@@ -57,19 +57,19 @@
 }
 
 .image-with-text__media--placeholder.image-with-text__media--adapt {
-  height: 20rem;
+  height: 12.5rem;
 }
 
 @media screen and (min-width: 750px) {
   .image-with-text__media--placeholder.image-with-text__media--adapt {
-    height: 30rem;
+    height: 19.0rem;
   }
 }
 
 .image-with-text__media--placeholder > svg {
   position: absolute;
   left: 50%;
-  max-width: 80rem;
+  max-width: 50.0rem;
   top: 50%;
   transform: translate(-50%, -50%);
   width: 100%;
@@ -82,7 +82,7 @@
   align-items: flex-start;
   height: 100%;
   justify-content: center;
-  padding: 4rem calc(4rem / var(--font-body-scale)) 5rem;
+  padding: 2.5rem calc(2.5rem / var(--font-body-scale)) 3.15rem;
 }
 
 @media screen and (min-width: 750px) {
@@ -93,16 +93,16 @@
 
 @media screen and (min-width: 990px) {
   .image-with-text__content {
-    padding: 6rem 7rem 7rem;
+    padding: 3.75rem 4.4rem 4.4rem;
   }
 }
 
 .image-with-text__content > * + * {
-  margin-top: 2rem;
+  margin-top: 1.25rem;
 }
 
 .image-with-text__content > .image-with-text__text:empty ~ a {
-  margin-top: 2rem;
+  margin-top: 1.25rem;
 }
 
 .image-with-text__content > :first-child:is(.image-with-text__heading) {
@@ -114,11 +114,11 @@
 }
 
 .image-with-text__content .button + .image-with-text__text {
-  margin-top: 2rem;
+  margin-top: 1.25rem;
 }
 
 .image-with-text__content .image-with-text__text + .button {
-  margin-top: 3rem;
+  margin-top: 1.9rem;
 }
 
 .image-with-text__heading {
@@ -127,5 +127,5 @@
 
 .image-with-text__text p {
   margin-top: 0;
-  margin-bottom: 1rem;
+  margin-bottom: 0.65rem;
 }

--- a/assets/component-list-menu.css
+++ b/assets/component-list-menu.css
@@ -5,7 +5,7 @@
 .list-menu--disclosure {
   position: absolute;
   min-width: 100%;
-  width: 20rem;
+  width: 12.5rem;
   border: 1px solid rgba(var(--color-foreground), 0.2);
   background-color: rgb(var(--color-background));
 }
@@ -16,12 +16,12 @@
 
 .list-menu__item--active {
   text-decoration: underline;
-  text-underline-offset: 0.3rem;
+  text-underline-offset: 0.19rem;
 }
 
 .list-menu--disclosure.localization-selector {
-  max-height: 18rem;
+  max-height: 11.5rem;
   overflow: auto;
-  width: 10rem;
-  padding: 0.5rem;
+  width: 6.5rem;
+  padding: 0.315rem;
 }

--- a/assets/component-list-payment.css
+++ b/assets/component-list-payment.css
@@ -2,15 +2,15 @@
   display: flex;
   flex-wrap: wrap;
   justify-content: center;
-  margin: -0.5rem 0;
-  padding-top: 1rem;
+  margin: -0.315rem 0;
+  padding-top: 0.65rem;
   padding-left: 0;
 }
 
 @media screen and (min-width: 750px) {
   .list-payment {
     justify-content: flex-end;
-    margin: -0.5rem;
+    margin: -0.315rem;
     padding-top: 0;
   }
 }
@@ -18,5 +18,5 @@
 .list-payment__item {
   align-items: center;
   display: flex;
-  padding: 0.5rem;
+  padding: 0.315rem;
 }

--- a/assets/component-list-social.css
+++ b/assets/component-list-social.css
@@ -11,14 +11,14 @@
 }
 
 .list-social__item .icon {
-  height: 1.8rem;
-  width: 1.8rem;
+  height: 1.15rem;
+  width: 1.15rem;
 }
 
 .list-social__link {
   align-items: center;
   display: flex;
-  padding: 1.3rem;
+  padding: 0.8rem;
   color: rgb(var(--color-foreground));
 }
 

--- a/assets/component-loading-overlay.css
+++ b/assets/component-loading-overlay.css
@@ -1,7 +1,7 @@
 .loading-overlay {
   position: absolute;
   z-index: 1;
-  width: 1.8rem;
+  width: 1.15rem;
 }
 
 @media screen and (max-width: 749px) {
@@ -18,7 +18,7 @@
 }
 
 .loading-overlay__spinner {
-  width: 1.8rem;
+  width: 1.15rem;
   display: inline-block;
 }
 

--- a/assets/component-menu-drawer.css
+++ b/assets/component-menu-drawer.css
@@ -35,9 +35,9 @@ menu-drawer > details[open] > summary::before {
   z-index: 3;
   left: 0;
   top: 100%;
-  width: calc(100vw - 4rem);
+  width: calc(100vw - 2.5rem);
   padding: 0;
-  border: 0.1rem solid rgba(var(--color-foreground), 0.2);
+  border: 0.065rem solid rgba(var(--color-foreground), 0.2);
   border-left: 0;
   background-color: rgb(var(--color-background));
   overflow-x: hidden;
@@ -65,7 +65,7 @@ details[open].menu-opening > .menu-drawer__submenu {
 
 @media screen and (min-width: 750px) {
   .menu-drawer {
-    width: 40rem;
+    width: 25.0rem;
   }
 
   .no-js .menu-drawer {
@@ -87,7 +87,7 @@ details[open].menu-opening > .menu-drawer__submenu {
 }
 
 .menu-drawer__navigation {
-  padding: 5.6rem 0;
+  padding: 3.5rem 0;
 }
 
 .menu-drawer__inner-submenu {
@@ -101,41 +101,41 @@ details[open].menu-opening > .menu-drawer__submenu {
 }
 
 .no-js .menu-drawer__navigation > ul > li {
-  border-bottom: 0.1rem solid rgba(var(--color-foreground), 0.04);
+  border-bottom: 0.065rem solid rgba(var(--color-foreground), 0.04);
 }
 
 .no-js .menu-drawer__submenu ul > li {
-  border-top: 0.1rem solid rgba(var(--color-foreground), 0.04);
+  border-top: 0.065rem solid rgba(var(--color-foreground), 0.04);
 }
 
 .js .menu-drawer__menu li {
-  margin-bottom: 0.2rem;
+  margin-bottom: 0.125rem;
 }
 
 .menu-drawer__menu-item {
-  padding: 1.1rem 3.2rem;
+  padding: 0.7rem 2.0rem;
   text-decoration: none;
-  font-size: 1.8rem;
+  font-size: 1.15rem;
 }
 
 .no-js .menu-drawer__menu-item {
-  font-size: 1.6rem;
+  font-size: 1.0rem;
 }
 
 .no-js .menu-drawer__submenu .menu-drawer__menu-item {
-  padding: 1.2rem 5.2rem 1.2rem 6rem;
+  padding: 0.75rem 3.25rem 0.75rem 3.75rem;
 }
 
 .no-js .menu-drawer__submenu .menu-drawer__submenu .menu-drawer__menu-item {
-  padding-left: 9rem;
+  padding-left: 5.5rem;
 }
 
 .menu-drawer summary.menu-drawer__menu-item {
-  padding-right: 5.2rem;
+  padding-right: 3.25rem;
 }
 
 .no-js .menu-drawer__menu-item .icon-caret {
-  right: 3rem;
+  right: 1.9rem;
 }
 
 .menu-drawer__menu-item--active,
@@ -158,7 +158,7 @@ details[open].menu-opening > .menu-drawer__submenu {
 
 .menu-drawer__menu-item > .icon-arrow {
   position: absolute;
-  right: 2.5rem;
+  right: 1.55rem;
   top: 50%;
   transform: translateY(-50%);
 }
@@ -170,7 +170,7 @@ details[open].menu-opening > .menu-drawer__submenu {
   bottom: 0;
   left: 0;
   background-color: rgb(var(--color-background));
-  border-left: 0.1rem solid rgba(var(--color-foreground), 0.2);
+  border-left: 0.065rem solid rgba(var(--color-foreground), 0.2);
   z-index: 1;
   transform: translateX(100%);
   visibility: hidden;
@@ -181,12 +181,12 @@ details[open].menu-opening > .menu-drawer__submenu {
 }
 
 .menu-drawer__close-button {
-  margin-top: 1.5rem;
-  padding: 1.2rem 2.6rem;
+  margin-top: 0.95rem;
+  padding: 0.75rem 1.65rem;
   text-decoration: none;
   display: flex;
   align-items: center;
-  font-size: 1.4rem;
+  font-size: 0.9rem;
   width: 100%;
   background-color: transparent;
   font-family: var(--font-body-family);
@@ -199,11 +199,11 @@ details[open].menu-opening > .menu-drawer__submenu {
 
 .menu-drawer__close-button .icon-arrow {
   transform: rotate(180deg);
-  margin-right: 1rem;
+  margin-right: 0.65rem;
 }
 
 .menu-drawer__utility-links {
-  padding: 2rem;
+  padding: 1.25rem;
   background-color: rgba(var(--color-foreground), 0.03);
 }
 
@@ -211,16 +211,16 @@ details[open].menu-opening > .menu-drawer__submenu {
   display: inline-flex;
   align-items: center;
   text-decoration: none;
-  padding: 1.2rem;
-  margin-left: -1.2rem;
-  font-size: 1.4rem;
+  padding: 0.75rem;
+  margin-left: -0.75rem;
+  font-size: 0.9rem;
   color: rgb(var(--color-foreground));
 }
 
 .menu-drawer__account .icon-account {
-  height: 2rem;
-  width: 2rem;
-  margin-right: 1rem;
+  height: 1.25rem;
+  width: 1.25rem;
+  margin-right: 0.65rem;
 }
 
 .menu-drawer__account:hover .icon-account {
@@ -229,8 +229,8 @@ details[open].menu-opening > .menu-drawer__submenu {
 
 .menu-drawer .list-social {
   justify-content: flex-start;
-  margin-left: -1.25rem;
-  margin-top: 2rem;
+  margin-left: -0.8rem;
+  margin-top: 1.25rem;
 }
 
 .menu-drawer .list-social:empty {
@@ -238,5 +238,5 @@ details[open].menu-opening > .menu-drawer__submenu {
 }
 
 .menu-drawer .list-social__link {
-  padding: 1.3rem 1.25rem;
+  padding: 0.8rem 0.8rem;
 }

--- a/assets/component-model-viewer-ui.css
+++ b/assets/component-model-viewer-ui.css
@@ -31,9 +31,9 @@
 }
 
 .shopify-model-viewer-ui .shopify-model-viewer-ui__poster-control-icon {
-  width: 4.8rem;
-  height: 4.8rem;
-  margin-top: .3rem;
+  width: 3.0rem;
+  height: 3.0rem;
+  margin-top: 0.19rem;
 }
 
 .shopify-model-viewer-ui .shopify-model-viewer-ui__button--poster:hover,

--- a/assets/component-newsletter.css
+++ b/assets/component-newsletter.css
@@ -12,7 +12,7 @@
     flex-direction: row;
     align-items: flex-start;
     margin: 0 auto;
-    max-width: 36rem;
+    max-width: 22.5rem;
   }
 }
 
@@ -21,7 +21,7 @@
 }
 
 .newsletter-form__field-wrapper .field__input {
-  padding-right: 5rem;
+  padding-right: 3.15rem;
 }
 
 .newsletter-form__message {
@@ -30,7 +30,7 @@
 }
 
 .newsletter-form__message--success {
-  margin-top: 2rem;
+  margin-top: 1.25rem;
 }
 
 @media screen and (min-width: 750px) {
@@ -46,10 +46,10 @@
 }
 
 .newsletter-form__button {
-  width: 4.4rem;
+  width: 2.75rem;
   margin: 0;
 }
 
 .newsletter-form__button .icon {
-  width: 1.5rem;
+  width: 0.95rem;
 }

--- a/assets/component-pagination.css
+++ b/assets/component-pagination.css
@@ -1,12 +1,12 @@
 .pagination-wrapper {
-  margin-top: 4rem;
-  margin-bottom: 7rem;
+  margin-top: 2.5rem;
+  margin-bottom: 4.4rem;
 }
 
 @media screen and (min-width: 990px) {
   .pagination-wrapper {
-    margin-top: 5rem;
-    margin-bottom: 10rem;
+    margin-top: 3.15rem;
+    margin-bottom: 6.5rem;
   }
 }
 
@@ -17,12 +17,12 @@
 }
 
 .pagination__list > li {
-  flex: 1 0 4.4rem;
-  max-width: 4.4rem;
+  flex: 1 0 2.75rem;
+  max-width: 2.75rem;
 }
 
 .pagination__list > li:not(:last-child) {
-  margin-right: 1rem;
+  margin-right: 0.65rem;
 }
 
 .pagination__item {
@@ -31,29 +31,29 @@
   justify-content: center;
   align-items: center;
   position: relative;
-  height: 4.4rem;
+  height: 2.75rem;
   width: 100%;
   padding: 0;
   text-decoration: none;
 }
 
 a.pagination__item:hover::after {
-  height: 0.1rem;
+  height: 0.065rem;
 }
 
 .pagination__item .icon-caret {
-  height: 0.6rem;
+  height: 0.375rem;
 }
 
 .pagination__item--current::after {
-  height: 0.1rem;
+  height: 0.065rem;
 }
 
 .pagination__item--current::after,
 .pagination__item:hover::after {
   content: '';
   display: block;
-  width: 2rem;
+  width: 1.25rem;
   position: absolute;
   bottom: 8px;
   left: 50%;
@@ -62,7 +62,7 @@ a.pagination__item:hover::after {
 }
 
 .pagination__item--next .icon {
-  margin-left: -0.2rem;
+  margin-left: -0.125rem;
   transform: rotate(90deg);
 }
 
@@ -71,7 +71,7 @@ a.pagination__item:hover::after {
 }
 
 .pagination__item--prev .icon {
-  margin-right: -0.2rem;
+  margin-right: -0.125rem;
   transform: rotate(-90deg);
 }
 

--- a/assets/component-pickup-availability.css
+++ b/assets/component-pickup-availability.css
@@ -3,31 +3,31 @@ pickup-availability {
 }
 
 pickup-availability[available] {
-  min-height: 8rem;
+  min-height: 5.0rem;
 }
 
 .pickup-availability-preview {
   align-items: flex-start;
   display: flex;
-  gap: 0.2rem;
-  padding: 1rem 2rem 0 0;
+  gap: 0.125rem;
+  padding: 0.65rem 1.25rem 0 0;
 }
 
 .pickup-availability-preview .icon {
   flex-shrink: 0;
-  height: 1.8rem;
+  height: 1.15rem;
 }
 
 .pickup-availability-preview .icon-unavailable {
-  height: 1.6rem;
-  margin-top: 0.1rem;
+  height: 1.0rem;
+  margin-top: 0.065rem;
 }
 
 .pickup-availability-button {
   background-color: transparent;
   color: rgba(var(--color-foreground), 0.75);
-  letter-spacing: 0.06rem;
-  padding: 0 0 0.2rem;
+  letter-spacing: 0.0375rem;
+  padding: 0 0 0.125rem;
   text-align: left;
   text-decoration: underline;
 }
@@ -37,16 +37,16 @@ pickup-availability[available] {
 }
 
 .pickup-availability-info * {
-  margin: 0 0 0.6rem;
+  margin: 0 0 0.375rem;
 }
 
 pickup-availability-drawer {
   background-color: rgb(var(--color-background));
-  border: 0.1rem solid rgba(var(--color-foreground), 0.2);
+  border: 0.065rem solid rgba(var(--color-foreground), 0.2);
   height: 100%;
   opacity: 0;
   overflow-y: auto;
-  padding: 2rem;
+  padding: 1.25rem;
   position: fixed;
   top: 0;
   right: 0;
@@ -65,7 +65,7 @@ pickup-availability-drawer[open] {
 @media screen and (min-width: 750px) {
   pickup-availability-drawer {
     transform: translateX(100%);
-    width: 37.5rem;
+    width: 23.5rem;
   }
 
   pickup-availability-drawer[open] {
@@ -79,15 +79,15 @@ pickup-availability-drawer[open] {
   align-items: flex-start;
   display: flex;
   justify-content: space-between;
-  margin-bottom: 1.2rem;
+  margin-bottom: 0.75rem;
 }
 
 .pickup-availability-drawer-title {
-  margin: 0.5rem 0 0;
+  margin: 0.315rem 0 0;
 }
 
 .pickup-availability-header .icon {
-  width: 2rem;
+  width: 1.25rem;
 }
 
 .pickup-availability-drawer-button {
@@ -96,9 +96,9 @@ pickup-availability-drawer[open] {
   color: rgb(var(--color-foreground));
   cursor: pointer;
   display: block;
-  height: 4.4rem;
-  padding: 1.2rem;
-  width: 4.4rem;
+  height: 2.75rem;
+  padding: 0.75rem;
+  width: 2.75rem;
 }
 
 .pickup-availability-drawer-button:hover {
@@ -106,23 +106,23 @@ pickup-availability-drawer[open] {
 }
 
 .pickup-availability-variant {
-  font-size: 1.3rem;
+  font-size: 0.8rem;
   line-height: calc(1 + 0.2 / var(--font-body-scale));
-  margin: 0 0 1.2rem;
+  margin: 0 0 0.75rem;
   text-transform: capitalize;
 }
 
 .pickup-availability-variant > * + strong {
-  margin-left: 1rem;
+  margin-left: 0.65rem;
 }
 
 .pickup-availability-list__item {
-  border-bottom: 0.1rem solid rgba(var(--color-foreground), 0.08);
-  padding: 2rem 0;
+  border-bottom: 0.065rem solid rgba(var(--color-foreground), 0.08);
+  padding: 1.25rem 0;
 }
 
 .pickup-availability-list__item:first-child {
-  border-top: 0.1rem solid rgba(var(--color-foreground), 0.08);
+  border-top: 0.065rem solid rgba(var(--color-foreground), 0.08);
 }
 
 .pickup-availability-list__item > * {
@@ -130,12 +130,12 @@ pickup-availability-drawer[open] {
 }
 
 .pickup-availability-list__item > * + * {
-  margin-top: 1rem;
+  margin-top: 0.65rem;
 }
 
 .pickup-availability-address {
   font-style: normal;
-  font-size: 1.2rem;
+  font-size: 0.75rem;
   line-height: calc(1 + 0.5 / var(--font-body-scale));
 }
 

--- a/assets/component-predictive-search.css
+++ b/assets/component-predictive-search.css
@@ -1,10 +1,10 @@
 .predictive-search {
   display: none;
   position: absolute;
-  top: calc(100% + 0.1rem);
-  width: calc(100% + 0.2rem);
-  left: -0.1rem;
-  border: 0.1rem solid rgba(var(--color-foreground), 0.2);
+  top: calc(100% + 0.065rem);
+  width: calc(100% + 0.125rem);
+  left: -0.065rem;
+  border: 0.065rem solid rgba(var(--color-foreground), 0.2);
   background-color: rgb(var(--color-background));
   z-index: 3;
 }
@@ -44,24 +44,24 @@ predictive-search[loading] .predictive-search {
 }
 
 .predictive-search__heading {
-  border-bottom: 0.1rem solid rgba(var(--color-foreground), 0.08);
+  border-bottom: 0.065rem solid rgba(var(--color-foreground), 0.08);
   margin: 0 auto;
-  padding: 1.5rem 0 0.75rem;
+  padding: 0.95rem 0 0.47rem;
   display: flex;
   justify-content: space-between;
   align-items: center;
-  width: calc(100% - 4rem);
+  width: calc(100% - 2.5rem);
   color: rgba(var(--color-foreground), 0.7);
 }
 
 predictive-search .spinner {
-  width: 1.5rem;
-  height: 1.5rem;
+  width: 0.95rem;
+  height: 0.95rem;
   line-height: 0;
 }
 
 .predictive-search__heading .spinner {
-  margin: 0 0.2rem 0 2rem;
+  margin: 0 0.125rem 0 1.25rem;
 }
 
 predictive-search:not([loading]) .predictive-search__heading .spinner,
@@ -73,7 +73,7 @@ predictive-search:not([loading]) .predictive-search-status__loading {
 predictive-search[loading] .predictive-search__loading-state {
   display: flex;
   justify-content: center;
-  padding: 1rem;
+  padding: 0.65rem;
 }
 
 predictive-search[loading] .predictive-search__heading ~ .predictive-search__loading-state,
@@ -82,7 +82,7 @@ predictive-search[loading] .predictive-search__results-list:first-child {
 }
 
 .predictive-search__list-item:nth-last-child(2) {
-  border-bottom: 0.1rem solid rgba(var(--color-foreground), 0.08);
+  border-bottom: 0.065rem solid rgba(var(--color-foreground), 0.08);
 }
 
 .predictive-search__list-item[aria-selected="true"] > *,
@@ -94,12 +94,12 @@ predictive-search[loading] .predictive-search__results-list:first-child {
 .predictive-search__list-item[aria-selected="true"] .predictive-search__item-heading,
 .predictive-search__list-item:hover .predictive-search__item-heading {
   text-decoration: underline;
-  text-underline-offset: 0.3rem;
+  text-underline-offset: 0.19rem;
 }
 
 .predictive-search__item {
   display: flex;
-  padding: 1rem 2rem;
+  padding: 0.65rem 1.25rem;
   text-align: left;
   text-decoration: none; 
   width: 100%;
@@ -107,8 +107,8 @@ predictive-search[loading] .predictive-search__results-list:first-child {
 
 .predictive-search__item--link {
   display: grid;
-  grid-template-columns: 5rem 1fr;
-  grid-column-gap: 2rem;
+  grid-template-columns: 3.15rem 1fr;
+  grid-column-gap: 1.25rem;
   grid-template-areas: 'product-image product-content';
 } 
 
@@ -123,7 +123,7 @@ predictive-search[loading] .predictive-search__results-list:first-child {
 }
 
 .predictive-search__item-vendor {
-  font-size: 0.9rem;
+  font-size: 0.55rem;
 }
 
 .predictive-search__item-heading {
@@ -132,34 +132,34 @@ predictive-search[loading] .predictive-search__results-list:first-child {
 
 .predictive-search__item .price {
   color: rgba(var(--color-foreground), 0.7);
-  font-size: 1.2rem;
+  font-size: 0.75rem;
 }
 
 .predictive-search__item-vendor + .predictive-search__item-heading,
 .predictive-search .price { 
-  margin-top: 0.5rem;
+  margin-top: 0.315rem;
 }
 
 .predictive-search__item--term {
   justify-content: space-between;
   align-items: center;
-  padding: 1.3rem 2rem;
+  padding: 0.8rem 1.25rem;
   word-break: break-all;
   line-height: calc(1 + 0.4 / var(--font-body-scale));
 }
 
 @media screen and (min-width: 750px) {
   .predictive-search__item--term {
-    padding-top: 1rem;
-    padding-bottom: 1rem;
+    padding-top: 0.65rem;
+    padding-bottom: 0.65rem;
   }
 }
 
 .predictive-search__item--term .icon-arrow {
-  width: calc(var(--font-heading-scale) * 1.4rem);
-  height: calc(var(--font-heading-scale) * 1.4rem);
+  width: calc(var(--font-heading-scale) * 0.9rem);
+  height: calc(var(--font-heading-scale) * 0.9rem);
   flex-shrink: 0;
-  margin-left: calc(var(--font-heading-scale) * 2rem);
+  margin-left: calc(var(--font-heading-scale) * 1.25rem);
   color: rgb(var(--color-link));
 }
 

--- a/assets/component-price.css
+++ b/assets/component-price.css
@@ -3,8 +3,8 @@
   display: flex;
   flex-direction: row;
   flex-wrap: wrap;
-  font-size: 1.6rem;
-  letter-spacing: 0.1rem;
+  font-size: 1.0rem;
+  letter-spacing: 0.065rem;
   line-height: calc(1 + 0.5 / var(--font-body-scale));
   color: rgb(var(--color-foreground));
 }
@@ -18,7 +18,7 @@
 }
 
 .price .price-item {
-  margin: 0 1rem 0 0;
+  margin: 0 0.65rem 0 0;
 }
 
 .price:not(.price--show-badge) .price-item--last:last-of-type {
@@ -32,14 +32,14 @@
 }
 
 .price--large {
-  font-size: 1.6rem;
+  font-size: 1.0rem;
   line-height: calc(1 + 0.5 / var(--font-body-scale));
-  letter-spacing: 0.13rem;
+  letter-spacing: 0.08rem;
 }
 
 @media screen and (min-width: 750px) {
   .price--large {
-    font-size: 1.8rem;
+    font-size: 1.15rem;
   }
 }
 
@@ -76,15 +76,15 @@
 .price--on-sale .price-item--regular {
   text-decoration: line-through;
   color: rgba(var(--color-foreground), 0.75);
-  font-size: 1.3rem;
+  font-size: 0.8rem;
 }
 
 .unit-price {
   display: block;
-  font-size: 1.1rem;
-  letter-spacing: 0.04rem;
+  font-size: 0.7rem;
+  letter-spacing: 0.025rem;
   line-height: calc(1 + 0.2 / var(--font-body-scale));
-  margin-top: 0.2rem;
+  margin-top: 0.125rem;
   text-transform: uppercase;
   color: rgba(var(--color-foreground), 0.7);
 }

--- a/assets/component-product-grid.css
+++ b/assets/component-product-grid.css
@@ -1,21 +1,21 @@
 .product-grid .grid__item {
-  padding-bottom: 2rem;
+  padding-bottom: 1.25rem;
 }
 
 .product-grid.negative-margin {
-  margin-bottom: -2rem;
+  margin-bottom: -1.25rem;
 }
 
 @media screen and (min-width: 750px) {
   .product-grid .grid__item {
-    padding-bottom: calc(5rem + var(--page-width-margin));
+    padding-bottom: calc(3.15rem + var(--page-width-margin));
   }
 
   .product-grid.negative-margin {
-    margin-bottom: calc(-5rem - var(--page-width-margin));
+    margin-bottom: calc(-3.15rem - var(--page-width-margin));
   }
 
   .product-grid.negative-margin--small {
-    margin-bottom: calc(-1rem - var(--page-width-margin));
+    margin-bottom: calc(-0.65rem - var(--page-width-margin));
   }
 }

--- a/assets/component-product-model.css
+++ b/assets/component-product-model.css
@@ -1,7 +1,7 @@
 .product__xr-button {
   background: rgba(var(--color-foreground), 0.08);
   color: rgb(var(--color-foreground));
-  margin: 1rem auto;
+  margin: 0.65rem auto;
   box-shadow: none;
   display: flex;
 }
@@ -35,6 +35,6 @@
 }
 
 .product__xr-button .icon {
-  width: 1.4rem;
-  margin-right: 1rem;
+  width: 0.9rem;
+  margin-right: 0.65rem;
 }

--- a/assets/component-rating.css
+++ b/assets/component-rating.css
@@ -21,8 +21,8 @@
           (var(--rating-max) * (var(--letter-spacing) + var(--font-size)))
       ) * 100%
   );
-  letter-spacing: calc(var(--letter-spacing) * 1rem);
-  font-size: calc(var(--font-size) * 1rem);
+  letter-spacing: calc(var(--letter-spacing) * 0.65rem);
+  font-size: calc(var(--font-size) * 0.65rem);
   line-height: 1;
   display: inline-block;
   font-family: Times;

--- a/assets/component-rte.css
+++ b/assets/component-rte.css
@@ -18,8 +18,8 @@
 
 @media screen and (min-width: 750px) {
   .rte table td {
-    padding-left: 1.2rem;
-    padding-right: 1.2rem;
+    padding-left: 0.75rem;
+    padding-right: 0.75rem;
   }
 }
 
@@ -29,7 +29,7 @@
 }
 
 .rte ul {
-  padding-left: 2rem;
+  padding-left: 1.25rem;
 }
 
 .rte li {
@@ -42,14 +42,14 @@
 
 .rte a {
   color: rgba(var(--color-link), var(--alpha-link));
-  text-underline-offset: 0.3rem;
-  text-decoration-thickness: 0.1rem;
+  text-underline-offset: 0.19rem;
+  text-decoration-thickness: 0.065rem;
   transition: text-decoration-thickness var(--duration-short) ease;
 }
 
 .rte a:hover {
   color: rgb(var(--color-link));
-  text-decoration-thickness: 0.2rem;
+  text-decoration-thickness: 0.125rem;
 }
 
 .rte blockquote {
@@ -57,5 +57,5 @@
 }
 
 .rte blockquote > * {
-  margin: -0.5rem 0 -0.5rem 0;
+  margin: -0.315rem 0 -0.315rem 0;
 }

--- a/assets/component-search.css
+++ b/assets/component-search.css
@@ -1,10 +1,10 @@
 .search__input.field__input {
-  padding-right: 5rem;
+  padding-right: 3.15rem;
 }
 
 .search__button .icon {
-  height: 1.8rem;
-  width: 1.8rem;
+  height: 1.15rem;
+  width: 1.15rem;
 }
 
 /* Remove extra spacing for search inputs in Safari */

--- a/assets/component-slider.css
+++ b/assets/component-slider.css
@@ -5,7 +5,7 @@ slider-component {
 
 @media screen and (max-width: 989px) {
   .no-js slider-component .slider {
-    padding-bottom: 3rem;
+    padding-bottom: 1.9rem;
   }
 }
 
@@ -21,9 +21,9 @@ slider-component {
     overflow-x: auto;
     scroll-snap-type: x mandatory;
     scroll-behavior: smooth;
-    scroll-padding-left: 1rem;
+    scroll-padding-left: 0.65rem;
     -webkit-overflow-scrolling: touch;
-    margin-bottom: 1rem;
+    margin-bottom: 0.65rem;
   }
 
   .slider.slider--mobile .slider__slide {
@@ -39,9 +39,9 @@ slider-component {
     overflow-x: auto;
     scroll-snap-type: x mandatory;
     scroll-behavior: smooth;
-    scroll-padding-left: 1rem;
+    scroll-padding-left: 0.65rem;
     -webkit-overflow-scrolling: touch;
-    margin-bottom: 1rem;
+    margin-bottom: 0.65rem;
   }
 
   .slider.slider--tablet .slider__slide {
@@ -59,8 +59,8 @@ slider-component {
 }
 
 .slider::-webkit-scrollbar {
-  height: 0.4rem;
-  width: 0.4rem;
+  height: 0.25rem;
+  width: 0.25rem;
   display: none;
 }
 
@@ -75,17 +75,17 @@ slider-component {
 
 .slider::-webkit-scrollbar-thumb {
   background-color: rgb(var(--color-foreground));
-  border-radius: 0.4rem;
+  border-radius: 0.25rem;
   border: 0;
 }
 
 .slider::-webkit-scrollbar-track {
   background: rgba(var(--color-foreground), 0.04);
-  border-radius: 0.4rem;
+  border-radius: 0.25rem;
 }
 
 .slider-counter {
-  margin: 0 1.2rem;
+  margin: 0 0.75rem;
 }
 
 .slider-buttons {
@@ -120,7 +120,7 @@ slider-component {
 }
 
 .slider-button .icon {
-  height: 0.6rem;
+  height: 0.375rem;
 }
 
 .slider-button[disabled] .icon {
@@ -128,19 +128,19 @@ slider-component {
 }
 
 .slider-button--next .icon {
-  margin-right: -0.2rem;
-  transform: rotate(-90deg) translateX(0.15rem);
+  margin-right: -0.125rem;
+  transform: rotate(-90deg) translateX(0.095rem);
 }
 
 .slider-button--prev .icon {
-  margin-left: -0.2rem;
-  transform: rotate(90deg) translateX(-0.15rem);
+  margin-left: -0.125rem;
+  transform: rotate(90deg) translateX(-0.095rem);
 }
 
 .slider-button--next:not([disabled]):hover .icon {
-  transform: rotate(-90deg) translateX(0.15rem) scale(1.07);
+  transform: rotate(-90deg) translateX(0.095rem) scale(1.07);
 }
 
 .slider-button--prev:not([disabled]):hover .icon {
-  transform: rotate(90deg) translateX(-0.15rem) scale(1.07);
+  transform: rotate(90deg) translateX(-0.095rem) scale(1.07);
 }

--- a/assets/component-totals.css
+++ b/assets/component-totals.css
@@ -5,12 +5,12 @@
 }
 
 .totals > * {
-  font-size: 1.6rem;
+  font-size: 1.0rem;
   margin: 0;
 }
 
 .totals > h3 {
-  font-size: calc(var(--font-heading-scale) * 1.6rem);
+  font-size: calc(var(--font-heading-scale) * 1.0rem);
 }
 
 .totals * {
@@ -18,15 +18,15 @@
 }
 
 .totals > * + * {
-  margin-left: 2rem;
+  margin-left: 1.25rem;
 }
 
 .totals__subtotal-value {
-  font-size: 1.8rem;
+  font-size: 1.15rem;
 }
 
 .cart__ctas + .totals {
-  margin-top: 2rem;
+  margin-top: 1.25rem;
 }
 
 @media all and (min-width: 750px) {

--- a/assets/customer.css
+++ b/assets/customer.css
@@ -1,29 +1,29 @@
 .customer:not(.account):not(.order) {
-  margin: 6rem auto 9rem;
-  max-width: 33.4rem;
-  padding: 0 1.5rem;
+  margin: 3.75rem auto 5.5rem;
+  max-width: 21.0rem;
+  padding: 0 0.95rem;
   text-align: center;
 }
 
 @media screen and (min-width: 750px) {
   .customer:not(.account):not(.order) {
-    max-width: 47.8rem;
+    max-width: 30.0rem;
   }
 }
 
 .customer form {
-  margin-top: 4rem;
+  margin-top: 2.5rem;
 }
 
 .customer button {
-  margin: 4rem 0 1.5rem;
+  margin: 2.5rem 0 0.95rem;
 }
 
 .customer ul {
   line-height: calc(1 + 0.6 / var(--font-body-scale));
-  padding-left: 4.4rem;
+  padding-left: 2.75rem;
   text-align: left;
-  margin-bottom: 4rem;
+  margin-bottom: 2.5rem;
 }
 
 .customer ul a {
@@ -36,17 +36,17 @@
 }
 
 .customer h2.form__message {
-  font-size: calc(var(--font-heading-scale) * 1.8rem);
+  font-size: calc(var(--font-heading-scale) * 1.15rem);
 }
 
 @media only screen and (min-width: 750px) {
   .customer h2.form__message {
-    font-size: calc(var(--font-heading-scale) * 2.2rem);
+    font-size: calc(var(--font-heading-scale) * 1.4rem);
   }
 }
 
 .customer .field {
-  margin: 2rem 0 0 0;
+  margin: 1.25rem 0 0 0;
 }
 
 .customer .field:first-of-type {
@@ -57,24 +57,24 @@
 .customer table {
   table-layout: auto;
   border-collapse: collapse;
-  border-bottom: 0.01rem solid rgba(var(--color-foreground), 0.08);
+  border-bottom: 0.0065rem solid rgba(var(--color-foreground), 0.08);
   box-shadow: none;
   width: 100%;
-  font-size: 1.6rem;
+  font-size: 1.0rem;
   position: relative;
 }
 
 @media screen and (min-width: 750px) {
   .customer table {
     border: none;
-    box-shadow: 0 0 0 0.1rem rgba(var(--color-foreground), 0.08);
+    box-shadow: 0 0 0 0.065rem rgba(var(--color-foreground), 0.08);
   }
 }
 
 @media screen and (forced-colors: active) {
   .customer table {
-    border-top: 0.1rem solid transparent;
-    border-bottom: 0.1rem solid transparent;
+    border-top: 0.065rem solid transparent;
+    border-bottom: 0.065rem solid transparent;
   }
 }
 
@@ -92,13 +92,13 @@
 
 @media screen and (min-width: 750px) {
   .customer td {
-    padding-right: 2.2rem;
+    padding-right: 1.4rem;
   }
 }
 
 .customer tbody td {
-  padding-top: 1rem;
-  padding-bottom: 1rem;
+  padding-top: 0.65rem;
+  padding-bottom: 0.65rem;
 }
 
 .customer td:empty {
@@ -106,13 +106,13 @@
 }
 
 .customer thead th {
-  font-size: 1.2rem;
-  letter-spacing: 0.07rem;
+  font-size: 0.75rem;
+  letter-spacing: 0.044rem;
   text-transform: uppercase;
 }
 
 .customer tbody td:first-of-type {
-  padding-top: 4rem;
+  padding-top: 2.5rem;
 }
 
 @media screen and (min-width: 750px) {
@@ -120,18 +120,18 @@
   .customer td:first-of-type {
     text-align: left;
     padding-left: 0;
-    padding-right: 2.2rem;
+    padding-right: 1.4rem;
   }
 
   .customer thead th,
   .customer tbody td {
-    padding-top: 2.4rem;
-    padding-bottom: 2.4rem;
+    padding-top: 1.5rem;
+    padding-bottom: 1.5rem;
   }
 
   .customer th:first-of-type,
   .customer td:first-of-type {
-    padding-left: 2.2rem;
+    padding-left: 1.4rem;
   }
 
   .customer tbody td {
@@ -139,12 +139,12 @@
   }
 
   .customer tbody td:first-of-type {
-    padding-top: 2.4rem;
+    padding-top: 1.5rem;
   }
 }
 
 .customer tbody td:last-of-type {
-  padding-bottom: 4rem;
+  padding-bottom: 2.5rem;
 }
 
 @media screen and (min-width: 750px) {
@@ -154,7 +154,7 @@
 }
 
 .customer tbody tr {
-  border-top: 0.01rem solid rgba(var(--color-foreground), 0.08);
+  border-top: 0.0065rem solid rgba(var(--color-foreground), 0.08);
 }
 
 @media screen and (min-width: 750px) {
@@ -165,14 +165,14 @@
 
 @media screen and (forced-colors: active) {
   .customer tbody tr {
-    border-top: 0.1rem solid transparent;
+    border-top: 0.065rem solid transparent;
   }
 }
 
 .customer tfoot td:first-of-type,
 .customer tfoot td {
-  padding-top: 0.6rem;
-  padding-bottom: 0.6rem;
+  padding-top: 0.375rem;
+  padding-bottom: 0.375rem;
 }
 
 .customer tfoot td:first-of-type {
@@ -180,24 +180,24 @@
 }
 
 .customer tfoot tr:first-of-type td {
-  padding-top: 4rem;
+  padding-top: 2.5rem;
 }
 
 @media screen and (min-width: 750px) {
   .customer tfoot tr:first-of-type td,
   .customer tfoot tr:first-of-type th {
-    padding-top: 2.4rem;
+    padding-top: 1.5rem;
   }
 }
 
 .customer tfoot tr:last-of-type td {
-  padding-bottom: 4rem;
+  padding-bottom: 2.5rem;
 }
 
 @media screen and (min-width: 750px) {
   .customer tfoot tr:last-of-type td,
   .customer tfoot tr:last-of-type th {
-    padding-bottom: 2.4rem;
+    padding-bottom: 1.5rem;
   }
 }
 
@@ -205,7 +205,7 @@
 .customer thead::after,
 .customer tfoot::before {
   content: ' ';
-  height: 0.1rem;
+  height: 0.065rem;
   width: 100%;
   display: block;
   position: absolute;
@@ -236,8 +236,8 @@
   .customer td::before {
     color: rgba(var(--color-foreground), 0.75);
     content: attr(data-label);
-    font-size: 1.4rem;
-    padding-right: 2rem;
+    font-size: 0.9rem;
+    padding-right: 1.25rem;
     text-transform: uppercase;
     flex-grow: 1;
     text-align: left;
@@ -258,14 +258,14 @@
 
 /* Pagination */
 .customer .pagination {
-  margin-top: 5rem;
-  margin-bottom: 7rem;
+  margin-top: 3.15rem;
+  margin-bottom: 4.4rem;
 }
 
 @media screen and (min-width: 990px) {
   .customer .pagination {
-    margin-top: 7rem;
-    margin-bottom: 10rem;
+    margin-top: 4.4rem;
+    margin-bottom: 6.5rem;
   }
 }
 
@@ -278,11 +278,11 @@
 
 .customer .pagination li {
   flex: 1 1;
-  max-width: 4rem;
+  max-width: 2.5rem;
 }
 
 .customer .pagination li:not(:last-child) {
-  margin-right: 1rem;
+  margin-right: 0.65rem;
 }
 
 .customer .pagination li :first-child {
@@ -290,33 +290,33 @@
   justify-content: center;
   align-items: center;
   position: relative;
-  height: 4rem;
+  height: 2.5rem;
   width: 100%;
   padding: 0;
   text-decoration: none;
 }
 
 .customer .pagination li :first-child svg {
-  height: 0.6rem;
+  height: 0.375rem;
 }
 
 .customer .pagination li:first-of-type svg {
-  margin-left: -0.2rem;
+  margin-left: -0.125rem;
   transform: rotate(90deg);
 }
 
 .customer .pagination li:last-of-type svg {
-  margin-right: -0.2rem;
+  margin-right: -0.125rem;
   transform: rotate(-90deg);
 }
 
 .customer .pagination li [aria-current]::after {
   content: '';
   display: block;
-  width: 2rem;
-  height: 0.01rem;
+  width: 1.25rem;
+  height: 0.0065rem;
   position: absolute;
-  bottom: 0.08rem;
+  bottom: 0.05rem;
   left: 50%;
   transform: translateX(-50%);
   background-color: currentColor;
@@ -335,17 +335,17 @@
 }
 
 .login .field + a {
-  margin-top: 1rem;
+  margin-top: 0.65rem;
 }
 
 .login p {
-  margin: 1.5rem 0;
+  margin: 0.95rem 0;
 }
 
 .login h3 {
-  margin-top: 1.5rem;
+  margin-top: 0.95rem;
   text-align: left;
-  font-size: calc(var(--font-heading-scale) * 1.6rem);
+  font-size: calc(var(--font-heading-scale) * 1.0rem);
 }
 
 #customer_login_guest button {
@@ -372,7 +372,7 @@
 
 #recover,
 #login {
-  scroll-margin-top: 20rem;
+  scroll-margin-top: 12.5rem;
 }
 
 #recover {
@@ -383,47 +383,47 @@
 .addresses li > button,
 .addresses form button[type] {
   background-color: transparent;
-  box-shadow: 0 0 0 0.1rem rgb(var(--color-link));
+  box-shadow: 0 0 0 0.065rem rgb(var(--color-link));
   color: rgb(var(--color-link));
 }
 
 .activate button[name='decline']:hover,
 .addresses li > button:hover,
 .addresses form button[type]:hover {
-  box-shadow: 0 0 0 0.2rem rgb(var(--color-link));
+  box-shadow: 0 0 0 0.125rem rgb(var(--color-link));
 }
 
 @media only screen and (min-width: 750px) {
   .activate button[name='decline'] {
     margin-top: inherit;
-    margin-left: 1rem;
+    margin-left: 0.65rem;
   }
 }
 
 /* Account/Order */
 :is(.account, .order) {
-  margin: 6rem auto 9rem;
+  margin: 3.75rem auto 5.5rem;
   max-width: var(--page-width);
-  padding: 0 2rem;
+  padding: 0 1.25rem;
 }
 
 @media screen and (min-width: 750px) {
   :is(.account, .order) {
-    padding: 0 5rem;
+    padding: 0 3.15rem;
   }
 }
 
 @media screen and (min-width: 990px) {
   :is(.account, .order) > div:nth-of-type(2) {
     display: flex;
-    margin-top: 5rem;
+    margin-top: 3.15rem;
   }
 }
 
 @media screen and (min-width: 990px) {
   :is(.account, .order) > div:nth-of-type(2) > div:first-of-type {
     flex-grow: 1;
-    padding-right: 3.2rem;
+    padding-right: 2.0rem;
   }
 }
 
@@ -433,22 +433,22 @@
   }
 
   .order > div:nth-of-type(2) > div:last-of-type div {
-    padding-right: 3.2rem;
+    padding-right: 2.0rem;
   }
 }
 
 :is(.account, .order) p {
-  margin: 0 0 2rem;
-  font-size: 1.6rem;
+  margin: 0 0 1.25rem;
+  font-size: 1.0rem;
 }
 
 :is(.account, .order) h1 {
-  margin-bottom: 1rem;
+  margin-bottom: 0.65rem;
 }
 
 :is(.account, .order) h2 {
-  margin-top: 4rem;
-  margin-bottom: 1rem;
+  margin-top: 2.5rem;
+  margin-bottom: 0.65rem;
 }
 
 @media screen and (min-width: 990px) {
@@ -463,9 +463,9 @@
 }
 
 .account a svg {
-  width: 1.5rem;
-  margin-bottom: -0.03rem;
-  margin-right: 1rem;
+  width: 0.95rem;
+  margin-bottom: -0.0185rem;
+  margin-right: 0.65rem;
 }
 
 @media screen and (min-width: 750px) {
@@ -475,21 +475,21 @@
   }
 
   .account table td:first-of-type {
-    padding-top: 1.2rem;
-    padding-bottom: 1.2rem;
+    padding-top: 0.75rem;
+    padding-bottom: 0.75rem;
   }
 }
 
 .account table td:first-of-type a {
-  padding: 1.1rem 1.5rem;
+  padding: 0.7rem 0.95rem;
   text-decoration: none;
-  box-shadow: 0 0 0 0.1rem rgba(var(--color-link), 0.2);
-  border: 0.1rem solid transparent;
-  font-size: 1.2rem;
+  box-shadow: 0 0 0 0.065rem rgba(var(--color-link), 0.2);
+  border: 0.065rem solid transparent;
+  font-size: 0.75rem;
 }
 
 .account table td:first-of-type a:hover {
-  box-shadow: 0 0 0 0.2rem rgba(var(--color-link), 0.2);
+  box-shadow: 0 0 0 0.125rem rgba(var(--color-link), 0.2);
 }
 
 .order td:first-of-type {
@@ -505,20 +505,20 @@
 
 .order tfoot tr:last-of-type td,
 .order tfoot tr:last-of-type th {
-  font-size: 2.2rem;
-  padding-top: 1.5rem;
-  padding-bottom: 4rem;
+  font-size: 1.4rem;
+  padding-top: 0.95rem;
+  padding-bottom: 2.5rem;
 }
 
 @media screen and (min-width: 750px) {
   .order tfoot tr:last-of-type td,
   .order tfoot tr:last-of-type th {
-    padding-bottom: 2.4rem;
+    padding-bottom: 1.5rem;
   }
 }
 
 .order tfoot tr:last-of-type td:before {
-  font-size: 2.2rem;
+  font-size: 1.4rem;
 }
 
 .order table p,
@@ -529,15 +529,15 @@
 
 .order > div:nth-of-type(2) > div:first-of-type h2 ~ p {
   margin-bottom: 0;
-  font-size: 1.4rem;
+  font-size: 0.9rem;
 }
 
 .order > div:nth-of-type(2) > div:first-of-type h2 ~ p:last-of-type {
-  margin-bottom: 3rem;
+  margin-bottom: 1.9rem;
 }
 
 .order .item-props {
-  font-size: 1.4rem;
+  font-size: 0.9rem;
   margin-top: 0.05px;
   display: flex;
   flex-direction: column;
@@ -550,15 +550,15 @@
 
 .order .fulfillment {
   width: fit-content;
-  border: 0.01rem solid rgba(var(--color-foreground), 0.2);
-  padding: 1rem;
-  margin-top: 1rem;
-  font-size: 1.4rem;
+  border: 0.0065rem solid rgba(var(--color-foreground), 0.2);
+  padding: 0.65rem;
+  margin-top: 0.65rem;
+  font-size: 0.9rem;
   text-align: left;
 }
 
 .order .fulfillment a {
-  margin: 0.7rem 0;
+  margin: 0.44rem 0;
 }
 
 .order .fulfillment span {
@@ -567,9 +567,9 @@
 
 .order .cart-discount {
   display: block;
-  margin-top: 1rem;
-  margin-bottom: 0.5rem;
-  font-size: 1.2rem;
+  margin-top: 0.65rem;
+  margin-bottom: 0.315rem;
+  font-size: 0.75rem;
 }
 
 @media screen and (min-width: 750px) {
@@ -580,10 +580,10 @@
 
 .order tbody ul {
   list-style: none;
-  font-size: 1.2rem;
+  font-size: 0.75rem;
   text-align: right;
   padding-left: 0;
-  margin-top: 1rem;
+  margin-top: 0.65rem;
   margin-bottom: 0;
 }
 
@@ -610,8 +610,8 @@
 }
 
 .order .properties {
-  font-size: 1.4rem;
-  margin-top: 1rem;
+  font-size: 0.9rem;
+  margin-top: 0.65rem;
 }
 
 .order .properties span {
@@ -620,9 +620,9 @@
 }
 
 .order svg {
-  width: 1.1rem;
+  width: 0.7rem;
   color: rgb(var(--color-base-accent-2));
-  margin-right: 0.5rem;
+  margin-right: 0.315rem;
 }
 
 .order dl {
@@ -639,44 +639,44 @@
 }
 
 .order .unit-price {
-  font-size: 1.1rem;
-  letter-spacing: 0.07rem;
+  font-size: 0.7rem;
+  letter-spacing: 0.044rem;
   line-height: calc(1 + 0.2 / var(--font-body-scale));
-  margin-top: 0.2rem;
+  margin-top: 0.125rem;
   text-transform: uppercase;
   color: rgba(var(--color-foreground), 0.7);
 }
 
 .order .regular-price {
-  font-size: 1.3rem;
+  font-size: 0.8rem;
 }
 
 /* Addresses */
 .addresses li > button {
-  margin-left: 0.5rem;
-  margin-right: 0.5rem;
+  margin-left: 0.315rem;
+  margin-right: 0.315rem;
 }
 
 .addresses li > button + button,
 .addresses form button + button {
-  margin-top: 0rem;
+  margin-top: 0.0rem;
 }
 
 @media screen and (min-width: 750px) {
   .addresses li > button:first-of-type {
-    margin-top: 3rem;
+    margin-top: 1.9rem;
   }
 }
 
 .addresses form button:first-of-type {
-  margin-right: 1rem;
+  margin-right: 0.65rem;
 }
 
 label[for='AddressCountryNew'],
 label[for='AddressProvinceNew'] {
   display: block;
-  font-size: 1.4rem;
-  margin-bottom: 0.6rem;
+  font-size: 0.9rem;
+  margin-bottom: 0.375rem;
 }
 
 .addresses form {
@@ -696,7 +696,7 @@ label[for='AddressProvinceNew'] {
 }
 
 li[data-address] {
-  margin-top: 5rem;
+  margin-top: 3.15rem;
 }
 
 .addresses [aria-expanded='false'] ~ div[id] {
@@ -713,13 +713,13 @@ li[data-address] {
 
 li[data-address] > h2 {
   text-align: center;
-  font-size: calc(var(--font-heading-scale) * 1.8rem);
+  font-size: calc(var(--font-heading-scale) * 1.15rem);
   margin-bottom: 0;
 }
 
 @media only screen and (min-width: 750px) {
   li[data-address] > h2 {
-    font-size: calc(var(--font-heading-scale) * 2.2rem);
+    font-size: calc(var(--font-heading-scale) * 1.4rem);
   }
 }
 
@@ -728,13 +728,13 @@ li[data-address] > h2 {
 }
 
 .addresses input[type='checkbox'] {
-  margin-top: 2rem;
+  margin-top: 1.25rem;
   margin-left: 0;
 }
 
 @media only screen and (min-width: 750px) {
   .addresses form > div:nth-of-type(1) {
-    padding-right: 2rem;
+    padding-right: 1.25rem;
   }
 
   .addresses form > div:nth-of-type(2) {
@@ -750,5 +750,5 @@ li[data-address] > h2 {
 
 .addresses form > div:nth-of-type(7),
 .addresses form > div:nth-of-type(7) + div[id] {
-  margin-top: 1.5rem;
+  margin-top: 0.95rem;
 }

--- a/assets/disclosure.css
+++ b/assets/disclosure.css
@@ -6,27 +6,27 @@
   align-items: center;
   cursor: pointer;
   display: flex;
-  height: 4rem;
-  padding: 0 1.5rem 0 1.5rem;
-  font-size: 1.3rem;
+  height: 2.5rem;
+  padding: 0 0.95rem 0 0.95rem;
+  font-size: 0.8rem;
   background-color: transparent;
 }
 
 .disclosure__list {
   border: 1px solid rgba(var(--color-foreground), 0.2);
-  font-size: 1.4rem;
-  margin-top: -0.5rem;
-  min-height: 8.2rem;
-  max-height: 19rem;
-  max-width: 22rem;
-  min-width: 12rem;
+  font-size: 0.9rem;
+  margin-top: -0.315rem;
+  min-height: 5.0rem;
+  max-height: 12.0rem;
+  max-width: 14.0rem;
+  min-width: 7.5rem;
   width: max-content;
   overflow-y: auto;
-  padding-bottom: 0.5rem;
-  padding-top: 0.5rem;
+  padding-bottom: 0.315rem;
+  padding-top: 0.315rem;
   position: absolute;
   bottom: 100%;
-  transform: translateY(-1rem);
+  transform: translateY(-0.65rem);
   z-index: 2;
   background-color: rgb(var(--color-background));
 }
@@ -37,7 +37,7 @@
 
 .disclosure__link {
   display: block;
-  padding: 0.5rem 2.2rem;
+  padding: 0.315rem 1.4rem;
   text-decoration: none;
   line-height: calc(1 + 0.8 / var(--font-body-scale));
 }

--- a/assets/newsletter-section.css
+++ b/assets/newsletter-section.css
@@ -1,36 +1,36 @@
 .newsletter--narrow .newsletter__wrapper,
 .newsletter:not(.newsletter--narrow) .newsletter__wrapper.color-background-1 {
-  margin-top: 5rem;
-  margin-bottom: 5rem;
+  margin-top: 3.15rem;
+  margin-bottom: 3.15rem;
 }
 
 .newsletter__wrapper:not(.color-background-1) {
-  padding-top: 5rem;
-  padding-bottom: 5rem;
+  padding-top: 3.15rem;
+  padding-bottom: 3.15rem;
 }
 
 @media screen and (min-width: 750px) {
   .newsletter--narrow .newsletter__wrapper,
   .newsletter:not(.newsletter--narrow) .newsletter__wrapper.color-background-1 {
-    margin-top: calc(5rem + var(--page-width-margin));
-    margin-bottom: calc(5rem + var(--page-width-margin));
+    margin-top: calc(3.15rem + var(--page-width-margin));
+    margin-bottom: calc(3.15rem + var(--page-width-margin));
   }
 
   .newsletter__wrapper:not(.color-background-1) {
-    padding-top: calc(5rem + var(--page-width-margin));
-    padding-bottom: calc(5rem + var(--page-width-margin));
+    padding-top: calc(3.15rem + var(--page-width-margin));
+    padding-bottom: calc(3.15rem + var(--page-width-margin));
   }
 }
 
 .newsletter__wrapper {
-  padding-right: calc(4rem / var(--font-body-scale));
-  padding-left: calc(4rem / var(--font-body-scale));
+  padding-right: calc(2.5rem / var(--font-body-scale));
+  padding-left: calc(2.5rem / var(--font-body-scale));
 }
 
 @media screen and (min-width: 750px) {
   .newsletter__wrapper {
-    padding-right: 9rem;
-    padding-left: 9rem;
+    padding-right: 5.5rem;
+    padding-left: 5.5rem;
   }
 }
 
@@ -40,35 +40,35 @@
 }
 
 .newsletter__wrapper > * + * {
-  margin-top: 2rem;
+  margin-top: 1.25rem;
 }
 
 .newsletter__wrapper > * + .newsletter-form {
-  margin-top: 3rem;
+  margin-top: 1.9rem;
 }
 
 .newsletter__subheading {
-  max-width: 70rem;
+  max-width: 44.0rem;
   margin-left: auto;
   margin-right: auto;
 }
 
 .newsletter__wrapper .newsletter-form__field-wrapper {
-  max-width: 36rem;
+  max-width: 22.5rem;
 }
 
 .newsletter-form__field-wrapper .newsletter-form__message {
-  margin-top: 1.5rem;
+  margin-top: 0.95rem;
 }
 
 .newsletter__button {
-  margin-top: 3rem;
+  margin-top: 1.9rem;
   width: fit-content;
 }
 
 @media screen and (min-width: 750px) {
   .newsletter__button {
     flex-shrink: 0;
-    margin: 0 0 0 1rem;
+    margin: 0 0 0 0.65rem;
   }
 }

--- a/assets/section-blog-post.css
+++ b/assets/section-blog-post.css
@@ -1,73 +1,73 @@
 .article-template > *:first-child:not(.article-template__hero-container) {
-  margin-top: 5rem;
+  margin-top: 3.15rem;
 }
 
 @media screen and (min-width: 750px) {
   .article-template > *:first-child:not(.article-template__hero-container) {
-    margin-top: calc(5rem + var(--page-width-margin));
+    margin-top: calc(3.15rem + var(--page-width-margin));
   }
 }
 
 .article-template__hero-container {
-  max-width: 130rem;
+  max-width: 80.0rem;
   margin: 0 auto;
 }
 
 @media screen and (min-width: 1320px) {
   .article-template__hero-container:first-child {
-    margin-top: calc(5rem + var(--page-width-margin));
+    margin-top: calc(3.15rem + var(--page-width-margin));
   }
 }
 
 .article-template__hero-small {
-  height: 11rem;
+  height: 7.0rem;
 }
 
 .article-template__hero-medium {
-  height: 22rem;
+  height: 14.0rem;
 }
 
 .article-template__hero-large {
-  height: 33rem;
+  height: 20.5rem;
 }
 
 @media screen and (min-width: 750px) and (max-width: 989px) {
   .article-template__hero-small {
-    height: 22rem;
+    height: 14.0rem;
   }
 
   .article-template__hero-medium {
-    height: 44rem;
+    height: 27.5rem;
   }
 
   .article-template__hero-large {
-    height: 66rem;
+    height: 41.5rem;
   }
 }
 
 @media screen and (min-width: 990px) {
   .article-template__hero-small {
-    height: 27.5rem;
+    height: 17.0rem;
   }
 
   .article-template__hero-medium {
-    height: 55rem;
+    height: 34.5rem;
   }
 
   .article-template__hero-large {
-    height: 82.5rem;
+    height: 50.0rem;
   }
 }
 
 .article-template header {
-  margin-top: 4.4rem;
-  margin-bottom: 2rem;
+  margin-top: 2.75rem;
+  margin-bottom: 1.25rem;
   line-height: calc(0.8 / var(--font-body-scale));
 }
 
 @media screen and (min-width: 750px) {
   .article-template header {
-    margin-top: 5rem;
+    margin-top: 3.15rem;
   }
 }
 
@@ -76,11 +76,11 @@
 }
 
 .article-template__title:not(:only-child) {
-  margin-bottom: 1rem;
+  margin-bottom: 0.65rem;
 }
 
 .article-template__link {
-  font-size: 1.8rem;
+  font-size: 1.15rem;
   display: flex;
   justify-content: center;
   align-items: center;
@@ -89,31 +89,31 @@
 
 .article-template__link .icon-wrap {
   display: flex;
-  margin-right: 1rem;
+  margin-right: 0.65rem;
   transform: rotate(180deg);
 }
 
 .article-template__content {
-  margin-top: 3rem;
-  margin-bottom: 3rem;
+  margin-top: 1.9rem;
+  margin-bottom: 1.9rem;
 }
 
 .article-template__social-sharing {
-  margin-top: 3rem;
+  margin-top: 1.9rem;
 }
 
 .article-template__social-sharing + header,
 .article-template__social-sharing + .article-template__content {
-  margin-top: 1.5rem;
+  margin-top: 0.95rem;
 }
 
 .article-template__comment-wrapper {
-  margin-top: 5rem;
+  margin-top: 3.15rem;
 }
 
 @media screen and (min-width: 750px) {
   .article-template__comment-wrapper {
-    margin-top: 6rem;
+    margin-top: 3.75rem;
   }
 }
 
@@ -122,54 +122,54 @@
 }
 
 .article-template__comments {
-  margin-bottom: 5rem;
+  margin-bottom: 3.15rem;
 }
 
 @media screen and (min-width: 750px) {
   .article-template__comments {
-    margin-bottom: 7rem;
+    margin-bottom: 4.4rem;
   }
 }
 
 .article-template__comments-fields {
-  margin-bottom: 4rem;
+  margin-bottom: 2.5rem;
 }
 
 .article-template__comments-comment {
   color: rgba(var(--color-foreground), 0.75);
   background-color: rgb(var(--color-background));
-  margin-bottom: 1.5rem;
-  padding: 2rem 2rem 1.5rem;
+  margin-bottom: 0.95rem;
+  padding: 1.25rem 1.25rem 0.95rem;
 }
 
 @media screen and (min-width: 750px) {
   .article-template__comments-comment {
-    padding: 2rem 2.5rem;
+    padding: 1.25rem 1.55rem;
   }
 }
 
 .article-template__comments-comment p {
-  margin: 0 0 1rem;
+  margin: 0 0 0.65rem;
 }
 
 .article-template__comment-fields > * {
-  margin-bottom: 3rem;
+  margin-bottom: 1.9rem;
 }
 
 @media screen and (min-width: 750px) {
   .article-template__comment-fields {
     display: grid;
     grid-template-columns: repeat(2, 1fr);
-    grid-column-gap: 4rem;
+    grid-column-gap: 2.5rem;
   }
 }
 
 .article-template__comment-warning {
-  margin: 2rem 0 2.5rem;
+  margin: 1.25rem 0 1.55rem;
 }
 
 @media screen and (min-width: 990px) {
   .article-template__comments .pagination-wrapper {
-    margin: 5rem 0 8rem;
+    margin: 3.15rem 0 5.0rem;
   }
 }

--- a/assets/section-collection-list.css
+++ b/assets/section-collection-list.css
@@ -1,15 +1,15 @@
 @media screen and (max-width: 749px) {
   .collage-section + .collection-list-section .no-heading.no-mobile-link {
-    margin-top: -7rem;
+    margin-top: -4.4rem;
   }
   .collage-section + .collection-list-section .no-heading:not(.no-mobile-link) {
-    margin-top: -1rem;
+    margin-top: -0.65rem;
   }
 }
 
 @media screen and (min-width: 750px) {
   .collage-section + .collection-list-section .no-heading {
-    margin-top: calc(-4rem - var(--page-width-margin));
+    margin-top: calc(-2.5rem - var(--page-width-margin));
   }
 }
 
@@ -28,20 +28,20 @@
   }
 
   .collection-list-section .collection-list:not(.slider) {
-    padding-left: 1.5rem;
-    padding-right: 1.5rem;
+    padding-left: 0.95rem;
+    padding-right: 0.95rem;
   }
 }
 
 @media screen and (max-width: 749px) {
   .collection-list-wrapper:not(.no-heading) .title-wrapper-with-link {
-    margin-top: -1rem;
+    margin-top: -0.65rem;
   }
 }
 
 @media screen and (min-width: 750px) {
   .collection-list-wrapper.no-heading {
-    margin-top: calc(6rem + var(--page-width-margin));
+    margin-top: calc(3.75rem + var(--page-width-margin));
   }
 }
 
@@ -51,20 +51,20 @@
 }
 
 .collection-list__item .card--light-border:hover {
-  border: 0.1rem solid rgba(var(--color-foreground), 0.04);
+  border: 0.065rem solid rgba(var(--color-foreground), 0.04);
 }
 
 .collection-list__item:only-child .media {
-  height: 35rem;
+  height: 22.0rem;
 }
 
 @media screen and (max-width: 749px) {
   .collection-list .collection-list__item {
-    width: calc(100% - 3rem);
+    width: calc(100% - 1.9rem);
   }
 
   .collection-list__item.grid__item {
-    padding-bottom: 1rem;
+    padding-bottom: 0.65rem;
   }
 
   .slider.collection-list--1-items {
@@ -73,7 +73,7 @@
 }
 
 .collection-list.negative-margin--small {
-  margin-bottom: -1rem;
+  margin-bottom: -0.65rem;
 }
 
 @media screen and (min-width: 750px) and (max-width: 989px) {
@@ -91,7 +91,7 @@
   }
 
   .collection-list__item:only-child .media {
-    height: 47rem;
+    height: 29.5rem;
   }
 
   .collection-list__item a:hover {

--- a/assets/section-contact-form.css
+++ b/assets/section-contact-form.css
@@ -7,26 +7,26 @@
 }
 
 .contact .icon-success {
-  margin-top: 0.2rem;
+  margin-top: 0.125rem;
 }
 
 .contact .field {
-  margin-bottom: 1.5rem;
+  margin-bottom: 0.95rem;
 }
 
 @media screen and (min-width: 750px) {
   .contact .field {
-    margin-bottom: 2rem;
+    margin-bottom: 1.25rem;
   }
 }
 
 .contact__button {
-  margin-top: 3rem;
+  margin-top: 1.9rem;
 }
 
 @media screen and (min-width: 750px) {
   .contact__button {
-    margin-top: 4rem;
+    margin-top: 2.5rem;
   }
 }
 
@@ -34,7 +34,7 @@
   .contact__fields {
     display: grid;
     grid-template-columns: repeat(2, 1fr);
-    grid-column-gap: 2rem;
+    grid-column-gap: 1.25rem;
   }
 }
 

--- a/assets/section-email-signup-banner.css
+++ b/assets/section-email-signup-banner.css
@@ -3,7 +3,7 @@
 }
 
 .email-signup-banner__box > * + .newsletter__subheading {
-  margin-top: 2rem;
+  margin-top: 1.25rem;
 }
 
 .email-signup-banner__box .newsletter__subheading p {

--- a/assets/section-featured-blog.css
+++ b/assets/section-featured-blog.css
@@ -1,24 +1,24 @@
 .blog:not(.background-secondary) {
-  margin: 5rem 0;
+  margin: 3.15rem 0;
 }
 
 .blog.background-secondary {
-  padding: 4rem 0 3rem;
+  padding: 2.5rem 0 1.9rem;
 }
 
 @media screen and (min-width: 750px) {
   .blog:not(.background-secondary) {
-    margin: calc(5rem + var(--page-width-margin)) 0;
+    margin: calc(3.15rem + var(--page-width-margin)) 0;
   }
 
   .blog.background-secondary {
-    padding-top: calc(5rem + var(--page-width-margin));
-    padding-bottom: calc(5rem + var(--page-width-margin));
+    padding-top: calc(3.15rem + var(--page-width-margin));
+    padding-bottom: calc(3.15rem + var(--page-width-margin));
   }
 }
 
 .blog-placeholder {
-  margin: 0 1.5rem;
+  margin: 0 0.95rem;
   background: rgb(var(--color-background));
 }
 
@@ -31,7 +31,7 @@
 }
 
 .blog-placeholder__content {
-  padding: 3rem;
+  padding: 1.9rem;
   background: rgba(var(--color-foreground), 0.04);
 }
 
@@ -41,7 +41,7 @@
 
 .blog-placeholder .placeholder-svg {
   height: auto;
-  max-width: 80rem;
+  max-width: 50.0rem;
   left: 50%;
   top: 50%;
   transform: translate(-50%, -50%);
@@ -52,19 +52,19 @@
 }
 
 .blog-placeholder .rte-width {
-  margin-top: 1.2rem;
+  margin-top: 0.75rem;
   color: rgba(var(--color-foreground), 0.75);
 }
 
 @media screen and (max-width: 749px) {
   .blog:not(.no-heading) {
-    margin-top: -1rem;
+    margin-top: -0.65rem;
   }
 }
 
 @media screen and (min-width: 750px) {
   .blog.no-heading {
-    margin-top: calc(6rem + var(--page-width-margin));
+    margin-top: calc(3.75rem + var(--page-width-margin));
   }
 }
 
@@ -77,7 +77,7 @@
 }
 
 .blog__posts.articles-wrapper {
-  margin-bottom: 1rem;
+  margin-bottom: 0.65rem;
 }
 
 @media screen and (min-width: 990px) {
@@ -92,14 +92,14 @@
 
 @media screen and (min-width: 750px) {
   .blog__posts .article + .article {
-    margin-left: 1rem;
+    margin-left: 0.65rem;
   }
 }
 
 @media screen and (max-width: 749px) {
   .blog__post.article {
-    width: calc(100% - 3rem);
-    padding-left: 0.5rem;
+    width: calc(100% - 1.9rem);
+    padding-left: 0.315rem;
   }
 }
 
@@ -109,11 +109,11 @@
 }
 
 .blog__button {
-  margin-top: 3rem;
+  margin-top: 1.9rem;
 }
 
 @media screen and (min-width: 750px) {
   .blog__button {
-    margin-top: 5rem;
+    margin-top: 3.15rem;
   }
 }

--- a/assets/section-featured-product.css
+++ b/assets/section-featured-product.css
@@ -1,5 +1,5 @@
 .featured-product {
-  margin-bottom: 5rem;
+  margin-bottom: 3.15rem;
 }
 
 .featured-product .product__media-list {
@@ -18,13 +18,13 @@
 }
 
 .featured-product-section .background-secondary {
-  padding-top: 5rem;
-  padding-bottom: 0.1rem;
+  padding-top: 3.15rem;
+  padding-bottom: 0.065rem;
 }
 
 .background-secondary .featured-product {
   background: rgb(var(--color-background));
-  padding: 2.5rem;
+  padding: 1.55rem;
 }
 
 .product__view-details {
@@ -34,12 +34,12 @@
 
 .product__view-details:hover {
   text-decoration: underline;
-  text-underline-offset: 0.3rem;
+  text-underline-offset: 0.19rem;
 }
 
 .product__view-details .icon {
-  width: 1.2rem;
-  margin-left: 1.2rem;
+  width: 0.75rem;
+  margin-left: 0.75rem;
   flex-shrink: 0;
 }
 
@@ -64,26 +64,26 @@
   }
 
   .featured-product-section .background-secondary {
-    padding-top: 7rem;
-    padding-bottom: 2rem;
+    padding-top: 4.4rem;
+    padding-bottom: 1.25rem;
   }
 
   .background-secondary .featured-product {
-    padding: 5rem;
+    padding: 3.15rem;
   }
 }
 
 @media screen and (min-width: 990px) {
   .background-secondary .featured-product:not(.product--no-media) > .product__info-wrapper {
-    padding: 0 0 0 5rem;
+    padding: 0 0 0 3.15rem;
   }
 
   .featured-product:not(.product--no-media) > .product__info-wrapper {
-    padding: 0 7rem;
+    padding: 0 4.4rem;
   }
 
   .background-secondary .featured-product {
     background: rgb(var(--color-background));
-    padding: 6rem 7rem;
+    padding: 3.75rem 4.4rem;
   }
 }

--- a/assets/section-footer.css
+++ b/assets/section-footer.css
@@ -1,5 +1,5 @@
 .footer {
-  border-top: 0.1rem solid rgba(var(--color-foreground), 0.08);
+  border-top: 0.065rem solid rgba(var(--color-foreground), 0.08);
 }
 
 .footer:not(.color-background-1) {
@@ -7,8 +7,8 @@
 }
 
 .footer__content-top {
-  padding-bottom: 5rem;
-  padding-top: 5rem;
+  padding-bottom: 3.15rem;
+  padding-top: 3.15rem;
   display: block;
 }
 
@@ -20,7 +20,7 @@
 
   .footer-block.grid__item {
     padding: 0;
-    margin: 4rem 0;
+    margin: 2.5rem 0;
     width: 100%;
   }
 
@@ -29,28 +29,28 @@
   }
 
   .footer__content-top {
-    padding-bottom: 3rem;
-    padding-left: calc(4rem / var(--font-body-scale));
-    padding-right: calc(4rem / var(--font-body-scale));
+    padding-bottom: 1.9rem;
+    padding-left: calc(2.5rem / var(--font-body-scale));
+    padding-right: calc(2.5rem / var(--font-body-scale));
   }
 }
 
 @media screen and (min-width: 750px) {
   .footer__content-top .grid {
-    margin-left: -3rem;
-    row-gap: 6rem;
+    margin-left: -1.9rem;
+    row-gap: 3.75rem;
     margin-bottom: 0;
   }
 
   .footer__content-top .grid__item {
-    padding-left: 3rem;
+    padding-left: 1.9rem;
   }
 }
 
 .footer__content-bottom {
-  border-top: solid 0.1rem rgba(var(--color-foreground), 0.08);
-  padding-top: 3rem;
-  padding-bottom: 3rem;
+  border-top: solid 0.065rem rgba(var(--color-foreground), 0.08);
+  padding-top: 1.9rem;
+  padding-bottom: 1.9rem;
 }
 
 .footer__content-bottom:only-child {
@@ -68,12 +68,12 @@
     padding-top: 0;
     padding-left: 0;
     padding-right: 0;
-    row-gap: 1.5rem;
+    row-gap: 0.95rem;
   }
 
   .footer__content-bottom-wrapper {
     flex-wrap: wrap;
-    row-gap: 1.5rem;
+    row-gap: 0.95rem;
   }
 }
 
@@ -83,7 +83,7 @@
 
 @media screen and (max-width: 749px) {
   .footer__localization:empty + .footer__column {
-    padding-top: 1.5rem;
+    padding-top: 0.95rem;
   }
 }
 .footer__column {
@@ -96,8 +96,8 @@
   flex-direction: column;
   justify-content: center;
   align-items: center;
-  padding-left: 2rem;
-  padding-right: 2rem;
+  padding-left: 1.25rem;
+  padding-right: 1.25rem;
 }
 
 @media screen and (min-width: 750px) {
@@ -110,7 +110,7 @@
 
 .footer-block:only-child:last-child {
   text-align: center;
-  max-width: 76rem;
+  max-width: 47.5rem;
   margin: 0 auto;
 }
 
@@ -130,7 +130,7 @@
   flex-wrap: wrap;
   justify-content: center;
   align-items: flex-end;
-  margin-top: 2rem;
+  margin-top: 1.25rem;
 }
 
 .footer-block--newsletter:only-child {
@@ -155,14 +155,14 @@
 }
 
 .footer-block__heading {
-  margin-bottom: 2rem;
+  margin-bottom: 1.25rem;
   margin-top: 0;
-  font-size: calc(var(--font-heading-scale) * 1.6rem);
+  font-size: calc(var(--font-heading-scale) * 1.0rem);
 }
 
 @media screen and (min-width: 990px) {
   .footer-block__heading {
-    font-size: calc(var(--font-heading-scale) * 1.8rem);
+    font-size: calc(var(--font-heading-scale) * 1.15rem);
   }
 }
 
@@ -180,7 +180,7 @@
 }
 
 .newsletter-form__field-wrapper {
-  max-width: 36rem;
+  max-width: 22.5rem;
 }
 
 @media screen and (min-width: 750px) {
@@ -199,7 +199,7 @@
 }
 
 .footer-block__newsletter + .footer__list-social {
-  margin-top: 3rem;
+  margin-top: 1.9rem;
 }
 
 @media screen and (max-width: 749px) {
@@ -216,7 +216,7 @@
 
 @media screen and (min-width: 750px) {
   .footer__content-bottom {
-    border-top-width: 0.1rem;
+    border-top-width: 0.065rem;
   }
 }
 
@@ -226,7 +226,7 @@
   justify-content: center;
   align-content: center;
   flex-wrap: wrap;
-  padding: 1rem 1rem 0;
+  padding: 0.65rem 0.65rem 0;
 }
 
 .footer__localization:empty {
@@ -237,7 +237,7 @@
   display: flex;
   flex-direction: column;
   flex: auto 1 0;
-  padding: 1rem;
+  padding: 0.65rem;
   margin: 0 auto;
 }
 
@@ -245,29 +245,29 @@
   display: inline-flex;
   flex-wrap: wrap;
   flex: initial;
-  padding: 1rem 0;
+  padding: 0.65rem 0;
 }
 
 .localization-form:only-child .button,
 .localization-form:only-child .localization-form__select {
-  margin: 1rem 1rem 0.5rem;
+  margin: 0.65rem 0.65rem 0.315rem;
   flex-grow: 1;
   width: auto;
 }
 
 .footer__localization h2 {
-  margin: 1rem 1rem 0.5rem;
+  margin: 0.65rem 0.65rem 0.315rem;
   color: rgba(var(--color-foreground), 0.75);
 }
 
 @media screen and (min-width: 750px) {
   .footer__localization {
-    padding: 0.4rem 0;
+    padding: 0.25rem 0;
     justify-content: flex-start;
   }
 
   .localization-form {
-    padding: 1rem 2rem 1rem 0;
+    padding: 0.65rem 1.25rem 0.65rem 0;
   }
 
   .localization-form:first-of-type {
@@ -277,12 +277,12 @@
   .localization-form:only-child {
     justify-content: start;
     width: auto;
-    margin: 0 0 0 -1rem;
+    margin: 0 0 0 -0.65rem;
   }
 
   .localization-form:only-child .button,
   .localization-form:only-child .localization-form__select {
-    margin: 1rem;
+    margin: 0.65rem;
   }
 }
 
@@ -294,7 +294,7 @@
 }
 
 .localization-form .button {
-  padding: 1rem;
+  padding: 0.65rem;
 }
 
 .localization-form__currency {
@@ -308,30 +308,30 @@
 }
 
 .localization-form__select {
-  box-shadow: 0 0 0 0.1rem rgba(var(--color-foreground), 0.55);
+  box-shadow: 0 0 0 0.065rem rgba(var(--color-foreground), 0.55);
   position: relative;
-  margin-bottom: 1.5rem;
-  border: 0.1rem solid transparent;
-  padding-left: 1rem;
+  margin-bottom: 0.95rem;
+  border: 0.065rem solid transparent;
+  padding-left: 0.65rem;
   text-align: left;
 }
 
 noscript .localization-form__select {
-  padding-left: 0rem;
+  padding-left: 0.0rem;
 }
 
 @media screen and (min-width: 750px) {
   noscript .localization-form__select {
-    min-width: 20rem;
+    min-width: 12.5rem;
   }
 }
 
 .localization-form__select .icon-caret {
   position: absolute;
   content: '';
-  height: 0.6rem;
-  right: 1.5rem;
-  top: calc(50% - 0.2rem);
+  height: 0.375rem;
+  right: 0.95rem;
+  top: calc(50% - 0.125rem);
 }
 
 .localization-selector.link {
@@ -341,17 +341,17 @@ noscript .localization-form__select {
   -moz-appearance: none;
   color: rgb(var(--color-foreground));
   width: 100%;
-  padding-right: 4rem;
-  padding-bottom: 1.5rem;
+  padding-right: 2.5rem;
+  padding-bottom: 0.95rem;
 }
 
 noscript .localization-selector.link {
-  padding-top: 1.5rem;
-  padding-left: 1.5rem;
+  padding-top: 0.95rem;
+  padding-left: 0.95rem;
 }
 
 .disclosure .localization-form__select {
-  padding-top: 1.5rem;
+  padding-top: 0.95rem;
 }
 
 .localization-selector option {
@@ -359,7 +359,7 @@ noscript .localization-selector.link {
 }
 
 .localization-selector + .disclosure__list {
-  margin-left: 1rem;
+  margin-left: 0.65rem;
   opacity: 1;
   animation: animateLocalization var(--duration-default) ease;
 }
@@ -367,13 +367,13 @@ noscript .localization-selector.link {
 
 @media screen and (min-width: 750px) {
   .footer__payment {
-    margin-top: 1.5rem;
+    margin-top: 0.95rem;
   }
 }
 
 .footer__copyright {
   text-align: center;
-  margin-top: 1.5rem;
+  margin-top: 0.95rem;
 }
 
 @media screen and (min-width: 750px) {
@@ -383,7 +383,7 @@ noscript .localization-selector.link {
 }
 
 /* .footer__copyright a {
-  font-size: 1.3rem;
+  font-size: 0.8rem;
   text-decoration: none;
   color: currentColor;
 }
@@ -395,7 +395,7 @@ noscript .localization-selector.link {
 @keyframes appear-down {
   0% {
     opacity: 0;
-    margin-top: -1rem;
+    margin-top: -0.65rem;
   }
   100% {
     opacity: 1;
@@ -404,7 +404,7 @@ noscript .localization-selector.link {
 }
 
 .footer-block__details-content {
-  margin-bottom: 4rem;
+  margin-bottom: 2.5rem;
 }
 
 @media screen and (min-width: 750px) {
@@ -422,7 +422,7 @@ noscript .localization-selector.link {
   }
 
   .footer-block__details-content > li:not(:last-child) {
-    margin-right: 1.5rem;
+    margin-right: 0.95rem;
   }
 }
 
@@ -441,25 +441,25 @@ noscript .localization-selector.link {
   .copyright__content a:hover {
     color: rgb(var(--color-foreground));
     text-decoration: underline;
-    text-underline-offset: 0.3rem;
+    text-underline-offset: 0.19rem;
   }
 
   .footer-block__details-content .list-menu__item--active:hover {
-    text-decoration-thickness: 0.2rem;
+    text-decoration-thickness: 0.125rem;
   }
 }
 
 @media screen and (max-width: 989px) {
   .footer-block__details-content .list-menu__item--link {
-    padding-top: 1rem;
-    padding-bottom: 1rem;
+    padding-top: 0.65rem;
+    padding-bottom: 0.65rem;
   }
 }
 
 @media screen and (min-width: 750px) {
   .footer-block__details-content .list-menu__item--link {
     display: inline-block;
-    font-size: 1.4rem;
+    font-size: 0.9rem;
   }
 
   .footer-block__details-content > :first-child .list-menu__item--link {
@@ -478,7 +478,7 @@ noscript .localization-selector.link {
 }
 
 .footer-block__details-content .placeholder-svg {
-  max-width: 20rem;
+  max-width: 12.5rem;
 }
 
 .copyright__content a {
@@ -494,12 +494,12 @@ noscript .localization-selector.link {
 
   100% {
     opacity: 1;
-    transform: translateY(-1rem);
+    transform: translateY(-0.65rem);
   }
 }
 
 .footer .disclosure__link {
-  padding: 0.95rem 3.5rem 0.95rem 2rem;
+  padding: 0.6rem 2.2rem 0.6rem 1.25rem;
   color: rgba(var(--color-foreground), 0.75);
 }
 

--- a/assets/section-image-banner.css
+++ b/assets/section-image-banner.css
@@ -7,29 +7,29 @@
 @media screen and (max-width: 749px) {
   .banner--small.banner--mobile-bottom:not(.banner--adapt) > .banner__media,
   .banner--small.banner--stacked:not(.banner--mobile-bottom):not(.banner--adapt) > .banner__media {
-    height: 28rem;
+    height: 17.5rem;
   }
 
   .banner--medium.banner--mobile-bottom:not(.banner--adapt) > .banner__media,
   .banner--medium.banner--stacked:not(.banner--mobile-bottom):not(.banner--adapt) > .banner__media {
-    height: 34rem;
+    height: 21.5rem;
   }
 
   .banner--large.banner--mobile-bottom:not(.banner--adapt) > .banner__media,
   .banner--large.banner--stacked:not(.banner--mobile-bottom):not(.banner--adapt) > .banner__media {
-    height: 39rem;
+    height: 24.5rem;
   }
 
   .banner--small:not(.banner--mobile-bottom):not(.banner--adapt) .banner__content {
-    min-height: 28rem;
+    min-height: 17.5rem;
   }
 
   .banner--medium:not(.banner--mobile-bottom):not(.banner--adapt) .banner__content {
-    min-height: 34rem;
+    min-height: 21.5rem;
   }
 
   .banner--large:not(.banner--mobile-bottom):not(.banner--adapt) .banner__content {
-    min-height: 39rem;
+    min-height: 24.5rem;
   }
 }
 
@@ -39,15 +39,15 @@
   }
 
   .banner--small:not(.banner--adapt) {
-    min-height: 42rem;
+    min-height: 26.5rem;
   }
 
   .banner--medium:not(.banner--adapt) {
-    min-height: 56rem;
+    min-height: 35.0rem;
   }
 
   .banner--large:not(.banner--adapt) {
-    min-height: 72rem;
+    min-height: 45.0rem;
   }
 }
 
@@ -177,8 +177,8 @@
 
 @media screen and (min-width: 750px) {
   .banner__content {
-    padding-bottom: 5rem;
-    padding-top: 5rem;
+    padding-bottom: 3.15rem;
+    padding-top: 3.15rem;
   }
 
   .banner__content--center {
@@ -187,18 +187,18 @@
 
   .banner__content--flex-start {
     align-items: flex-start;
-    padding-bottom: 15rem;
+    padding-bottom: 9.5rem;
   }
 
   .banner__content--flex-end {
     align-items: flex-end;
-    padding-top: 15rem;
+    padding-top: 9.5rem;
   }
 }
 
 .banner__box {
   border: 0;
-  padding: 4rem 3.5rem;
+  padding: 2.5rem 2.2rem;
   position: relative;
   height: fit-content;
   align-items: center;
@@ -212,7 +212,7 @@
     --color-foreground: 255, 255, 255;
     --color-button: 255, 255, 255;
     --color-button-text: 0, 0, 0;
-    max-width: 89rem;
+    max-width: 55.0rem;
   }
 
   .banner--desktop-transparent .button--secondary {
@@ -241,14 +241,14 @@
 .banner__box > .banner__buttons {
   display: flex;
   align-items: baseline;
-  gap: 1rem;
+  gap: 0.65rem;
   justify-content: center;
   flex-wrap: wrap;
 }
 
 .banner__box > * + .banner__buttons--multiple {
   display: flex;
-  max-width: 45rem;
+  max-width: 28.0rem;
   flex-wrap: wrap;
   align-items: baseline;
   justify-content: center;
@@ -258,7 +258,7 @@
 
 @media screen and (min-width: 750px) {
   .banner__box > * + .banner__buttons {
-    margin-top: 2rem;
+    margin-top: 1.25rem;
   }
 }
 
@@ -267,17 +267,17 @@
 }
 
 .banner__box > * + .banner__text {
-  margin-top: 1.5rem;
+  margin-top: 0.95rem;
 }
 
 @media screen and (min-width: 750px) {
   .banner__box > * + .banner__text {
-    margin-top: 2rem;
+    margin-top: 1.25rem;
   }
 }
 
 .banner__box > * + * {
-  margin-top: 1rem;
+  margin-top: 0.65rem;
 }
 
 .banner__box > *:first-child {
@@ -296,10 +296,10 @@
 
 @media screen and (min-width: 750px) {
   .banner__box {
-    padding: 5rem;
+    padding: 3.15rem;
     width: auto;
-    max-width: 71rem;
-    min-width: 45rem;
+    max-width: 44.5rem;
+    min-width: 28.0rem;
   }
 
   .banner__box > .banner__buttons:only-child .button {
@@ -309,7 +309,7 @@
 
 @media screen and (min-width: 1400px) {
   .banner__box {
-    max-width: 90rem;
+    max-width: 55.0rem;
   }
 }
 

--- a/assets/section-main-blog.css
+++ b/assets/section-main-blog.css
@@ -1,6 +1,6 @@
 .blog-articles {
   display: grid;
-  grid-gap: 1rem;
+  grid-gap: 0.65rem;
 }
 
 @media screen and (min-width: 750px) {
@@ -16,33 +16,33 @@
 
   .blog-articles--collage > *:nth-child(3n + 1) .article-card__image--small,
   .blog-articles--collage > *:nth-child(3n + 2):last-child .article-card__image--small {
-    padding-bottom: 22rem;
+    padding-bottom: 14.0rem;
   }
 
   .blog-articles--collage > *:nth-child(3n + 1) .article-card__image--medium,
   .blog-articles--collage > *:nth-child(3n + 2):last-child .article-card__image--medium {
-    padding-bottom: 44rem;
+    padding-bottom: 27.5rem;
   }
 
   .blog-articles--collage > *:nth-child(3n + 1) .article-card__image--large,
   .blog-articles--collage > *:nth-child(3n + 2):last-child .article-card__image--large {
-    padding-bottom: 66rem;
+    padding-bottom: 41.5rem;
   }
 }
 
 @media screen and (min-width: 990px) {
   .blog-articles--collage > *:nth-child(3n + 1) .article-card__image--small,
   .blog-articles--collage > *:nth-child(3n + 2):last-child .article-card__image--small {
-    padding-bottom: 27.5rem;
+    padding-bottom: 17.0rem;
   }
 
   .blog-articles--collage > *:nth-child(3n + 1) .article-card__image--medium,
   .blog-articles--collage > *:nth-child(3n + 2):last-child .article-card__image--medium {
-    padding-bottom: 55rem;
+    padding-bottom: 34.5rem;
   }
 
   .blog-articles--collage > *:nth-child(3n + 1) .article-card__image--large,
   .blog-articles--collage > *:nth-child(3n + 2):last-child .article-card__image--large {
-    padding-bottom: 82.5rem;
+    padding-bottom: 50.0rem;
   }
 }

--- a/assets/section-main-page.css
+++ b/assets/section-main-page.css
@@ -3,12 +3,12 @@
 }
 
 .main-page-title {
-  margin-bottom: 3rem;
+  margin-bottom: 1.9rem;
 }
 
 @media screen and (min-width: 750px) {
   .main-page-title {
-    margin-bottom: 4rem;
+    margin-bottom: 2.5rem;
   }
 }
 
@@ -18,6 +18,6 @@
 }
 
 .page-placeholder {
-  width: 52.5rem;
-  height: 52.5rem;
+  width: 33.0rem;
+  height: 33.0rem;
 }

--- a/assets/section-main-product.css
+++ b/assets/section-main-product.css
@@ -3,7 +3,7 @@
 }
 
 .product--no-media {
-  max-width: 57rem;
+  max-width: 35.5rem;
   margin: 0 auto;
 }
 
@@ -25,12 +25,12 @@
 @media screen and (min-width: 750px) {
   .product__info-container--sticky {
     position: sticky;
-    top: 3rem;
+    top: 1.9rem;
     z-index: 2;
   }
 
   .product__info-wrapper {
-    padding-left: 5rem;
+    padding-left: 3.15rem;
   }
 
   .product__media-container .slider-buttons {
@@ -41,13 +41,13 @@
 @media screen and (min-width: 990px) {
   .product:not(.product--no-media):not(.featured-product) .product__media-wrapper {
     max-width: 64%;
-    width: calc(64% - 1rem / 2);
+    width: calc(64% - 0.65rem / 2);
   }
 
   .product:not(.product--no-media):not(.featured-product) .product__info-wrapper {
-    padding-left: 4rem;
+    padding-left: 2.5rem;
     max-width: 36%;
-    width: calc(36% - 1rem / 2);
+    width: calc(36% - 0.65rem / 2);
   }
 }
 
@@ -56,14 +56,14 @@
 .shopify-payment-button__button {
   border-radius: 0;
   font-family: inherit;
-  min-height: 4.6rem;
+  min-height: 2.9rem;
 }
 
 .shopify-payment-button__button [role="button"].focused,
 .no-js .shopify-payment-button__button [role="button"]:focus {
-  outline: .2rem solid rgba(var(--color-foreground),.5) !important;
-  outline-offset: 0.3rem;
-  box-shadow: 0 0 0 .1rem rgba(var(--color-button),var(--alpha-button-border)),0 0 0 .3rem rgb(var(--color-background)),0 0 .5rem .4rem rgba(var(--color-foreground),.3) !important;
+  outline: 0.125rem solid rgba(var(--color-foreground),.5) !important;
+  outline-offset: 0.19rem;
+  box-shadow: 0 0 0 0.065rem rgba(var(--color-button),var(--alpha-button-border)),0 0 0 0.19rem rgb(var(--color-background)),0 0 0.315rem 0.25rem rgba(var(--color-foreground),.3) !important;
 }
 
 .shopify-payment-button__button [role="button"]:focus:not(:focus-visible) {
@@ -72,17 +72,17 @@
 }
 
 .shopify-payment-button__button [role="button"]:focus-visible {
-  outline: .2rem solid rgba(var(--color-foreground),.5) !important;
-  box-shadow: 0 0 0 .1rem rgba(var(--color-button),var(--alpha-button-border)),0 0 0 .3rem rgb(var(--color-background)),0 0 .5rem .4rem rgba(var(--color-foreground),.3) !important;
+  outline: 0.125rem solid rgba(var(--color-foreground),.5) !important;
+  box-shadow: 0 0 0 0.065rem rgba(var(--color-button),var(--alpha-button-border)),0 0 0 0.19rem rgb(var(--color-background)),0 0 0.315rem 0.25rem rgba(var(--color-foreground),.3) !important;
 }
 
 .shopify-payment-button__button--unbranded {
   background-color: rgba(var(--color-button), var(--alpha-button-background));
-  box-shadow: 0 0 0 0.1rem rgba(var(--color-button), var(--alpha-button-border));
+  box-shadow: 0 0 0 0.065rem rgba(var(--color-button), var(--alpha-button-border));
   color: rgb(var(--color-button-text));
-  font-size: 1.4rem;
+  font-size: 0.9rem;
   line-height: calc(1 + 0.2 / var(--font-body-scale));
-  letter-spacing: 0.07rem;
+  letter-spacing: 0.044rem;
 }
 
 .shopify-payment-button__button--unbranded::selection {
@@ -92,16 +92,16 @@
 .shopify-payment-button__button--unbranded:hover,
 .shopify-payment-button__button--unbranded:hover:not([disabled]) {
   background-color: rgba(var(--color-button), var(--alpha-button-background));
-  box-shadow: 0 0 0 0.2rem rgba(var(--color-button), var(--alpha-button-border));
+  box-shadow: 0 0 0 0.125rem rgba(var(--color-button), var(--alpha-button-border));
 }
 
 .shopify-payment-button__more-options {
-  margin: 1.6rem 0 1rem;
-  font-size: 1.2rem;
+  margin: 1.0rem 0 0.65rem;
+  font-size: 0.75rem;
   line-height: calc(1 + 0.5 / var(--font-body-scale));
-  letter-spacing: 0.05rem;
+  letter-spacing: 0.0315rem;
   text-decoration: underline;
-  text-underline-offset: 0.3rem;
+  text-underline-offset: 0.19rem;
 }
 
 .shopify-payment-button__button--hidden {
@@ -117,24 +117,24 @@
 .product-form__error-message-wrapper:not([hidden]) {
   display: flex;
   align-items: flex-start;
-  font-size: 1.2rem;
-  margin-bottom: 1.5rem;
+  font-size: 0.75rem;
+  margin-bottom: 0.95rem;
 }
 
 .product-form__error-message-wrapper svg {
   flex-shrink: 0;
-  width: 1.2rem;
-  height: 1.2rem;
-  margin-right: 0.7rem;
-  margin-top: 0.5rem;
+  width: 0.75rem;
+  height: 0.75rem;
+  margin-right: 0.44rem;
+  margin-top: 0.315rem;
 }
 
 /* Form Elements */
 .product-form__input {
   flex: 0 0 100%;
   padding: 0;
-  margin: 0 0 1.2rem 0;
-  max-width: 37rem;
+  margin: 0 0 0.75rem 0;
+  max-width: 23.0rem;
   min-width: fit-content;
   border: none;
 }
@@ -145,7 +145,7 @@ variant-selects {
 }
 
 .product-form__input--dropdown {
-  margin-bottom: 1.6rem;
+  margin-bottom: 1.0rem;
 }
 
 .product-form__input .form__label {
@@ -153,7 +153,7 @@ variant-selects {
 }
 
 fieldset.product-form__input .form__label {
-  margin-bottom: 0.2rem;
+  margin-bottom: 0.125rem;
 }
 
 .product-form__input input[type='radio'] {
@@ -165,14 +165,14 @@ fieldset.product-form__input .form__label {
 }
 
 .product-form__input input[type='radio'] + label {
-  border: 0.1rem solid rgba(var(--color-foreground), 0.55);
-  border-radius: 4rem;
+  border: 0.065rem solid rgba(var(--color-foreground), 0.55);
+  border-radius: 2.5rem;
   color: rgb(var(--color-foreground));
   display: inline-block;
-  margin: 0.7rem 0.5rem 0.2rem 0;
-  padding: 1rem 2rem;
-  font-size: 1.4rem;
-  letter-spacing: 0.1rem;
+  margin: 0.44rem 0.315rem 0.125rem 0;
+  padding: 0.65rem 1.25rem;
+  font-size: 0.9rem;
+  letter-spacing: 0.065rem;
   line-height: 1;
   text-align: center;
   transition: border var(--duration-short) ease;
@@ -180,7 +180,7 @@ fieldset.product-form__input .form__label {
 }
 
 .product-form__input input[type='radio'] + label:hover {
-  border: 0.1rem solid rgb(var(--color-foreground));
+  border: 0.065rem solid rgb(var(--color-foreground));
 }
 
 .product-form__input input[type='radio']:checked + label {
@@ -204,15 +204,15 @@ fieldset.product-form__input .form__label {
   text-decoration: line-through;
 }
 .product-form__input input[type='radio']:focus-visible + label {
-  box-shadow: 0 0 0 0.3rem rgb(var(--color-background)),
-    0 0 0 0.5rem rgba(var(--color-foreground), 0.55);
+  box-shadow: 0 0 0 0.19rem rgb(var(--color-background)),
+    0 0 0 0.315rem rgba(var(--color-foreground), 0.55);
 }
 
 /* Fallback */
 .product-form__input input[type='radio'].focused + label,
 .no-js .shopify-payment-button__button [role="button"]:focus + label {
-  box-shadow: 0 0 0 0.3rem rgb(var(--color-background)),
-    0 0 0 0.5rem rgba(var(--color-foreground), 0.55);
+  box-shadow: 0 0 0 0.19rem rgb(var(--color-background)),
+    0 0 0 0.315rem rgba(var(--color-foreground), 0.55);
 }
 
 /* No outline when focus-visible is available in the browser */
@@ -221,11 +221,11 @@ fieldset.product-form__input .form__label {
 }
 
 .product-form__input .select {
-  max-width: 25rem;
+  max-width: 15.5rem;
 }
 
 .product-form__submit {
-  margin-bottom: 1rem;
+  margin-bottom: 0.65rem;
 }
 
 .no-js .product-form__submit.button--secondary {
@@ -251,19 +251,19 @@ fieldset.product-form__input .form__label {
 }
 
 .shopify-payment-button__button {
-  font-size: 1.5rem;
-  letter-spacing: 0.1rem;
+  font-size: 0.95rem;
+  letter-spacing: 0.065rem;
 }
 
 /* Product info */
 
 .product__info-container > * + * {
-  margin: 1.5rem 0;
+  margin: 0.95rem 0;
 }
 
 .product__info-container .product-form,
 .product__info-container .product__description {
-  margin: 2.5rem 0;
+  margin: 1.55rem 0;
 }
 
 .product__text {
@@ -282,11 +282,11 @@ a.product__text {
 
 .product__title {
   word-break: break-word;
-  margin-bottom: 1.5rem;
+  margin-bottom: 0.95rem;
 }
 
 .product__title + .product__text.caption-with-letter-spacing {
-  margin-top: -1.5rem;
+  margin-top: -0.95rem;
 }
 
 .product__text.caption-with-letter-spacing + .product__title {
@@ -294,7 +294,7 @@ a.product__text {
 }
 
 .product__accordion .accordion__content {
-  padding: 0 1rem;
+  padding: 0 0.65rem;
 }
 
 .product .price {
@@ -302,13 +302,13 @@ a.product__text {
 }
 
 .product .price .badge {
-  margin-top: 0.5rem;
-  margin-bottom: 0.5rem;
+  margin-top: 0.315rem;
+  margin-bottom: 0.315rem;
 }
 
 .product .price dl {
-  margin-top: 0.5rem;
-  margin-bottom: 0.5rem;
+  margin-top: 0.315rem;
+  margin-bottom: 0.315rem;
 }
 
 .product .price--sold-out .price__badge-sold-out {
@@ -323,7 +323,7 @@ a.product__text {
 
 @media screen and (min-width: 750px) {
   .product__info-container .price--on-sale .price-item--regular {
-    font-size: 1.6rem;
+    font-size: 1.0rem;
   }
 
   .product__info-container > *:first-child {
@@ -343,7 +343,7 @@ a.product__text {
 }
 
 .product__tax {
-  margin-top: -1.4rem;
+  margin-top: -0.9rem;
 }
 
 .product--no-media noscript .product-form__input,
@@ -369,7 +369,7 @@ a.product__text {
 }
 
 .product--no-media .product-form > .form {
-  max-width: 30rem;
+  max-width: 19.0rem;
   width: 100%;
 }
 
@@ -381,7 +381,7 @@ a.product__text {
 
 .product--no-media fieldset.product-form__input {
   flex-wrap: wrap;
-  margin: 0 auto 1.2rem auto;
+  margin: 0 auto 0.75rem auto;
 }
 
 .product--no-media .product__info-container > modal-opener {
@@ -405,25 +405,25 @@ a.product__text {
 
 @media screen and (max-width: 749px) {
   .product__media-list {
-    margin-left: -2.5rem;
-    padding-bottom: 2rem;
-    margin-bottom: 3rem;
-    width: calc(100% + 4rem);
+    margin-left: -1.55rem;
+    padding-bottom: 1.25rem;
+    margin-bottom: 1.9rem;
+    width: calc(100% + 2.5rem);
   }
 
   .product__media-wrapper slider-component {
-    margin-left: -1.5rem;
-    margin-right: -1.5rem;
+    margin-left: -0.95rem;
+    margin-right: -0.95rem;
   }
 
   .slider.slider--mobile.product__media-list {
     padding-bottom: 0;
-    margin-bottom: 0.5rem;
+    margin-bottom: 0.315rem;
   }
 
   .slider.product__media-list::-webkit-scrollbar {
-    height: 0.2rem;
-    width: 0.2rem;
+    height: 0.125rem;
+    width: 0.125rem;
   }
 
   .product__media-list::-webkit-scrollbar-thumb {
@@ -435,11 +435,11 @@ a.product__text {
   }
 
   .product__media-list .product__media-item {
-    width: calc(100% - 3rem);
+    width: calc(100% - 1.9rem);
   }
 
   .slider.product__media-list .product__media-item:first-of-type {
-    padding-left: 1.5rem;
+    padding-left: 0.95rem;
   }
 }
 
@@ -467,7 +467,7 @@ a.product__text {
 
 @media screen and (max-width: 749px) {
   .product__media-item--variant:first-child {
-    padding-right: 1.5rem;
+    padding-right: 0.95rem;
   }
 }
 
@@ -477,29 +477,29 @@ a.product__text {
   }
 
   .product__media-list .product__media-item {
-    padding: 0 0 0.5rem;
+    padding: 0 0 0.315rem;
     width: 100%;
   }
 }
 
 .product__media-icon .icon {
-  width: 1.2rem;
-  height: 1.4rem;
+  width: 0.75rem;
+  height: 0.9rem;
 }
 
 .product__media-icon {
   background-color: rgb(var(--color-background));
   border-radius: 50%;
-  border: 0.1rem solid rgba(var(--color-foreground), 0.1);
+  border: 0.065rem solid rgba(var(--color-foreground), 0.1);
   color: rgb(var(--color-foreground));
   display: flex;
   align-items: center;
   justify-content: center;
-  height: 3rem;
-  width: 3rem;
+  height: 1.9rem;
+  width: 1.9rem;
   position: absolute;
-  left: 1.5rem;
-  top: 1.5rem;
+  left: 0.95rem;
+  top: 0.95rem;
   z-index: 1;
   transition: color var(--duration-short) ease,
     opacity var(--duration-short) ease;
@@ -514,7 +514,7 @@ a.product__text {
 }
 
 .product__modal-opener:hover .product__media-icon {
-  border: 0.1rem solid rgba(var(--color-foreground), 0.1);
+  border: 0.065rem solid rgba(var(--color-foreground), 0.1);
 }
 
 @media screen and (min-width: 750px) {
@@ -591,7 +591,7 @@ a.product__text {
 
 @media screen and (min-width: 750px) {
   .product-media-modal__content {
-    padding-bottom: 2rem;
+    padding-bottom: 1.25rem;
   }
 
   .product-media-modal__content > *:not(.active) {
@@ -609,14 +609,14 @@ a.product__text {
 
 .product__media-list .deferred-media,
 .product__media-list .product__modal-opener {
-  border: 0.1rem solid rgba(var(--color-foreground), 0.04);
+  border: 0.065rem solid rgba(var(--color-foreground), 0.04);
 }
 
 .product-media-modal__content > * {
   display: block;
   height: auto;
   margin: auto;
-  border: 0.1rem solid rgba(var(--color-foreground), 0.04);
+  border: 0.065rem solid rgba(var(--color-foreground), 0.04);
 }
 
 .product-media-modal__content .media {
@@ -629,19 +629,19 @@ a.product__text {
 
 .product-media-modal__toggle {
   background-color: rgb(var(--color-background));
-  border: 0.1rem solid rgba(var(--color-foreground), 0.1);
+  border: 0.065rem solid rgba(var(--color-foreground), 0.1);
   border-radius: 50%;
   color: rgba(var(--color-foreground), 0.55);
   display: flex;
   align-items: center;
   justify-content: center;
   cursor: pointer;
-  right: 2rem;
-  padding: 1.2rem;
+  right: 1.25rem;
+  padding: 0.75rem;
   position: fixed;
   z-index: 2;
-  top: 2rem;
-  width: 4rem;
+  top: 1.25rem;
+  width: 2.5rem;
 }
 
 .product-media-modal__content .deferred-media {
@@ -650,7 +650,7 @@ a.product__text {
 
 @media screen and (min-width: 750px) {
   .product-media-modal__content {
-    padding: 2rem 11rem;
+    padding: 1.25rem 7.0rem;
   }
 
   .product-media-modal__content > * {
@@ -658,30 +658,30 @@ a.product__text {
   }
 
   .product-media-modal__content > * + * {
-    margin-top: 2rem;
+    margin-top: 1.25rem;
   }
 
   .product-media-modal__toggle {
-    right: 5rem;
-    top: 2.2rem;
+    right: 3.15rem;
+    top: 1.4rem;
   }
 }
 
 @media screen and (min-width: 990px) {
   .product-media-modal__content {
-    padding: 2rem 11rem;
+    padding: 1.25rem 7.0rem;
   }
 
   .product-media-modal__content > * + * {
-    margin-top: 1.5rem;
+    margin-top: 0.95rem;
   }
 
   .product-media-modal__content {
-    padding-bottom: 1.5rem;
+    padding-bottom: 0.95rem;
   }
 
   .product-media-modal__toggle {
-    right: 5rem;
+    right: 3.15rem;
   }
 }
 
@@ -692,7 +692,7 @@ a.product__text {
 .product-media-modal__toggle .icon {
   height: auto;
   margin: 0;
-  width: 2.2rem;
+  width: 1.4rem;
 }
 
 /* Product popup */
@@ -725,19 +725,19 @@ a.product__text {
   margin: 0 auto;
   left: 50%;
   transform: translateX(-50%);
-  margin-top: 5rem;
+  margin-top: 3.15rem;
   width: 92%;
   position: absolute;
   top: 0;
-  padding: 0 1.5rem 0 3rem;
+  padding: 0 0.95rem 0 1.9rem;
 }
 
 @media screen and (min-width: 750px) {
   .product-popup-modal__content {
-    padding-right: 1.5rem;
-    margin-top: 10rem;
+    padding-right: 0.95rem;
+    margin-top: 6.5rem;
     width: 70%;
-    padding: 0 3rem;
+    padding: 0 1.9rem;
   }
 }
 
@@ -760,21 +760,21 @@ a.product__text {
 }
 
 .product-popup-modal__button {
-  font-size: 1.6rem;
-  padding-right: 1.3rem;
+  font-size: 1.0rem;
+  padding-right: 0.8rem;
   padding-left: 0;
-  height: 4.4rem;
-  text-underline-offset: 0.3rem;
-  text-decoration-thickness: 0.1rem;
+  height: 2.75rem;
+  text-underline-offset: 0.19rem;
+  text-decoration-thickness: 0.065rem;
   transition: text-decoration-thickness var(--duration-short) ease;
 }
 
 .product-popup-modal__button:hover {
-  text-decoration-thickness: 0.2rem;
+  text-decoration-thickness: 0.125rem;
 }
 
 .product-popup-modal__content-info {
-  padding-right: 4.4rem;
+  padding-right: 2.75rem;
 }
 
 .product-popup-modal__content-info > * {
@@ -792,7 +792,7 @@ a.product__text {
 
 .product-popup-modal__toggle {
   background-color: rgb(var(--color-background));
-  border: 0.1rem solid rgba(var(--color-foreground), 0.1);
+  border: 0.065rem solid rgba(var(--color-foreground), 0.1);
   border-radius: 50%;
   color: rgba(var(--color-foreground), 0.55);
   display: flex;
@@ -800,10 +800,10 @@ a.product__text {
   justify-content: center;
   cursor: pointer;
   position: sticky;
-  padding: 1.2rem;
+  padding: 0.75rem;
   z-index: 2;
-  top: 1.5rem;
-  width: 4rem;
+  top: 0.95rem;
+  width: 2.5rem;
   margin: 0 0 0 auto;
 }
 
@@ -814,5 +814,5 @@ a.product__text {
 .product-popup-modal__toggle .icon {
   height: auto;
   margin: 0;
-  width: 2.2rem;
+  width: 1.4rem;
 }

--- a/assets/section-multicolumn.css
+++ b/assets/section-multicolumn.css
@@ -8,13 +8,13 @@
 
 @media screen and (max-width: 749px) {
   .multicolumn.no-heading.background-secondary {
-    padding-top: 5rem;
+    padding-top: 3.15rem;
   }
 }
 
 @media screen and (min-width: 750px) {
   .multicolumn.no-heading:not(.background-secondary) {
-    margin-top: calc(6rem + var(--page-width-margin));
+    margin-top: calc(3.75rem + var(--page-width-margin));
   }
 }
 
@@ -24,7 +24,7 @@
 
 @media screen and (max-width: 749px) {
   .multicolumn .title-wrapper-with-link {
-    margin-bottom: 3rem;
+    margin-bottom: 1.9rem;
   }
 }
 
@@ -44,12 +44,12 @@
 }
 
 .multicolumn .button {
-  margin-top: 1.5rem;
+  margin-top: 0.95rem;
 }
 
 @media screen and (min-width: 750px) {
   .multicolumn .button {
-    margin-top: 4rem;
+    margin-top: 2.5rem;
   }
 }
 
@@ -59,7 +59,7 @@
 }
 
 .multicolumn-list__item:only-child {
-  max-width: 72rem;
+  max-width: 45.0rem;
 }
 
 .multicolumn:not(.background-none) .multicolumn-card {
@@ -72,29 +72,29 @@
 }
 
 .multicolumn.background-secondary {
-  padding: 4rem 0 5rem;
+  padding: 2.5rem 0 3.15rem;
 }
 
 @media screen and (min-width: 750px) {
   .multicolumn.background-secondary {
-    padding: calc(4rem + var(--page-width-margin)) 0
-      calc(5rem + var(--page-width-margin));
+    padding: calc(2.5rem + var(--page-width-margin)) 0
+      calc(3.15rem + var(--page-width-margin));
   }
 }
 
 @media screen and (max-width: 749px) {
   .multicolumn.background-secondary .slider-buttons {
-    margin-bottom: -2rem;
+    margin-bottom: -1.25rem;
   }
 }
 
 .multicolumn:not(.background-secondary) {
-  margin: 5rem 0;
+  margin: 3.15rem 0;
 }
 
 @media screen and (min-width: 750px) {
   .multicolumn:not(.background-secondary) {
-    margin: calc(5rem + var(--page-width-margin)) 0;
+    margin: calc(3.15rem + var(--page-width-margin)) 0;
   }
 }
 
@@ -108,13 +108,13 @@
 }
 
 .multicolumn-card-spacing {
-  padding-top: 2.5rem;
-  margin-left: 2.5rem;
-  margin-right: 2.5rem;
+  padding-top: 1.55rem;
+  margin-left: 1.55rem;
+  margin-right: 1.55rem;
 }
 
 .multicolumn-card__info > :nth-child(2) {
-  margin-top: 1rem;
+  margin-top: 0.65rem;
 }
 
 .multicolumn-list__item.center .media--adapt,
@@ -138,21 +138,21 @@
   }
 
   .multicolumn-list__item {
-    margin: 0 0 1rem;
+    margin: 0 0 0.65rem;
     padding: 0;
   }
 
   .multicolumn-list:not(.slider) {
-    padding-left: 1.5rem;
-    padding-right: 1.5rem;
+    padding-left: 0.95rem;
+    padding-right: 0.95rem;
   }
 
   .multicolumn-list.slider .multicolumn-list__item {
-    width: calc(100% - 3rem);
+    width: calc(100% - 1.9rem);
   }
 
   .multicolumn-list.slider .multicolumn-list__item + .multicolumn-list__item {
-    padding-left: 0.5rem;
+    padding-left: 0.315rem;
   }
 }
 
@@ -168,12 +168,12 @@
   }
 
   .grid--2-col-tablet .multicolumn-list__item {
-    margin-top: 1rem;
+    margin-top: 0.65rem;
     max-width: 50%;
   }
 
   .background-none .grid--2-col-tablet .multicolumn-list__item {
-    margin-top: 4rem;
+    margin-top: 2.5rem;
   }
 
   .grid--2-col-tablet .multicolumn-list__item:nth-of-type(-n + 2) {
@@ -198,7 +198,7 @@
 }
 
 .multicolumn-card__info {
-  padding: 2.5rem 2.5rem;
+  padding: 1.55rem 1.55rem;
 }
 
 .background-none .multicolumn-card__info {
@@ -212,42 +212,42 @@
 }
 
 .background-none .multicolumn-card__image-wrapper + .multicolumn-card__info {
-  padding-top: 2.5rem;
+  padding-top: 1.55rem;
 }
 
 .background-none .slider .multicolumn-card__info {
-  padding-left: 0.5rem;
+  padding-left: 0.315rem;
 }
 
 .background-none
   .slider
   .multicolumn-card__image-wrapper
   + .multicolumn-card__info {
-  padding-left: 1.5rem;
+  padding-left: 0.95rem;
 }
 
 .background-none
   .multicolumn-list:not(.slider)
   .center
   .multicolumn-card__info {
-  padding-left: 2.5rem;
-  padding-right: 2.5rem;
+  padding-left: 1.55rem;
+  padding-right: 1.55rem;
 }
 
 @media screen and (max-width: 749px) {
   .background-none .slider .multicolumn-card__info {
-    padding-bottom: 1rem;
+    padding-bottom: 0.65rem;
   }
 
   .multicolumn.background-none .slider.slider--mobile {
-    margin-bottom: 0rem;
+    margin-bottom: 0.0rem;
   }
 }
 
 @media screen and (min-width: 750px) {
   .background-none .multicolumn-card__image-wrapper {
-    margin-left: 1.5rem;
-    margin-right: 1.5rem;
+    margin-left: 0.95rem;
+    margin-right: 0.95rem;
   }
 
   .background-none .multicolumn-list .multicolumn-card__info,
@@ -255,18 +255,18 @@
     .multicolumn-list:not(.slider)
     .center
     .multicolumn-card__info {
-    padding-left: 1.5rem;
-    padding-right: 1.5rem;
+    padding-left: 0.95rem;
+    padding-right: 0.95rem;
   }
 }
 
 .multicolumn-card__info .link {
   text-decoration: none;
   font-size: inherit;
-  margin-top: 1.5rem;
+  margin-top: 0.95rem;
 }
 
 .multicolumn-card__info .icon-wrap {
-  margin-left: 0.8rem;
+  margin-left: 0.5rem;
   white-space: nowrap;
 }

--- a/assets/section-password.css
+++ b/assets/section-password.css
@@ -14,8 +14,8 @@ html {
 body {
   background-color: rgb(var(--color-background));
   color: rgb(var(--color-foreground));
-  font-size: 1.5rem;
-  letter-spacing: 0.07rem;
+  font-size: 0.95rem;
+  letter-spacing: 0.044rem;
   line-height: calc(1 + 0.8 / var(--font-body-scale));
   margin: 0;
   min-height: 100vh;
@@ -28,20 +28,20 @@ body {
 
 @media screen and (min-width: 750px) {
   body {
-    font-size: 1.6rem;
+    font-size: 1.0rem;
     line-height: calc(1 + 0.8 / var(--font-body-scale));
   }
 }
 
 .password-modal__content-heading {
-  font-size: 1.8rem;
+  font-size: 1.15rem;
   font-weight: 400;
   line-height: calc(1 + 0.6 / var(--font-body-scale));
 }
 
 @media only screen and (min-width: 750px) {
   .password-modal__content-heading {
-    font-size: 1.8rem;
+    font-size: 1.15rem;
   }
 }
 
@@ -58,19 +58,19 @@ body {
 
 .password-link {
   align-items: center;
-  font-size: 1.4rem;
+  font-size: 0.9rem;
   font-weight: 400;
   white-space: nowrap;
 }
 
 .password-link svg {
-  width: 1.8rem;
-  height: 1.8rem;
-  margin-right: 1rem;
+  width: 1.15rem;
+  height: 1.15rem;
+  margin-right: 0.65rem;
 }
 
 .password-modal__content {
-  padding: 4.5rem 3.2rem;
+  padding: 2.8rem 2.0rem;
   display: flex;
   flex-direction: column;
   align-items: center;
@@ -82,54 +82,54 @@ body {
 }
 
 .password-modal__content-heading {
-  font-size: 1.8rem;
+  font-size: 1.15rem;
   font-weight: 400;
   line-height: calc(1 + 0.6 / var(--font-body-scale));
 }
 
 @media only screen and (min-width: 750px) {
   .password-modal__content-heading {
-    font-size: 1.8rem;
+    font-size: 1.15rem;
   }
 }
 
 .password-modal .password-form {
-  max-width: 50rem;
+  max-width: 31.5rem;
 }
 
 .password-form {
   display: flex;
   flex-wrap: wrap;
   align-items: center;
-  margin-top: 4rem;
-  margin-bottom: 2rem;
+  margin-top: 2.5rem;
+  margin-bottom: 1.25rem;
   width: 100%;
 }
 
 .password-field.field {
   display: block;
-  flex: 1 20rem;
+  flex: 1 12.5rem;
 }
 
 .password-field .form__message {
-  margin-top: 1.5rem;
+  margin-top: 0.95rem;
 }
 
 .password-button {
-  margin-top: 3rem;
+  margin-top: 1.9rem;
   width: 100%;
 }
 
 @media only screen and (max-width: 749px) {
   .password-field--error + .password-button {
-    margin-top: 1.5rem;
+    margin-top: 0.95rem;
   }
 }
 
 @media only screen and (min-width: 750px) {
   .password-button {
     margin-top: 0;
-    margin-left: 2rem;
+    margin-left: 1.25rem;
     width: auto;
     align-self: start;
   }
@@ -137,7 +137,7 @@ body {
 
 .password-logo {
   width: 100%;
-  margin-bottom: 1.5rem;
+  margin-bottom: 0.95rem;
 }
 
 @media only screen and (min-width: 750px) {
@@ -147,7 +147,7 @@ body {
 }
 
 .password-heading {
-  margin-top: 5rem;
+  margin-top: 3.15rem;
   font-weight: 400;
 }
 
@@ -183,14 +183,14 @@ body {
 
 .password__footer-text a {
   padding: 0;
-  font-size: 1.3rem;
+  font-size: 0.8rem;
   font-weight: 400;
   line-height: calc(1 + 0.5 / var(--font-body-scale));
 }
 
 .password__footer-login {
-  margin-top: 1.2rem;
-  padding-bottom: 4rem;
+  margin-top: 0.75rem;
+  padding-bottom: 2.5rem;
 }
 
 .password-modal .icon-close {
@@ -201,7 +201,7 @@ body {
   display: flex;
   flex-direction: column;
   align-items: center;
-  padding-top: 4rem;
+  padding-top: 2.5rem;
   background-color: rgb(var(--color-background));
   color: rgb(var(--color-foreground));
 }
@@ -211,7 +211,7 @@ hr {
 }
 
 .list-social:not(:empty) + .password__footer-caption {
-  margin-top: 3rem;
+  margin-top: 1.9rem;
 }
 
 .password__footer-caption a {
@@ -227,9 +227,9 @@ hr {
 details[open] .modal__toggle,
 .modal__close-button {
   position: absolute;
-  top: 2.2rem;
-  right: 2.2rem;
-  padding: 0.8rem;
+  top: 1.4rem;
+  right: 1.4rem;
+  padding: 0.5rem;
   color: rgb(var(--color-foreground));
   background-color: transparent;
 }
@@ -254,14 +254,14 @@ details[open].modal .modal__toggle-close {
   background: rgb(var(--color-background));
   cursor: pointer;
   display: flex;
-  padding: 0.8rem;
+  padding: 0.5rem;
   z-index: 1;
 }
 
 details[open].modal .modal__toggle-close svg,
 .modal__close-button svg {
-  height: 1.7rem;
-  width: 1.7rem;
+  height: 1.05rem;
+  width: 1.05rem;
 }
 
 details[open].modal .modal__toggle-close:hover {
@@ -281,7 +281,7 @@ details.modal .modal__toggle-open {
 }
 
 .password-header {
-  padding: 2rem 1.5rem 2.5rem;
+  padding: 1.25rem 0.95rem 1.55rem;
   display: flex;
   justify-content: space-between;
   align-items: center;
@@ -295,9 +295,9 @@ details.modal .modal__toggle-open {
 @media only screen and (min-width: 750px) {
   .password-header {
     display: grid;
-    gap: 3rem;
+    gap: 1.9rem;
     grid-template-columns: 1fr 1.5fr 1fr;
-    padding: 2rem 5rem 2.5rem;
+    padding: 1.25rem 3.15rem 1.55rem;
     text-align: left;
   }
 }
@@ -312,8 +312,8 @@ details.modal .modal__toggle-open {
 
 @media only screen and (max-width: 749px) {
   .password-content {
-    margin-bottom: 1.8rem;
-    margin-top: 1rem;
+    margin-bottom: 1.15rem;
+    margin-top: 0.65rem;
   }
 }
 
@@ -325,8 +325,8 @@ details.modal .modal__toggle-open {
 }
 
 .icon-shopify {
-  width: 7rem;
-  height: 2rem;
+  width: 4.4rem;
+  height: 1.25rem;
   vertical-align: top;
   color: rgb(var(--color-foreground));
 }

--- a/assets/section-product-recommendations.css
+++ b/assets/section-product-recommendations.css
@@ -4,5 +4,5 @@
 
 .product-recommendations__heading {
   margin: 0;
-  margin-bottom: 3rem;
+  margin-bottom: 1.9rem;
 }

--- a/assets/section-rich-text.css
+++ b/assets/section-rich-text.css
@@ -10,8 +10,8 @@
 
 .rich-text__blocks {
   margin: auto;
-  /* 2.5rem margin on left & right */
-  width: calc(100% - 5rem / var(--font-body-scale));
+  /* 1.55rem margin on left & right */
+  width: calc(100% - 3.15rem / var(--font-body-scale));
 }
 
 .rich-text__blocks * {
@@ -19,46 +19,46 @@
 }
 
 .rich-text--full-width .rich-text__blocks {
-  /* 4rem (1.5rem + 2.5rem) margin on left & right */
-  width: calc(100% - 8rem / var(--font-body-scale));
+  /* 2.5rem (0.95rem + 1.55rem) margin on left & right */
+  width: calc(100% - 5.0rem / var(--font-body-scale));
 }
 
 .rich-text:not(.rich-text--full-width),
 .rich-text--full-width.color-background-1 {
-  margin-top: 5rem;
-  margin-bottom: 5rem;
+  margin-top: 3.15rem;
+  margin-bottom: 3.15rem;
 }
 
 .rich-text:not(.color-background-1) {
-  padding-top: 5rem;
-  padding-bottom: 5rem;
+  padding-top: 3.15rem;
+  padding-bottom: 3.15rem;
 }
 
 @media screen and (min-width: 750px) {
   .rich-text:not(.rich-text--full-width),
   .rich-text--full-width.color-background-1 {
-    margin-top: calc(5rem + var(--page-width-margin));
-    margin-bottom: calc(5rem + var(--page-width-margin));
+    margin-top: calc(3.15rem + var(--page-width-margin));
+    margin-bottom: calc(3.15rem + var(--page-width-margin));
   }
 
   .rich-text:not(.color-background-1) {
-    padding-top: calc(5rem + var(--page-width-margin));
-    padding-bottom: calc(5rem + var(--page-width-margin));
+    padding-top: calc(3.15rem + var(--page-width-margin));
+    padding-bottom: calc(3.15rem + var(--page-width-margin));
   }
 
   .rich-text__blocks {
-    max-width: 50rem;
+    max-width: 31.5rem;
   }
 
   .rich-text--full-width .rich-text__blocks {
-    /* 7.5rem (5rem + 2.5rem) margin on left & right */
-    width: calc(100% - 15rem);
+    /* 4.7rem (3.15rem + 1.55rem) margin on left & right */
+    width: calc(100% - 9.5rem);
   }
 }
 
 @media screen and (min-width: 990px) {
   .rich-text__blocks {
-    max-width: 78rem;
+    max-width: 49.0rem;
   }
 }
 
@@ -70,9 +70,9 @@
 }
 
 .rich-text__blocks > * + * {
-  margin-top: 2rem;
+  margin-top: 1.25rem;
 }
 
 .rich-text__blocks > * + a {
-  margin-top: 3rem;
+  margin-top: 1.9rem;
 }

--- a/assets/template-collection.css
+++ b/assets/template-collection.css
@@ -1,5 +1,5 @@
 .collection-grid-section {
-  margin-top: 3rem;
+  margin-top: 1.9rem;
 }
 
 .collection {
@@ -13,19 +13,19 @@
   }
 
   .collection .title:not(.title--no-heading) {
-    margin-top: -1rem;
+    margin-top: -0.65rem;
   }
 }
 
 @media screen and (min-width: 750px) {
   .collection .title-wrapper-with-link--no-heading {
-    margin-top: calc(6rem + var(--page-width-margin));
+    margin-top: calc(3.75rem + var(--page-width-margin));
   }
 }
 
 @media screen and (max-width: 989px) {
   .collection .slider.slider--tablet {
-    margin-bottom: 1.5rem;
+    margin-bottom: 0.95rem;
   }
 }
 
@@ -36,14 +36,14 @@
   left: 0;
   display: none;
   width: 100%;
-  padding: 0 1.5rem;
+  padding: 0 0.95rem;
   opacity: 0.7;
 }
 
 @media screen and (min-width: 750px) {
   .collection .loading-overlay {
-    padding-left: 5rem;
-    padding-right: 5rem;
+    padding-left: 3.15rem;
+    padding-right: 3.15rem;
   }
 }
 
@@ -52,6 +52,6 @@
 }
 
 .collection--empty .title-wrapper {
-  margin-top: 10rem;
-  margin-bottom: 15rem;
+  margin-top: 6.5rem;
+  margin-bottom: 9.5rem;
 }

--- a/assets/template-giftcard.css
+++ b/assets/template-giftcard.css
@@ -30,12 +30,12 @@ html {
 body {
   background-color: rgb(var(--color-base-background-1));
   color: rgb(var(--color-base-text));
-  font-size: 1.5rem;
-  letter-spacing: 0.07rem;
+  font-size: 0.95rem;
+  letter-spacing: 0.044rem;
   line-height: calc(1 + 0.8 / var(--font-body-scale));
   max-width: var(--page-width);
   margin: 0 auto;
-  padding: 0 2rem;
+  padding: 0 1.25rem;
   flex: 1 0 auto;
   font-family: var(--font-body-family);
   font-style: var(--font-body-style);
@@ -44,9 +44,9 @@ body {
 
 @media only screen and (min-width: 750px) {
   body {
-    font-size: 1.6rem;
+    font-size: 1.0rem;
     line-height: calc(1 + 0.8 / var(--font-body-scale));
-    padding: 0 5rem;
+    padding: 0 3.15rem;
   }
 }
 
@@ -61,31 +61,31 @@ h2,
   font-family: var(--font-heading-family);
   font-style: var(--font-heading-style);
   font-weight: var(--font-heading-weight);
-  letter-spacing: calc(var(--font-heading-scale) * 0.06rem);
+  letter-spacing: calc(var(--font-heading-scale) * 0.0375rem);
   line-height: calc(1 + 0.3 / max(1, var(--font-heading-scale)));
 }
 
 h1,
 .h1 {
-  font-size: calc(var(--font-heading-scale) * 3rem);
+  font-size: calc(var(--font-heading-scale) * 1.9rem);
 }
 
 @media only screen and (min-width: 750px) {
   h1,
   .h1 {
-    font-size: calc(var(--font-heading-scale) * 4rem);
+    font-size: calc(var(--font-heading-scale) * 2.5rem);
   }
 }
 
 h2,
 .h2 {
-  font-size: calc(var(--font-heading-scale) * 2rem);
+  font-size: calc(var(--font-heading-scale) * 1.25rem);
 }
 
 @media only screen and (min-width: 750px) {
   h2,
   .h2 {
-    font-size: calc(var(--font-heading-scale) * 2.4rem);
+    font-size: calc(var(--font-heading-scale) * 1.5rem);
   }
 }
 
@@ -104,8 +104,8 @@ h2,
   border: none;
   box-shadow: none;
   background-color: transparent;
-  padding: 0.4rem;
-  font-size: 1.6rem;
+  padding: 0.25rem;
+  font-size: 1.0rem;
   line-height: 1;
   text-decoration: underline;
   color: rgb(var(--color-base-outline-button-labels));
@@ -122,15 +122,15 @@ h2,
   justify-content: center;
   align-items: center;
   border: none;
-  padding: 1.5rem 3rem;
+  padding: 0.95rem 1.9rem;
   text-decoration: none;
   background-color: rgb(var(--color-base-accent-1));
-  box-shadow: 0 0 0 0.1rem rgb(var(--color-base-accent-1));
+  box-shadow: 0 0 0 0.065rem rgb(var(--color-base-accent-1));
   color: rgb(var(--color-base-solid-button-labels));
-  min-width: 12rem;
+  min-width: 7.5rem;
   height: auto;
-  font-size: 1.5rem;
-  letter-spacing: 0.1rem;
+  font-size: 0.95rem;
+  letter-spacing: 0.065rem;
   line-height: calc(1 + 0.2 / var(--font-body-scale));
 }
 
@@ -139,12 +139,12 @@ h2,
 }
 
 .button:hover {
-  box-shadow: 0 0 0 0.2rem rgb(var(--color-base-accent-1));
+  box-shadow: 0 0 0 0.125rem rgb(var(--color-base-accent-1));
 }
 
 .button--secondary {
   color: rgb(var(--color-base-outline-button-labels));
-  box-shadow: 0 0 0 0.1rem rgb(var(--color-base-outline-button-labels));
+  box-shadow: 0 0 0 0.065rem rgb(var(--color-base-outline-button-labels));
   background-color: transparent;
 }
 
@@ -153,22 +153,22 @@ h2,
 }
 
 .button--secondary:hover {
-  box-shadow: 0 0 0 0.2rem rgb(var(--color-base-outline-button-labels));
+  box-shadow: 0 0 0 0.125rem rgb(var(--color-base-outline-button-labels));
 }
 
 .gift-card {
-  padding-bottom: 3.4rem;
+  padding-bottom: 2.15rem;
 }
 
 .gift-card__title {
   text-align: center;
   word-break: break-word;
-  padding: 4rem 0 1.7rem;
+  padding: 2.5rem 0 1.05rem;
 }
 
 @media only screen and (min-width: 990px) {
   .gift-card__title {
-    padding: 6rem 0 2.6rem;
+    padding: 3.75rem 0 1.65rem;
   }
 }
 
@@ -178,20 +178,20 @@ h2,
   align-items: center;
   height: 100%;
   background-color: rgb(var(--color-base-background-1));
-  margin-bottom: 0.8rem;
+  margin-bottom: 0.5rem;
   margin: 0 auto;
 }
 
 @media only screen and (min-width: 750px) {
   .gift-card__image-wrapper {
     margin-bottom: 0;
-    width: 40rem;
+    width: 25.0rem;
   }
 }
 
 .gift-card__image {
   max-width: 100%;
-  padding: 0 2rem;
+  padding: 0 1.25rem;
   height: auto;
 }
 
@@ -203,14 +203,14 @@ h2,
 
 .gift-card__heading {
   font-weight: 400;
-  margin: 2.5rem 0 1rem;
+  margin: 1.55rem 0 0.65rem;
 }
 
 .gift-card__price {
   display: flex;
   align-items: center;
   justify-content: center;
-  font-size: 1.6rem;
+  font-size: 1.0rem;
   font-weight: 400;
   letter-spacing: 1px;
   line-height: calc(1 + 0.5 / var(--font-body-scale));
@@ -218,12 +218,12 @@ h2,
 }
 
 .gift-card__price > p:first-child {
-  margin-bottom: 1rem;
+  margin-bottom: 0.65rem;
 }
 
 @media only screen and (min-width: 750px) {
   .gift-card__price {
-    font-size: 2rem;
+    font-size: 1.25rem;
   }
 }
 
@@ -236,47 +236,47 @@ h2,
   background-color: transparent;
   border: none;
   color: rgb(var(--color-base-text));
-  font-size: 1.8rem;
+  font-size: 1.15rem;
   font-weight: 400;
   line-height: calc(1 + 0.6 / var(--font-body-scale));
   text-align: center;
   width: 100%;
-  margin-bottom: 1rem;
+  margin-bottom: 0.65rem;
 }
 
 @media only screen and (min-width: 750px) {
   .gift-card__number {
-    font-size: 1.8rem;
+    font-size: 1.15rem;
   }
 }
 
 .gift-card__text {
-  margin-bottom: 4rem;
+  margin-bottom: 2.5rem;
   opacity: 0.7;
 }
 
 .gift-card__information {
   text-align: center;
-  margin-top: 3rem;
+  margin-top: 1.9rem;
 }
 
 .gift-card__label {
-  font-size: 1.3rem;
-  letter-spacing: 0.05rem;
+  font-size: 0.8rem;
+  letter-spacing: 0.0315rem;
   font-weight: 500;
   display: inline;
-  margin-left: 1rem;
+  margin-left: 0.65rem;
 }
 
 .badge {
   border: 1px solid transparent;
-  margin: 1.7rem 0 1rem 1rem;
-  border-radius: 4rem;
+  margin: 1.05rem 0 0.65rem 0.65rem;
+  border-radius: 2.5rem;
   display: inline-block;
-  font-size: 1.2rem;
-  letter-spacing: 0.1rem;
+  font-size: 0.75rem;
+  letter-spacing: 0.065rem;
   line-height: 1;
-  padding: 0.6rem 1.3rem;
+  padding: 0.375rem 0.8rem;
   text-align: center;
   background-color: rgb(var(--color-base-background-1));
   border-color: rgba(var(--color-base-text), 0.04);
@@ -290,22 +290,22 @@ h2,
 }
 
 .caption-large {
-  font-size: 1.3rem;
+  font-size: 0.8rem;
   line-height: calc(1 + 0.5 / var(--font-body-scale));
-  letter-spacing: 0.04rem;
+  letter-spacing: 0.025rem;
 }
 
 .gift-card__copy-code {
-  margin-bottom: 2.2rem;
+  margin-bottom: 1.4rem;
 }
 
 .gift-card__qr-code {
-  margin-top: 3rem;
+  margin-top: 1.9rem;
 }
 
 @media only screen and (min-width: 750px) {
   .gift-card__qr-code {
-    margin-top: 5rem;
+    margin-top: 3.15rem;
   }
 }
 
@@ -316,20 +316,20 @@ h2,
 .gift_card__apple-wallet {
   line-height: 0;
   display: block;
-  margin-bottom: 5rem;
+  margin-bottom: 3.15rem;
 }
 
 .gift-card__buttons {
   display: flex;
   flex-direction: column;
-  max-width: 25rem;
+  max-width: 15.5rem;
   flex-wrap: wrap;
   margin: 0 auto;
 }
 
 .gift-card__buttons > .button:first-child {
   display: block;
-  margin-bottom: 2rem;
+  margin-bottom: 1.25rem;
 }
 
 /*
@@ -343,24 +343,24 @@ h2,
 }
 
 *:focus-visible {
-  outline: 0.2rem solid rgba(var(--color-base-text), 0.5);
-  outline-offset: 0.3rem;
-  box-shadow: 0 0 0 0.3rem rgb(var(--color-base-background-1)),
-    0 0 0.5rem 0.4rem rgba(var(--color-base-text), 0.3);
+  outline: 0.125rem solid rgba(var(--color-base-text), 0.5);
+  outline-offset: 0.19rem;
+  box-shadow: 0 0 0 0.19rem rgb(var(--color-base-background-1)),
+    0 0 0.315rem 0.25rem rgba(var(--color-base-text), 0.3);
 }
 
 /* Fallback - for browsers that don't support :focus-visible, a fallback is set for :focus */
 .focused, .no-js *:focus {
-  outline: 0.2rem solid rgba(var(--color-foreground), 0.5);
-  outline-offset: 0.3rem;
-  box-shadow: 0 0 0 0.3rem rgb(var(--color-background)),
-    0 0 0.5rem 0.4rem rgba(var(--color-foreground), 0.3);
+  outline: 0.125rem solid rgba(var(--color-foreground), 0.5);
+  outline-offset: 0.19rem;
+  box-shadow: 0 0 0 0.19rem rgb(var(--color-background)),
+    0 0 0.315rem 0.25rem rgba(var(--color-foreground), 0.3);
 }
 
 .button:focus-visible {
-  box-shadow: 0 0 0 0.1rem rgb(var(--color-base-accent-1)),
-    0 0 0 0.3rem rgb(var(--color-base-background-1)),
-    0 0 0.5rem 0.4rem rgba(var(--color-base-text), 0.3);
+  box-shadow: 0 0 0 0.065rem rgb(var(--color-base-accent-1)),
+    0 0 0 0.19rem rgb(var(--color-base-background-1)),
+    0 0 0.315rem 0.25rem rgba(var(--color-base-text), 0.3);
 }
 
 /* Negate the fallback side-effect for browsers that support :focus-visible */
@@ -370,37 +370,37 @@ h2,
 }
 
 .button:focus {
-  box-shadow: 0 0 0 0.1rem rgb(var(--color-base-accent-1)),
-    0 0 0 0.3rem rgb(var(--color-base-background-1)),
-    0 0 0.5rem 0.4rem rgba(var(--color-base-text), 0.3);
+  box-shadow: 0 0 0 0.065rem rgb(var(--color-base-accent-1)),
+    0 0 0 0.19rem rgb(var(--color-base-background-1)),
+    0 0 0.315rem 0.25rem rgba(var(--color-base-text), 0.3);
 }
 
 .button--secondary:focus-visible {
-  box-shadow: 0 0 0 0.1rem rgb(var(--color-base-outline-button-labels)),
-    0 0 0 0.3rem rgb(var(--color-base-background-1)),
-    0 0 0.5rem 0.4rem rgba(var(--color-base-text), 0.3);
+  box-shadow: 0 0 0 0.065rem rgb(var(--color-base-outline-button-labels)),
+    0 0 0 0.19rem rgb(var(--color-base-background-1)),
+    0 0 0.315rem 0.25rem rgba(var(--color-base-text), 0.3);
 }
 
 .button--secondary:focus {
-  box-shadow: 0 0 0 0.1rem rgb(var(--color-base-outline-button-labels)),
-    0 0 0 0.3rem rgb(var(--color-base-background-1)),
-    0 0 0.5rem 0.4rem rgba(var(--color-base-text), 0.3);
+  box-shadow: 0 0 0 0.065rem rgb(var(--color-base-outline-button-labels)),
+    0 0 0 0.19rem rgb(var(--color-base-background-1)),
+    0 0 0.315rem 0.25rem rgba(var(--color-base-text), 0.3);
 }
 
 .form__message {
   align-items: center;
   display: flex;
-  font-size: 1.2rem;
+  font-size: 0.75rem;
   line-height: 1;
-  margin-top: 1rem;
+  margin-top: 0.65rem;
   justify-content: center;
 }
 
 .form__message .icon {
   flex-shrink: 0;
-  height: 1.3rem;
-  margin-right: 0.5rem;
-  width: 1.3rem;
+  height: 0.8rem;
+  margin-right: 0.315rem;
+  width: 0.8rem;
 }
 
 @media print {

--- a/assets/video-section.css
+++ b/assets/video-section.css
@@ -1,12 +1,12 @@
 .video-section.page-width {
-  margin-top: 5rem;
-  margin-bottom: 5rem;
+  margin-top: 3.15rem;
+  margin-bottom: 3.15rem;
 }
 
 @media screen and (min-width: 750px) {
   .video-section.page-width {
-    margin-top: calc(5rem + var(--page-width-margin));
-    margin-bottom: calc(5rem + var(--page-width-margin));
+    margin-top: calc(3.15rem + var(--page-width-margin));
+    margin-bottom: calc(3.15rem + var(--page-width-margin));
   }
 }
 
@@ -20,7 +20,7 @@
 }
 
 .video-section__poster.deferred-media__poster:focus {
-  outline-offset: 0.3rem;
+  outline-offset: 0.19rem;
 }
 
 .video-section__media iframe {

--- a/layout/theme.liquid
+++ b/layout/theme.liquid
@@ -83,7 +83,6 @@
 
       html {
         box-sizing: border-box;
-        font-size: calc(var(--font-body-scale) * 62.5%);
         height: 100%;
       }
 
@@ -93,8 +92,8 @@
         grid-template-columns: 100%;
         min-height: 100%;
         margin: 0;
-        font-size: 1.5rem;
-        letter-spacing: 0.06rem;
+        font-size: 0.95rem;
+        letter-spacing: 0.0375rem;
         line-height: calc(1 + 0.8 / var(--font-body-scale));
         font-family: var(--font-body-family);
         font-style: var(--font-body-style);
@@ -103,7 +102,7 @@
 
       @media screen and (min-width: 750px) {
         body {
-          font-size: 1.6rem;
+          font-size: 1.0rem;
         }
       }
     {% endstyle %}

--- a/sections/collection-list.liquid
+++ b/sections/collection-list.liquid
@@ -51,8 +51,8 @@
                       src="{{ block.settings.collection.featured_image | img_url: '1500x' }}"
                       sizes="
                       (min-width: {{ settings.page_width }}px) {{ settings.page_width | minus: 100 | divided_by: columns }}px,
-                      (min-width: 750px) {% if section.blocks.size > 1 %}calc((100vw - 10rem) / 2){% else %}calc(100vw - 10rem){% endif %},
-                      calc(100vw - 3rem)"
+                      (min-width: 750px) {% if section.blocks.size > 1 %}calc((100vw - 6.5rem) / 2){% else %}calc(100vw - 6.5rem){% endif %},
+                      calc(100vw - 1.9rem)"
                       alt="{{ block.settings.collection.title | escape }}"
                       height="{{ block.settings.collection.featured_image.height }}"
                       width="{{ block.settings.collection.featured_image.width }}"

--- a/sections/header.liquid
+++ b/sections/header.liquid
@@ -17,7 +17,7 @@
 <style>
   header-drawer {
     justify-self: start;
-    margin-left: -1.2rem;
+    margin-left: -0.75rem;
   }
 
   @media screen and (min-width: 990px) {
@@ -42,7 +42,7 @@
   }
 
   summary.list-menu__item {
-    padding-right: 2.7rem;
+    padding-right: 1.7rem;
   }
 
   .list-menu__item {
@@ -53,15 +53,15 @@
 
   .list-menu__item--link {
     text-decoration: none;
-    padding-bottom: 1rem;
-    padding-top: 1rem;
+    padding-bottom: 0.65rem;
+    padding-top: 0.65rem;
     line-height: calc(1 + 0.8 / var(--font-body-scale));
   }
 
   @media screen and (min-width: 750px) {
     .list-menu__item--link {
-      padding-bottom: 0.5rem;
-      padding-top: 0.5rem;
+      padding-bottom: 0.315rem;
+      padding-top: 0.315rem;
     }
   }
 </style>

--- a/sections/main-404.liquid
+++ b/sections/main-404.liquid
@@ -1,11 +1,11 @@
 <style type="text/css">
   .template-404 .title + * {
-    margin-top: 1rem;
+    margin-top: 0.65rem;
   }
 
   @media screen and (min-width: 750px) {
     .template-404 .title + * {
-      margin-top: 2rem;
+      margin-top: 1.25rem;
     }
   }
 </style>

--- a/sections/main-article.liquid
+++ b/sections/main-article.liquid
@@ -22,7 +22,7 @@
                   {% if article.image.width >= 2200 %}{{ article.image | img_url: '2200x' }} 2200w,{% endif %}
                   {% if article.image.width >= 3000 %}{{ article.image | img_url: '3000x' }} 3000w,{% endif %}
                   {{ article.image | img_url: 'master' }} {{ article.image.width }}w"
-                sizes="(min-width: {{ settings.page_width }}px) {{ settings.page_width | minus: 100 }}px, (min-width: 750px) calc(100vw - 10rem), 100vw"
+                sizes="(min-width: {{ settings.page_width }}px) {{ settings.page_width | minus: 100 }}px, (min-width: 750px) calc(100vw - 6.5rem), 100vw"
                 src="{{ article.image | img_url: '1100x' }}"
                 loading="lazy"
                 width="{{ article.image.width }}"

--- a/sections/main-search.liquid
+++ b/sections/main-search.liquid
@@ -14,38 +14,38 @@
 
 <style>
   .template-search__header {
-    margin-bottom: 3rem;
+    margin-bottom: 1.9rem;
   }
 
   .template-search__search {
-    margin: 0 auto 3.5rem;
-    max-width: 47.8rem;
+    margin: 0 auto 2.2rem;
+    max-width: 30.0rem;
   }
 
   .template-search__search .search {
-    margin-top: 3rem;
+    margin-top: 1.9rem;
   }
 
   .template-search--empty {
-    padding-bottom: 18rem;
+    padding-bottom: 11.5rem;
   }
 
   .template-search .grid__item--small:not(:last-child) {
-    padding-bottom: 0.5rem;
+    padding-bottom: 0.315rem;
   }
 
   @media screen and (min-width: 750px) {
     .template-search__header {
-      margin-bottom: 5rem;
+      margin-bottom: 3.15rem;
     }
 
     .template-search .grid__item--small:not(:last-child) {
-      padding-bottom: 1rem;
+      padding-bottom: 0.65rem;
     }
   }
 
   .search__button .icon {
-    height: 1.8rem;
+    height: 1.15rem;
   }
 </style>
 

--- a/sections/video.liquid
+++ b/sections/video.liquid
@@ -22,7 +22,7 @@
               {%- if section.settings.cover_image.width >= 3840 -%}{{ section.settings.cover_image | img_url: '3840x' }} 3840w,{%- endif -%}
               {{ section.settings.cover_image | img_url: 'master' }} {{ section.settings.cover_image.width }}w"
             src="{{ section.settings.cover_image | img_url: '1920x' }}"
-            sizes="{% if section.settings.full_width %}100vw{% else %}(min-width: {{ settings.page_width }}px) {{ settings.page_width | minus: 100 }}px, (min-width: 750px) calc(100vw - 10rem), 100vw{% endif %}"
+            sizes="{% if section.settings.full_width %}100vw{% else %}(min-width: {{ settings.page_width }}px) {{ settings.page_width | minus: 100 }}px, (min-width: 750px) calc(100vw - 6.5rem), 100vw{% endif %}"
             alt="{{ 'sections.video.load_video' | t: description: section.settings.description | escape }}"
             loading="lazy"
             width="{{ section.settings.cover_image.width }}"
@@ -54,7 +54,7 @@
             {%- if section.settings.cover_image.width >= 3840 -%}{{ section.settings.cover_image | img_url: '3840x' }} 3840w,{%- endif -%}
             {{ section.settings.cover_image | img_url: 'master' }} {{ section.settings.cover_image.width }}w"
           src="{{ section.settings.cover_image | img_url: '1920x' }}"
-          sizes="{% if section.settings.full_width %}100vw{% else %}(min-width: {{ settings.page_width }}px) {{ settings.page_width | minus: 100 }}px, (min-width: 750px) calc(100vw - 10rem), 100vw{% endif %}"
+          sizes="{% if section.settings.full_width %}100vw{% else %}(min-width: {{ settings.page_width }}px) {{ settings.page_width | minus: 100 }}px, (min-width: 750px) calc(100vw - 6.5rem), 100vw{% endif %}"
           alt="{{ 'sections.video.load_video' | t: description: section.settings.description | escape }}"
           loading="lazy"
           width="{{ section.settings.cover_image.width }}"

--- a/snippets/facets.liquid
+++ b/snippets/facets.liquid
@@ -71,13 +71,13 @@
                               {% if value.count == 0 and value.active == false %}disabled{% endif %}
                             >
 
-                            <svg width="1.6rem" height="1.6rem" viewBox="0 0 16 16" aria-hidden="true" focusable="false">
+                            <svg width="1.0rem" height="1.0rem" viewBox="0 0 16 16" aria-hidden="true" focusable="false">
                               <rect width="16" height="16" stroke="currentColor" fill="none" stroke-width="1"></rect>
                             </svg>
 
                             <svg class="icon icon-checkmark"
-                              width="1.1rem"
-                              height="0.7rem"
+                              width="0.7rem"
+                              height="0.44rem"
                               viewBox="0 0 11 7"
                               fill="none"
                               xmlns="http://www.w3.org/2000/svg">
@@ -320,11 +320,11 @@
 
                               <span class="mobile-facets__highlight"></span>
 
-                              <svg width="1.6rem" height="1.6rem" viewBox="0 0 16 16" aria-hidden="true" focusable="false">
+                              <svg width="1.0rem" height="1.0rem" viewBox="0 0 16 16" aria-hidden="true" focusable="false">
                                 <rect width="16" height="16" stroke="currentColor" fill="none" stroke-width="1"></rect>
                               </svg>
 
-                              <svg class="icon icon-checkmark" width="1.1rem" height="0.7rem" viewBox="0 0 11 7" fill="none" xmlns="http://www.w3.org/2000/svg">
+                              <svg class="icon icon-checkmark" width="0.7rem" height="0.44rem" viewBox="0 0 11 7" fill="none" xmlns="http://www.w3.org/2000/svg">
                                 <path d="M1.5 3.5L2.83333 4.75L4.16667 6L9.5 1" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round" />
                               </svg>
 

--- a/snippets/product-media.liquid
+++ b/snippets/product-media.liquid
@@ -25,7 +25,7 @@
             {%- if media.preview_image.width >= 2890 -%}{{ media.preview_image | img_url: '2890x' }} 2890w,{%- endif -%}
             {%- if media.preview_image.width >= 4096 -%}{{ media.preview_image | img_url: '4096x' }} 4096w,{%- endif -%}
             {{ media.preview_image | img_url: 'master' }} {{ media.preview_image.width }}w"
-    sizes="(min-width: 750px) calc(100vw - 22rem), 1100px"
+    sizes="(min-width: 750px) calc(100vw - 14.0rem), 1100px"
     src="{{ media.preview_image | img_url: '1445x' }}"
     alt="{{ media.alt | escape }}"
     loading="lazy"
@@ -37,9 +37,9 @@
 {%- else -%}
   {%- if media.media_type == 'model' -%}
     <div class="product-media-modal__model" data-media-id="{{ media.id }}">
-      <product-model class="deferred-media media media--transparent" style="padding-top: min(calc(100vh - 12rem), 100%)">
+      <product-model class="deferred-media media media--transparent" style="padding-top: min(calc(100vh - 7.5rem), 100%)">
   {%- else -%}
-    <deferred-media class="deferred-media media" style="padding-top: min(calc(100vh - 12rem), {{ 1 | divided_by: media.aspect_ratio | times: 100 }}%)" data-media-id="{{ media.id }}">
+    <deferred-media class="deferred-media media" style="padding-top: min(calc(100vh - 7.5rem), {{ 1 | divided_by: media.aspect_ratio | times: 100 }}%)" data-media-id="{{ media.id }}">
   {%- endif -%}
 
     <button id="Deferred-Poster-Modal-{{ media.id }}" class="deferred-media__poster" type="button">
@@ -57,7 +57,7 @@
                 {% if media.preview_image.width >= 1100 %}{{ media.preview_image | img_url: '1100x' }} 1100w,{% endif %}
                 {{ media.preview_image | img_url: 'master' }} {{ media.preview_image.width }}w"
         src="{{ media | img_url: '550x550' }}"
-        sizes="(min-width: 1200px) calc((1200px - 10rem) / 2), (min-width: 750px) calc((100vw - 11.5rem) / 2), calc(100vw - 4rem)"
+        sizes="(min-width: 1200px) calc((1200px - 6.5rem) / 2), (min-width: 750px) calc((100vw - 7.0rem) / 2), calc(100vw - 2.5rem)"
         loading="lazy"
         width="576"
         height="{{ 576 | divided_by: media.preview_image.aspect_ratio }}"

--- a/snippets/product-thumbnail.liquid
+++ b/snippets/product-thumbnail.liquid
@@ -29,7 +29,7 @@
           {% if media.preview_image.width >= 1500 %}{{ media.preview_image | img_url: '1500x' }} 1500w,{% endif %}
           {{ media.preview_image | img_url: 'master' }} {{ media.preview_image.width }}w"
         src="{{ media | img_url: '1500x' }}"
-        sizes="(min-width: {{ settings.page_width }}px) {{ settings.page_width | minus: 100 | times: 0.64 | round }}px, (min-width: 750px) calc((100vw - 11.5rem) / 2), calc(100vw - 4rem)"
+        sizes="(min-width: {{ settings.page_width }}px) {{ settings.page_width | minus: 100 | times: 0.64 | round }}px, (min-width: 750px) calc((100vw - 7.0rem) / 2), calc(100vw - 2.5rem)"
         loading="lazy"
         width="576"
         height="{{ 576 | divided_by: media.preview_image.aspect_ratio | ceil }}"
@@ -49,7 +49,7 @@
           {% if media.preview_image.width >= 1500 %}{{ media.preview_image | img_url: '1500x' }} 1500w,{% endif %}
           {{ media.preview_image | img_url: 'master' }} {{ media.preview_image.width }}w"
         src="{{ media | img_url: '1500x' }}"
-        sizes="(min-width: {{ settings.page_width }}px) {{ settings.page_width | minus: 100 | times: 0.64 | round }}px, (min-width: 750px) calc((100vw - 11.5rem) / 2), calc(100vw - 4rem)"
+        sizes="(min-width: {{ settings.page_width }}px) {{ settings.page_width | minus: 100 | times: 0.64 | round }}px, (min-width: 750px) calc((100vw - 7.0rem) / 2), calc(100vw - 2.5rem)"
         loading="lazy"
         width="576"
         height="{{ 576 | divided_by: media.preview_image.aspect_ratio | ceil }}"
@@ -82,7 +82,7 @@
         {% if media.preview_image.width >= 1500 %}{{ media.preview_image | img_url: '1500x' }} 1500w,{% endif %}
         {{ media.preview_image | img_url: 'master' }} {{ media.preview_image.width }}w"
       src="{{ media | img_url: '1500x' }}"
-      sizes="(min-width: {{ settings.page_width }}px) {{ settings.page_width | minus: 100 | times: 0.64 | round }}px, (min-width: 750px) calc((100vw - 11.5rem) / 2), calc(100vw - 4rem)"
+      sizes="(min-width: {{ settings.page_width }}px) {{ settings.page_width | minus: 100 | times: 0.64 | round }}px, (min-width: 750px) calc((100vw - 7.0rem) / 2), calc(100vw - 2.5rem)"
       loading="lazy"
       width="576"
       height="{{ 576 | divided_by: media.preview_image.aspect_ratio | ceil }}"
@@ -124,7 +124,7 @@
         {% if media.preview_image.width >= 1500 %}{{ media.preview_image | img_url: '1500x' }} 1500w,{% endif %}
         {{ media.preview_image | img_url: 'master' }} {{ media.preview_image.width }}w"
       src="{{ media | img_url: '1500x' }}"
-      sizes="(min-width: {{ settings.page_width }}px) {{ settings.page_width | minus: 100 | times: 0.64 | round }}px, (min-width: 750px) calc((100vw - 11.5rem) / 2), calc(100vw - 4rem)"
+      sizes="(min-width: {{ settings.page_width }}px) {{ settings.page_width | minus: 100 | times: 0.64 | round }}px, (min-width: 750px) calc((100vw - 7.0rem) / 2), calc(100vw - 2.5rem)"
       loading="lazy"
       width="576"
       height="{{ 576 | divided_by: media.preview_image.aspect_ratio }}"


### PR DESCRIPTION
Remove REM = 10px alias.

**Why are these changes introduced?**

Fixes #883 

**What approach did you take?**

Replaced all mentions of REM units that depends on the non-standard rem value with an almost equal value that do not depends on the non-standard rem value.

**Other considerations**

It use the following code:

``` ruby
require 'bigdecimal'

def custom_round value
  BigDecimal(value * 2, 2).to_f / 2
end

Dir.glob('**/*.{css,liquid}').each do |file|
  fixed_file_content = File.read(file).gsub(/(?<!\w)([\d\.]+)rem/) do
    value_in_pixels = $1.to_f * 10
    value_in_standard_rems = value_in_pixels.to_f / 16
    "#{ custom_round(value_in_standard_rems) }rem"
  end
  File.write file, fixed_file_content
end
```

**Demo links**

I would really appreciate if someone can add that as I have no idea about how to get that...

**Checklist**
- [X] Followed [theme code principles](https://github.com/Shopify/dawn/blob/main/.github/CONTRIBUTING.md#theme-code-principles)
- [X] Linted with [Theme Check](https://github.com/Shopify/theme-check)
- [ ] Tested on [mobile](https://shopify.dev/themes/store/requirements#mobile-browser-requirements)
- [ ] Tested on [multiple browsers](https://shopify.dev/themes/store/requirements#desktop-browser-requirements)
- [ ] Tested for [accessibility](https://shopify.dev/themes/best-practices/accessibility)