### PR TITLE
Use Brand instead of invalid Thing for schema.org's Brand tag.

### DIFF
--- a/sections/main-product.liquid
+++ b/sections/main-product.liquid
@@ -502,7 +502,7 @@
       "sku": {{ product.selected_or_first_available_variant.sku | json }},
     {%- endif %}
     "brand": {
-      "@type": "Thing",
+      "@type": "Brand",
       "name": {{ product.vendor | json }}
     },
     "offers": [


### PR DESCRIPTION
**Why are these changes introduced?**

According to schema.org's documentation, the only valid specs for a product's brand are Organization or Brand.

See https://schema.org/Product (search for property Brand)

**What approach did you take?**

Looked at Google Search Console errors, which highlighted this problem. Made the change, and waited a few days. Google Search Console now reports "all clear".

**Other considerations**

**Demo links**

- [See any of the procucts listed in this store](https://thesmallbatchproject.ch/en/collections/all)

**Checklist**
- [ ] Followed [theme code principles](https://github.com/Shopify/dawn/blob/main/.github/CONTRIBUTING.md#theme-code-principles)
- [ ] Linted with [Theme Check](https://github.com/Shopify/theme-check)
- [ ] Tested on [mobile](https://shopify.dev/themes/store/requirements#mobile-browser-requirements)
- [ ] Tested on [multiple browsers](https://shopify.dev/themes/store/requirements#desktop-browser-requirements)
- [ ] Tested for [accessibility](https://shopify.dev/themes/best-practices/accessibility)
