### PR TITLE
Card shadow updates

### DIFF
--- a/assets/component-card.css
+++ b/assets/component-card.css
@@ -12,12 +12,32 @@
 
 .card--card,
 .card--standard .card__inner { 
-  background-clip: padding-box;
   border-radius: var(--card-corner-radius);
   border: var(--card-border-width) solid rgba(var(--color-foreground), var(--card-border-opacity));
-  box-shadow: var(--card-shadow-horizontal-offset) var(--card-shadow-vertical-offset) var(--card-shadow-blur-radius) rgba(var(--color-foreground), var(--card-shadow-opacity));
-  overflow: hidden;
   position: relative;
+}
+
+.card--card:after,
+.card--standard .card__inner:after {
+  content: '';
+  position: absolute;
+  width: calc(var(--card-border-width) * 2 + 100%);
+  height: calc(var(--card-border-width) * 2 + 100%);
+  top: calc(var(--card-border-width) * -1);
+  left: calc(var(--card-border-width) * -1);
+  z-index: -1;
+  border-radius: var(--card-corner-radius);
+  box-shadow: var(--card-shadow-horizontal-offset) var(--card-shadow-vertical-offset) var(--card-shadow-blur-radius) rgba(var(--color-foreground), var(--card-shadow-opacity));
+}
+
+.card .card__inner .card__media {
+  overflow: hidden;
+  border-radius: calc(var(--card-corner-radius) - var(--card-border-width) - var(--card-image-padding));
+}
+
+.card--card .card__inner .card__media {
+  border-bottom-right-radius: 0;
+  border-bottom-left-radius: 0;
 }
 
 .card--standard.card--text {


### PR DESCRIPTION
**Why are these changes introduced?**

Refs #979 
Fixes potential shadow overlap in card grids

**What approach did you take?**

Applied the shadow on a pseudo element within the cards so its z-index can be controlled. The pseudo element varies depending on the card style.

**Other considerations**

**Testing notes**
Check various.. 
- image ratio settings
- image padding
- card style 
- card shadow offsets
- card border widths

**Demo links**

- [Editor](https://os2-demo.myshopify.com/admin/themes/127007981590/editor)

**Checklist**
- [ ] Followed [theme code principles](https://github.com/Shopify/dawn/blob/main/.github/CONTRIBUTING.md#theme-code-principles)
- [ ] Linted with [Theme Check](https://github.com/Shopify/theme-check)
- [ ] Tested on [mobile](https://shopify.dev/themes/store/requirements#mobile-browser-requirements)
- [ ] Tested on [multiple browsers](https://shopify.dev/themes/store/requirements#desktop-browser-requirements)
- [ ] Tested for [accessibility](https://shopify.dev/themes/best-practices/accessibility)
