### PR TITLE
Media shadow updates

### DIFF
--- a/assets/collage.css
+++ b/assets/collage.css
@@ -474,8 +474,22 @@
 .collage-card:not(.collage-product, .collage-collection) {
   border: var(--media-border-width) solid rgba(var(--color-foreground), var(--media-border-opacity));
   border-radius: var(--media-radius);
-  box-shadow: var(--media-shadow-horizontal-offset)
-    var(--media-shadow-vertical-offset)
-    var(--media-shadow-blur-radius)
-    rgba(var(--color-foreground), var(--media-shadow-opacity));
+  background: rgb(var(--color-background));
+}
+
+.collage-card:not(.collage-product, .collage-collection):after {
+  border-radius: var(--media-radius);
+  box-shadow: var(--media-shadow-horizontal-offset) var(--media-shadow-vertical-offset) var(--media-shadow-blur-radius) rgba(var(--color-foreground), var(--media-shadow-opacity));
+  content: '';
+  position: absolute;
+  width: calc(var(--media-border-width) * 2 + 100%);
+  height: calc(var(--media-border-width) * 2 + 100%);
+  top: calc(var(--media-border-width) * -1);
+  left: calc(var(--media-border-width) * -1);
+  z-index: -1;
+}
+
+.collage-card:not(.collage-product, .collage-collection) .media {
+  border-radius: calc(var(--media-radius) - var(--media-border-width));
+  overflow: hidden;
 }

--- a/assets/section-main-product.css
+++ b/assets/section-main-product.css
@@ -608,11 +608,6 @@ a.product__text {
   }
 }
 
-.product__media-list .deferred-media,
-.product__media-list .product__modal-opener {
-  border: 0.1rem solid rgba(var(--color-foreground), 0.04);
-}
-
 .product-media-modal__content > * {
   display: block;
   height: auto;
@@ -828,11 +823,26 @@ a.product__text {
   width: 2.2rem;
 }
 
-.product__media {
+.product__media-list .media {
   border: var(--media-border-width) solid rgba(var(--color-foreground), var(--media-border-opacity));
   border-radius: var(--media-radius);
-  box-shadow: var(--media-shadow-horizontal-offset)
-    var(--media-shadow-vertical-offset)
-    var(--media-shadow-blur-radius)
-    rgba(var(--color-foreground), var(--media-shadow-opacity));
+  overflow: visible;
+  background: rgb(var(--color-background));
+}
+
+.product__media-list .media:after {
+  border-radius: var(--media-radius);
+  box-shadow: var(--media-shadow-horizontal-offset) var(--media-shadow-vertical-offset) var(--media-shadow-blur-radius) rgba(var(--color-foreground), var(--media-shadow-opacity));
+  content: '';
+  position: absolute;
+  width: calc(var(--media-border-width) * 2 + 100%);
+  height: calc(var(--media-border-width) * 2 + 100%);
+  top: calc(var(--media-border-width) * -1);
+  left: calc(var(--media-border-width) * -1);
+  z-index: -1;
+}
+
+.product__media-list .media > * {
+  border-radius: calc(var(--media-radius) - var(--media-border-width));
+  overflow: hidden;
 }


### PR DESCRIPTION
**Why are these changes introduced?**

Refs #979 
Fixes potential shadow overlap in product media and collage media (image/video).

**What approach did you take?**

Applied the shadow on a pseudo element within the media list items so their z-index can be controlled. The approach used on product media is exactly the same as on collage but applies to different elements.

If there were more instances of media type items needing these styles I would consider creating some new global classes to abstract away some of the redundancies.

**Other considerations**

**Demo links**

- [Store](url)
- [Editor](url)

**Checklist**
- [ ] Followed [theme code principles](https://github.com/Shopify/dawn/blob/main/.github/CONTRIBUTING.md#theme-code-principles)
- [ ] Linted with [Theme Check](https://github.com/Shopify/theme-check)
- [ ] Tested on [mobile](https://shopify.dev/themes/store/requirements#mobile-browser-requirements)
- [ ] Tested on [multiple browsers](https://shopify.dev/themes/store/requirements#desktop-browser-requirements)
- [ ] Tested for [accessibility](https://shopify.dev/themes/best-practices/accessibility)
