### PR TITLE
Multicolumn shadow updates

### DIFF
--- a/assets/section-multicolumn.css
+++ b/assets/section-multicolumn.css
@@ -16,6 +16,10 @@
   }
 }
 
+.multicolumn .multicolumn-list {
+  filter: drop-shadow(var(--text-boxes-shadow-horizontal-offset) var(--text-boxes-shadow-vertical-offset) var(--text-boxes-shadow-blur-radius) rgba(var(--color-foreground), var(--text-boxes-shadow-opacity)));
+}
+
 .multicolumn-card__image-wrapper--third-width {
   width: 33%;
 }
@@ -52,12 +56,12 @@
 }
 
 .multicolumn:not(.background-none) .multicolumn-card {
-  background: rgba(var(--color-foreground), 0.04);
+  background: rgb(var(--color-background));
   height: 100%;
 }
 
-.multicolumn.background-secondary .multicolumn-card {
-  background: rgb(var(--color-background));
+.multicolumn.background-primary .multicolumn-card {
+  background: rgb(var(--color-background)) linear-gradient(rgba(var(--color-foreground), 0.04), rgba(var(--color-foreground), 0.04));
 }
 
 .multicolumn-list h3 {
@@ -225,10 +229,7 @@
 .multicolumn-card {
   border: var(--text-boxes-border-width) solid rgba(var(--color-foreground), var(--text-boxes-border-opacity));
   border-radius: var(--text-boxes-radius);
-  box-shadow: var(--text-boxes-shadow-horizontal-offset)
-    var(--text-boxes-shadow-vertical-offset)
-    var(--text-boxes-shadow-blur-radius)
-    rgba(var(--color-foreground), var(--text-boxes-shadow-opacity));
+  overflow: hidden;
 }
 
 .multicolumn-card__info .link {

--- a/sections/multicolumn.liquid
+++ b/sections/multicolumn.liquid
@@ -2,7 +2,7 @@
 <link rel="stylesheet" href="{{ 'component-slider.css' | asset_url }}" media="print" onload="this.media='all'">
 <noscript>{{ 'component-slider.css' | asset_url | stylesheet_tag }}</noscript>
 
-<div class="multicolumn background-{{ section.settings.background_style }}{% if section.settings.title == blank %} no-heading{% endif %}">
+<div class="multicolumn {% if section.settings.background_style == 'none' and settings.text_boxes_border_thickness > 0 or settings.text_boxes_shadow_opacity > 0 %}background-none--styled{% else %}background-{{ section.settings.background_style }}{% endif %}{% if section.settings.title == blank %} no-heading{% endif %}">
   <div class="page-width">
     <div class="title-wrapper-with-link title-wrapper--self-padded-mobile{% if section.settings.title == blank %} title-wrapper-with-link--no-heading{% endif %}">
       <h2 class="title">


### PR DESCRIPTION
**Why are these changes introduced?**

Refs #979 

Prevents shadow overlap on multicolumn content containers.

**What approach did you take?**

Multicolumn cards don't ever receive any focus outline or hover state, so its safe to use a drop-shadow filter on the whole list instead of individual cards which solves the overlap problem. The background of the cards needed actual background color to prevent seeing the shadows below.

The `Secondary background: none` setting poses some questions. Is this supposed to be a minimal style stripped of any "container" look? Or simply the same multicolumn card look but with no secondary background applied anywhere? Currently, paddings and margins are reduced or removed for background-none, but if borders and shadows _are_ to be applied here, we need the same paddings as the other 2 settings so the content doesn't clash with the borders. I also considered if background-none should only apply borders/shadow/radius to the image, but that's getting into more of "standard card" look.

**Other considerations**

**Demo links**

- [Store](url)
- [Editor](url)

**Checklist**
- [ ] Followed [theme code principles](https://github.com/Shopify/dawn/blob/main/.github/CONTRIBUTING.md#theme-code-principles)
- [ ] Linted with [Theme Check](https://github.com/Shopify/theme-check)
- [ ] Tested on [mobile](https://shopify.dev/themes/store/requirements#mobile-browser-requirements)
- [ ] Tested on [multiple browsers](https://shopify.dev/themes/store/requirements#desktop-browser-requirements)
- [ ] Tested for [accessibility](https://shopify.dev/themes/best-practices/accessibility)
