### PR TITLE
Slideshow previous button disabled fix

### DIFF
--- a/assets/global.js
+++ b/assets/global.js
@@ -616,6 +616,9 @@ class SlideshowComponent extends SliderComponent {
   update() {
     super.update();
     this.sliderControlButtons = this.querySelectorAll('.slider-counter__link');
+    if (this.prevButton.hasAttribute('disabled')) {
+      this.prevButton.removeAttribute('disabled');
+    }
 
     if (!this.sliderControlButtons.length) return;
 

--- a/assets/global.js
+++ b/assets/global.js
@@ -616,9 +616,7 @@ class SlideshowComponent extends SliderComponent {
   update() {
     super.update();
     this.sliderControlButtons = this.querySelectorAll('.slider-counter__link');
-    if (this.prevButton.hasAttribute('disabled')) {
-      this.prevButton.removeAttribute('disabled');
-    }
+    this.prevButton.removeAttribute('disabled');
 
     if (!this.sliderControlButtons.length) return;
 


### PR DESCRIPTION
**Why are these changes introduced?**

Fixes an issue where the previous button on the slideshow is disabled. It doesn't come up when you first add the section in the editor but does once you've saved. 

Didn't notice it before, so I'm wondering what could potentially have triggered it 🤔  Seems like an issue with the order in which functions/values are being called. 

I think it's due to the fact that the slideshow component is extending the slider component and has a different value for `this.enableSliderLooping`. But when it runs `update()` it's using the `false` value set in `sliderComponent` first which disables the previous button and only after that it notices the different value set within the slideshow component.

**What approach did you take?**

I added a check in the `update()` within the slideshow component. So that if it sees the `disabled` attribute it removes it. 

**Other considerations**

**Demo links**

- [Store](https://os2-demo.myshopify.com/?preview_theme_id=127020859414)
- [Editor](https://os2-demo.myshopify.com/admin/themes/127020859414/editor)

**Checklist**
- [x] Followed [theme code principles](https://github.com/Shopify/dawn/blob/main/.github/CONTRIBUTING.md#theme-code-principles)
- [x] Linted with [Theme Check](https://github.com/Shopify/theme-check)
- [x] Tested on [mobile](https://shopify.dev/themes/store/requirements#mobile-browser-requirements)
- [x] Tested on [multiple browsers](https://shopify.dev/themes/store/requirements#desktop-browser-requirements)
- [x] Tested for [accessibility](https://shopify.dev/themes/best-practices/accessibility)
