### PR TITLE
Blog cards update

### DIFF
--- a/assets/component-article-card.css
+++ b/assets/component-article-card.css
@@ -27,32 +27,6 @@
   box-sizing: border-box;
 }
 
-.article-content {
-  width: 100%;
-  height: 100%;
-  display: flex;
-  flex-direction: column;
-  text-decoration: none;
-  color: inherit;
-}
-
-.article-content:hover .article-card__title {
-  text-decoration: underline;
-  text-underline-offset: 0.3rem;
-}
-
-.article-card__image {
-  overflow: hidden;
-}
-
-.article-content img {
-  transition: transform var(--duration-long) ease;
-}
-
-.article-content:hover img {
-  transform: scale(1.07);
-}
-
 .article-card__image-wrapper > a {
   display: block;
 }
@@ -80,10 +54,6 @@
 
 .article-card__link {
   text-underline-offset: 0.3rem;
-}
-
-.article-content:hover .article-card__link {
-  text-decoration-thickness: 0.2rem;
 }
 
 .article-card .card__heading {

--- a/assets/component-article-card.css
+++ b/assets/component-article-card.css
@@ -27,10 +27,6 @@
   box-sizing: border-box;
 }
 
-.article-card.card--card {
-  height: 100%;
-}
-
 .article-content {
   width: 100%;
   height: 100%;
@@ -132,42 +128,42 @@
   }
 }
 
-.article-card__image--small {
+.article-card__image--small .ratio::before {
   padding-bottom: 11rem;
 }
 
-.article-card__image--medium {
+.article-card__image--medium .ratio::before {
   padding-bottom: 22rem;
 }
 
-.article-card__image--large {
+.article-card__image--large .ratio::before {
   padding-bottom: 33rem;
 }
 
 @media screen and (min-width: 750px) {
-  .article-card__image--small {
+  .article-card__image--small .ratio::before {
     padding-bottom: 14.3rem;
   }
 
-  .article-card__image--medium {
+  .article-card__image--medium .ratio::before {
     padding-bottom: 21.9rem;
   }
 
-  .article-card__image--large {
+  .article-card__image--large .ratio::before {
     padding-bottom: 27.5rem;
   }
 }
 
 @media screen and (min-width: 990px) {
-  .article-card__image--small {
+  .article-card__image--small .ratio::before {
     padding-bottom: 17.7rem;
   }
 
-  .article-card__image--medium {
+  .article-card__image--medium .ratio::before {
     padding-bottom: 30.7rem;
   }
 
-  .article-card__image--large {
+  .article-card__image--large .ratio::before {
     padding-bottom: 40.7rem;
   }
 }

--- a/assets/component-article-card.css
+++ b/assets/component-article-card.css
@@ -23,18 +23,25 @@
   padding: 0;
 }
 
-.article-card {
-  background-color: rgba(var(--color-foreground), 0.04);
-  align-self: flex-start;
-  flex: 0 1 100%;
-  display: flex;
-  align-items: flex-start;
-  height: 100%;
-}
-
 .grid--peek .article-card {
   box-sizing: border-box;
 }
+
+.article-card.card--card {
+  height: 100%;
+  background: rgb(var(--color-background)) linear-gradient(rgba(var(--color-foreground), 0.04), rgba(var(--color-foreground), 0.04));
+}
+
+.background-secondary .article-card.card--card {
+  background: rgb(var(--color-background));
+}
+
+.article-card.card .card__content,
+.article-card.card .card__information {
+  padding: 0;
+}
+
+
 
 .article-card__info {
   padding: 3rem;
@@ -76,6 +83,18 @@
 .article-card__title {
   text-decoration: none;
   word-break: break-word;
+}
+
+.article-card__title a:after {
+  bottom: 0;
+  content: "";
+  height: 100%;
+  left: 0;
+  position: absolute;
+  right: 0;
+  top: 0;
+  width: 100%;
+  z-index: 1;
 }
 
 .article-card__link.link {

--- a/assets/component-article-card.css
+++ b/assets/component-article-card.css
@@ -29,25 +29,6 @@
 
 .article-card.card--card {
   height: 100%;
-  background: rgb(var(--color-background)) linear-gradient(rgba(var(--color-foreground), 0.04), rgba(var(--color-foreground), 0.04));
-}
-
-.background-secondary .article-card.card--card {
-  background: rgb(var(--color-background));
-}
-
-.article-card.card .card__content,
-.article-card.card .card__information {
-  padding: 0;
-}
-
-
-
-.article-card__info {
-  padding: 3rem;
-  display: flex;
-  flex-direction: column;
-  flex-grow: 1;
 }
 
 .article-content {
@@ -109,26 +90,18 @@
   text-decoration-thickness: 0.2rem;
 }
 
-.article-card__header {
-  line-height: calc(0.8 / var(--font-body-scale));
-  margin-bottom: 1.2rem;
+.article-card .card__heading {
+  margin-bottom: 0.6rem;
 }
 
-.article-card__header h2 {
-  margin: 0 0 0.6rem;
+.blog-articles .article-card .card__information,
+.blog__posts .article-card .card__information {
+  padding-left: 2rem;
+  padding-right: 2rem;
 }
 
-.article-card__header h2:only-child {
-  margin: 0;
-}
-
-.article-card__header h2:not(:first-child) {
-  margin-top: 1rem;
-}
-
-.article-card__header h2 + span {
-  display: inline-block;
-  margin-top: 0.4rem;
+.article-card__info {
+  padding-top: 0.4rem;
 }
 
 .article-card__footer {
@@ -146,6 +119,7 @@
 
 .article-card__excerpt {
   width: 100%;
+  margin-top: 1.2rem;
 }
 
 .article-card__link:not(:only-child) {

--- a/assets/component-card.css
+++ b/assets/component-card.css
@@ -10,6 +10,10 @@
   text-decoration: none;
 }
 
+.card--card {
+  height: 100%;
+}
+
 .card--card,
 .card--standard .card__inner { 
   border-radius: var(--card-corner-radius);
@@ -191,8 +195,9 @@
 }
 
 .card--standard.card--media .card__inner .card__information,
-.card--standard.card--text > .card__content .card__information,
+.card--standard.card--text > .card__content .card__heading,
 .card--standard > .card__content .card__badge,
+.card--standard.card--text > .card__content,
 .card--standard > .card__content .card__caption {
   display: none;
 }
@@ -210,23 +215,6 @@
 .card--card.card--text .card__inner,
 .card--card.card--media > .card__content .card__badge {
   display: none;
-}
-
-.card--height-auto .card__inner:before,
-.card--height-auto.card--standard:before,
-.card--height-auto.card--text:before { 
-  display: none;
-}
-
-.card--height-auto {
-  height: 100%;
-  display: flex;
-  flex-direction: column;
-}
-
-.card--height-auto.card--text.card--card .card__content,
-.card--height-auto .card__inner { 
-  flex-grow: 1;
 }
 
 .card .icon-wrap {
@@ -265,4 +253,8 @@
 
 .card-information .caption {
   letter-spacing: 0.07rem;
+}
+
+.card-article-info {
+  margin-top: 1rem;
 }

--- a/assets/component-card.css
+++ b/assets/component-card.css
@@ -191,10 +191,8 @@
 }
 
 .card--standard.card--media .card__inner .card__information,
-.card--standard.card--text > .card__content .card__heading,
+.card--standard.card--text > .card__content .card__information,
 .card--standard > .card__content .card__badge,
-.card--standard.card--text > .card__content .card-article-info,
-.card--standard.card--text > .card__content .article-card__info,
 .card--standard > .card__content .card__caption {
   display: none;
 }
@@ -267,8 +265,4 @@
 
 .card-information .caption {
   letter-spacing: 0.07rem;
-}
-
-.card-article-info {
-  margin-top: 1rem;
 }

--- a/assets/component-card.css
+++ b/assets/component-card.css
@@ -194,6 +194,7 @@
 .card--standard.card--text > .card__content .card__heading,
 .card--standard > .card__content .card__badge,
 .card--standard.card--text > .card__content .card-article-info,
+.card--standard.card--text > .card__content .article-card__info,
 .card--standard > .card__content .card__caption {
   display: none;
 }

--- a/assets/component-card.css
+++ b/assets/component-card.css
@@ -197,7 +197,7 @@
 .card--standard.card--media .card__inner .card__information,
 .card--standard.card--text > .card__content .card__heading,
 .card--standard > .card__content .card__badge,
-.card--standard.card--text > .card__content,
+.card--standard.card--text.article-card > .card__content .card__information,
 .card--standard > .card__content .card__caption {
   display: none;
 }

--- a/assets/section-featured-blog.css
+++ b/assets/section-featured-blog.css
@@ -76,6 +76,16 @@
   width: 100%;
 }
 
+/* To be removed if secondary background setting is removed */
+.blog__posts .article-card.card--card.color-background-1,
+.blog__posts .article-card.card--standard.card--text .card__inner.color-background-1 {
+  background: rgb(var(--color-background)) linear-gradient(rgba(var(--color-foreground), 0.04), rgba(var(--color-foreground), 0.04));
+}
+.background-secondary .blog__posts .article-card.card--card,
+.background-secondary .blog__posts .article-card.card--standard.card--text .card__inner  {
+  background: rgb(var(--color-background));
+}
+
 .blog__button {
   margin-top: 3rem;
 }

--- a/assets/section-featured-blog.css
+++ b/assets/section-featured-blog.css
@@ -68,9 +68,12 @@
   }
 }
 
-.background-secondary .article-card,
 .background-secondary .blog-placeholder__content {
   background-color: rgb(var(--color-background));
+}
+
+.blog__posts .card-wrapper {
+  width: 100%;
 }
 
 .blog__button {

--- a/assets/section-featured-blog.css
+++ b/assets/section-featured-blog.css
@@ -76,16 +76,6 @@
   width: 100%;
 }
 
-/* To be removed if secondary background setting is removed */
-.blog__posts .article-card.card--card.color-background-1,
-.blog__posts .article-card.card--standard.card--text .card__inner.color-background-1 {
-  background: rgb(var(--color-background)) linear-gradient(rgba(var(--color-foreground), 0.04), rgba(var(--color-foreground), 0.04));
-}
-.background-secondary .blog__posts .article-card.card--card,
-.background-secondary .blog__posts .article-card.card--standard.card--text .card__inner  {
-  background: rgb(var(--color-background));
-}
-
 .blog__button {
   margin-top: 3rem;
 }

--- a/assets/section-main-blog.css
+++ b/assets/section-main-blog.css
@@ -5,6 +5,10 @@
   row-gap: var(--grid-mobile-vertical-spacing);
 }
 
+.blog-articles .card-wrapper {
+  width: 100%;
+}
+
 @media screen and (min-width: 750px) {
   .blog-articles {
     grid-template-columns: 1fr 1fr;

--- a/assets/section-main-blog.css
+++ b/assets/section-main-blog.css
@@ -22,35 +22,40 @@
     text-align: center;
   }
 
-  .blog-articles--collage > *:nth-child(3n + 1) .article-card__image--small,
-  .blog-articles--collage > *:nth-child(3n + 2):last-child .article-card__image--small {
+  .blog-articles--collage > *:nth-child(3n + 1) .card,
+  .blog-articles--collage > *:nth-child(3n + 2):last-child .card {
+    text-align: center;
+  }
+
+  .blog-articles--collage > *:nth-child(3n + 1) .article-card__image--small .ratio::before,
+  .blog-articles--collage > *:nth-child(3n + 2):last-child .article-card__image--small .ratio::before {
     padding-bottom: 22rem;
   }
 
-  .blog-articles--collage > *:nth-child(3n + 1) .article-card__image--medium,
-  .blog-articles--collage > *:nth-child(3n + 2):last-child .article-card__image--medium {
+  .blog-articles--collage > *:nth-child(3n + 1) .article-card__image--medium .ratio::before,
+  .blog-articles--collage > *:nth-child(3n + 2):last-child .article-card__image--medium .ratio::before {
     padding-bottom: 44rem;
   }
 
-  .blog-articles--collage > *:nth-child(3n + 1) .article-card__image--large,
-  .blog-articles--collage > *:nth-child(3n + 2):last-child .article-card__image--large {
+  .blog-articles--collage > *:nth-child(3n + 1) .article-card__image--large .ratio::before,
+  .blog-articles--collage > *:nth-child(3n + 2):last-child .article-card__image--large .ratio::before {
     padding-bottom: 66rem;
   }
 }
 
 @media screen and (min-width: 990px) {
-  .blog-articles--collage > *:nth-child(3n + 1) .article-card__image--small,
-  .blog-articles--collage > *:nth-child(3n + 2):last-child .article-card__image--small {
+  .blog-articles--collage > *:nth-child(3n + 1) .article-card__image--small .ratio .ratio::before,
+  .blog-articles--collage > *:nth-child(3n + 2):last-child .article-card__image--small .ratio .ratio::before {
     padding-bottom: 27.5rem;
   }
 
-  .blog-articles--collage > *:nth-child(3n + 1) .article-card__image--medium,
-  .blog-articles--collage > *:nth-child(3n + 2):last-child .article-card__image--medium {
+  .blog-articles--collage > *:nth-child(3n + 1) .article-card__image--medium .ratio::before,
+  .blog-articles--collage > *:nth-child(3n + 2):last-child .article-card__image--medium .ratio::before {
     padding-bottom: 55rem;
   }
 
-  .blog-articles--collage > *:nth-child(3n + 1) .article-card__image--large,
-  .blog-articles--collage > *:nth-child(3n + 2):last-child .article-card__image--large {
+  .blog-articles--collage > *:nth-child(3n + 1) .article-card__image--large .ratio::before,
+  .blog-articles--collage > *:nth-child(3n + 2):last-child .article-card__image--large .ratio::before {
     padding-bottom: 82.5rem;
   }
 }

--- a/sections/featured-blog.liquid
+++ b/sections/featured-blog.liquid
@@ -36,7 +36,7 @@
         >
           {%- for article in section.settings.blog.articles limit: section.settings.post_limit -%}
             <li id="Slide-{{ section.id }}-{{ forloop.index }}" class="blog__post grid__item article slider__slide slider__slide--full-width">
-              {% render 'article-card', blog: section.settings.blog, article: article, show_image: section.settings.show_image, show_date: section.settings.show_date, show_author: section.settings.show_author, show_excerpt: true %}
+              {% render 'article-card', blog: section.settings.blog, article: article, media_aspect_ratio: 1.66, show_image: section.settings.show_image, show_date: section.settings.show_date, show_author: section.settings.show_author, show_excerpt: true %}
             </li>
           {%- endfor -%}
         </ul>

--- a/sections/featured-blog.liquid
+++ b/sections/featured-blog.liquid
@@ -36,7 +36,7 @@
         >
           {%- for article in section.settings.blog.articles limit: section.settings.post_limit -%}
             <li id="Slide-{{ section.id }}-{{ forloop.index }}" class="blog__post grid__item article slider__slide slider__slide--full-width">
-              {% render 'article-card', blog: section.settings.blog, article: article, show_image: section.settings.show_image, show_date: section.settings.show_date, show_author: section.settings.show_author %}
+              {% render 'article-card', blog: section.settings.blog, article: article, show_image: section.settings.show_image, show_date: section.settings.show_date, show_author: section.settings.show_author, show_excerpt: true %}
             </li>
           {%- endfor -%}
         </ul>

--- a/sections/main-blog.liquid
+++ b/sections/main-blog.liquid
@@ -11,7 +11,15 @@
     <div class="blog-articles {% if section.settings.layout == 'collage' %}blog-articles--collage{% endif %}">
       {%- for article in blog.articles -%}
         <div class="blog-articles__article article">
-          {%- render 'article-card', article: article, image_height: section.settings.image_height, show_image: section.settings.show_image, show_date: section.settings.show_date, show_author: section.settings.show_author, show_excerpt: true -%}
+          {%- render 'article-card',
+            article: article,
+            media_height: section.settings.image_height,
+            media_aspect_ratio: article.image.aspect_ratio,
+            show_image: section.settings.show_image,
+            show_date: section.settings.show_date,
+            show_author: section.settings.show_author,
+            show_excerpt: true 
+          -%}
         </div>
       {%- endfor -%}
     </div>

--- a/sections/main-blog.liquid
+++ b/sections/main-blog.liquid
@@ -11,7 +11,7 @@
     <div class="blog-articles {% if section.settings.layout == 'collage' %}blog-articles--collage{% endif %}">
       {%- for article in blog.articles -%}
         <div class="blog-articles__article article">
-          {%- render 'article-card', article: article, image_height: section.settings.image_height, show_image: section.settings.show_image, show_date: section.settings.show_date, show_author: section.settings.show_author -%}
+          {%- render 'article-card', article: article, image_height: section.settings.image_height, show_image: section.settings.show_image, show_date: section.settings.show_date, show_author: section.settings.show_author, show_excerpt: true -%}
         </div>
       {%- endfor -%}
     </div>

--- a/sections/main-search.liquid
+++ b/sections/main-search.liquid
@@ -163,85 +163,13 @@
                         show_rating: section.settings.show_rating
                       %}
                     {%- when 'article' -%}
-                      {%- liquid
-                        assign ratio = 1
-                        if item.image and settings.card_style == 'card'
-                          assign ratio = 1.6
-                        endif
-                      -%}
-                      <div class="card-wrapper underline-links-hover">
-                        <div class="card
-                          card--{{ settings.card_style }}
-                          {% if item.image %} card--media{% else %} card--text{% endif %}
-                          {% if settings.card_style == 'card' %} color-{{ settings.card_color_scheme }}{% endif %}
-                          {% if item.image == nil and settings.card_style == 'card' %} ratio{% endif %}"
-                          style="--ratio-percent: {{ 1 | divided_by: ratio | times: 100 }}%;"
-                        >
-                          <div class="card__inner {% if settings.card_style == 'standard' %}color-{{ settings.card_color_scheme }}{% endif %}{% if item.image or settings.card_style == 'standard' %} ratio{% endif %}" style="--ratio-percent: {{ 1 | divided_by: ratio | times: 100 }}%;">
-                            {%- if item.image -%}
-                              <div class="card__media">
-                                <div class="media media--hover-effect">
-                                  <img
-                                    srcset="{%- if item.image.src.width >= 165 -%}{{ item.image.src | img_url: '165x' }} 165w,{%- endif -%}
-                                      {%- if item.image.src.width >= 360 -%}{{ item.image.src | img_url: '360x' }} 360w,{%- endif -%}
-                                      {%- if item.image.src.width >= 533 -%}{{ item.image.src | img_url: '533x' }} 533w,{%- endif -%}
-                                      {%- if item.image.src.width >= 720 -%}{{ item.image.src | img_url: '720x' }} 720w,{%- endif -%}
-                                      {%- if item.image.src.width >= 940 -%}{{ item.image.src | img_url: '940x' }} 940w,{%- endif -%}
-                                      {%- if item.image.src.width >= 1065 -%}{{ item.image.src | img_url: '1065x' }} 1065w,{%- endif -%}
-                                      {{ item.image.src | img_url: 'master' }} {{ item.image.src.width }}w"
-                                    src="{{ item.image.src | img_url: '940x' }}"
-                                    loading="lazy"
-                                    sizes="(min-width: {{ settings.page_width }}px) {{ settings.page_width | minus: 130 | divided_by: 4 }}px, (min-width: 990px) calc((100vw - 130px) / 4), (min-width: 750px) calc((100vw - 120px) / 3), calc((100vw - 35px) / 2)"
-                                    width="{{ item.image.src.width }}"
-                                    height="{{ item.image.src.height }}"
-                                    alt="{{ item.image.src.alt | escape }}"
-                                >
-                                </div>
-                              </div>
-                            {%- endif -%}
-                            <div class="card__content">        
-                              <div class="card__information">
-                                <h3 class="card__heading">
-                                  <a href="{{ item.url }}" class="full-unstyled-link">
-                                    {{ item.title | truncate: 50 | escape }}
-                                  </a>
-                                </h3>
-                                <div class="card-article-info caption-with-letter-spacing h5">
-                                  {%- if section.settings.article_show_date -%}
-                                    <span class="circle-divider">{{ item.published_at | time_tag: format: 'date' }}</span>
-                                  {%- endif -%}
-                                  {%- if section.settings.article_show_author -%}
-                                    <span>{{ item.author }}</span>
-                                  {%- endif -%}
-                                </div>
-                              </div>      
-                              <div class="card__badge {{ settings.badge_position }}"> 
-                                <span class="badge color-background-1">{{ 'blogs.article.blog' | t }}</span>
-                              </div>
-                            </div>
-                          </div>
-                          <div class="card__content">
-                            <div class="card__information">  
-                              <h3 class="card__heading">
-                                <a href="{{ item.url }}" class="full-unstyled-link">
-                                  {{ item.title | truncate: 50 | escape }}
-                                </a>
-                              </h3>
-                              <div class="card-article-info caption-with-letter-spacing h5">
-                                {%- if section.settings.article_show_date -%}
-                                  <span class="circle-divider">{{ item.published_at | time_tag: format: 'date' }}</span>
-                                {%- endif -%}
-                                {%- if section.settings.article_show_author -%}
-                                  <span>{{ item.author }}</span>
-                                {%- endif -%}
-                              </div>
-                            </div>     
-                            <div class="card__badge {{ settings.badge_position }}">
-                              <span class="badge color-background-1">{{ 'blogs.article.blog' | t }}</span>
-                            </div>
-                          </div>
-                        </div>
-                      </div>
+                      {% render 'article-card',
+                        article: item,
+                        show_image: true,
+                        show_date: section.settings.article_show_date,
+                        show_author: section.settings.article_show_author,
+                        show_badge: true
+                      %}
                     {%- when 'page' -%}                
                       <div class="card-wrapper underline-links-hover">
                         <div class="card card--card card--text ratio color-{{ settings.card_color_scheme }}" style="--ratio-percent: 100%;">

--- a/sections/main-search.liquid
+++ b/sections/main-search.liquid
@@ -169,6 +169,7 @@
                         show_date: section.settings.article_show_date,
                         show_author: section.settings.article_show_author,
                         show_badge: true
+                        media_aspect_ratio: 1
                       %}
                     {%- when 'page' -%}                
                       <div class="card-wrapper underline-links-hover">

--- a/snippets/article-card.liquid
+++ b/snippets/article-card.liquid
@@ -4,10 +4,12 @@
     Accepts:
     - blog: {Object} Blog object
     - article: {Object} Article object
-    - media_height: {String} The setting changes the height of the article image, if shown
+    - media_aspect_ratio: {String} The setting changes the aspect ratio of the article image, if shown
+    - media_height: {String} The setting changes the height of the article image. Overrides media_aspect_ratio.
     - show_image: {String} The setting either show the article image or not. If it's not included it will show the image by default
     - show_date: {String} The setting either show the article date or not. If it's not included it will not show the image by default
     - show_author: {String} The setting either show the article author or not. If it's not included it will not show the author by default
+    - show_badge: {String} The setting either show the blog badge or not.
 
     Usage:
     {% render 'article-card' blog: blog, article: article, show_image: section.settings.show_image %}
@@ -55,7 +57,6 @@
         {%- endif -%}
         <div class="card__content">        
           <div class="card__information">
-            {% comment %} <h2 class="article-card__title" id="Article-{{ article.id }}"> {% endcomment %}
             <h3 class="card__heading{% if show_excerpt %} h2{% endif %}">
               <a href="{{ article.url }}" class="full-unstyled-link">
                 {{ article.title | truncate: 50 | escape }}
@@ -95,7 +96,6 @@
       </div>
       <div class="card__content">
         <div class="card__information">
-          {% comment %} <h2 class="article-card__title" id="Article-{{ article.id }}"> {% endcomment %}
           <h3 class="card__heading{% if show_excerpt %} h2{% endif %}">
             <a href="{{ article.url }}" class="full-unstyled-link">
               {{ article.title | truncate: 50 | escape }}

--- a/snippets/article-card.liquid
+++ b/snippets/article-card.liquid
@@ -16,6 +16,7 @@
 {%- if article and article != empty -%}
 
 <div class="card-wrapper underline-links-hover">
+  {% comment %} <article aria-labelledby="Article-{{ article.id }}"> {% endcomment %}
   <div class="card article-card
     card--{{ settings.card_style }}
     {% if article.image and show_image %} card--media{% else %} card--text{% endif %}
@@ -49,22 +50,21 @@
       {%- endif -%}
       <div class="card__content">        
         <div class="card__information">
-          <div class="article-card__info">
-            <header class="article-card__header">
-              <h2 class="article-card__title" id="Article-{{ article.id }}">
-                <a href="{{ article.url }}" class="article-content motion-reduce">
-                  {{ article.title | escape }}
-                </a>
-              </h2>
-              {%- if show_date -%}
-                <span class="circle-divider caption-with-letter-spacing">
-                  {{- article.published_at | time_tag: format: 'date' -}}
-                </span>
-              {%- endif -%}
-              {%- if show_author -%}
-                <span class="caption-with-letter-spacing">{{ article.author -}}</span>
-              {%- endif -%}
-            </header>
+          {% comment %} <h2 class="article-card__title" id="Article-{{ article.id }}"> {% endcomment %}
+          <h3 class="card__heading{% if show_excerpt %} h2{% endif %}">
+            <a href="{{ article.url }}" class="full-unstyled-link">
+              {{ article.title | truncate: 50 | escape }}
+            </a>
+          </h3>
+          <div class="article-card__info caption-with-letter-spacing h5">
+            {%- if show_date -%}
+              <span class="circle-divider">{{ article.published_at | time_tag: format: 'date' }}</span>
+            {%- endif -%}
+            {%- if show_author -%}
+              <span>{{ article.author }}</span>
+            {%- endif -%}
+          </div>
+          {%- if show_excerpt -%}
             {%- if article.excerpt.size > 0 or article.content.size > 0 -%}
               <p class="article-card__excerpt rte-width">
                 {%- if article.excerpt.size > 0 -%}
@@ -79,28 +79,32 @@
                 <span>{{ 'blogs.article.comments' | t: count: article.comments_count }}</span>
               {%- endif -%}
             </div>
+          {%- endif -%}
+        </div>
+        {%- if show_badge -%}
+          <div class="card__badge {{ settings.badge_position }}">
+            <span class="badge color-background-1">{{ 'blogs.article.blog' | t }}</span>
           </div>
-        </div>      
+        {%- endif -%}
       </div>
     </div>
     <div class="card__content">
-      <div class="card__information">  
-        <div class="article-card__info">
-          <header class="article-card__header">
-            <h2 class="article-card__title" id="Article-{{ article.id }}">
-              <a href="{{ article.url }}" class="article-content motion-reduce">
-                {{ article.title | escape }}
-              </a>
-            </h2>
-            {%- if show_date -%}
-              <span class="circle-divider caption-with-letter-spacing">
-                {{- article.published_at | time_tag: format: 'date' -}}
-              </span>
-            {%- endif -%}
-            {%- if show_author -%}
-              <span class="caption-with-letter-spacing">{{ article.author -}}</span>
-            {%- endif -%}
-          </header>
+      <div class="card__information">
+        {% comment %} <h2 class="article-card__title" id="Article-{{ article.id }}"> {% endcomment %}
+        <h3 class="card__heading{% if show_excerpt %} h2{% endif %}">
+          <a href="{{ article.url }}" class="full-unstyled-link">
+            {{ article.title | truncate: 50 | escape }}
+          </a>
+        </h3>
+        <div class="article-card__info caption-with-letter-spacing h5">
+          {%- if show_date -%}
+            <span class="circle-divider">{{ article.published_at | time_tag: format: 'date' }}</span>
+          {%- endif -%}
+          {%- if show_author -%}
+            <span>{{ article.author }}</span>
+          {%- endif -%}
+        </div>
+        {%- if show_excerpt -%}
           {%- if article.excerpt.size > 0 or article.content.size > 0 -%}
             <p class="article-card__excerpt rte-width">
               {%- if article.excerpt.size > 0 -%}
@@ -115,10 +119,13 @@
               <span>{{ 'blogs.article.comments' | t: count: article.comments_count }}</span>
             {%- endif -%}
           </div>
+        {%- endif -%}
+      </div>
+      {%- if show_badge -%}
+        <div class="card__badge {{ settings.badge_position }}">
+          <span class="badge color-background-1">{{ 'blogs.article.blog' | t }}</span>
         </div>
-
-      
-      </div>     
+      {%- endif -%}  
     </div>
   </div>
 </div>

--- a/snippets/article-card.liquid
+++ b/snippets/article-card.liquid
@@ -4,7 +4,7 @@
     Accepts:
     - blog: {Object} Blog object
     - article: {Object} Article object
-    - image_height: {String} The setting changes the height of the article image, if shown
+    - media_height: {String} The setting changes the height of the article image, if shown
     - show_image: {String} The setting either show the article image or not. If it's not included it will show the image by default
     - show_date: {String} The setting either show the article date or not. If it's not included it will not show the image by default
     - show_author: {String} The setting either show the article author or not. If it's not included it will not show the author by default
@@ -14,41 +14,86 @@
 {% endcomment %}
 
 {%- if article and article != empty -%}
-
-<div class="card-wrapper underline-links-hover">
-  {% comment %} <article aria-labelledby="Article-{{ article.id }}"> {% endcomment %}
-  <div class="card article-card
-    card--{{ settings.card_style }}
-    {% if article.image and show_image %} card--media{% else %} card--text{% endif %}
-    {% if image_height == 'adapt' %} card--height-auto{% endif %}
-    {% if settings.card_style == 'card' %} color-{{ settings.card_color_scheme }}{% endif %}
-    {% if settings.card_style == 'card' and article.image == nil or show_image == false %} ratio{% endif %}"
-    style="--ratio-percent: 66.66%;"
-  >
-    <div class="card__inner {% if settings.card_style == 'standard' %} color-{{ settings.card_color_scheme }}{% endif %}{% if article.image and show_image or settings.card_style == 'standard' %} ratio{% endif %}" style="--ratio-percent: 66.66%;">
-      {%- if show_image == true and article.image -%}
-        <div class="article-card__image-wrapper card__media">
-          <div class="article-card__image media {% if image_height %}article-card__image--{{ image_height }}{% else %}media--landscape{% endif %}" {% if section.settings.image_height == 'adapt' %} style="padding-bottom: {{ 1 | divided_by: article.image.aspect_ratio | times: 100 }}%;"{% endif %}>
-            <img
-              srcset="{%- if article.image.src.width >= 165 -%}{{ article.image.src | img_url: '165x' }} 165w,{%- endif -%}
-                {%- if article.image.src.width >= 360 -%}{{ article.image.src | img_url: '360x' }} 360w,{%- endif -%}
-                {%- if article.image.src.width >= 533 -%}{{ article.image.src | img_url: '533x' }} 533w,{%- endif -%}
-                {%- if article.image.src.width >= 720 -%}{{ article.image.src | img_url: '720x' }} 720w,{%- endif -%}
-                {%- if article.image.src.width >= 1000 -%}{{ article.image.src | img_url: '1000x' }} 1000w,{%- endif -%}
-                {%- if article.image.src.width >= 1500 -%}{{ article.image.src | img_url: '1500x' }} 1500w,{%- endif -%}
-                {{ article.image.src | img_url: 'master' }} {{ article.image.src.width }}w"
-              src="{{ article.image.src | img_url: '533x' }}"
-              sizes="(min-width: {{ settings.page_width }}px) {{ settings.page_width | minus: 100 | divided_by: 2 }}px, (min-width: 750px) calc((100vw - 130px) / 2), calc((100vw - 50px) / 2)"
-              alt="{{ article.image.src.alt | escape }}"
-              width="{{ article.image.width }}"
-              height="{{ article.image.height }}"
-              loading="lazy"
-              class="motion-reduce"
-            >
+  {%- liquid
+    assign ratio = 1
+    if media_aspect_ratio != nil
+      assign ratio = media_aspect_ratio
+    endif
+  -%}
+  <div class="card-wrapper underline-links-hover">
+    {% comment %} <article aria-labelledby="Article-{{ article.id }}"> {% endcomment %}
+    <div class="card article-card
+      card--{{ settings.card_style }}
+      {% if media_height and media_height != 'adapt' %} article-card__image--{{ media_height }}{% endif %}
+      {% if article.image and show_image %} card--media{% else %} card--text{% endif %}
+      {% if settings.card_style == 'card' %} color-{{ settings.card_color_scheme }}{% endif %}
+      {% if settings.card_style == 'card' and media_height == nil and article.image == empty or show_image == false %} ratio{% endif %}"
+      style="--ratio-percent: {{ 1 | divided_by: ratio | times: 100 }}%;"
+    >
+      <div class="card__inner {% if settings.card_style == 'standard' %} color-{{ settings.card_color_scheme }}{% endif %}{% if article.image and show_image or settings.card_style == 'standard' %} ratio{% endif %}" style="--ratio-percent: {{ 1 | divided_by: ratio | times: 100 }}%;">
+        {%- if show_image == true and article.image -%}
+          <div class="article-card__image-wrapper card__media">
+            <div class="article-card__image media media--hover-effect" {% if section.settings.media_height == 'adapt' %} style="padding-bottom: {{ 1 | divided_by: article.image.aspect_ratio | times: 100 }}%;"{% endif %}>
+              <img
+                srcset="{%- if article.image.src.width >= 165 -%}{{ article.image.src | img_url: '165x' }} 165w,{%- endif -%}
+                  {%- if article.image.src.width >= 360 -%}{{ article.image.src | img_url: '360x' }} 360w,{%- endif -%}
+                  {%- if article.image.src.width >= 533 -%}{{ article.image.src | img_url: '533x' }} 533w,{%- endif -%}
+                  {%- if article.image.src.width >= 720 -%}{{ article.image.src | img_url: '720x' }} 720w,{%- endif -%}
+                  {%- if article.image.src.width >= 1000 -%}{{ article.image.src | img_url: '1000x' }} 1000w,{%- endif -%}
+                  {%- if article.image.src.width >= 1500 -%}{{ article.image.src | img_url: '1500x' }} 1500w,{%- endif -%}
+                  {{ article.image.src | img_url: 'master' }} {{ article.image.src.width }}w"
+                src="{{ article.image.src | img_url: '533x' }}"
+                sizes="(min-width: {{ settings.page_width }}px) {{ settings.page_width | minus: 100 | divided_by: 2 }}px, (min-width: 750px) calc((100vw - 130px) / 2), calc((100vw - 50px) / 2)"
+                alt="{{ article.image.src.alt | escape }}"
+                width="{{ article.image.width }}"
+                height="{{ article.image.height }}"
+                loading="lazy"
+                class="motion-reduce"
+              >
+            </div>
           </div>
+        {%- endif -%}
+        <div class="card__content">        
+          <div class="card__information">
+            {% comment %} <h2 class="article-card__title" id="Article-{{ article.id }}"> {% endcomment %}
+            <h3 class="card__heading{% if show_excerpt %} h2{% endif %}">
+              <a href="{{ article.url }}" class="full-unstyled-link">
+                {{ article.title | truncate: 50 | escape }}
+              </a>
+            </h3>
+            <div class="article-card__info caption-with-letter-spacing h5">
+              {%- if show_date -%}
+                <span class="circle-divider">{{ article.published_at | time_tag: format: 'date' }}</span>
+              {%- endif -%}
+              {%- if show_author -%}
+                <span>{{ article.author }}</span>
+              {%- endif -%}
+            </div>
+            {%- if show_excerpt -%}
+              {%- if article.excerpt.size > 0 or article.content.size > 0 -%}
+                <p class="article-card__excerpt rte-width">
+                  {%- if article.excerpt.size > 0 -%}
+                    {{ article.excerpt | strip_html | truncatewords: 30 }}
+                  {%- else -%}
+                    {{ article.content | strip_html | truncatewords: 30 }}
+                  {%- endif -%}
+                </p>
+              {%- endif -%}
+              <div class="article-card__footer">
+                {%- if article.comments_count > 0 and blog.comments_enabled? -%}
+                  <span>{{ 'blogs.article.comments' | t: count: article.comments_count }}</span>
+                {%- endif -%}
+              </div>
+            {%- endif -%}
+          </div>
+          {%- if show_badge -%}
+            <div class="card__badge {{ settings.badge_position }}">
+              <span class="badge color-background-1">{{ 'blogs.article.blog' | t }}</span>
+            </div>
+          {%- endif -%}
         </div>
-      {%- endif -%}
-      <div class="card__content">        
+      </div>
+      <div class="card__content">
         <div class="card__information">
           {% comment %} <h2 class="article-card__title" id="Article-{{ article.id }}"> {% endcomment %}
           <h3 class="card__heading{% if show_excerpt %} h2{% endif %}">
@@ -85,48 +130,8 @@
           <div class="card__badge {{ settings.badge_position }}">
             <span class="badge color-background-1">{{ 'blogs.article.blog' | t }}</span>
           </div>
-        {%- endif -%}
+        {%- endif -%}  
       </div>
-    </div>
-    <div class="card__content">
-      <div class="card__information">
-        {% comment %} <h2 class="article-card__title" id="Article-{{ article.id }}"> {% endcomment %}
-        <h3 class="card__heading{% if show_excerpt %} h2{% endif %}">
-          <a href="{{ article.url }}" class="full-unstyled-link">
-            {{ article.title | truncate: 50 | escape }}
-          </a>
-        </h3>
-        <div class="article-card__info caption-with-letter-spacing h5">
-          {%- if show_date -%}
-            <span class="circle-divider">{{ article.published_at | time_tag: format: 'date' }}</span>
-          {%- endif -%}
-          {%- if show_author -%}
-            <span>{{ article.author }}</span>
-          {%- endif -%}
-        </div>
-        {%- if show_excerpt -%}
-          {%- if article.excerpt.size > 0 or article.content.size > 0 -%}
-            <p class="article-card__excerpt rte-width">
-              {%- if article.excerpt.size > 0 -%}
-                {{ article.excerpt | strip_html | truncatewords: 30 }}
-              {%- else -%}
-                {{ article.content | strip_html | truncatewords: 30 }}
-              {%- endif -%}
-            </p>
-          {%- endif -%}
-          <div class="article-card__footer">
-            {%- if article.comments_count > 0 and blog.comments_enabled? -%}
-              <span>{{ 'blogs.article.comments' | t: count: article.comments_count }}</span>
-            {%- endif -%}
-          </div>
-        {%- endif -%}
-      </div>
-      {%- if show_badge -%}
-        <div class="card__badge {{ settings.badge_position }}">
-          <span class="badge color-background-1">{{ 'blogs.article.blog' | t }}</span>
-        </div>
-      {%- endif -%}  
     </div>
   </div>
-</div>
 {%- endif -%}

--- a/snippets/article-card.liquid
+++ b/snippets/article-card.liquid
@@ -13,59 +13,113 @@
     {% render 'article-card' blog: blog, article: article, show_image: section.settings.show_image %}
 {% endcomment %}
 
-<article class="article-card{% if article.image == blank or show_image == false %} article-card--no-image{% endif %}" aria-labelledby="Article-{{ article.id }}">
-  <a href="{{ article.url }}" class="article-content motion-reduce">
-    {%- if show_image == true and article.image -%}
-      <div class="article-card__image-wrapper">
-        <div class="article-card__image media {% if image_height %}article-card__image--{{ image_height }}{% else %}media--landscape{% endif %}" {% if section.settings.image_height == 'adapt' %} style="padding-bottom: {{ 1 | divided_by: article.image.aspect_ratio | times: 100 }}%;"{% endif %}>
-          <img
-            srcset="{%- if article.image.src.width >= 165 -%}{{ article.image.src | img_url: '165x' }} 165w,{%- endif -%}
-              {%- if article.image.src.width >= 360 -%}{{ article.image.src | img_url: '360x' }} 360w,{%- endif -%}
-              {%- if article.image.src.width >= 533 -%}{{ article.image.src | img_url: '533x' }} 533w,{%- endif -%}
-              {%- if article.image.src.width >= 720 -%}{{ article.image.src | img_url: '720x' }} 720w,{%- endif -%}
-              {%- if article.image.src.width >= 1000 -%}{{ article.image.src | img_url: '1000x' }} 1000w,{%- endif -%}
-              {%- if article.image.src.width >= 1500 -%}{{ article.image.src | img_url: '1500x' }} 1500w,{%- endif -%}
-              {{ article.image.src | img_url: 'master' }} {{ article.image.src.width }}w"
-            src="{{ article.image.src | img_url: '533x' }}"
-            sizes="(min-width: {{ settings.page_width }}px) {{ settings.page_width | minus: 100 | divided_by: 2 }}px, (min-width: 750px) calc((100vw - 130px) / 2), calc((100vw - 50px) / 2)"
-            alt="{{ article.image.src.alt | escape }}"
-            width="{{ article.image.width }}"
-            height="{{ article.image.height }}"
-            loading="lazy"
-            class="motion-reduce"
-          >
-        </div>
-      </div>
-    {%- endif -%}
+{%- if article and article != empty -%}
 
-    <div class="article-card__info">
-      <header class="article-card__header">
-        <h2 class="article-card__title" id="Article-{{ article.id }}">
-          {{ article.title | escape }}
-        </h2>
-        {%- if show_date -%}
-          <span class="circle-divider caption-with-letter-spacing">
-            {{- article.published_at | time_tag: format: 'date' -}}
-          </span>
-        {%- endif -%}
-        {%- if show_author -%}
-          <span class="caption-with-letter-spacing">{{ article.author -}}</span>
-        {%- endif -%}
-      </header>
-      {%- if article.excerpt.size > 0 or article.content.size > 0 -%}
-        <p class="article-card__excerpt rte-width">
-          {%- if article.excerpt.size > 0 -%}
-            {{ article.excerpt | strip_html | truncatewords: 30 }}
-          {%- else -%}
-            {{ article.content | strip_html | truncatewords: 30 }}
-          {%- endif -%}
-        </p>
+<div class="card-wrapper underline-links-hover">
+  <div class="card article-card
+    card--{{ settings.card_style }}
+    {% if article.image and show_image %} card--media{% else %} card--text{% endif %}
+    {% if image_height == 'adapt' %} card--height-auto{% endif %}
+    {% if settings.card_style == 'card' %} color-{{ settings.card_color_scheme }}{% endif %}
+    {% if settings.card_style == 'card' and article.image == nil or show_image == false %} ratio{% endif %}"
+    style="--ratio-percent: 66.66%;"
+  >
+    <div class="card__inner {% if settings.card_style == 'standard' %} color-{{ settings.card_color_scheme }}{% endif %}{% if article.image and show_image or settings.card_style == 'standard' %} ratio{% endif %}" style="--ratio-percent: 66.66%;">
+      {%- if show_image == true and article.image -%}
+        <div class="article-card__image-wrapper card__media">
+          <div class="article-card__image media {% if image_height %}article-card__image--{{ image_height }}{% else %}media--landscape{% endif %}" {% if section.settings.image_height == 'adapt' %} style="padding-bottom: {{ 1 | divided_by: article.image.aspect_ratio | times: 100 }}%;"{% endif %}>
+            <img
+              srcset="{%- if article.image.src.width >= 165 -%}{{ article.image.src | img_url: '165x' }} 165w,{%- endif -%}
+                {%- if article.image.src.width >= 360 -%}{{ article.image.src | img_url: '360x' }} 360w,{%- endif -%}
+                {%- if article.image.src.width >= 533 -%}{{ article.image.src | img_url: '533x' }} 533w,{%- endif -%}
+                {%- if article.image.src.width >= 720 -%}{{ article.image.src | img_url: '720x' }} 720w,{%- endif -%}
+                {%- if article.image.src.width >= 1000 -%}{{ article.image.src | img_url: '1000x' }} 1000w,{%- endif -%}
+                {%- if article.image.src.width >= 1500 -%}{{ article.image.src | img_url: '1500x' }} 1500w,{%- endif -%}
+                {{ article.image.src | img_url: 'master' }} {{ article.image.src.width }}w"
+              src="{{ article.image.src | img_url: '533x' }}"
+              sizes="(min-width: {{ settings.page_width }}px) {{ settings.page_width | minus: 100 | divided_by: 2 }}px, (min-width: 750px) calc((100vw - 130px) / 2), calc((100vw - 50px) / 2)"
+              alt="{{ article.image.src.alt | escape }}"
+              width="{{ article.image.width }}"
+              height="{{ article.image.height }}"
+              loading="lazy"
+              class="motion-reduce"
+            >
+          </div>
+        </div>
       {%- endif -%}
-      <div class="article-card__footer">
-        {%- if article.comments_count > 0 and blog.comments_enabled? -%}
-          <span>{{ 'blogs.article.comments' | t: count: article.comments_count }}</span>
-        {%- endif -%}
+      <div class="card__content">        
+        <div class="card__information">
+          <div class="article-card__info">
+            <header class="article-card__header">
+              <h2 class="article-card__title" id="Article-{{ article.id }}">
+                <a href="{{ article.url }}" class="article-content motion-reduce">
+                  {{ article.title | escape }}
+                </a>
+              </h2>
+              {%- if show_date -%}
+                <span class="circle-divider caption-with-letter-spacing">
+                  {{- article.published_at | time_tag: format: 'date' -}}
+                </span>
+              {%- endif -%}
+              {%- if show_author -%}
+                <span class="caption-with-letter-spacing">{{ article.author -}}</span>
+              {%- endif -%}
+            </header>
+            {%- if article.excerpt.size > 0 or article.content.size > 0 -%}
+              <p class="article-card__excerpt rte-width">
+                {%- if article.excerpt.size > 0 -%}
+                  {{ article.excerpt | strip_html | truncatewords: 30 }}
+                {%- else -%}
+                  {{ article.content | strip_html | truncatewords: 30 }}
+                {%- endif -%}
+              </p>
+            {%- endif -%}
+            <div class="article-card__footer">
+              {%- if article.comments_count > 0 and blog.comments_enabled? -%}
+                <span>{{ 'blogs.article.comments' | t: count: article.comments_count }}</span>
+              {%- endif -%}
+            </div>
+          </div>
+        </div>      
       </div>
     </div>
-  </a>
-</article>
+    <div class="card__content">
+      <div class="card__information">  
+        <div class="article-card__info">
+          <header class="article-card__header">
+            <h2 class="article-card__title" id="Article-{{ article.id }}">
+              <a href="{{ article.url }}" class="article-content motion-reduce">
+                {{ article.title | escape }}
+              </a>
+            </h2>
+            {%- if show_date -%}
+              <span class="circle-divider caption-with-letter-spacing">
+                {{- article.published_at | time_tag: format: 'date' -}}
+              </span>
+            {%- endif -%}
+            {%- if show_author -%}
+              <span class="caption-with-letter-spacing">{{ article.author -}}</span>
+            {%- endif -%}
+          </header>
+          {%- if article.excerpt.size > 0 or article.content.size > 0 -%}
+            <p class="article-card__excerpt rte-width">
+              {%- if article.excerpt.size > 0 -%}
+                {{ article.excerpt | strip_html | truncatewords: 30 }}
+              {%- else -%}
+                {{ article.content | strip_html | truncatewords: 30 }}
+              {%- endif -%}
+            </p>
+          {%- endif -%}
+          <div class="article-card__footer">
+            {%- if article.comments_count > 0 and blog.comments_enabled? -%}
+              <span>{{ 'blogs.article.comments' | t: count: article.comments_count }}</span>
+            {%- endif -%}
+          </div>
+        </div>
+
+      
+      </div>     
+    </div>
+  </div>
+</div>
+{%- endif -%}


### PR DESCRIPTION
**Why are these changes introduced?**

Refs #929
Updates blog cards to use the same structure and styles as product cards.

Changes affect..
- Featured blog section
- Search results (with articles)
- Main blog

**What approach did you take?**

Markup was updated to match product cards (and the existing blog search result card), but blog cards had a specific semantic structure that I'm not sure is worth replicating. For now I've decided it's best for them to match products exactly, but there may be a11y concerns involved.

There are two ways article card media can be sized via the rendering section, height (small, med, large, adapt) or aspect ratio. Height values are needed for the main blog image height settings (which correspond to specific css rules).

Replaced the inline article card markup in the search section with an article-card render.

**Other considerations**

An existing issue with standard style cards that will be more noticeable on blog cards now is the lack of padding between the card content and adjacent cards. This will be handled in a separate issue https://github.com/Shopify/dawn/issues/1035

**Demo links**

- [Editor](https://os2-demo.myshopify.com/admin/themes/127022006294/editor)

**Checklist**
- [ ] Followed [theme code principles](https://github.com/Shopify/dawn/blob/main/.github/CONTRIBUTING.md#theme-code-principles)
- [ ] Linted with [Theme Check](https://github.com/Shopify/theme-check)
- [ ] Tested on [mobile](https://shopify.dev/themes/store/requirements#mobile-browser-requirements)
- [ ] Tested on [multiple browsers](https://shopify.dev/themes/store/requirements#desktop-browser-requirements)
- [ ] Tested for [accessibility](https://shopify.dev/themes/best-practices/accessibility)
