### PR TITLE
Slider spacing fixes

### DIFF
--- a/assets/base.css
+++ b/assets/base.css
@@ -154,6 +154,40 @@
   --color-icon: rgb(var(--color-base-outline-button-labels));
 }
 
+.product-grid,
+.collection-list,
+.card {
+  --border-radius: var(--card-corner-radius);
+  --border-width: var(--card-border-width);
+  --border-opacity: var(--card-border-opacity);
+  --shadow-horizontal-offset: var(--card-shadow-horizontal-offset);
+  --shadow-vertical-offset: var(--card-shadow-vertical-offset);
+  --shadow-blur-radius: var(--card-shadow-blur-radius);
+  --shadow-opacity: var(--card-shadow-opacity);
+}
+
+.multicolumn-list,
+.multicolumn-card {
+  --border-radius: var(--text-boxes-radius);
+  --border-width: var(--text-boxes-border-width);
+  --border-opacity: var(--text-boxes-border-opacity);
+  --shadow-horizontal-offset: var(--text-boxes-shadow-horizontal-offset);
+  --shadow-vertical-offset: var(--text-boxes-shadow-vertical-offset);
+  --shadow-blur-radius: var(--text-boxes-shadow-blur-radius);
+  --shadow-opacity: var(--text-boxes-shadow-opacity);
+}
+
+.product__media-list,
+.product__media-item {
+  --border-radius: var(--media-radius);
+  --border-width: var(--media-border-width);
+  --border-opacity: var(--media-border-opacity);
+  --shadow-horizontal-offset: var(--media-shadow-horizontal-offset);
+  --shadow-vertical-offset: var(--media-shadow-vertical-offset);
+  --shadow-blur-radius: var(--media-shadow-blur-radius);
+  --shadow-opacity: var(--media-shadow-opacity);
+}
+
 /* base */
 
 .no-js:not(html) {
@@ -1066,7 +1100,7 @@ summary::-webkit-details-marker {
   }
 
   .grid--peek .grid__item {
-    padding-left: 0.5rem;
+    padding-left: var(--grid-mobile-horizontal-spacing);
   }
 
   .grid--peek .grid__item:first-of-type {

--- a/assets/component-card.css
+++ b/assets/component-card.css
@@ -15,6 +15,7 @@
   border-radius: var(--card-corner-radius);
   border: var(--card-border-width) solid rgba(var(--color-foreground), var(--card-border-opacity));
   position: relative;
+  box-sizing: border-box;
 }
 
 .card--card:after,

--- a/assets/component-slider.css
+++ b/assets/component-slider.css
@@ -24,6 +24,8 @@ slider-component {
     scroll-padding-left: 1rem;
     -webkit-overflow-scrolling: touch;
     margin-bottom: 1rem;
+    padding-top: calc(var(--shadow-vertical-offset) * -1 + var(--shadow-blur-radius));
+    padding-bottom: calc(var(--shadow-vertical-offset) + var(--shadow-blur-radius));
   }
 
   .slider.slider--mobile .slider__slide {
@@ -59,6 +61,8 @@ slider-component {
     scroll-padding-left: 1rem;
     -webkit-overflow-scrolling: touch;
     margin-bottom: 1rem;
+    padding-top: calc(var(--shadow-vertical-offset) * -1 + var(--shadow-blur-radius));
+    padding-bottom: calc(var(--shadow-vertical-offset) + var(--shadow-blur-radius));
   }
 
   .slider.slider--tablet .slider__slide {

--- a/assets/section-multicolumn.css
+++ b/assets/section-multicolumn.css
@@ -112,10 +112,6 @@
   .multicolumn-list.slider .multicolumn-list__item {
     width: calc(100% - 3rem);
   }
-
-  .multicolumn-list.slider .multicolumn-list__item + .multicolumn-list__item {
-    padding-left: 0.5rem;
-  }
 }
 
 @media screen and (min-width: 750px) {
@@ -224,6 +220,7 @@
 
 .multicolumn-card {
   position: relative;
+  box-sizing: border-box;
   border-radius: var(--text-boxes-radius);
   border: var(--text-boxes-border-width) solid rgba(var(--color-foreground), var(--text-boxes-border-opacity));
 }

--- a/assets/template-collection.css
+++ b/assets/template-collection.css
@@ -18,7 +18,6 @@
 @media screen and (max-width: 989px) {
   .collection .slider.slider--tablet {
     margin-bottom: 1.5rem;
-    padding-bottom: 0;
   } 
 }
 


### PR DESCRIPTION
**Why are these changes introduced?**

Fixes #1027
Refs #929

Changes included..
- Adds padding above or below sliders to account for shadow offsets and blur radius ([example](https://screenshot.click/16-34-0famm-vo5sv.png))
- Prevent border from overflowing container (multicolumn, standard card) ([example](https://screenshot.click/16-30-my0hr-7uy3n.png))
- Remove fixed spacing on slider slides ([example](https://screenshot.click/21-12-qcgg5-xuc8z.png))

**What approach did you take?**

**Other considerations**

**Demo links**

- [Store](url)
- [Editor](url)

**Checklist**
- [ ] Followed [theme code principles](https://github.com/Shopify/dawn/blob/main/.github/CONTRIBUTING.md#theme-code-principles)
- [ ] Linted with [Theme Check](https://github.com/Shopify/theme-check)
- [ ] Tested on [mobile](https://shopify.dev/themes/store/requirements#mobile-browser-requirements)
- [ ] Tested on [multiple browsers](https://shopify.dev/themes/store/requirements#desktop-browser-requirements)
- [ ] Tested for [accessibility](https://shopify.dev/themes/best-practices/accessibility)
