### PR TITLE
Fix content container box shadow

### DIFF
--- a/assets/section-image-banner.css
+++ b/assets/section-image-banner.css
@@ -340,6 +340,10 @@
     --color-button-text: 255, 255, 255;
     --alpha-button-background: 0;
   }
+
+  .banner--desktop-transparent .content-container:after {
+    display: none;
+  }
 }
 
 @media screen and (max-width: 749px) {


### PR DESCRIPTION
**Why are these changes introduced?**

Fixes issue on desktop where the box shadow of the content-container is showing when set to transparent:
![](https://screenshot.click/21-12-960l2-wmdjp.png)

**What approach did you take?**

Added some styling for the pseudo element when the class `banner--desktop-transparent` is present. 

**Other considerations**

**Demo links**

- [Store](https://os2-demo.myshopify.com/?preview_theme_id=127036719126)
- [Editor](https://os2-demo.myshopify.com/admin/themes/127036719126/editor)

**Checklist**
- [x] Followed [theme code principles](https://github.com/Shopify/dawn/blob/main/.github/CONTRIBUTING.md#theme-code-principles)
- [x] Linted with [Theme Check](https://github.com/Shopify/theme-check)
- [x] Tested on [mobile](https://shopify.dev/themes/store/requirements#mobile-browser-requirements)
- [x] Tested on [multiple browsers](https://shopify.dev/themes/store/requirements#desktop-browser-requirements)
- [x] Tested for [accessibility](https://shopify.dev/themes/best-practices/accessibility)
