### PR TITLE
Update card focus to use focus-visible

### DIFF
--- a/assets/component-card.css
+++ b/assets/component-card.css
@@ -155,13 +155,26 @@
   z-index: 1;
 }
 
-.card-wrapper:focus-within .card {
-  box-shadow: 0 0 0 .3rem rgb(var(--color-background)),0 0 .5rem .4rem rgba(var(--color-foreground),.3);
+.card__heading a:after {
   outline-offset: 0.3rem;
+}
+
+.card__heading a:focus:after {
+  box-shadow: 0 0 0 .3rem rgb(var(--color-background)),0 0 .5rem .4rem rgba(var(--color-foreground),.3);
   outline: .2rem solid rgba(var(--color-foreground),.5);
 }
 
-.card-wrapper:focus-within .card__heading a {
+.card__heading a:focus-visible:after {
+  box-shadow: 0 0 0 .3rem rgb(var(--color-background)),0 0 .5rem .4rem rgba(var(--color-foreground),.3);
+  outline: .2rem solid rgba(var(--color-foreground),.5);
+}
+
+.card__heading a:focus:not(:focus-visible):after {
+  box-shadow: none;
+  outline: 0;
+}
+
+.card__heading a:focus {
   box-shadow: none;
   outline: 0;
 }


### PR DESCRIPTION
### **Why are these changes introduced?**

Fixes #1028

### **What approach did you take?**

#### 1 - Apply the following approach to `.card__heading a:after`:
``` css
:focus-visible {
  /* Focus styles - for browsers that support `:focus-visible` */
}

:focus {
  /* Focus styles fallback - for browsers that do not support `:focus-visible` */
}

:focus:not(:focus-visible) {
  /* Negate side-effects of fallback - for browsers that support `:focus-visible` */
}
```

#### 2 - Remove focus styles for `.card__heading a` since focus styles are now applied to its `after` pseudo-element

### **Other considerations**

n/a

### **Demo links**

- [Store](https://os2-demo.myshopify.com/?preview_theme_id=127061327894)
- [Editor](https://os2-demo.myshopify.com/admin/themes/127061327894/editor)

### **Checklist**
- [ ] Followed [theme code principles](https://github.com/Shopify/dawn/blob/main/.github/CONTRIBUTING.md#theme-code-principles)
- [ ] Linted with [Theme Check](https://github.com/Shopify/theme-check)
- [ ] Tested on [mobile](https://shopify.dev/themes/store/requirements#mobile-browser-requirements)
- [ ] Tested on [multiple browsers](https://shopify.dev/themes/store/requirements#desktop-browser-requirements)
- [ ] Tested for [accessibility](https://shopify.dev/themes/best-practices/accessibility)
