### PR TITLE
Add media settings to product section

### DIFF
--- a/assets/base.css
+++ b/assets/base.css
@@ -2539,6 +2539,14 @@ details-disclosure > details {
   z-index: -1;
 }
 
+.global-media-settings--no-shadow {
+  overflow: hidden !important;
+}
+
+.global-media-settings--no-shadow:after {
+  content: none;
+}
+
 .global-media-settings img,
 .global-media-settings iframe,
 .global-media-settings model-viewer,

--- a/assets/base.css
+++ b/assets/base.css
@@ -2555,8 +2555,8 @@ details-disclosure > details {
   border-radius: calc(var(--media-radius) - var(--media-border-width));
 }
 
-.global-media-settings--full-width,
 .content-container--full-width,
+.global-media-settings--full-width,
 .global-media-settings--full-width img {
   border-radius: 0;
   border-left: none;

--- a/assets/base.css
+++ b/assets/base.css
@@ -2528,6 +2528,7 @@ details-disclosure > details {
   border: var(--media-border-width) solid rgba(var(--color-foreground), var(--media-border-opacity));
   border-radius: var(--media-radius);
   overflow: visible !important;
+  background-color: rgb(var(--color-background));
 }
 
 .global-media-settings:after {

--- a/assets/base.css
+++ b/assets/base.css
@@ -178,7 +178,7 @@
   --shadow-opacity: var(--text-boxes-shadow-opacity);
 }
 
-.product__media-list,
+.product__media-gallery .slider,
 .product__media-item {
   --border-radius: var(--media-radius);
   --border-width: var(--media-border-width);
@@ -2540,7 +2540,9 @@ details-disclosure > details {
 }
 
 .global-media-settings img,
-.global-media-settings iframe {
+.global-media-settings iframe,
+.global-media-settings model-viewer,
+.global-media-settings video {
   border-radius: calc(var(--media-radius) - var(--media-border-width));
 }
 

--- a/assets/component-deferred-media.css
+++ b/assets/component-deferred-media.css
@@ -6,12 +6,7 @@
   padding: 0;
   height: 100%;
   width: 100%;
-  border-radius: calc(var(--media-radius) - var(--media-border-width));
   overflow: hidden;
-}
-
-.global-media-settings--full-width .deferred-media__poster {
-  border-radius: 0;
 }
 
 .media > .deferred-media__poster {
@@ -22,6 +17,7 @@
 
 .deferred-media__poster img {
   width: auto;
+  max-width: 100%;
   height: 100%;
 }
 
@@ -37,8 +33,21 @@
   display: none;
 }
 
+.deferred-media__poster:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 var(--media-border-width) rgba(var(--color-foreground), var(--media-border-opacity)), 0 0 0 calc(var(--media-border-width) + 0.3rem) rgb(var(--color-background)),0 0 0 calc(var(--media-border-width) + 0.5rem) rgba(var(--color-foreground),.5);
+  border-radius: calc(var(--media-radius) - var(--media-border-width));
+}
+
 .deferred-media__poster:focus {
-  outline-offset: -0.3rem;
+  outline: none;
+  box-shadow: 0 0 0 var(--media-border-width) rgba(var(--color-foreground), var(--media-border-opacity)), 0 0 0 calc(var(--media-border-width) + 0.3rem) rgb(var(--color-background)),0 0 0 calc(var(--media-border-width) + 0.5rem) rgba(var(--color-foreground),.5);
+  border-radius: calc(var(--media-radius) - var(--media-border-width));
+}
+
+.deferred-media__poster:focus:not(:focus-visible) {
+  outline: 0;
+  box-shadow: none;
 }
 
 .deferred-media__poster-button {

--- a/assets/component-slider.css
+++ b/assets/component-slider.css
@@ -24,6 +24,9 @@ slider-component {
     scroll-padding-left: 1rem;
     -webkit-overflow-scrolling: touch;
     margin-bottom: 1rem;
+  }
+
+  .slider--mobile.product__media-list {
     padding-top: calc(var(--shadow-vertical-offset) * -1 + var(--shadow-blur-radius));
     padding-bottom: calc(var(--shadow-vertical-offset) + var(--shadow-blur-radius));
   }

--- a/assets/section-featured-product.css
+++ b/assets/section-featured-product.css
@@ -4,6 +4,14 @@
   padding-bottom: 0;
 }
 
+.featured-product .global-media-settings:after {
+  z-index: 0;
+}
+
+.featured-product .product__modal-opener {
+  margin-bottom: var(--media-shadow-vertical-offset);
+}
+
 .featured-product .product__media-item {
   padding-left: 0;
   width: 100%;

--- a/assets/section-main-product.css
+++ b/assets/section-main-product.css
@@ -829,6 +829,10 @@ a.product__text {
     width: 70%;
     padding: 0 3rem;
   }
+
+  .product-media-modal__dialog .global-media-settings--no-shadow {
+    overflow: visible !important;
+  }
 }
 
 .product-popup-modal__content img {
@@ -842,6 +846,11 @@ a.product__text {
     overflow-x: auto;
     white-space: nowrap;
     margin: 0;
+  }
+
+  .product-media-modal__dialog .global-media-settings {
+    border: none;
+    border-radius: 0;
   }
 }
 

--- a/assets/section-main-product.css
+++ b/assets/section-main-product.css
@@ -26,6 +26,10 @@
     z-index: 2;
   }
 
+  .product--thumbnail .thumbnail-list {
+    padding-right: var(--media-shadow-horizontal-offset);
+  }
+
   .product__info-wrapper {
     padding-left: 5rem;
   }
@@ -463,7 +467,6 @@ a.product__text {
 }
 
 @media screen and (min-width: 750px) {
-
   .product--thumbnail .product__media-list,
   .product--thumbnail_slider .product__media-list {
     padding-bottom: var(--media-shadow-vertical-offset);
@@ -537,8 +540,8 @@ a.product__text {
   height: 3rem;
   width: 3rem;
   position: absolute;
-  left: 1.5rem;
-  top: 1.5rem;
+  left: calc( 0.4rem + var(--media-border-width));
+  top: calc(0.4rem + var(--media-border-width));
   z-index: 1;
   transition: color var(--duration-short) ease,
     opacity var(--duration-short) ease;
@@ -1010,16 +1013,18 @@ a.product__text {
   color: rgb(var(--color-base-text));
   cursor: pointer;
   background-color: transparent;
-  border: 0.1rem solid rgba(var(--color-foreground),.04);
-  border-radius: var(--media-radius);
 }
 
 .thumbnail:hover {
   opacity: 0.7;
 }
 
+.thumbnail.global-media-settings img {
+  border-radius: 0;
+}
+
 .thumbnail[aria-current] {
-  border: 0.1rem solid rgb(var(--color-base-text));
+  border-width: calc(0.1rem + var(--media-border-width));
 }
 
 .thumbnail img {

--- a/assets/section-main-product.css
+++ b/assets/section-main-product.css
@@ -603,17 +603,24 @@ a.product__text {
   width: 100%;
 }
 
-.product__media-toggle:focus-visible,
+.product__media-toggle:focus-visible {
+  outline: 0;
+  box-shadow: none;
+}
+
 .product__media-toggle.focused {
   outline: 0;
   box-shadow: none;
 }
 
-.product__media-toggle:focus-visible:after,
+.product__media-toggle:focus-visible:after {
+  box-shadow: 0 0 0 0.3rem rgb(var(--color-background)),0 0 0rem 0.5rem rgba(var(--color-foreground), 0.5);
+  border-radius: var(--media-radius) - var(--media-border-width);
+}
+
 .product__media-toggle.focused:after {
-  outline: 0.2rem solid rgba(var(--color-foreground), 0.5);
-  outline-offset: 0.3rem;
-  box-shadow: 0 0 0 0.3rem rgb(var(--color-background)), 0 0 0.5rem 0.4rem rgba(var(--color-foreground), 0.3);
+  box-shadow: 0 0 0 0.3rem rgb(var(--color-background)),0 0 0rem 0.5rem rgba(var(--color-foreground), 0.5);
+  border-radius: var(--media-radius);
 }
 
 .product__media-toggle:focus-visible:after {
@@ -690,7 +697,6 @@ a.product__text {
   display: block;
   height: auto;
   margin: auto;
-  border: 0.1rem solid rgba(var(--color-foreground), 0.04);
 }
 
 .product-media-modal__content .media {
@@ -1024,7 +1030,23 @@ a.product__text {
 }
 
 .thumbnail[aria-current] {
-  border-width: calc(0.1rem + var(--media-border-width));
+  box-shadow: 0 0 0rem 0.1rem rgb(var(--color-foreground));
+  border-color: rgb(var(--color-foreground));
+}
+
+.thumbnail[aria-current]:focus-visible {
+  box-shadow: 0 0 0 0.3rem rgb(var(--color-background)),0 0 0rem 0.5rem rgba(var(--color-foreground), 0.5);
+}
+
+.thumbnail[aria-current]:focus,
+.thumbnail.focused {
+  outline: 0;
+  box-shadow: 0 0 0 0.3rem rgb(var(--color-background)),0 0 0rem 0.5rem rgba(var(--color-foreground), 0.5);
+}
+
+.thumbnail[aria-current]:focus:not(:focus-visible) {
+  outline: 0;
+  box-shadow: none;
 }
 
 .thumbnail img {

--- a/assets/section-main-product.css
+++ b/assets/section-main-product.css
@@ -423,6 +423,9 @@ a.product__text {
 }
 
 /* Product media */
+.product__media-list video {
+  border-radius: calc(var(--media-radius) - var(--media-border-width));
+}
 
 @media screen and (max-width: 749px) {
   .product__media-list {
@@ -435,11 +438,6 @@ a.product__text {
   .product__media-wrapper slider-component:not(.thumbnail-slider--no-slide) {
     margin-left: -1.5rem;
     margin-right: -1.5rem;
-  }
-
-  .slider.slider--mobile.product__media-list {
-    padding-bottom: 0;
-    margin-bottom: 0.5rem;
   }
 
   .slider.product__media-list::-webkit-scrollbar {
@@ -465,6 +463,16 @@ a.product__text {
 }
 
 @media screen and (min-width: 750px) {
+
+  .product--thumbnail .product__media-list,
+  .product--thumbnail_slider .product__media-list {
+    padding-bottom: var(--media-shadow-vertical-offset);
+  }
+
+  .product__media-list {
+    padding-right: var(--media-shadow-horizontal-offset);
+  }
+
   .product__media-item:first-child {
     width: 100%;
   }
@@ -592,26 +600,21 @@ a.product__text {
   width: 100%;
 }
 
-.product__media-toggle:focus-visible {
-  outline: 0;
-  box-shadow: none;
-}
-
+.product__media-toggle:focus-visible,
 .product__media-toggle.focused {
   outline: 0;
   box-shadow: none;
 }
 
-.product__media-toggle:focus-visible:after {
+.product__media-toggle:focus-visible:after,
+.product__media-toggle.focused:after {
   outline: 0.2rem solid rgba(var(--color-foreground), 0.5);
   outline-offset: 0.3rem;
   box-shadow: 0 0 0 0.3rem rgb(var(--color-background)), 0 0 0.5rem 0.4rem rgba(var(--color-foreground), 0.3);
 }
 
-.product__media-toggle.focused::after {
-  outline: 0.2rem solid rgba(var(--color-foreground), 0.5);
-  outline-offset: 0.3rem;
-  box-shadow: 0 0 0 0.3rem rgb(var(--color-background)), 0 0 0.5rem 0.4rem rgba(var(--color-foreground), 0.3);
+.product__media-toggle:focus-visible:after {
+  border-radius: var(--media-radius);
 }
 
 .product-media-modal {
@@ -678,11 +681,6 @@ a.product__text {
     display: block;
     width: 100%;
   }
-}
-
-.product__media-list .deferred-media,
-.product__media-list .product__modal-opener {
-  border: 0.1rem solid rgba(var(--color-foreground), 0.04);
 }
 
 .product-media-modal__content > * {
@@ -900,27 +898,7 @@ a.product__text {
   width: 2.2rem;
 }
 
-.product__media-list .media {
-  border: var(--media-border-width) solid rgba(var(--color-foreground), var(--media-border-opacity));
-  border-radius: var(--media-radius);
-  overflow: visible;
-  background: rgb(var(--color-background));
-}
-
-.product__media-list .media:after {
-  border-radius: var(--media-radius);
-  box-shadow: var(--media-shadow-horizontal-offset) var(--media-shadow-vertical-offset) var(--media-shadow-blur-radius) rgba(var(--color-shadow), var(--media-shadow-opacity));
-  content: '';
-  position: absolute;
-  width: calc(var(--media-border-width) * 2 + 100%);
-  height: calc(var(--media-border-width) * 2 + 100%);
-  top: calc(var(--media-border-width) * -1);
-  left: calc(var(--media-border-width) * -1);
-  z-index: -1;
-}
-
 .product__media-list .media > * {
-  border-radius: calc(var(--media-radius) - var(--media-border-width));
   overflow: hidden;
 }
 
@@ -1033,6 +1011,7 @@ a.product__text {
   cursor: pointer;
   background-color: transparent;
   border: 0.1rem solid rgba(var(--color-foreground),.04);
+  border-radius: var(--media-radius);
 }
 
 .thumbnail:hover {
@@ -1073,8 +1052,8 @@ a.product__text {
   height: 2rem;
   width: 2rem;
   left: auto;
-  right: 0.4rem;
-  top: 0.4rem;
+  right: calc(0.4rem + var(--media-border-width));
+  top: calc(0.4rem + var(--media-border-width));
 }
 
 @media screen and (min-width: 750px) {

--- a/assets/section-main-product.css
+++ b/assets/section-main-product.css
@@ -848,7 +848,11 @@ a.product__text {
     margin: 0;
   }
 
-  .product-media-modal__dialog .global-media-settings {
+  .product-media-modal__dialog .global-media-settings,
+  .product-media-modal__dialog .global-media-settings video,
+  .product-media-modal__dialog .global-media-settings model-viewer,
+  .product-media-modal__dialog .global-media-settings iframe,
+  .product-media-modal__dialog .global-media-settings img {
     border: none;
     border-radius: 0;
   }

--- a/assets/template-giftcard.css
+++ b/assets/template-giftcard.css
@@ -410,7 +410,7 @@ h2,
 }
 
 .gradient {
-  background: var(--color-base-background-1);
+  background: rgb(var(--color-base-background-1));
   background: var(--gradient-base-background-1);
   background-attachment: fixed;
 }

--- a/sections/main-cart-items.liquid
+++ b/sections/main-cart-items.liquid
@@ -62,7 +62,7 @@
                     {% if item.image %}
                       {% comment %} Leave empty space due to a:empty CSS display: none rule {% endcomment %}
                       <a href="{{ item.url }}" class="cart-item__link" aria-hidden="true" tabindex="-1"> </a>
-                        <div class="cart-item__image-container global-media-settings">
+                        <div class="cart-item__image-container gradient global-media-settings">
                           <img src="{{ item.image | img_url: '300x' }}"
                             class="cart-item__image"
                             alt="{{ item.image.alt | escape }}"

--- a/sections/main-product.liquid
+++ b/sections/main-product.liquid
@@ -110,8 +110,8 @@
                   {%- endif -%}
                 {%- endcapture -%}
                 {%- assign media_index = media_index | plus: 1 -%}
-                <li id="Slide-Thumbnails-{{ section.id }}-0" class="thumbnail-list__item slider__slide{% if section.settings.hide_variants and variant_images contains featured_media.src %} thumbnail-list_item--variant{% endif %} global-media-settings" data-target="{{ section.id }}-{{ featured_media.id }}" data-media-position="{{ media_index }}">
-                  <button class="thumbnail {% if featured_media.preview_image.aspect_ratio > 1 %}thumbnail--wide{% else %}thumbnail--narrow{% endif %}"
+                <li id="Slide-Thumbnails-{{ section.id }}-0" class="thumbnail-list__item slider__slide{% if section.settings.hide_variants and variant_images contains featured_media.src %} thumbnail-list_item--variant{% endif %}" data-target="{{ section.id }}-{{ featured_media.id }}" data-media-position="{{ media_index }}">
+                  <button class="thumbnail global-media-settings global-media-settings--no-shadow {% if featured_media.preview_image.aspect_ratio > 1 %}thumbnail--wide{% else %}thumbnail--narrow{% endif %}"
                     aria-label="{%- if featured_media.media_type == 'image' -%}{{ 'products.product.media.load_image' | t: index: media_index }}{%- elsif featured_media.media_type == 'model' -%}{{ 'products.product.media.load_model' | t: index: media_index }}{%- elsif featured_media.media_type == 'video' or featured_media.media_type == 'external_video' -%}{{ 'products.product.media.load_video' | t: index: media_index }}{%- endif -%}"
                     aria-current="true"
                     aria-controls="GalleryViewer-{{ section.id }}"
@@ -154,14 +154,13 @@
                         {%- render 'icon-play' -%}
                       </span>
                     {%- endif -%}
-                    <button class="thumbnail {% if media.preview_image.aspect_ratio > 1 %}thumbnail--wide{% else %}thumbnail--narrow{% endif %}"
+                    <button class="thumbnail global-media-settings global-media-settings--no-shadow {% if media.preview_image.aspect_ratio > 1 %}thumbnail--wide{% else %}thumbnail--narrow{% endif %}"
                       aria-label="{%- if media.media_type == 'image' -%}{{ 'products.product.media.load_image' | t: index: media_index }}{%- elsif media.media_type == 'model' -%}{{ 'products.product.media.load_model' | t: index: media_index }}{%- elsif media.media_type == 'video' or media.media_type == 'external_video' -%}{{ 'products.product.media.load_video' | t: index: media_index }}{%- endif -%}"
                       {% if media == product.selected_or_first_available_variant.featured_media or product.selected_or_first_available_variant.featured_media == null and forloop.index == 1 %} aria-current="true"{% endif %}
                       aria-controls="GalleryViewer-{{ section.id }}"
                       aria-describedby="Thumbnail-{{ section.id }}-{{ forloop.index }}"
                     >
                       <img id="Thumbnail-{{ section.id }}-{{ forloop.index }}"
-                        class="global-media-settings"
                         srcset="{% if media.preview_image.width >= 59 %}{{ media.preview_image | img_url: '59x' }} 59x,{% endif %}
                                 {% if media.preview_image.width >= 118 %}{{ media.preview_image | img_url: '118x' }} 118w,{% endif %}
                                 {% if media.preview_image.width >= 84 %}{{ media.preview_image | img_url: '84x' }} 84w,{% endif %}

--- a/sections/main-product.liquid
+++ b/sections/main-product.liquid
@@ -110,7 +110,7 @@
                   {%- endif -%}
                 {%- endcapture -%}
                 {%- assign media_index = media_index | plus: 1 -%}
-                <li id="Slide-Thumbnails-{{ section.id }}-0" class="thumbnail-list__item slider__slide{% if section.settings.hide_variants and variant_images contains featured_media.src %} thumbnail-list_item--variant{% endif %}" data-target="{{ section.id }}-{{ featured_media.id }}" data-media-position="{{ media_index }}">
+                <li id="Slide-Thumbnails-{{ section.id }}-0" class="thumbnail-list__item slider__slide{% if section.settings.hide_variants and variant_images contains featured_media.src %} thumbnail-list_item--variant{% endif %} global-media-settings" data-target="{{ section.id }}-{{ featured_media.id }}" data-media-position="{{ media_index }}">
                   <button class="thumbnail {% if featured_media.preview_image.aspect_ratio > 1 %}thumbnail--wide{% else %}thumbnail--narrow{% endif %}"
                     aria-label="{%- if featured_media.media_type == 'image' -%}{{ 'products.product.media.load_image' | t: index: media_index }}{%- elsif featured_media.media_type == 'model' -%}{{ 'products.product.media.load_model' | t: index: media_index }}{%- elsif featured_media.media_type == 'video' or featured_media.media_type == 'external_video' -%}{{ 'products.product.media.load_video' | t: index: media_index }}{%- endif -%}"
                     aria-current="true"
@@ -161,6 +161,7 @@
                       aria-describedby="Thumbnail-{{ section.id }}-{{ forloop.index }}"
                     >
                       <img id="Thumbnail-{{ section.id }}-{{ forloop.index }}"
+                        class="global-media-settings"
                         srcset="{% if media.preview_image.width >= 59 %}{{ media.preview_image | img_url: '59x' }} 59x,{% endif %}
                                 {% if media.preview_image.width >= 118 %}{{ media.preview_image | img_url: '118x' }} 118w,{% endif %}
                                 {% if media.preview_image.width >= 84 %}{{ media.preview_image | img_url: '84x' }} 84w,{% endif %}

--- a/snippets/product-media.liquid
+++ b/snippets/product-media.liquid
@@ -37,9 +37,9 @@
 {%- else -%}
   {%- if media.media_type == 'model' -%}
     <div class="product-media-modal__model" data-media-id="{{ media.id }}">
-      <product-model class="deferred-media media media--transparent" style="padding-top: min(calc(100vh - 12rem), 100%)">
+      <product-model class="deferred-media media media--transparent global-media-settings" style="padding-top: min(calc(100vh - 12rem), 100%)">
   {%- else -%}
-    <deferred-media class="deferred-media media" style="padding-top: min(calc(100vh - 12rem), {{ 1 | divided_by: media.aspect_ratio | times: 100 }}%)" data-media-id="{{ media.id }}">
+    <deferred-media class="deferred-media media global-media-settings" style="padding-top: min(calc(100vh - 12rem), {{ 1 | divided_by: media.aspect_ratio | times: 100 }}%)" data-media-id="{{ media.id }}">
   {%- endif -%}
 
     <button id="Deferred-Poster-Modal-{{ media.id }}" class="deferred-media__poster" type="button">

--- a/snippets/product-media.liquid
+++ b/snippets/product-media.liquid
@@ -16,6 +16,7 @@
 
 {%- if media.media_type == 'image' -%}
   <img
+    class="global-media-settings global-media-settings--no-shadow"
     srcset="{%- if media.preview_image.width >= 550 -%}{{ media.preview_image | img_url: '550x' }} 550w,{%- endif -%}
             {%- if media.preview_image.width >= 1100 -%}{{ media.preview_image | img_url: '1100x' }} 1100w,{%- endif -%}
             {%- if media.preview_image.width >= 1445 -%}{{ media.preview_image | img_url: '1445x' }} 1445w,{%- endif -%}
@@ -37,9 +38,9 @@
 {%- else -%}
   {%- if media.media_type == 'model' -%}
     <div class="product-media-modal__model" data-media-id="{{ media.id }}">
-      <product-model class="deferred-media media media--transparent global-media-settings" style="padding-top: min(calc(100vh - 12rem), 100%)">
+      <product-model class="deferred-media media media--transparent global-media-settings global-media-settings--no-shadow" style="padding-top: min(calc(100vh - 12rem), 100%)">
   {%- else -%}
-    <deferred-media class="deferred-media media global-media-settings" style="padding-top: min(calc(100vh - 12rem), {{ 1 | divided_by: media.aspect_ratio | times: 100 }}%)" data-media-id="{{ media.id }}">
+    <deferred-media class="deferred-media media global-media-settings global-media-settings--no-shadow" style="padding-top: min(calc(100vh - 12rem), {{ 1 | divided_by: media.aspect_ratio | times: 100 }}%)" data-media-id="{{ media.id }}">
   {%- endif -%}
 
     <button id="Deferred-Poster-Modal-{{ media.id }}" class="deferred-media__poster" type="button">

--- a/snippets/product-thumbnail.liquid
+++ b/snippets/product-thumbnail.liquid
@@ -22,7 +22,7 @@
 <noscript>
   {%- if media.media_type == 'video' or media.media_type == 'external_video' -%}
     <span class="product__media-icon motion-reduce">{% render 'icon-play' %}</span>
-    <div class="product__media media global-media-settings" style="padding-top: {{ 1 | divided_by: media.preview_image.aspect_ratio | times: 100 }}%;">
+    <div class="product__media media gradient global-media-settings" style="padding-top: {{ 1 | divided_by: media.preview_image.aspect_ratio | times: 100 }}%;">
       <img
         srcset="{% if media.preview_image.width >= 493 %}{{ media.preview_image | img_url: '493x' }} 493w,{% endif %}
           {% if media.preview_image.width >= 600 %}{{ media.preview_image | img_url: '600x' }} 600w,{% endif %}
@@ -48,7 +48,7 @@
       <span class="visually-hidden">{{ 'products.product.video_exit_message' | t: title: product.title | escape }}</span>
     </a>
   {%- else -%}
-    <div class="product__media media global-media-settings" style="padding-top: {{ 1 | divided_by: media.preview_image.aspect_ratio | times: 100 }}%;">
+    <div class="product__media media gradient global-media-settings" style="padding-top: {{ 1 | divided_by: media.preview_image.aspect_ratio | times: 100 }}%;">
       <img
         srcset="{% if media.preview_image.width >= 493 %}{{ media.preview_image | img_url: '493x' }} 493w,{% endif %}
           {% if media.preview_image.width >= 600 %}{{ media.preview_image | img_url: '600x' }} 600w,{% endif %}
@@ -87,7 +87,7 @@
     -%}
   </span>
 
-  <div class="product__media media media--transparent global-media-settings" style="padding-top: {{ 1 | divided_by: media.preview_image.aspect_ratio | times: 100 }}%;">
+  <div class="product__media media media--transparent gradient global-media-settings" style="padding-top: {{ 1 | divided_by: media.preview_image.aspect_ratio | times: 100 }}%;">
     <img
       srcset="{% if media.preview_image.width >= 493 %}{{ media.preview_image | img_url: '493x' }} 493w,{% endif %}
         {% if media.preview_image.width >= 600 %}{{ media.preview_image | img_url: '600x' }} 600w,{% endif %}

--- a/snippets/product-thumbnail.liquid
+++ b/snippets/product-thumbnail.liquid
@@ -22,7 +22,7 @@
 <noscript>
   {%- if media.media_type == 'video' or media.media_type == 'external_video' -%}
     <span class="product__media-icon motion-reduce">{% render 'icon-play' %}</span>
-    <div class="product__media media" style="padding-top: {{ 1 | divided_by: media.preview_image.aspect_ratio | times: 100 }}%;">
+    <div class="product__media media global-media-settings" style="padding-top: {{ 1 | divided_by: media.preview_image.aspect_ratio | times: 100 }}%;">
       <img
         srcset="{% if media.preview_image.width >= 493 %}{{ media.preview_image | img_url: '493x' }} 493w,{% endif %}
           {% if media.preview_image.width >= 600 %}{{ media.preview_image | img_url: '600x' }} 600w,{% endif %}
@@ -48,7 +48,7 @@
       <span class="visually-hidden">{{ 'products.product.video_exit_message' | t: title: product.title | escape }}</span>
     </a>
   {%- else -%}
-    <div class="product__media media" style="padding-top: {{ 1 | divided_by: media.preview_image.aspect_ratio | times: 100 }}%;">
+    <div class="product__media media global-media-settings" style="padding-top: {{ 1 | divided_by: media.preview_image.aspect_ratio | times: 100 }}%;">
       <img
         srcset="{% if media.preview_image.width >= 493 %}{{ media.preview_image | img_url: '493x' }} 493w,{% endif %}
           {% if media.preview_image.width >= 600 %}{{ media.preview_image | img_url: '600x' }} 600w,{% endif %}
@@ -87,7 +87,7 @@
     -%}
   </span>
 
-  <div class="product__media media media--transparent" style="padding-top: {{ 1 | divided_by: media.preview_image.aspect_ratio | times: 100 }}%;">
+  <div class="product__media media media--transparent global-media-settings" style="padding-top: {{ 1 | divided_by: media.preview_image.aspect_ratio | times: 100 }}%;">
     <img
       srcset="{% if media.preview_image.width >= 493 %}{{ media.preview_image | img_url: '493x' }} 493w,{% endif %}
         {% if media.preview_image.width >= 600 %}{{ media.preview_image | img_url: '600x' }} 600w,{% endif %}
@@ -118,9 +118,9 @@
 
 {%- if media.media_type != 'image' -%}
   {%- if media.media_type == 'model' -%}
-    <product-model class="deferred-media media media--transparent no-js-hidden" style="padding-top: 100%" data-media-id="{{ media.id }}">
+    <product-model class="deferred-media media media--transparent global-media-settings no-js-hidden" style="padding-top: 100%" data-media-id="{{ media.id }}">
   {%- else -%}
-    <deferred-media class="deferred-media media no-js-hidden" style="padding-top: {{ 1 | divided_by: media.aspect_ratio | times: 100 }}%" data-media-id="{{ media.id }}">
+    <deferred-media class="deferred-media global-media-settings media no-js-hidden" style="padding-top: {{ 1 | divided_by: media.aspect_ratio | times: 100 }}%" data-media-id="{{ media.id }}">
   {%- endif -%}
   <button id="Deferred-Poster-Modal-{{ media.id }}" class="deferred-media__poster" type="button">
     <span class="deferred-media__poster-button motion-reduce">

--- a/snippets/product-thumbnail.liquid
+++ b/snippets/product-thumbnail.liquid
@@ -118,9 +118,9 @@
 
 {%- if media.media_type != 'image' -%}
   {%- if media.media_type == 'model' -%}
-    <product-model class="deferred-media media media--transparent global-media-settings no-js-hidden" style="padding-top: 100%" data-media-id="{{ media.id }}">
+    <product-model class="deferred-media media media--transparent gradient global-media-settings no-js-hidden" style="padding-top: 100%" data-media-id="{{ media.id }}">
   {%- else -%}
-    <deferred-media class="deferred-media global-media-settings media no-js-hidden" style="padding-top: {{ 1 | divided_by: media.aspect_ratio | times: 100 }}%" data-media-id="{{ media.id }}">
+    <deferred-media class="deferred-media gradient global-media-settings media no-js-hidden" style="padding-top: {{ 1 | divided_by: media.aspect_ratio | times: 100 }}%" data-media-id="{{ media.id }}">
   {%- endif -%}
   <button id="Deferred-Poster-Modal-{{ media.id }}" class="deferred-media__poster" type="button">
     <span class="deferred-media__poster-button motion-reduce">


### PR DESCRIPTION
**Why are these changes introduced?**
This PR adds the media global settings / class to the product template and featured product sections.

Fixes #1057

**What approach did you take?**
I applied the `global-media-settings` class to the: 
* [Product] slideshow items
* [Product] Slideshow thumbnails - Decision was made to remove box-shadow from thumbnails for technical reasons
* [Featured product] Featured Media 

I added padding - left and right on the media gallery so that the box shadow does not overlap the product content and thumbnails (when shown).

**Other considerations**
The decision was made to not include global media settings on media in the `zoom` modal, so that focus remains on the media.

**Demo links**
- [Editor](https://os2-demo.myshopify.com/admin/themes/127066177558/editor?previewPath=%2Fproducts%2Ftest-3d-models-video&context=theme&category=gid%3A%2F%2Fshopify%2FOnlineStoreThemeSettingsCategory%2FMedia%3Ftheme_id%3D127066177558%26first_setting_id%3Dmedia_border_thickness)

**Testing**
- [ ] Product media gallery options Desktop: Stacked, Thumbnail, Thumbnail Carousel
- [ ] Product media gallery options Mobile: Thumbnails, no Thumbnails
- [ ] Desktop media size: Small, Medium, Large
- [ ] Featured Media
- [ ] With and without media settings 

**Checklist**
- [ ] Followed [theme code principles](https://github.com/Shopify/dawn/blob/main/.github/CONTRIBUTING.md#theme-code-principles)
- [ ] Linted with [Theme Check](https://github.com/Shopify/theme-check)
- [ ] Tested on [mobile](https://shopify.dev/themes/store/requirements#mobile-browser-requirements)
- [ ] Tested on [multiple browsers](https://shopify.dev/themes/store/requirements#desktop-browser-requirements)
- [ ] Tested for [accessibility](https://shopify.dev/themes/best-practices/accessibility)
