### PR TITLE
Adjust grid space to use gap values instead of padding

### DIFF
--- a/assets/base.css
+++ b/assets/base.css
@@ -971,14 +971,18 @@ summary::-webkit-details-marker {
   display: flex;
   flex-wrap: wrap;
   margin-bottom: 2rem;
-  margin-left: calc(-1 * var(--grid-mobile-horizontal-spacing));;
+  /* margin-left: calc(-1 * var(--grid-mobile-horizontal-spacing)); */
   padding: 0;
   list-style: none;
+  column-gap: var(--grid-mobile-horizontal-spacing);
+  row-gap: var(--grid-mobile-vertical-spacing);
 }
 
 @media screen and (min-width: 750px) {
   .grid {
-    margin-left: calc(-1 * var(--grid-desktop-horizontal-spacing));
+    /* margin-left: calc(-1 * var(--grid-desktop-horizontal-spacing)); */
+    column-gap: var(--grid-desktop-horizontal-spacing);
+    row-gap: var(--grid-desktop-vertical-spacing);
   }
 }
 
@@ -987,8 +991,8 @@ summary::-webkit-details-marker {
 }
 
 .grid__item {
-  padding-left: var(--grid-mobile-horizontal-spacing);
-  padding-bottom: var(--grid-mobile-vertical-spacing);
+  /* padding-left: var(--grid-mobile-horizontal-spacing);
+  padding-bottom: var(--grid-mobile-vertical-spacing); */
   width: calc(25% - 0.5rem * 3 / 4);
   max-width: 50%;
   flex-grow: 1;
@@ -997,16 +1001,16 @@ summary::-webkit-details-marker {
 
 @media screen and (min-width: 750px) {
   .grid__item {
-    padding-left: var(--grid-desktop-horizontal-spacing);
-    padding-bottom: var(--grid-desktop-vertical-spacing);
+    /* padding-left: var(--grid-desktop-horizontal-spacing);
+    padding-bottom: var(--grid-desktop-vertical-spacing); */
     width: calc(25% - var(--grid-desktop-horizontal-spacing) * 3 / 4);
     max-width: 50%;
   }
 }
 
-.grid--gapless .grid__item {
-  padding-left: 0;
-  padding-bottom: 0;
+.grid--gapless.grid {
+  column-gap: 0;
+  row-gap: 0;
 }
 
 @media screen and (max-width: 749px) {

--- a/assets/base.css
+++ b/assets/base.css
@@ -976,15 +976,19 @@ summary::-webkit-details-marker {
   list-style: none;
 }
 
+.grid:last-child {
+  margin-bottom: calc(-1 * var(--grid-mobile-vertical-spacing));
+}
+
 @media screen and (min-width: 750px) {
   .grid {
     margin-bottom: calc(2rem - var(--grid-desktop-vertical-spacing));
     margin-left: calc(-1 * var(--grid-desktop-horizontal-spacing));
   }
-}
 
-.grid:last-child {
-  margin-bottom: 0;
+  .grid:last-child {
+    margin-bottom: calc(-1 * var(--grid-desktop-vertical-spacing));
+  }
 }
 
 .grid__item {
@@ -2427,6 +2431,16 @@ details[open] .modal-overlay::after {
   .search-modal__close-button {
     position: initial;
     margin-left: 0.5rem;
+  }
+}
+
+.template-search__results .grid {
+  margin-bottom: calc(-1 * var(--grid-mobile-vertical-spacing));
+}
+
+@media screen and (min-width: 750px) {
+  .template-search__results .grid {
+    margin-bottom: calc(-1 * var(--grid-desktop-vertical-spacing));
   }
 }
 

--- a/assets/base.css
+++ b/assets/base.css
@@ -1077,15 +1077,6 @@ summary::-webkit-details-marker {
   }
 }
 
-.grid__item--vertical-align {
-  align-self: center;
-}
-
-.grid__item--full-width {
-  flex: 0 0 100%;
-  max-width: 100%;
-}
-
 @media screen and (max-width: 749px) {
   .grid--peek.slider--mobile {
     margin: 0;

--- a/assets/base.css
+++ b/assets/base.css
@@ -990,7 +990,7 @@ summary::-webkit-details-marker {
 .grid__item {
   padding-left: var(--grid-mobile-horizontal-spacing);
   padding-bottom: var(--grid-mobile-vertical-spacing);
-  width: calc(25% - var(--grid-mobile-horizontal-spacing) * 3 / 4);
+  width: calc(25% - 0.5rem * 3 / 4);
   max-width: 50%;
   flex-grow: 1;
   flex-shrink: 0;
@@ -1102,7 +1102,7 @@ summary::-webkit-details-marker {
 
   .grid--peek .grid__item {
     padding-left: var(--grid-mobile-horizontal-spacing);
-    width: calc(50% - var(--grid-mobile-horizontal-spacing) / 2);
+    width: calc(50% - 3.75rem / 2);
   }
 
   .grid--peek .grid__item:first-of-type {
@@ -1116,15 +1116,15 @@ summary::-webkit-details-marker {
 
 @media screen and (min-width: 750px) and (max-width: 989px) {
   .slider--tablet.grid--peek .grid__item {
-    width: calc(25% - var(--grid-desktop-horizontal-spacing) * 3 / 4);
+    width: calc(25% - 4rem * 3 / 4);
   }
 
   .slider--tablet.grid--peek.grid--3-col-tablet .grid__item {
-    width: calc(33.33% - var(--grid-desktop-horizontal-spacing) * 2 / 3);
+    width: calc(33.33% - 4rem * 2 / 3);
   }
 
   .slider--tablet.grid--peek.grid--2-col-tablet .grid__item {
-    width: calc(50% - var(--grid-desktop-horizontal-spacing) / 2);
+    width: calc(50% - 4rem / 2);
   }
 
   .slider--tablet.grid--peek .grid__item:first-of-type {

--- a/assets/base.css
+++ b/assets/base.css
@@ -2735,3 +2735,46 @@ details-disclosure > details {
   border-left: none;
   border-right: none;
 }
+
+@supports not (inset: 10px) {
+  .grid {
+    margin-left: calc(-1 * var(--grid-mobile-horizontal-spacing));
+  }
+
+  .grid__item {
+    padding-left: var(--grid-mobile-horizontal-spacing);
+    padding-bottom: var(--grid-mobile-vertical-spacing);
+  }
+
+  @media screen and (min-width: 750px) {
+    .grid {
+      margin-left: calc(-1 * var(--grid-desktop-horizontal-spacing));
+    }
+
+    .grid__item {
+      padding-left: var(--grid-desktop-horizontal-spacing);
+      padding-bottom: var(--grid-desktop-vertical-spacing);
+    }
+  }
+
+  .grid--gapless .grid__item {
+    padding-left: 0;
+    padding-bottom: 0;
+  }
+
+  @media screen and (min-width: 749px) {
+    .grid--peek .grid__item {
+      padding-left: var(--grid-mobile-horizontal-spacing);
+    }
+  }
+
+  .product-grid .grid__item {
+    padding-bottom: var(--grid-mobile-vertical-spacing);
+  }
+
+  @media screen and (min-width: 750px) {
+    .product-grid .grid__item {
+      padding-bottom: var(--grid-desktop-vertical-spacing);
+    }
+  }
+}

--- a/assets/base.css
+++ b/assets/base.css
@@ -989,7 +989,7 @@ summary::-webkit-details-marker {
 }
 
 .grid__item {
-  width: calc(25% - 0.5rem * 3 / 4);
+  width: calc(25% - var(--grid-mobile-horizontal-spacing) * 3 / 4);
   max-width: 50%;
   flex-grow: 1;
   flex-shrink: 0;
@@ -1016,13 +1016,13 @@ summary::-webkit-details-marker {
 
 @media screen and (min-width: 750px) and (max-width: 989px) {
   .grid--one-third-max.grid--3-col-tablet .grid__item {
-    max-width: 33.33%;
+    max-width: calc(33.33% - var(--grid-desktop-horizontal-spacing) * 2 / 3);
   }
 }
 
 @media screen and (min-width: 990px) {
   .grid--quarter-max.grid--4-col-desktop .grid__item {
-    max-width: 25%;
+    max-width: calc(25% - var(--grid-desktop-horizontal-spacing) * 3 / 4);
   }
 }
 

--- a/assets/base.css
+++ b/assets/base.css
@@ -990,7 +990,7 @@ summary::-webkit-details-marker {
 
 .grid__item {
   width: calc(25% - var(--grid-mobile-horizontal-spacing) * 3 / 4);
-  max-width: 50%;
+  max-width: calc(50% - var(--grid-mobile-horizontal-spacing) / 2);
   flex-grow: 1;
   flex-shrink: 0;
 }
@@ -998,7 +998,7 @@ summary::-webkit-details-marker {
 @media screen and (min-width: 750px) {
   .grid__item {
     width: calc(25% - var(--grid-desktop-horizontal-spacing) * 3 / 4);
-    max-width: 50%;
+    max-width: calc(50% - var(--grid-desktop-horizontal-spacing) / 2);
   }
 }
 

--- a/assets/base.css
+++ b/assets/base.css
@@ -1098,7 +1098,7 @@ summary::-webkit-details-marker {
   }
 
   .grid--peek .grid__item {
-    width: calc(50% - 3.75rem / 2);
+    width: calc(50% - var(--grid-mobile-horizontal-spacing) * 2);
   }
 
   .grid--peek .grid__item:first-of-type {

--- a/assets/base.css
+++ b/assets/base.css
@@ -1107,10 +1107,6 @@ summary::-webkit-details-marker {
     width: calc(50% - 3.75rem / 2);
   }
 
-  .grid--peek .grid__item {
-    padding-left: var(--grid-mobile-horizontal-spacing);
-  }
-
   .grid--peek .grid__item:first-of-type {
     padding-left: 1.5rem;
   }

--- a/assets/base.css
+++ b/assets/base.css
@@ -970,30 +970,25 @@ summary::-webkit-details-marker {
 .grid {
   display: flex;
   flex-wrap: wrap;
-  margin-bottom: calc(2rem - var(--grid-mobile-vertical-spacing));
-  margin-left: calc(-1 * var(--grid-mobile-horizontal-spacing));
+  margin-bottom: 2rem;
   padding: 0;
   list-style: none;
-}
-
-.grid:last-child {
-  margin-bottom: calc(-1 * var(--grid-mobile-vertical-spacing));
+  column-gap: var(--grid-mobile-horizontal-spacing);
+  row-gap: var(--grid-mobile-vertical-spacing);
 }
 
 @media screen and (min-width: 750px) {
   .grid {
-    margin-bottom: calc(2rem - var(--grid-desktop-vertical-spacing));
-    margin-left: calc(-1 * var(--grid-desktop-horizontal-spacing));
-  }
-
-  .grid:last-child {
-    margin-bottom: calc(-1 * var(--grid-desktop-vertical-spacing));
+    column-gap: var(--grid-desktop-horizontal-spacing);
+    row-gap: var(--grid-desktop-vertical-spacing);
   }
 }
 
+.grid:last-child {
+  margin-bottom: 0;
+}
+
 .grid__item {
-  padding-left: var(--grid-mobile-horizontal-spacing);
-  padding-bottom: var(--grid-mobile-vertical-spacing);
   width: calc(25% - 0.5rem * 3 / 4);
   max-width: 50%;
   flex-grow: 1;
@@ -1002,16 +997,14 @@ summary::-webkit-details-marker {
 
 @media screen and (min-width: 750px) {
   .grid__item {
-    padding-left: var(--grid-desktop-horizontal-spacing);
-    padding-bottom: var(--grid-desktop-vertical-spacing);
     width: calc(25% - var(--grid-desktop-horizontal-spacing) * 3 / 4);
     max-width: 50%;
   }
 }
 
-.grid--gapless .grid__item {
-  padding-left: 0;
-  padding-bottom: 0;
+.grid--gapless.grid {
+  column-gap: 0;
+  row-gap: 0;
 }
 
 @media screen and (max-width: 749px) {
@@ -1105,8 +1098,7 @@ summary::-webkit-details-marker {
   }
 
   .grid--peek .grid__item {
-    padding-left: var(--grid-mobile-horizontal-spacing);
-    width: calc(50% - 3.75rem / 2);
+    width: calc(50% - var(--grid-mobile-horizontal-spacing) - 3rem);
   }
 
   .grid--peek .grid__item:first-of-type {
@@ -1120,15 +1112,15 @@ summary::-webkit-details-marker {
 
 @media screen and (min-width: 750px) and (max-width: 989px) {
   .slider--tablet.grid--peek .grid__item {
-    width: calc(25% - 4rem * 3 / 4);
+    width: calc(25% - var(--grid-desktop-horizontal-spacing) - 3rem);
   }
 
   .slider--tablet.grid--peek.grid--3-col-tablet .grid__item {
-    width: calc(33.33% - 4rem * 2 / 3);
+    width: calc(33.33% - var(--grid-desktop-horizontal-spacing) - 3rem);
   }
 
   .slider--tablet.grid--peek.grid--2-col-tablet .grid__item {
-    width: calc(50% - 4rem / 2);
+    width: calc(50% - var(--grid-desktop-horizontal-spacing) - 3rem);
   }
 
   .slider--tablet.grid--peek .grid__item:first-of-type {
@@ -2434,16 +2426,6 @@ details[open] .modal-overlay::after {
   }
 }
 
-.template-search__results .grid {
-  margin-bottom: calc(-1 * var(--grid-mobile-vertical-spacing));
-}
-
-@media screen and (min-width: 750px) {
-  .template-search__results .grid {
-    margin-bottom: calc(-1 * var(--grid-desktop-vertical-spacing));
-  }
-}
-
 /* Header menu drawer */
 .header__icon--menu .icon {
   display: block;
@@ -2752,4 +2734,48 @@ details-disclosure > details {
   border-radius: 0;
   border-left: none;
   border-right: none;
+}
+
+/* check for flexbox gap in older Safari versions */
+@supports not (inset: 10px) {
+  .grid {
+    margin-left: calc(-1 * var(--grid-mobile-horizontal-spacing));
+  }
+
+  .grid__item {
+    padding-left: var(--grid-mobile-horizontal-spacing);
+    padding-bottom: var(--grid-mobile-vertical-spacing);
+  }
+
+  @media screen and (min-width: 750px) {
+    .grid {
+      margin-left: calc(-1 * var(--grid-desktop-horizontal-spacing));
+    }
+
+    .grid__item {
+      padding-left: var(--grid-desktop-horizontal-spacing);
+      padding-bottom: var(--grid-desktop-vertical-spacing);
+    }
+  }
+
+  .grid--gapless .grid__item {
+    padding-left: 0;
+    padding-bottom: 0;
+  }
+
+  @media screen and (min-width: 749px) {
+    .grid--peek .grid__item {
+      padding-left: var(--grid-mobile-horizontal-spacing);
+    }
+  }
+
+  .product-grid .grid__item {
+    padding-bottom: var(--grid-mobile-vertical-spacing);
+  }
+
+  @media screen and (min-width: 750px) {
+    .product-grid .grid__item {
+      padding-bottom: var(--grid-desktop-vertical-spacing);
+    }
+  }
 }

--- a/assets/base.css
+++ b/assets/base.css
@@ -970,17 +970,16 @@ summary::-webkit-details-marker {
 .grid {
   display: flex;
   flex-wrap: wrap;
-  margin-bottom: 2rem;
+  margin-bottom: calc(2rem - var(--grid-mobile-vertical-spacing));
+  margin-left: calc(-1 * var(--grid-mobile-horizontal-spacing));
   padding: 0;
   list-style: none;
-  column-gap: var(--grid-mobile-horizontal-spacing);
-  row-gap: var(--grid-mobile-vertical-spacing);
 }
 
 @media screen and (min-width: 750px) {
   .grid {
-    column-gap: var(--grid-desktop-horizontal-spacing);
-    row-gap: var(--grid-desktop-vertical-spacing);
+    margin-bottom: calc(2rem - var(--grid-desktop-vertical-spacing));
+    margin-left: calc(-1 * var(--grid-desktop-horizontal-spacing));
   }
 }
 
@@ -989,7 +988,9 @@ summary::-webkit-details-marker {
 }
 
 .grid__item {
-  width: calc(25% - 0.5rem * 3 / 4);
+  padding-left: var(--grid-mobile-horizontal-spacing);
+  padding-bottom: var(--grid-mobile-vertical-spacing);
+  width: calc(25% - var(--grid-mobile-horizontal-spacing) * 3 / 4);
   max-width: 50%;
   flex-grow: 1;
   flex-shrink: 0;
@@ -997,14 +998,16 @@ summary::-webkit-details-marker {
 
 @media screen and (min-width: 750px) {
   .grid__item {
+    padding-left: var(--grid-desktop-horizontal-spacing);
+    padding-bottom: var(--grid-desktop-vertical-spacing);
     width: calc(25% - var(--grid-desktop-horizontal-spacing) * 3 / 4);
     max-width: 50%;
   }
 }
 
-.grid--gapless.grid {
-  column-gap: 0;
-  row-gap: 0;
+.grid--gapless .grid__item {
+  padding-left: 0;
+  padding-bottom: 0;
 }
 
 @media screen and (max-width: 749px) {
@@ -1098,7 +1101,8 @@ summary::-webkit-details-marker {
   }
 
   .grid--peek .grid__item {
-    width: calc(50% - var(--grid-mobile-horizontal-spacing) - 3rem);
+    padding-left: var(--grid-mobile-horizontal-spacing);
+    width: calc(50% - var(--grid-mobile-horizontal-spacing) / 2);
   }
 
   .grid--peek .grid__item:first-of-type {
@@ -1112,15 +1116,15 @@ summary::-webkit-details-marker {
 
 @media screen and (min-width: 750px) and (max-width: 989px) {
   .slider--tablet.grid--peek .grid__item {
-    width: calc(25% - var(--grid-desktop-horizontal-spacing) - 3rem);
+    width: calc(25% - var(--grid-desktop-horizontal-spacing) * 3 / 4);
   }
 
   .slider--tablet.grid--peek.grid--3-col-tablet .grid__item {
-    width: calc(33.33% - var(--grid-desktop-horizontal-spacing) - 3rem);
+    width: calc(33.33% - var(--grid-desktop-horizontal-spacing) * 2 / 3);
   }
 
   .slider--tablet.grid--peek.grid--2-col-tablet .grid__item {
-    width: calc(50% - var(--grid-desktop-horizontal-spacing) - 3rem);
+    width: calc(50% - var(--grid-desktop-horizontal-spacing) / 2);
   }
 
   .slider--tablet.grid--peek .grid__item:first-of-type {
@@ -2734,47 +2738,4 @@ details-disclosure > details {
   border-radius: 0;
   border-left: none;
   border-right: none;
-}
-
-@supports not (inset: 10px) {
-  .grid {
-    margin-left: calc(-1 * var(--grid-mobile-horizontal-spacing));
-  }
-
-  .grid__item {
-    padding-left: var(--grid-mobile-horizontal-spacing);
-    padding-bottom: var(--grid-mobile-vertical-spacing);
-  }
-
-  @media screen and (min-width: 750px) {
-    .grid {
-      margin-left: calc(-1 * var(--grid-desktop-horizontal-spacing));
-    }
-
-    .grid__item {
-      padding-left: var(--grid-desktop-horizontal-spacing);
-      padding-bottom: var(--grid-desktop-vertical-spacing);
-    }
-  }
-
-  .grid--gapless .grid__item {
-    padding-left: 0;
-    padding-bottom: 0;
-  }
-
-  @media screen and (min-width: 749px) {
-    .grid--peek .grid__item {
-      padding-left: var(--grid-mobile-horizontal-spacing);
-    }
-  }
-
-  .product-grid .grid__item {
-    padding-bottom: var(--grid-mobile-vertical-spacing);
-  }
-
-  @media screen and (min-width: 750px) {
-    .product-grid .grid__item {
-      padding-bottom: var(--grid-desktop-vertical-spacing);
-    }
-  }
 }

--- a/assets/base.css
+++ b/assets/base.css
@@ -1098,7 +1098,7 @@ summary::-webkit-details-marker {
   }
 
   .grid--peek .grid__item {
-    width: calc(50% - var(--grid-mobile-horizontal-spacing) * 2);
+    width: calc(50% - var(--grid-mobile-horizontal-spacing) - 3rem);
   }
 
   .grid--peek .grid__item:first-of-type {
@@ -1112,15 +1112,15 @@ summary::-webkit-details-marker {
 
 @media screen and (min-width: 750px) and (max-width: 989px) {
   .slider--tablet.grid--peek .grid__item {
-    width: calc(25% - 4rem * 3 / 4);
+    width: calc(25% - var(--grid-desktop-horizontal-spacing) - 3rem);
   }
 
   .slider--tablet.grid--peek.grid--3-col-tablet .grid__item {
-    width: calc(33.33% - 4rem * 2 / 3);
+    width: calc(33.33% - var(--grid-desktop-horizontal-spacing) - 3rem);
   }
 
   .slider--tablet.grid--peek.grid--2-col-tablet .grid__item {
-    width: calc(50% - 4rem / 2);
+    width: calc(50% - var(--grid-desktop-horizontal-spacing) - 3rem);
   }
 
   .slider--tablet.grid--peek .grid__item:first-of-type {

--- a/assets/base.css
+++ b/assets/base.css
@@ -971,7 +971,6 @@ summary::-webkit-details-marker {
   display: flex;
   flex-wrap: wrap;
   margin-bottom: 2rem;
-  /* margin-left: calc(-1 * var(--grid-mobile-horizontal-spacing)); */
   padding: 0;
   list-style: none;
   column-gap: var(--grid-mobile-horizontal-spacing);
@@ -980,7 +979,6 @@ summary::-webkit-details-marker {
 
 @media screen and (min-width: 750px) {
   .grid {
-    /* margin-left: calc(-1 * var(--grid-desktop-horizontal-spacing)); */
     column-gap: var(--grid-desktop-horizontal-spacing);
     row-gap: var(--grid-desktop-vertical-spacing);
   }
@@ -991,8 +989,6 @@ summary::-webkit-details-marker {
 }
 
 .grid__item {
-  /* padding-left: var(--grid-mobile-horizontal-spacing);
-  padding-bottom: var(--grid-mobile-vertical-spacing); */
   width: calc(25% - 0.5rem * 3 / 4);
   max-width: 50%;
   flex-grow: 1;
@@ -1001,8 +997,6 @@ summary::-webkit-details-marker {
 
 @media screen and (min-width: 750px) {
   .grid__item {
-    /* padding-left: var(--grid-desktop-horizontal-spacing);
-    padding-bottom: var(--grid-desktop-vertical-spacing); */
     width: calc(25% - var(--grid-desktop-horizontal-spacing) * 3 / 4);
     max-width: 50%;
   }

--- a/assets/collapsible-content.css
+++ b/assets/collapsible-content.css
@@ -89,17 +89,20 @@
   text-underline-offset: 0.3rem;
 }
 
-@media screen and (min-width: 750px) {
-  .collapsible-content__grid:not(.collapsible-content__grid--reverse) .grid__item:last-child,
-  .collapsible-content__grid--reverse .collapsible-content__grid-item {
-    padding-left: 5rem;
-    padding-right: 0;
+/* check for flexbox gap in older Safari versions */
+@supports not (inset: 10px) {
+  @media screen and (min-width: 750px) {
+    .collapsible-content__grid:not(.collapsible-content__grid--reverse) .grid__item:last-child,
+    .collapsible-content__grid--reverse .collapsible-content__grid-item {
+      padding-left: 5rem;
+      padding-right: 0;
+    }
   }
-}
 
-@media screen and (min-width: 990px) {
-  .collapsible-content__grid:not(.collapsible-content__grid--reverse) .grid__item:last-child,
-  .collapsible-content__grid--reverse .collapsible-content__grid-item {
-    padding-left: 7rem;
+  @media screen and (min-width: 990px) {
+    .collapsible-content__grid:not(.collapsible-content__grid--reverse) .grid__item:last-child,
+    .collapsible-content__grid--reverse .collapsible-content__grid-item {
+      padding-left: 7rem;
+    }
   }
 }

--- a/assets/collapsible-content.css
+++ b/assets/collapsible-content.css
@@ -88,3 +88,20 @@
   text-decoration: underline;
   text-underline-offset: 0.3rem;
 }
+
+@supports not (inset: 10px) {
+  @media screen and (min-width: 750px) {
+    .collapsible-content__grid:not(.collapsible-content__grid--reverse) .grid__item:last-child,
+    .collapsible-content__grid--reverse .collapsible-content__grid-item {
+      padding-left: 5rem;
+      padding-right: 0;
+    }
+  }
+
+  @media screen and (min-width: 990px) {
+    .collapsible-content__grid:not(.collapsible-content__grid--reverse) .grid__item:last-child,
+    .collapsible-content__grid--reverse .collapsible-content__grid-item {
+      padding-left: 7rem;
+    }
+  }
+}

--- a/assets/collapsible-content.css
+++ b/assets/collapsible-content.css
@@ -89,19 +89,18 @@
   text-underline-offset: 0.3rem;
 }
 
-@supports not (inset: 10px) {
-  @media screen and (min-width: 750px) {
-    .collapsible-content__grid:not(.collapsible-content__grid--reverse) .grid__item:last-child,
-    .collapsible-content__grid--reverse .collapsible-content__grid-item {
-      padding-left: 5rem;
-      padding-right: 0;
-    }
-  }
 
-  @media screen and (min-width: 990px) {
-    .collapsible-content__grid:not(.collapsible-content__grid--reverse) .grid__item:last-child,
-    .collapsible-content__grid--reverse .collapsible-content__grid-item {
-      padding-left: 7rem;
-    }
+@media screen and (min-width: 750px) {
+  .collapsible-content__grid:not(.collapsible-content__grid--reverse) .grid__item:last-child,
+  .collapsible-content__grid--reverse .collapsible-content__grid-item {
+    padding-left: 5rem;
+    padding-right: 0;
+  }
+}
+
+@media screen and (min-width: 990px) {
+  .collapsible-content__grid:not(.collapsible-content__grid--reverse) .grid__item:last-child,
+  .collapsible-content__grid--reverse .collapsible-content__grid-item {
+    padding-left: 7rem;
   }
 }

--- a/assets/collapsible-content.css
+++ b/assets/collapsible-content.css
@@ -89,7 +89,6 @@
   text-underline-offset: 0.3rem;
 }
 
-
 @media screen and (min-width: 750px) {
   .collapsible-content__grid:not(.collapsible-content__grid--reverse) .grid__item:last-child,
   .collapsible-content__grid--reverse .collapsible-content__grid-item {

--- a/assets/collapsible-content.css
+++ b/assets/collapsible-content.css
@@ -88,18 +88,3 @@
   text-decoration: underline;
   text-underline-offset: 0.3rem;
 }
-
-@media screen and (min-width: 750px) {
-  .collapsible-content__grid:not(.collapsible-content__grid--reverse) .grid__item:last-child,
-  .collapsible-content__grid--reverse .collapsible-content__grid-item {
-    padding-left: 5rem;
-    padding-right: 0;
-  }
-}
-
-@media screen and (min-width: 990px) {
-  .collapsible-content__grid:not(.collapsible-content__grid--reverse) .grid__item:last-child,
-  .collapsible-content__grid--reverse .collapsible-content__grid-item {
-    padding-left: 7rem;
-  }
-}

--- a/assets/component-article-card.css
+++ b/assets/component-article-card.css
@@ -1,13 +1,3 @@
-.articles-wrapper.grid {
-  margin: 0 0 5rem 0;
-}
-
-@media screen and (min-width: 750px) {
-  .articles-wrapper.grid {
-    margin-bottom: 7rem;
-  }
-}
-
 @media screen and (max-width: 749px) {
   .articles-wrapper .article {
     width: 100%;
@@ -135,5 +125,18 @@
 
   .article-card__image--large .ratio::before {
     padding-bottom: 40.7rem;
+  }
+}
+
+/* check for flexbox gap in older Safari versions */
+@supports not (inset: 10px) {
+  .articles-wrapper.grid {
+    margin: 0 0 5rem 0;
+  }
+
+  @media screen and (min-width: 750px) {
+    .articles-wrapper.grid {
+      margin-bottom: 7rem;
+    }
   }
 }

--- a/assets/component-article-card.css
+++ b/assets/component-article-card.css
@@ -1,13 +1,3 @@
-.articles-wrapper.grid {
-  margin: 0 0 5rem 0;
-}
-
-@media screen and (min-width: 750px) {
-  .articles-wrapper.grid {
-    margin-bottom: 7rem;
-  }
-}
-
 @media screen and (max-width: 749px) {
   .articles-wrapper .article {
     width: 100%;

--- a/assets/component-article-card.css
+++ b/assets/component-article-card.css
@@ -127,3 +127,15 @@
     padding-bottom: 40.7rem;
   }
 }
+
+@supports not (inset: 10px) {
+  .articles-wrapper.grid {
+    margin: 0 0 5rem 0;
+  }
+
+  @media screen and (min-width: 750px) {
+    .articles-wrapper.grid {
+      margin-bottom: 7rem;
+    }
+  }
+}

--- a/assets/component-article-card.css
+++ b/assets/component-article-card.css
@@ -1,3 +1,13 @@
+.articles-wrapper.grid {
+  margin: 0 0 5rem 0;
+}
+
+@media screen and (min-width: 750px) {
+  .articles-wrapper.grid {
+    margin-bottom: 7rem;
+  }
+}
+
 @media screen and (max-width: 749px) {
   .articles-wrapper .article {
     width: 100%;
@@ -125,17 +135,5 @@
 
   .article-card__image--large .ratio::before {
     padding-bottom: 40.7rem;
-  }
-}
-
-@supports not (inset: 10px) {
-  .articles-wrapper.grid {
-    margin: 0 0 5rem 0;
-  }
-
-  @media screen and (min-width: 750px) {
-    .articles-wrapper.grid {
-      margin-bottom: 7rem;
-    }
   }
 }

--- a/assets/component-image-with-text.css
+++ b/assets/component-image-with-text.css
@@ -1,5 +1,4 @@
 .image-with-text .grid {
-  margin-left: 0;
   margin-bottom: 0;
 }
 

--- a/assets/component-image-with-text.css
+++ b/assets/component-image-with-text.css
@@ -317,3 +317,9 @@
   margin-top: 0;
   margin-bottom: 1rem;
 }
+
+@supports not (inset: 10px) {
+  .image-with-text .grid {
+    margin-left: 0;
+  }
+}

--- a/assets/component-image-with-text.css
+++ b/assets/component-image-with-text.css
@@ -1,6 +1,5 @@
 .image-with-text .grid {
   margin-bottom: 0;
-  margin-left: 0;
 }
 
 .image-with-text .grid__item {
@@ -317,4 +316,11 @@
 .image-with-text__text p {
   margin-top: 0;
   margin-bottom: 1rem;
+}
+
+/* check for flexbox gap in older Safari versions */
+@supports not (inset: 10px) {
+  .image-with-text .grid {
+    margin-left: 0;
+  }
 }

--- a/assets/component-image-with-text.css
+++ b/assets/component-image-with-text.css
@@ -1,5 +1,6 @@
 .image-with-text .grid {
   margin-bottom: 0;
+  margin-left: 0;
 }
 
 .image-with-text .grid__item {
@@ -316,10 +317,4 @@
 .image-with-text__text p {
   margin-top: 0;
   margin-bottom: 1rem;
-}
-
-@supports not (inset: 10px) {
-  .image-with-text .grid {
-    margin-left: 0;
-  }
 }

--- a/assets/component-product-grid.css
+++ b/assets/component-product-grid.css
@@ -1,9 +1,0 @@
-.product-grid .grid__item {
-  padding-bottom: var(--grid-mobile-vertical-spacing);
-}
-
-@media screen and (min-width: 750px) {
-  .product-grid .grid__item {
-    padding-bottom: var(--grid-desktop-vertical-spacing);
-  }
-}

--- a/assets/component-product-grid.css
+++ b/assets/component-product-grid.css
@@ -1,0 +1,9 @@
+.product-grid .grid__item {
+  padding-bottom: var(--grid-mobile-vertical-spacing);
+}
+
+@media screen and (min-width: 750px) {
+  .product-grid .grid__item {
+    padding-bottom: var(--grid-desktop-vertical-spacing);
+  }
+}

--- a/assets/component-product-grid.css
+++ b/assets/component-product-grid.css
@@ -1,4 +1,4 @@
-.product-grid .grid__item {
+/* .product-grid .grid__item {
   padding-bottom: var(--grid-mobile-vertical-spacing);
 }
 
@@ -6,4 +6,4 @@
   .product-grid .grid__item {
     padding-bottom: var(--grid-desktop-vertical-spacing);
   }
-}
+} */

--- a/assets/component-product-grid.css
+++ b/assets/component-product-grid.css
@@ -1,9 +1,0 @@
-/* .product-grid .grid__item {
-  padding-bottom: var(--grid-mobile-vertical-spacing);
-}
-
-@media screen and (min-width: 750px) {
-  .product-grid .grid__item {
-    padding-bottom: var(--grid-desktop-vertical-spacing);
-  }
-} */

--- a/assets/component-slider.css
+++ b/assets/component-slider.css
@@ -21,7 +21,7 @@ slider-component {
     overflow-x: auto;
     scroll-snap-type: x mandatory;
     scroll-behavior: smooth;
-    scroll-padding-left: 1rem;
+    scroll-padding-left: 1.5rem;
     -webkit-overflow-scrolling: touch;
     margin-bottom: 1rem;
   }
@@ -61,7 +61,7 @@ slider-component {
     overflow-x: auto;
     scroll-snap-type: x mandatory;
     scroll-behavior: smooth;
-    scroll-padding-left: 1rem;
+    scroll-padding-left: 1.5rem;
     -webkit-overflow-scrolling: touch;
     margin-bottom: 1rem;
     padding-top: calc(var(--shadow-vertical-offset) * -1 + var(--shadow-blur-radius));

--- a/assets/component-slider.css
+++ b/assets/component-slider.css
@@ -21,7 +21,7 @@ slider-component {
     overflow-x: auto;
     scroll-snap-type: x mandatory;
     scroll-behavior: smooth;
-    scroll-padding-left: 1.5rem;
+    scroll-padding-left: 1rem;
     -webkit-overflow-scrolling: touch;
     margin-bottom: 1rem;
   }
@@ -61,7 +61,7 @@ slider-component {
     overflow-x: auto;
     scroll-snap-type: x mandatory;
     scroll-behavior: smooth;
-    scroll-padding-left: 1.5rem;
+    scroll-padding-left: 1rem;
     -webkit-overflow-scrolling: touch;
     margin-bottom: 1rem;
     padding-top: calc(var(--shadow-vertical-offset) * -1 + var(--shadow-blur-radius));

--- a/assets/component-slideshow.css
+++ b/assets/component-slideshow.css
@@ -13,6 +13,7 @@ slideshow-component .slideshow.banner {
   flex-direction: row;
   flex-wrap: nowrap;
   margin: 0;
+  gap: 0;
 }
 
 .slideshow__slide {

--- a/assets/component-slideshow.css
+++ b/assets/component-slideshow.css
@@ -13,7 +13,6 @@ slideshow-component .slideshow.banner {
   flex-direction: row;
   flex-wrap: nowrap;
   margin: 0;
-  gap: 0;
 }
 
 .slideshow__slide {

--- a/assets/section-collection-list.css
+++ b/assets/section-collection-list.css
@@ -71,13 +71,13 @@
   }
 
   .collection-list.grid--3-col-tablet .grid__item {
-    max-width: 33.33%;
+    max-width: calc(33.33% - var(--grid-desktop-horizontal-spacing) * 2 / 3);
   }
 
   .collection-list--4-items .grid__item,
   .collection-list--7-items .grid__item:nth-child(n + 4),
   .collection-list--10-items .grid__item:nth-child(n + 7) {
-    width: 50%;
+    width: calc(50% - var(--grid-desktop-horizontal-spacing) / 2);
   }
 }
 

--- a/assets/section-featured-blog.css
+++ b/assets/section-featured-blog.css
@@ -52,16 +52,9 @@
   scroll-snap-align: start;
 }
 
-@media screen and (min-width: 750px) {
-  .blog__posts .article + .article {
-    margin-left: var(--grid-desktop-horizontal-spacing);
-  }
-}
-
 @media screen and (max-width: 749px) {
   .blog__post.article {
     width: calc(100% - 3rem);
-    padding-left: 0.5rem;
   }
 }
 
@@ -80,5 +73,14 @@
 @media screen and (min-width: 750px) {
   .blog__button {
     margin-top: 5rem;
+  }
+}
+
+/* check for flexbox gap in older Safari versions */
+@supports not (inset: 10px) {
+  @media screen and (min-width: 750px) {
+    .blog__posts .article + .article {
+      margin-left: var(--grid-desktop-horizontal-spacing);
+    }
   }
 }

--- a/assets/section-featured-blog.css
+++ b/assets/section-featured-blog.css
@@ -52,6 +52,12 @@
   scroll-snap-align: start;
 }
 
+@media screen and (min-width: 750px) {
+  .blog__posts .article + .article {
+    margin-left: var(--grid-desktop-horizontal-spacing);
+  }
+}
+
 @media screen and (max-width: 749px) {
   .blog__post.article {
     width: calc(100% - 3rem);
@@ -73,13 +79,5 @@
 @media screen and (min-width: 750px) {
   .blog__button {
     margin-top: 5rem;
-  }
-}
-
-@supports not (inset: 10px) {
-  @media screen and (min-width: 750px) {
-    .blog__posts .article + .article {
-      margin-left: var(--grid-desktop-horizontal-spacing);
-    }
   }
 }

--- a/assets/section-featured-blog.css
+++ b/assets/section-featured-blog.css
@@ -76,3 +76,11 @@
     margin-top: 5rem;
   }
 }
+
+@supports not (inset: 10px) {
+  @media screen and (min-width: 750px) {
+    .blog__posts .article + .article {
+      margin-left: var(--grid-desktop-horizontal-spacing);
+    }
+  }
+}

--- a/assets/section-featured-blog.css
+++ b/assets/section-featured-blog.css
@@ -61,6 +61,7 @@
 @media screen and (max-width: 749px) {
   .blog__post.article {
     width: calc(100% - 3rem);
+    padding-left: 0.5rem;
   }
 }
 

--- a/assets/section-featured-blog.css
+++ b/assets/section-featured-blog.css
@@ -55,7 +55,6 @@
 @media screen and (max-width: 749px) {
   .blog__post.article {
     width: calc(100% - 3rem);
-    padding-left: 0.5rem;
   }
 }
 

--- a/assets/section-featured-blog.css
+++ b/assets/section-featured-blog.css
@@ -52,12 +52,6 @@
   scroll-snap-align: start;
 }
 
-@media screen and (min-width: 750px) {
-  .blog__posts .article + .article {
-    margin-left: var(--grid-desktop-horizontal-spacing);
-  }
-}
-
 @media screen and (max-width: 749px) {
   .blog__post.article {
     width: calc(100% - 3rem);

--- a/assets/section-featured-product.css
+++ b/assets/section-featured-product.css
@@ -73,11 +73,11 @@
 
 @media screen and (min-width: 990px) {
   .background-secondary .featured-product:not(.product--no-media) > .product__info-wrapper {
-    padding: 0 0 0 5rem;
+    padding: 0 0 0 2rem;
   }
 
   .featured-product:not(.product--no-media) > .product__info-wrapper {
-    padding: 0 7rem;
+    padding: 0 2rem;
   }
 
   .background-secondary .featured-product {

--- a/assets/section-featured-product.css
+++ b/assets/section-featured-product.css
@@ -73,11 +73,11 @@
 
 @media screen and (min-width: 990px) {
   .background-secondary .featured-product:not(.product--no-media) > .product__info-wrapper {
-    padding: 0 0 0 2rem;
+    padding: 0 0 0 5rem;
   }
 
   .featured-product:not(.product--no-media) > .product__info-wrapper {
-    padding: 0 2rem;
+    padding: 0 7rem;
   }
 
   .background-secondary .featured-product {

--- a/assets/section-footer.css
+++ b/assets/section-footer.css
@@ -14,7 +14,6 @@
 @media screen and (max-width: 749px) {
   .footer .grid {
     display: block;
-    margin-left: 0;
   }
 
   .footer-block.grid__item {
@@ -36,13 +35,8 @@
 
 @media screen and (min-width: 750px) {
   .footer__content-top .grid {
-    margin-left: -3rem;
     row-gap: 6rem;
     margin-bottom: 0;
-  }
-
-  .footer__content-top .grid__item {
-    padding-left: 3rem;
   }
 }
 
@@ -510,4 +504,23 @@ noscript .localization-selector.link {
 
 .footer .disclosure__link--active {
   text-decoration: underline;
+}
+
+/* check for flexbox gap in older Safari versions */
+@supports not (inset: 10px) {
+  @media screen and (max-width: 749px) {
+    .footer .grid {
+      margin-left: 0;
+    }
+  }
+
+  @media screen and (min-width: 750px) {
+    .footer__content-top .grid {
+      margin-left: -3rem;
+    }
+
+    .footer__content-top .grid__item {
+      padding-left: 3rem;
+    }
+  }
 }

--- a/assets/section-footer.css
+++ b/assets/section-footer.css
@@ -14,6 +14,7 @@
 @media screen and (max-width: 749px) {
   .footer .grid {
     display: block;
+    margin-left: 0;
   }
 
   .footer-block.grid__item {
@@ -35,8 +36,13 @@
 
 @media screen and (min-width: 750px) {
   .footer__content-top .grid {
+    margin-left: -3rem;
     row-gap: 6rem;
     margin-bottom: 0;
+  }
+
+  .footer__content-top .grid__item {
+    padding-left: 3rem;
   }
 }
 
@@ -504,22 +510,4 @@ noscript .localization-selector.link {
 
 .footer .disclosure__link--active {
   text-decoration: underline;
-}
-
-@supports not (inset: 10px) {
-  @media screen and (max-width: 749px) {
-    .footer .grid {
-      margin-left: 0;
-    }
-  }
-
-  @media screen and (min-width: 750px) {
-    .footer__content-top .grid {
-      margin-left: -3rem;
-    }
-
-    .footer__content-top .grid__item {
-      padding-left: 3rem;
-    }
-  }
 }

--- a/assets/section-footer.css
+++ b/assets/section-footer.css
@@ -505,3 +505,21 @@ noscript .localization-selector.link {
 .footer .disclosure__link--active {
   text-decoration: underline;
 }
+
+@supports not (inset: 10px) {
+  @media screen and (max-width: 749px) {
+    .footer .grid {
+      margin-left: 0;
+    }
+  }
+
+  @media screen and (min-width: 750px) {
+    .footer__content-top .grid {
+      margin-left: -3rem;
+    }
+
+    .footer__content-top .grid__item {
+      padding-left: 3rem;
+    }
+  }
+}

--- a/assets/section-footer.css
+++ b/assets/section-footer.css
@@ -14,7 +14,6 @@
 @media screen and (max-width: 749px) {
   .footer .grid {
     display: block;
-    margin-left: 0;
   }
 
   .footer-block.grid__item {
@@ -36,13 +35,8 @@
 
 @media screen and (min-width: 750px) {
   .footer__content-top .grid {
-    margin-left: -3rem;
     row-gap: 6rem;
     margin-bottom: 0;
-  }
-
-  .footer__content-top .grid__item {
-    padding-left: 3rem;
   }
 }
 

--- a/assets/section-main-product.css
+++ b/assets/section-main-product.css
@@ -984,10 +984,11 @@ a.product__text {
     align-items: center;
   }
 
-  .thumbnail-list.slider {
+  .thumbnail-slider .thumbnail-list.slider {
     display: flex;
     padding: 0.5rem;
     flex: 1;
+    scroll-padding-left: 0.5rem;
   }
 
   .thumbnail-list__item.slider__slide {
@@ -1001,10 +1002,11 @@ a.product__text {
     align-items: center;
   }
 
-  .thumbnail-list.slider--tablet-up {
+  .thumbnail-slider .thumbnail-list.slider--tablet-up {
     display: flex;
     padding: 0.5rem;
     flex: 1;
+    scroll-padding-left: 0.5rem;
   }
 
   .product__media-gallery .slider-mobile-gutter .slider-button {

--- a/assets/section-main-product.css
+++ b/assets/section-main-product.css
@@ -2,6 +2,10 @@
   margin: 0;
 }
 
+.product.grid {
+  gap: 0;
+}
+
 .product--no-media {
   max-width: 57rem;
   margin: 0 auto;
@@ -31,7 +35,7 @@
   }
 
   .product__info-wrapper {
-    padding-left: 2rem;
+    padding-left: 5rem;
   }
 
   .product__media-container .slider-buttons {
@@ -46,6 +50,7 @@
   }
 
   .product--large:not(.product--no-media) .product__info-wrapper {
+    padding-left: 4rem;
     max-width: 35%;
     width: calc(35% - var(--grid-desktop-horizontal-spacing) / 2);
   }

--- a/assets/section-main-product.css
+++ b/assets/section-main-product.css
@@ -32,7 +32,6 @@
 
   .product__info-wrapper {
     padding-left: 2rem;
-    margin-left: var(--grid-desktop-horizontal-spacing);
   }
 
   .product__media-container .slider-buttons {

--- a/assets/section-main-product.css
+++ b/assets/section-main-product.css
@@ -43,24 +43,24 @@
 @media screen and (min-width: 990px) {
   .product--large:not(.product--no-media) .product__media-wrapper {
     max-width: 65%;
-    width: calc(65% - var(--grid-desktop-horizontal-spacing) / 2);
+    width: calc(65% - 1rem / 2);
   }
 
   .product--large:not(.product--no-media) .product__info-wrapper {
     max-width: 35%;
-    width: calc(35% - var(--grid-desktop-horizontal-spacing) / 2);
+    width: calc(35% - 1rem / 2);
   }
 
   .product--medium:not(.product--no-media) .product__media-wrapper,
   .product--small:not(.product--no-media) .product__info-wrapper {
     max-width: 55%;
-    width: calc(55% - var(--grid-desktop-horizontal-spacing) / 2);
+    width: calc(55% - 1rem / 2);
   }
 
   .product--medium:not(.product--no-media) .product__info-wrapper,
   .product--small:not(.product--no-media) .product__media-wrapper {
     max-width: 45%;
-    width: calc(45% - var(--grid-desktop-horizontal-spacing) / 2);
+    width: calc(45% - 1rem / 2);
   }
 }
 

--- a/assets/section-main-product.css
+++ b/assets/section-main-product.css
@@ -42,25 +42,25 @@
 @media screen and (min-width: 990px) {
   .product--large:not(.product--no-media) .product__media-wrapper {
     max-width: 65%;
-    width: calc(65% - 1rem / 2);
+    width: calc(65% - var(--grid-desktop-horizontal-spacing) / 2);
   }
 
   .product--large:not(.product--no-media) .product__info-wrapper {
     padding-left: 4rem;
     max-width: 35%;
-    width: calc(35% - 1rem / 2);
+    width: calc(35% - var(--grid-desktop-horizontal-spacing) / 2);
   }
 
   .product--medium:not(.product--no-media) .product__media-wrapper,
   .product--small:not(.product--no-media) .product__info-wrapper {
     max-width: 55%;
-    width: calc(55% - 1rem / 2);
+    width: calc(55% - var(--grid-desktop-horizontal-spacing) / 2);
   }
 
   .product--medium:not(.product--no-media) .product__info-wrapper,
   .product--small:not(.product--no-media) .product__media-wrapper {
     max-width: 45%;
-    width: calc(45% - 1rem / 2);
+    width: calc(45% - var(--grid-desktop-horizontal-spacing) / 2);
   }
 }
 

--- a/assets/section-main-product.css
+++ b/assets/section-main-product.css
@@ -32,6 +32,7 @@
 
   .product__info-wrapper {
     padding-left: 2rem;
+    margin-left: var(--grid-desktop-horizontal-spacing);
   }
 
   .product__media-container .slider-buttons {

--- a/assets/section-main-product.css
+++ b/assets/section-main-product.css
@@ -31,7 +31,7 @@
   }
 
   .product__info-wrapper {
-    padding-left: 5rem;
+    padding-left: 2rem;
   }
 
   .product__media-container .slider-buttons {
@@ -46,7 +46,6 @@
   }
 
   .product--large:not(.product--no-media) .product__info-wrapper {
-    padding-left: 4rem;
     max-width: 35%;
     width: calc(35% - var(--grid-desktop-horizontal-spacing) / 2);
   }

--- a/assets/section-main-product.css
+++ b/assets/section-main-product.css
@@ -43,24 +43,24 @@
 @media screen and (min-width: 990px) {
   .product--large:not(.product--no-media) .product__media-wrapper {
     max-width: 65%;
-    width: calc(65% - 1rem / 2);
+    width: calc(65% - var(--grid-desktop-horizontal-spacing) / 2);
   }
 
   .product--large:not(.product--no-media) .product__info-wrapper {
     max-width: 35%;
-    width: calc(35% - 1rem / 2);
+    width: calc(35% - var(--grid-desktop-horizontal-spacing) / 2);
   }
 
   .product--medium:not(.product--no-media) .product__media-wrapper,
   .product--small:not(.product--no-media) .product__info-wrapper {
     max-width: 55%;
-    width: calc(55% - 1rem / 2);
+    width: calc(55% - var(--grid-desktop-horizontal-spacing) / 2);
   }
 
   .product--medium:not(.product--no-media) .product__info-wrapper,
   .product--small:not(.product--no-media) .product__media-wrapper {
     max-width: 45%;
-    width: calc(45% - 1rem / 2);
+    width: calc(45% - var(--grid-desktop-horizontal-spacing) / 2);
   }
 }
 

--- a/assets/section-multicolumn.css
+++ b/assets/section-multicolumn.css
@@ -120,6 +120,7 @@
   }
 }
 
+
 @media screen and (min-width: 750px) {
   .multicolumn-list.slider,
   .multicolumn-list.grid--4-col-desktop {

--- a/assets/section-multicolumn.css
+++ b/assets/section-multicolumn.css
@@ -120,7 +120,6 @@
   }
 }
 
-
 @media screen and (min-width: 750px) {
   .multicolumn-list.slider,
   .multicolumn-list.grid--4-col-desktop {

--- a/assets/section-multicolumn.css
+++ b/assets/section-multicolumn.css
@@ -120,8 +120,10 @@
   }
 }
 
-.multicolumn-list.slider {
-  gap: 0 0.5rem;
+@media screen and (max-width: 749px) {
+  .multicolumn-list.slider {
+    gap: 0 0.5rem;
+  }
 }
 
 @media screen and (min-width: 750px) {

--- a/assets/section-multicolumn.css
+++ b/assets/section-multicolumn.css
@@ -120,6 +120,10 @@
   }
 }
 
+.multicolumn-list.slider {
+  gap: 0 0.5rem;
+}
+
 @media screen and (min-width: 750px) {
   .multicolumn-list.slider,
   .multicolumn-list.grid--4-col-desktop {

--- a/assets/section-multicolumn.css
+++ b/assets/section-multicolumn.css
@@ -120,11 +120,6 @@
   }
 }
 
-@media screen and (max-width: 749px) {
-  .multicolumn-list.slider {
-    gap: 0 0.5rem;
-  }
-}
 
 @media screen and (min-width: 750px) {
   .multicolumn-list.slider,

--- a/assets/template-collection.css
+++ b/assets/template-collection.css
@@ -19,12 +19,6 @@
 @media screen and (max-width: 989px) {
   .collection .slider.slider--tablet {
     margin-bottom: 1.5rem;
-  } 
-}
-
-@media screen and (min-width: 750px) and (max-width: 989px){
-  .collection .slider__slide {
-    padding-left: 1rem
   }
 }
 

--- a/assets/template-collection.css
+++ b/assets/template-collection.css
@@ -22,6 +22,12 @@
   }
 }
 
+@media screen and (min-width: 750px) and (max-width: 989px){
+  .collection .slider__slide {
+    padding-left: 1rem
+  }
+}
+
 .collection .loading-overlay {
   top: 0;
   right: 0;

--- a/assets/template-collection.css
+++ b/assets/template-collection.css
@@ -22,12 +22,6 @@
   }
 }
 
-@media screen and (min-width: 750px) and (max-width: 989px){
-  .collection .slider__slide {
-    padding-left: 1rem
-  }
-}
-
 .collection .loading-overlay {
   top: 0;
   right: 0;

--- a/sections/featured-collection.liquid
+++ b/sections/featured-collection.liquid
@@ -1,6 +1,5 @@
 {{ 'component-card.css' | asset_url | stylesheet_tag }}
 {{ 'component-price.css' | asset_url | stylesheet_tag }}
-{{ 'component-product-grid.css' | asset_url | stylesheet_tag }}
 
 <link rel="stylesheet" href="{{ 'component-slider.css' | asset_url }}" media="print" onload="this.media='all'">
 <link rel="stylesheet" href="{{ 'template-collection.css' | asset_url }}" media="print" onload="this.media='all'">

--- a/sections/featured-collection.liquid
+++ b/sections/featured-collection.liquid
@@ -1,5 +1,6 @@
 {{ 'component-card.css' | asset_url | stylesheet_tag }}
 {{ 'component-price.css' | asset_url | stylesheet_tag }}
+{{ 'component-product-grid.css' | asset_url | stylesheet_tag }}
 
 <link rel="stylesheet" href="{{ 'component-slider.css' | asset_url }}" media="print" onload="this.media='all'">
 <link rel="stylesheet" href="{{ 'template-collection.css' | asset_url }}" media="print" onload="this.media='all'">

--- a/sections/main-collection-product-grid.liquid
+++ b/sections/main-collection-product-grid.liquid
@@ -2,7 +2,6 @@
 {{ 'component-loading-overlay.css' | asset_url | stylesheet_tag }}
 {{ 'component-card.css' | asset_url | stylesheet_tag }}
 {{ 'component-price.css' | asset_url | stylesheet_tag }}
-{{ 'component-product-grid.css' | asset_url | stylesheet_tag }}
 
 <link rel="preload" href="{{ 'component-rte.css' | asset_url }}" as="style" onload="this.onload=null;this.rel='stylesheet'">
 

--- a/sections/main-collection-product-grid.liquid
+++ b/sections/main-collection-product-grid.liquid
@@ -2,6 +2,7 @@
 {{ 'component-loading-overlay.css' | asset_url | stylesheet_tag }}
 {{ 'component-card.css' | asset_url | stylesheet_tag }}
 {{ 'component-price.css' | asset_url | stylesheet_tag }}
+{{ 'component-product-grid.css' | asset_url | stylesheet_tag }}
 
 <link rel="preload" href="{{ 'component-rte.css' | asset_url }}" as="style" onload="this.onload=null;this.rel='stylesheet'">
 

--- a/sections/main-search.liquid
+++ b/sections/main-search.liquid
@@ -1,6 +1,7 @@
 {{ 'template-collection.css' | asset_url | stylesheet_tag }}
 {{ 'component-card.css' | asset_url | stylesheet_tag }}
 {{ 'component-price.css' | asset_url | stylesheet_tag }}
+{{ 'component-product-grid.css' | asset_url | stylesheet_tag }}
 
 <link rel="stylesheet" href="{{ 'component-search.css' | asset_url }}" media="print" onload="this.media='all'">
 

--- a/sections/main-search.liquid
+++ b/sections/main-search.liquid
@@ -1,7 +1,6 @@
 {{ 'template-collection.css' | asset_url | stylesheet_tag }}
 {{ 'component-card.css' | asset_url | stylesheet_tag }}
 {{ 'component-price.css' | asset_url | stylesheet_tag }}
-{{ 'component-product-grid.css' | asset_url | stylesheet_tag }}
 
 <link rel="stylesheet" href="{{ 'component-search.css' | asset_url }}" media="print" onload="this.media='all'">
 
@@ -30,9 +29,17 @@
     padding-bottom: 18rem;
   }
 
+  .template-search .grid__item--small:not(:last-child) {
+    padding-bottom: 0.5rem;
+  }
+
   @media screen and (min-width: 750px) {
     .template-search__header {
       margin-bottom: 5rem;
+    }
+
+    .template-search .grid__item--small:not(:last-child) {
+      padding-bottom: 1rem;
     }
   }
 
@@ -162,7 +169,7 @@
                   {%- assign lazy_load = true -%}
                 {%- endif -%}
 
-                <li class="grid__item">
+                <li class="grid__item{% unless item.object_type == 'product' %} grid__item--small{% endunless %}">
                   {%- case item.object_type -%}
                     {%- when 'product' -%}
                       {%- capture product_settings -%}{%- if section.settings.product_show_vendor -%}vendor,{%- endif -%}title,price{%- endcapture -%}

--- a/sections/main-search.liquid
+++ b/sections/main-search.liquid
@@ -30,17 +30,9 @@
     padding-bottom: 18rem;
   }
 
-  .template-search .grid__item--small:not(:last-child) {
-    padding-bottom: 0.5rem;
-  }
-
   @media screen and (min-width: 750px) {
     .template-search__header {
       margin-bottom: 5rem;
-    }
-
-    .template-search .grid__item--small:not(:last-child) {
-      padding-bottom: 1rem;
     }
   }
 
@@ -170,7 +162,7 @@
                   {%- assign lazy_load = true -%}
                 {%- endif -%}
 
-                <li class="grid__item{% unless item.object_type == 'product' %} grid__item--small{% endunless %}">
+                <li class="grid__item">
                   {%- case item.object_type -%}
                     {%- when 'product' -%}
                       {%- capture product_settings -%}{%- if section.settings.product_show_vendor -%}vendor,{%- endif -%}title,price{%- endcapture -%}

--- a/sections/main-search.liquid
+++ b/sections/main-search.liquid
@@ -1,7 +1,6 @@
 {{ 'template-collection.css' | asset_url | stylesheet_tag }}
 {{ 'component-card.css' | asset_url | stylesheet_tag }}
 {{ 'component-price.css' | asset_url | stylesheet_tag }}
-{{ 'component-product-grid.css' | asset_url | stylesheet_tag }}
 
 <link rel="stylesheet" href="{{ 'component-search.css' | asset_url }}" media="print" onload="this.media='all'">
 
@@ -79,7 +78,7 @@
     <div class="template-search__search">
       {%- if settings.predictive_search_enabled -%}
         <predictive-search data-loading-text="{{ 'accessibility.loading' | t }}">
-      {%- endif -%} 
+      {%- endif -%}
         <form action="{{ routes.search_url }}" method="get" role="search" class="search">
           <div class="field">
             <input
@@ -95,7 +94,7 @@
                 aria-owns="predictive-search-results-list"
                 aria-controls="predictive-search-results-list"
                 aria-haspopup="listbox"
-                aria-autocomplete="list" 
+                aria-autocomplete="list"
                 autocorrect="off"
                 autocomplete="off"
                 autocapitalize="off"
@@ -113,10 +112,10 @@
                   </svg>
                 </div>
               </div>
-  
-              <span class="predictive-search-status visually-hidden" role="status" aria-hidden="true"></span> 
+
+              <span class="predictive-search-status visually-hidden" role="status" aria-hidden="true"></span>
             {%- endif -%}
-                
+
             <button type="submit" class="search__button field__button" aria-label="{{ 'general.search.search' | t }}">
               <svg class="icon icon-search">
                 <use xlink:href="#icon-search">
@@ -126,16 +125,16 @@
         </form>
       {%- if settings.predictive_search_enabled -%}
         </predictive-search>
-      {%- endif -%} 
+      {%- endif -%}
 
     </div>
     {%- if search.performed -%}
-      {%- unless section.settings.enable_filtering or section.settings.enable_sorting -%} 
-        {%- if search.results_count > 0 -%}        
+      {%- unless section.settings.enable_filtering or section.settings.enable_sorting -%}
+        {%- if search.results_count > 0 -%}
           <p role="status">{{ 'templates.search.results_with_count_and_term' | t: terms: search.terms, count: search.results_count }}</p>
         {%- endif -%}
       {%- endunless -%}
-      {%- if search.results_count == 0 and search.filters == empty -%}        
+      {%- if search.results_count == 0 and search.filters == empty -%}
         <p role="status">{{ 'templates.search.no_results' | t: terms: search.terms }}</p>
       {%- endif -%}
     {%- endif -%}
@@ -192,20 +191,20 @@
                         media_aspect_ratio: 1,
                         lazy_load: lazy_load
                       %}
-                    {%- when 'page' -%}                
+                    {%- when 'page' -%}
                       <div class="card-wrapper underline-links-hover">
                         <div class="card card--card card--text ratio color-{{ settings.card_color_scheme }}" style="--ratio-percent: 100%;">
-                            <div class="card__content">        
+                            <div class="card__content">
                               <div class="card__information">
                                 <h3 class="card__heading">
                                   <a href="{{ item.url }}" class="full-unstyled-link">
                                     {{ item.title | truncate: 50 | escape }}
                                   </a>
                                 </h3>
-                              </div>      
-                              <div class="card__badge {{ settings.badge_position }}"> 
+                              </div>
+                              <div class="card__badge {{ settings.badge_position }}">
                                 <span class="badge color-background-1">{{ 'templates.search.page' | t }}</span>
-                              </div>                    
+                              </div>
                         </div>
                       </div>
                   {%- endcase -%}
@@ -216,9 +215,9 @@
               {% render 'pagination', paginate: paginate %}
             {%- endif -%}
           </div>
-        {% endpaginate %}    
+        {% endpaginate %}
       {%- endif -%}
-    </div> 
+    </div>
   {%- endif -%}
 </div>
 

--- a/sections/main-search.liquid
+++ b/sections/main-search.liquid
@@ -29,17 +29,9 @@
     padding-bottom: 18rem;
   }
 
-  .template-search .grid__item--small:not(:last-child) {
-    padding-bottom: 0.5rem;
-  }
-
   @media screen and (min-width: 750px) {
     .template-search__header {
       margin-bottom: 5rem;
-    }
-
-    .template-search .grid__item--small:not(:last-child) {
-      padding-bottom: 1rem;
     }
   }
 
@@ -169,7 +161,7 @@
                   {%- assign lazy_load = true -%}
                 {%- endif -%}
 
-                <li class="grid__item{% unless item.object_type == 'product' %} grid__item--small{% endunless %}">
+                <li class="grid__item">
                   {%- case item.object_type -%}
                     {%- when 'product' -%}
                       {%- capture product_settings -%}{%- if section.settings.product_show_vendor -%}vendor,{%- endif -%}title,price{%- endcapture -%}

--- a/sections/product-recommendations.liquid
+++ b/sections/product-recommendations.liquid
@@ -1,11 +1,9 @@
 <link rel="stylesheet" href="{{ 'component-card.css' | asset_url }}" media="print" onload="this.media='all'">
 <link rel="stylesheet" href="{{ 'component-price.css' | asset_url }}" media="print" onload="this.media='all'">
-<link rel="stylesheet" href="{{ 'component-product-grid.css' | asset_url }}" media="print" onload="this.media='all'">
 <link rel="stylesheet" href="{{ 'section-product-recommendations.css' | asset_url }}" media="print" onload="this.media='all'">
 
 <noscript>{{ 'component-card.css' | asset_url | stylesheet_tag }}</noscript>
 <noscript>{{ 'component-price.css' | asset_url | stylesheet_tag }}</noscript>
-<noscript>{{ 'component-product-grid.css' | asset_url | stylesheet_tag }}</noscript>
 <noscript>{{ 'section-product-recommendations.css' | asset_url | stylesheet_tag }}</noscript>
 
 {%- style -%}

--- a/sections/product-recommendations.liquid
+++ b/sections/product-recommendations.liquid
@@ -1,9 +1,11 @@
 <link rel="stylesheet" href="{{ 'component-card.css' | asset_url }}" media="print" onload="this.media='all'">
 <link rel="stylesheet" href="{{ 'component-price.css' | asset_url }}" media="print" onload="this.media='all'">
+<link rel="stylesheet" href="{{ 'component-product-grid.css' | asset_url }}" media="print" onload="this.media='all'">
 <link rel="stylesheet" href="{{ 'section-product-recommendations.css' | asset_url }}" media="print" onload="this.media='all'">
 
 <noscript>{{ 'component-card.css' | asset_url | stylesheet_tag }}</noscript>
 <noscript>{{ 'component-price.css' | asset_url | stylesheet_tag }}</noscript>
+<noscript>{{ 'component-product-grid.css' | asset_url | stylesheet_tag }}</noscript>
 <noscript>{{ 'section-product-recommendations.css' | asset_url | stylesheet_tag }}</noscript>
 
 {%- style -%}


### PR DESCRIPTION
**Why are these changes introduced?**

Fixes #1054 

**What approach did you take?**

Using `column-gap` and `row-gap` instead of dealing with the spacing using `padding`. 

**Other considerations**

Safari supports those properties in its current version 15 and previous version 14. But not prior to that.

**Testing**

Check where the horizontal and vertical space have an effect: 
- Collage,
- collection page, 
- feat. collection section,
- multicolumn section, 
- search page,
- collection list, 
- sliders (slideshow, blog posts, multicolumn, feat. collection, etc)

**Demo links**

- [Store](https://os2-demo.myshopify.com/?preview_theme_id=127066767382)
- [Editor](https://os2-demo.myshopify.com/admin/themes/127066767382/editor)

**Checklist**
- [ ] Followed [theme code principles](https://github.com/Shopify/dawn/blob/main/.github/CONTRIBUTING.md#theme-code-principles)
- [ ] Linted with [Theme Check](https://github.com/Shopify/theme-check)
- [ ] Tested on [mobile](https://shopify.dev/themes/store/requirements#mobile-browser-requirements)
- [ ] Tested on [multiple browsers](https://shopify.dev/themes/store/requirements#desktop-browser-requirements)
- [ ] Tested for [accessibility](https://shopify.dev/themes/best-practices/accessibility)
