### PR TITLE
Fix border card hover safari

### DIFF
--- a/assets/component-card.css
+++ b/assets/component-card.css
@@ -8,6 +8,7 @@
 .card {
   text-align: var(--card-text-alignment);
   text-decoration: none;
+  position: relative;
 }
 
 .card--card {
@@ -37,6 +38,7 @@
 
 .card .card__inner .card__media {
   overflow: hidden;
+  -webkit-mask-image: -webkit-radial-gradient(white, black);
   border-radius: calc(var(--card-corner-radius) - var(--card-border-width) - var(--card-image-padding));
 }
 
@@ -175,14 +177,6 @@
   .card:hover .media.media--hover-effect > img:first-child:only-child,
   .card-wrapper:hover .media.media--hover-effect > img:first-child:only-child {
     transform: scale(1.03);
-  }
-
-  .card .card__inner .card__media {
-    z-index: 1;
-  }
-
-  .card .card__inner  {
-    z-index: 2;
   }
 
   .card-wrapper:hover

--- a/assets/component-card.css
+++ b/assets/component-card.css
@@ -37,6 +37,7 @@
 
 .card .card__inner .card__media {
   overflow: hidden;
+  /* Fix for Safari border bug on hover */
   z-index: 0;
   border-radius: calc(var(--card-corner-radius) - var(--card-border-width) - var(--card-image-padding));
 }

--- a/assets/component-card.css
+++ b/assets/component-card.css
@@ -38,7 +38,7 @@
 
 .card .card__inner .card__media {
   overflow: hidden;
-  -webkit-mask-image: -webkit-radial-gradient(white, black);
+  z-index: 0;
   border-radius: calc(var(--card-corner-radius) - var(--card-border-width) - var(--card-image-padding));
 }
 

--- a/assets/component-card.css
+++ b/assets/component-card.css
@@ -177,6 +177,14 @@
     transform: scale(1.03);
   }
 
+  .card .card__inner .card__media {
+    z-index: 1;
+  }
+
+  .card .card__inner  {
+    z-index: 2;
+  }
+
   .card-wrapper:hover
     .media.media--hover-effect
     > img:first-child:not(:only-child) {

--- a/assets/component-card.css
+++ b/assets/component-card.css
@@ -8,7 +8,6 @@
 .card {
   text-align: var(--card-text-alignment);
   text-decoration: none;
-  position: relative;
 }
 
 .card--card {


### PR DESCRIPTION
**Why are these changes introduced?**

Fixes #1121 .

**What approach did you take?**

Updated the z-index for the card and the media. The reason this was happening is because when we apply `transform` or `opacity` (which we are for the animation), the order doesn't stay the same even with `position: relative`. So the solution is to set the index. More here: https://coder-coder.com/z-index-isnt-working/

**Other considerations**

**Demo links**

Test on safari: 
- [Editor](https://os2-demo.myshopify.com/admin/themes/127073845270/editor)

**Checklist**
- [ ] Followed [theme code principles](https://github.com/Shopify/dawn/blob/main/.github/CONTRIBUTING.md#theme-code-principles)
- [ ] Linted with [Theme Check](https://github.com/Shopify/theme-check)
- [ ] Tested on [mobile](https://shopify.dev/themes/store/requirements#mobile-browser-requirements)
- [ ] Tested on [multiple browsers](https://shopify.dev/themes/store/requirements#desktop-browser-requirements)
- [ ] Tested for [accessibility](https://shopify.dev/themes/best-practices/accessibility)
