### PR TITLE
Fix fullwidth content container shadows

### DIFF
--- a/assets/base.css
+++ b/assets/base.css
@@ -2491,10 +2491,7 @@ details-disclosure > details {
 .content-container:after {
   content: '';
   position: absolute;
-  width: calc(var(--text-boxes-border-width) * 2 + 100%);
-  height: calc(var(--text-boxes-border-width) * 2 + 100%);
-  top: calc(var(--text-boxes-border-width) * -1);
-  left: calc(var(--text-boxes-border-width) * -1);
+  inset: calc(var(--text-boxes-border-width) * -1);
   z-index: -1;
   border-radius: var(--text-boxes-radius);
   box-shadow: var(--text-boxes-shadow-horizontal-offset)
@@ -2504,7 +2501,8 @@ details-disclosure > details {
 }
 
 .content-container--full-width:after {
-  width: 100%;
+  left: 0;
+  right: 0;
   border-radius: 0;
 }
 


### PR DESCRIPTION
**Why are these changes introduced?**

Refs #1099 

Fixes the weird shadow offset noticeable on fullwidth content container sections like newsletter and rich text.

**What approach did you take?**

Removed the left/right positioning offset for the shadow pseudo element when the content container is full width.

**Other considerations**

**Demo links**

- [Editor](https://os2-demo.myshopify.com/admin/themes/127074271254/editor)

**Checklist**
- [ ] Followed [theme code principles](https://github.com/Shopify/dawn/blob/main/.github/CONTRIBUTING.md#theme-code-principles)
- [ ] Linted with [Theme Check](https://github.com/Shopify/theme-check)
- [ ] Tested on [mobile](https://shopify.dev/themes/store/requirements#mobile-browser-requirements)
- [ ] Tested on [multiple browsers](https://shopify.dev/themes/store/requirements#desktop-browser-requirements)
- [ ] Tested for [accessibility](https://shopify.dev/themes/best-practices/accessibility)
