### PR TITLE
Safari bug fix with drop shadows

### DIFF
--- a/assets/base.css
+++ b/assets/base.css
@@ -1524,6 +1524,7 @@ details[open] > .share-button__fallback {
     var(--inputs-shadow-blur-radius)
     rgba(var(--color-shadow), var(--inputs-shadow-opacity))
   );
+  /* fix drop-shadow issue in Safari */
   transform: translateZ(0);
 }
 

--- a/assets/base.css
+++ b/assets/base.css
@@ -1524,6 +1524,7 @@ details[open] > .share-button__fallback {
     var(--inputs-shadow-blur-radius)
     rgba(var(--color-shadow), var(--inputs-shadow-opacity))
   );
+  transform: translateZ(0);
 }
 
 .select__select {


### PR DESCRIPTION
**Why are these changes introduced?**

Fixes #1120 

**What approach did you take?**

Looked online and it seems like a know Safari issue with some bugs filed for Webkit already. Someone mentioned an interesting fix for it which make CSS render using GPU by using `transform: translateZ(0)`. 

Another CSS fix was using `will-change: filter;` but this seemed like a bad excuse to use it as it's mentioned to be used sparingly. 

**Other considerations**

**Our approach is changing about inputs' shadow, so this fix might not be applicable anymore once #1097 is merged.**

**Testing**

In order to replicate, use Safari, click on the search icon in the header and start typing a few letters to trigger predictive search. 
The issue came up when adding/removing letters which was triggering predictive search to load new results but the browser wasn't applying the shadow or updating it as it was happening. Which resulted in an odd experience, sometimes showing the shadow sometimes not.

**Demo links**

- [Store](https://os2-demo.myshopify.com/?preview_theme_id=127077318678)
- [Editor](https://os2-demo.myshopify.com/admin/themes/127077318678/editor)

**Checklist**
- [ ] Followed [theme code principles](https://github.com/Shopify/dawn/blob/main/.github/CONTRIBUTING.md#theme-code-principles)
- [ ] Linted with [Theme Check](https://github.com/Shopify/theme-check)
- [ ] Tested on [mobile](https://shopify.dev/themes/store/requirements#mobile-browser-requirements)
- [ ] Tested on [multiple browsers](https://shopify.dev/themes/store/requirements#desktop-browser-requirements)
- [ ] Tested for [accessibility](https://shopify.dev/themes/best-practices/accessibility)
