### PR TITLE
Collage video block focus style update

### DIFF
--- a/assets/collage.css
+++ b/assets/collage.css
@@ -150,8 +150,13 @@
   border: 0;
 }
 
-.collage-card .deferred-media__poster:focus-visible,
 .collage-card .deferred-media__poster:focus {
+  box-shadow: 0 0 0 0.3rem rgb(var(--color-background)),0 0 0.5rem 0.4rem rgba(var(--color-foreground), 0.3);
+  outline-offset: 0.3rem;
+  outline: 0.2rem solid rgba(var(--color-foreground), 0.5);
+}
+
+.collage-card .deferred-media__poster:focus-visible {
   box-shadow: 0 0 0 0.3rem rgb(var(--color-background)),0 0 0.5rem 0.4rem rgba(var(--color-foreground), 0.3);
   outline-offset: 0.3rem;
   outline: 0.2rem solid rgba(var(--color-foreground), 0.5);

--- a/assets/collage.css
+++ b/assets/collage.css
@@ -108,12 +108,6 @@
   }
 }
 
-.collage__item--video:focus-within {
-  box-shadow: 0 0 0 0.3rem rgb(var(--color-background)),0 0 0.5rem 0.4rem rgba(var(--color-foreground), 0.3);
-  outline-offset: 0.3rem;
-  outline: 0.2rem solid rgba(var(--color-foreground), 0.5);
-}
-
 .collage-card {
   background: rgb(var(--color-background));
   border-radius: var(--card-corner-radius);
@@ -156,8 +150,15 @@
   border: 0;
 }
 
-.collage-card .deferred-media__poster:focus,
-.collage-card .collage-card__link:focus {
+.collage-card .deferred-media__poster:focus-visible,
+.collage-card .deferred-media__poster:focus {
+  box-shadow: 0 0 0 0.3rem rgb(var(--color-background)),0 0 0.5rem 0.4rem rgba(var(--color-foreground), 0.3);
+  outline-offset: 0.3rem;
+  outline: 0.2rem solid rgba(var(--color-foreground), 0.5);
+}
+
+.collage-card .deferred-media__poster:focus:not(:focus-visible),
+.collage-card .collage-card__link:focus:not(:focus-visible) {
   outline-offset: 0.3rem;
   outline: none;
   box-shadow: none;

--- a/assets/collage.css
+++ b/assets/collage.css
@@ -159,10 +159,10 @@
   right: calc(var(--card-border-width) * -1);
   top: calc(var(--card-border-width) * -1);
   outline-offset: 0.3rem;
+  border-radius: var(--card-corner-radius);
 }
 
 .collage-card .deferred-media__poster:focus:after {
-  box-shadow: 0 0 0 0.3rem rgb(var(--color-background)),0 0 0.5rem 0.4rem rgba(var(--color-foreground), 0.3);
   outline: 0.2rem solid rgba(var(--color-foreground), 0.5);
 }
 
@@ -172,8 +172,7 @@
 }
 
 .collage-card .deferred-media__poster:focus:not(:focus-visible),
-.collage-card .deferred-media__poster:focus:not(:focus-visible):after,
-.collage-card .collage-card__link:focus:not(:focus-visible) {
+.collage-card .deferred-media__poster:focus:not(:focus-visible):after {
   outline: none;
   box-shadow: none;
 }

--- a/assets/collage.css
+++ b/assets/collage.css
@@ -159,7 +159,6 @@
   right: calc(var(--card-border-width) * -1);
   top: calc(var(--card-border-width) * -1);
   outline-offset: 0.3rem;
-  border-radius: var(--card-corner-radius);
 }
 
 .collage-card .deferred-media__poster:focus:after {

--- a/assets/collage.css
+++ b/assets/collage.css
@@ -150,21 +150,35 @@
   border: 0;
 }
 
-.collage-card .deferred-media__poster:focus {
-  box-shadow: 0 0 0 0.3rem rgb(var(--color-background)),0 0 0.5rem 0.4rem rgba(var(--color-foreground), 0.3);
+.collage-card .deferred-media__poster:after {
+  content: "";
+  position: absolute;
+  z-index: 1;
+  bottom: calc(var(--card-border-width) * -1);
+  left: calc(var(--card-border-width) * -1);
+  right: calc(var(--card-border-width) * -1);
+  top: calc(var(--card-border-width) * -1);
   outline-offset: 0.3rem;
+}
+
+.collage-card .deferred-media__poster:focus:after {
+  box-shadow: 0 0 0 0.3rem rgb(var(--color-background)),0 0 0.5rem 0.4rem rgba(var(--color-foreground), 0.3);
   outline: 0.2rem solid rgba(var(--color-foreground), 0.5);
 }
 
-.collage-card .deferred-media__poster:focus-visible {
+.collage-card .deferred-media__poster:focus-visible:after {
   box-shadow: 0 0 0 0.3rem rgb(var(--color-background)),0 0 0.5rem 0.4rem rgba(var(--color-foreground), 0.3);
-  outline-offset: 0.3rem;
   outline: 0.2rem solid rgba(var(--color-foreground), 0.5);
 }
 
 .collage-card .deferred-media__poster:focus:not(:focus-visible),
+.collage-card .deferred-media__poster:focus:not(:focus-visible):after,
 .collage-card .collage-card__link:focus:not(:focus-visible) {
-  outline-offset: 0.3rem;
+  outline: none;
+  box-shadow: none;
+}
+
+.collage-card .deferred-media__poster:focus {
   outline: none;
   box-shadow: none;
 }

--- a/assets/collage.css
+++ b/assets/collage.css
@@ -163,12 +163,12 @@
 }
 
 .collage-card .deferred-media__poster:focus:after {
-  box-shadow: 0 0 0 0.3rem rgb(var(--color-background)),0 0 0.5rem 0.4rem rgba(var(--color-foreground), 0.3);
+  box-shadow: 0 0 0 0.3rem rgb(var(--color-background)), 0 0 0.5rem 0.4rem rgba(var(--color-foreground), 0.3);
   outline: 0.2rem solid rgba(var(--color-foreground), 0.5);
 }
 
 .collage-card .deferred-media__poster:focus-visible:after {
-  box-shadow: 0 0 0 0.3rem rgb(var(--color-background)),0 0 0.5rem 0.4rem rgba(var(--color-foreground), 0.3);
+  box-shadow: 0 0 0 0.3rem rgb(var(--color-background)), 0 0 0.5rem 0.4rem rgba(var(--color-foreground), 0.3);
   outline: 0.2rem solid rgba(var(--color-foreground), 0.5);
 }
 

--- a/assets/collage.css
+++ b/assets/collage.css
@@ -163,6 +163,7 @@
 }
 
 .collage-card .deferred-media__poster:focus:after {
+  box-shadow: 0 0 0 0.3rem rgb(var(--color-background)),0 0 0.5rem 0.4rem rgba(var(--color-foreground), 0.3);
   outline: 0.2rem solid rgba(var(--color-foreground), 0.5);
 }
 

--- a/assets/component-card.css
+++ b/assets/component-card.css
@@ -169,6 +169,7 @@
 }
 
 .card__heading a:focus:after {
+  box-shadow: 0 0 0 .3rem rgb(var(--color-background)),0 0 .5rem .4rem rgba(var(--color-foreground),.3);
   outline: .2rem solid rgba(var(--color-foreground),.5);
 }
 

--- a/assets/component-card.css
+++ b/assets/component-card.css
@@ -169,13 +169,13 @@
 }
 
 .card__heading a:focus:after {
-  box-shadow: 0 0 0 .3rem rgb(var(--color-background)),0 0 .5rem .4rem rgba(var(--color-foreground),.3);
-  outline: .2rem solid rgba(var(--color-foreground),.5);
+  box-shadow: 0 0 0 0.3rem rgb(var(--color-background)), 0 0 0.5rem 0.4rem rgba(var(--color-foreground), 0.3);
+  outline: 0.2rem solid rgba(var(--color-foreground), 0.5);
 }
 
 .card__heading a:focus-visible:after {
-  box-shadow: 0 0 0 .3rem rgb(var(--color-background)),0 0 .5rem .4rem rgba(var(--color-foreground),.3);
-  outline: .2rem solid rgba(var(--color-foreground),.5);
+  box-shadow: 0 0 0 0.3rem rgb(var(--color-background)), 0 0 0.5rem 0.4rem rgba(var(--color-foreground), 0.3);
+  outline: 0.2rem solid rgba(var(--color-foreground), 0.5);
 }
 
 .card__heading a:focus:not(:focus-visible):after {

--- a/assets/component-card.css
+++ b/assets/component-card.css
@@ -165,7 +165,6 @@
 
 .card__heading a:after {
   outline-offset: 0.3rem;
-  border-radius: var(--card-corner-radius);
 }
 
 .card__heading a:focus:after {

--- a/assets/component-card.css
+++ b/assets/component-card.css
@@ -165,10 +165,10 @@
 
 .card__heading a:after {
   outline-offset: 0.3rem;
+  border-radius: var(--card-corner-radius);
 }
 
 .card__heading a:focus:after {
-  box-shadow: 0 0 0 .3rem rgb(var(--color-background)),0 0 .5rem .4rem rgba(var(--color-foreground),.3);
   outline: .2rem solid rgba(var(--color-foreground),.5);
 }
 


### PR DESCRIPTION
**Why are these changes introduced?**

The focus style on the video block is updated to use the same kinda logic (focus/focus-visible) as the cards.

**What approach did you take?**

Removed `focus-within` and used the `focus, focus-visible` approach.

**Other considerations**

**Demo links**

- [Store](https://os2-demo.myshopify.com/?preview_theme_id=127083380758)
- [Editor](https://os2-demo.myshopify.com/admin/themes/127083380758/editor)

**Checklist**
- [ ] Followed [theme code principles](https://github.com/Shopify/dawn/blob/main/.github/CONTRIBUTING.md#theme-code-principles)
- [ ] Linted with [Theme Check](https://github.com/Shopify/theme-check)
- [ ] Tested on [mobile](https://shopify.dev/themes/store/requirements#mobile-browser-requirements)
- [ ] Tested on [multiple browsers](https://shopify.dev/themes/store/requirements#desktop-browser-requirements)
- [ ] Tested for [accessibility](https://shopify.dev/themes/best-practices/accessibility)
