### PR TITLE
Fix sort caret position

### DIFF
--- a/assets/component-facets.css
+++ b/assets/component-facets.css
@@ -91,6 +91,10 @@
   padding-right: 1.75rem;
 }
 
+.facet-filters__sort + .icon-caret {
+  right: 0;
+}
+
 @media screen and (forced-colors: active) {
   .facet-filters__sort {
     border: none;


### PR DESCRIPTION
**Why are these changes introduced?**

Fixes #999

**What approach did you take?**

Adjust `right` position of caret icon

**Other considerations**

Additional enhancements to sort `select` element (https://github.com/Shopify/dawn/issues/999#issuecomment-1006121299) are not addressed in this PR

**Demo links**

- [Store](https://os2-demo.myshopify.com/?preview_theme_id=127084986390)
- [Editor](https://os2-demo.myshopify.com/admin/themes/127084986390/editor)

**Checklist**
- [ ] Followed [theme code principles](https://github.com/Shopify/dawn/blob/main/.github/CONTRIBUTING.md#theme-code-principles)
- [ ] Linted with [Theme Check](https://github.com/Shopify/theme-check)
- [ ] Tested on [mobile](https://shopify.dev/themes/store/requirements#mobile-browser-requirements)
- [ ] Tested on [multiple browsers](https://shopify.dev/themes/store/requirements#desktop-browser-requirements)
- [ ] Tested for [accessibility](https://shopify.dev/themes/best-practices/accessibility)
