### PR TITLE
Automatic discount cart position fix

### DIFF
--- a/assets/component-discounts.css
+++ b/assets/component-discounts.css
@@ -12,8 +12,14 @@
   color: rgba(var(--color-button), var(--alpha-button-background));
 }
 
-.discounts__discount--end {
-  justify-content: flex-end;
+.discounts__discount--position {
+  justify-content: center;
+}
+
+@media screen and (min-width: 750px) {
+  .discounts__discount--position {
+    justify-content: flex-end;
+  }
 }
 
 .discounts__discount > .icon {

--- a/sections/main-cart-footer.liquid
+++ b/sections/main-cart-footer.liquid
@@ -29,7 +29,7 @@
                   {%- if cart.cart_level_discount_applications.size > 0 -%}
                     <ul class="discounts list-unstyled" role="list" aria-label="{{ 'customer.order.discount' | t }}">
                       {%- for discount in cart.cart_level_discount_applications -%}
-                        <li class="discounts__discount discounts__discount--end">
+                        <li class="discounts__discount discounts__discount--position">
                           {%- render 'icon-discount' -%}
                           {{ discount.title }}
                           (-{{ discount.total_allocated_amount | money }})


### PR DESCRIPTION
**Why are these changes introduced?**

When you set an automatic discount on the cart (not an individual one for items) the mention of that discount isn't aligned properly on mobile. 

If you go and add more than $100 into the cart you should see it come up under the subtotal. 

**What approach did you take?**

It had some flex styling to have it always use `flex-end` so I changed it to be a different value on mobile. 

**Demo links**

- [Store](https://os2-demo.myshopify.com/?preview_theme_id=127096520726)
- [Editor](https://os2-demo.myshopify.com/admin/themes/127096520726/editor)

**Checklist**
- [ ] Followed [theme code principles](https://github.com/Shopify/dawn/blob/main/.github/CONTRIBUTING.md#theme-code-principles)
- [ ] Linted with [Theme Check](https://github.com/Shopify/theme-check)
- [ ] Tested on [mobile](https://shopify.dev/themes/store/requirements#mobile-browser-requirements)
- [ ] Tested on [multiple browsers](https://shopify.dev/themes/store/requirements#desktop-browser-requirements)
- [ ] Tested for [accessibility](https://shopify.dev/themes/best-practices/accessibility)
