### PR TITLE
Fix for sticky menu close

### DIFF
--- a/assets/base.css
+++ b/assets/base.css
@@ -1974,6 +1974,10 @@ input[type='checkbox'] {
   transform: translateY(-100%);
 }
 
+.shopify-section-header-hidden.menu-open {
+  transform: translateY(0);
+}
+
 #shopify-section-header.animate {
   transition: transform 0.15s ease-out;
 }

--- a/assets/global.js
+++ b/assets/global.js
@@ -408,6 +408,7 @@ class HeaderDrawer extends MenuDrawer {
     this.header = this.header || document.getElementById('shopify-section-header');
     this.borderOffset = this.borderOffset || this.closest('.header-wrapper').classList.contains('header-wrapper--border-bottom') ? 1 : 0;
     document.documentElement.style.setProperty('--header-bottom-position', `${parseInt(this.header.getBoundingClientRect().bottom - this.borderOffset)}px`);
+    document.querySelector('#shopify-section-header').classList.add('menu-open');
 
     setTimeout(() => {
       this.mainDetailsToggle.classList.add('menu-opening');
@@ -416,6 +417,20 @@ class HeaderDrawer extends MenuDrawer {
     summaryElement.setAttribute('aria-expanded', true);
     trapFocus(this.mainDetailsToggle, summaryElement);
     document.body.classList.add(`overflow-hidden-${this.dataset.breakpoint}`);
+  }
+
+  closeMenuDrawer(event, elementToFocus = false) {
+    if (event !== undefined) {
+      this.mainDetailsToggle.classList.remove('menu-opening');
+      this.mainDetailsToggle.querySelectorAll('details').forEach(details =>  {
+        details.removeAttribute('open');
+        details.classList.remove('menu-opening');
+      });
+      document.body.classList.remove(`overflow-hidden-${this.dataset.breakpoint}`);
+      removeTrapFocus(elementToFocus);
+      this.closeAnimation(this.mainDetailsToggle);
+      document.querySelector('#shopify-section-header').classList.remove('menu-open');
+    }
   }
 }
 


### PR DESCRIPTION
**Why are these changes introduced?**

Fixes #896.

**What approach did you take?**

I added a class that resets the transform to `0` if the menu is open.  This accounts for the issue with the sticky header.

**Other considerations**

Technically, if you have sticky header disabled, you can focus the hamburger and then scroll and hit enter, which opens the menu and the close button is not visible... but that is expected since the close button **is** part of the header.  If you hit enter again, it will close.

Also, I wasn't really able to reproduce the bug the way it was described in the issue.  Instead, I just scrolled the header out of view while the menu open button was focused and then hit enter.  Will need to be tested with the conditions of the original issue to ensure this fix solves it - I think it will.

**Demo links**

- [Store](https://os2-demo.myshopify.com/?_ab=0&_fd=0&_sc=1&preview_theme_id=127099240470)
- [Editor](https://os2-demo.myshopify.com/admin/themes/127099240470/editor)

**Checklist**
- [ ] Followed [theme code principles](https://github.com/Shopify/dawn/blob/main/.github/CONTRIBUTING.md#theme-code-principles)
- [ ] Linted with [Theme Check](https://github.com/Shopify/theme-check)
- [ ] Tested on [mobile](https://shopify.dev/themes/store/requirements#mobile-browser-requirements)
- [ ] Tested on [multiple browsers](https://shopify.dev/themes/store/requirements#desktop-browser-requirements)
- [ ] Tested for [accessibility](https://shopify.dev/themes/best-practices/accessibility)
