### PR TITLE
Improve lazy loading strategy

### DIFF
--- a/sections/main-collection-banner.liquid
+++ b/sections/main-collection-banner.liquid
@@ -34,7 +34,6 @@
           src="{{ collection.image | img_url: '750x' }}"
           sizes="(min-width: {{ settings.page_width }}px) {{ settings.page_width | minus: 100 | divided_by: 2 }}px, (min-width: 750px) calc(50vw - 130px), calc(50vw - 55px)"
           alt="{{ collection.title | escape }}"
-          loading="lazy"
           width="{{ collection.image.width }}"
           height="{{ collection.image.height }}"
         >

--- a/sections/main-collection-product-grid.liquid
+++ b/sections/main-collection-product-grid.liquid
@@ -54,13 +54,19 @@
               {% if collection.products_count == 4 %} grid--4-col-desktop{% else %} grid--3-col-tablet grid--one-third-max grid--4-col-desktop grid--quarter-max{% endif %}
             {% endif %}">
             {%- for product in collection.products -%}
+              {% assign lazy_load = false %}
+              {%- if forloop.index != 1 and forloop.index != 2 -%}
+                {%- assign lazy_load = true -%}
+              {%- endif -%}
+
               <li class="grid__item">
                 {% render 'card-product',
                   card_product: product,
                   media_aspect_ratio: section.settings.image_ratio,
                   show_secondary_image: section.settings.show_secondary_image,
                   show_vendor: section.settings.show_vendor,
-                  show_rating: section.settings.show_rating
+                  show_rating: section.settings.show_rating,
+                  lazy_load: lazy_load
                 %}
               </li>
             {%- endfor -%}

--- a/sections/main-collection-product-grid.liquid
+++ b/sections/main-collection-product-grid.liquid
@@ -55,7 +55,7 @@
             {% endif %}">
             {%- for product in collection.products -%}
               {% assign lazy_load = false %}
-              {%- if forloop.index != 1 and forloop.index != 2 -%}
+              {%- if forloop.index > 2 -%}
                 {%- assign lazy_load = true -%}
               {%- endif -%}
 

--- a/sections/main-product.liquid
+++ b/sections/main-product.liquid
@@ -61,7 +61,7 @@
               {%- assign featured_media = product.selected_or_first_available_variant.featured_media -%}
               <li id="Slide-{{ section.id }}-{{ featured_media.id }}" class="product__media-item grid__item slider__slide is-active{% if featured_media.media_type != 'image' %} product__media-item--full{% endif %}{% if section.settings.hide_variants and variant_images contains featured_media.src %} product__media-item--variant{% endif %}" data-media-id="{{ section.id }}-{{ featured_media.id }}">
                 {%- assign media_position = 1 -%}
-                {% render 'product-thumbnail', media: featured_media, position: media_position, loop: section.settings.enable_video_looping, modal_id: section.id, xr_button: true, media_width: media_width %}
+                {% render 'product-thumbnail', media: featured_media, position: media_position, loop: section.settings.enable_video_looping, modal_id: section.id, xr_button: true, media_width: media_width, lazy_load: false %}
               </li>
             {%- endif -%}
             {%- for media in product.media -%}

--- a/sections/main-product.liquid
+++ b/sections/main-product.liquid
@@ -68,7 +68,7 @@
               {%- unless media.id == product.selected_or_first_available_variant.featured_media.id -%}
                 <li id="Slide-{{ section.id }}-{{ media.id }}" class="product__media-item grid__item slider__slide{% if product.selected_or_first_available_variant.featured_media == null and forloop.index == 1 %} is-active{% endif %}{% if media.media_type != 'image' %} product__media-item--full{% endif %}{% if section.settings.hide_variants and variant_images contains media.src %} product__media-item--variant{% endif %}" data-media-id="{{ section.id }}-{{ media.id }}">
                   {%- assign media_position = media_position | default: 0 | plus: 1 -%}
-                  {% render 'product-thumbnail', media: media, position: media_position, loop: section.settings.enable_video_looping, modal_id: section.id, xr_button: true, media_width: media_width %}
+                  {% render 'product-thumbnail', media: media, position: media_position, loop: section.settings.enable_video_looping, modal_id: section.id, xr_button: true, media_width: media_width, lazy_load: true %}
                 </li>
               {%- endunless -%}
             {%- endfor -%}

--- a/sections/main-search.liquid
+++ b/sections/main-search.liquid
@@ -166,7 +166,7 @@
             <ul class="grid grid--4-col-desktop grid--3-col-tablet grid--2-col grid--one-third-max grid--quarter-max product-grid" role="list">
               {%- for item in search.results -%}
                 {% assign lazy_load = false %}
-                {%- if forloop.index != 1 and forloop.index != 2 -%}
+                {%- if forloop.index > 2 -%}
                   {%- assign lazy_load = true -%}
                 {%- endif -%}
 

--- a/sections/main-search.liquid
+++ b/sections/main-search.liquid
@@ -165,6 +165,11 @@
             <div class="loading-overlay gradient"></div>
             <ul class="grid grid--4-col-desktop grid--3-col-tablet grid--2-col grid--one-third-max grid--quarter-max product-grid" role="list">
               {%- for item in search.results -%}
+                {% assign lazy_load = false %}
+                {%- if forloop.index != 1 and forloop.index != 2 -%}
+                  {%- assign lazy_load = true -%}
+                {%- endif -%}
+
                 <li class="grid__item{% unless item.object_type == 'product' %} grid__item--small{% endunless %}">
                   {%- case item.object_type -%}
                     {%- when 'product' -%}
@@ -174,7 +179,8 @@
                         media_aspect_ratio: section.settings.image_ratio,
                         show_secondary_image: section.settings.show_secondary_image,
                         show_vendor: section.settings.show_vendor,
-                        show_rating: section.settings.show_rating
+                        show_rating: section.settings.show_rating,
+                        lazy_load: lazy_load
                       %}
                     {%- when 'article' -%}
                       {% render 'article-card',
@@ -182,8 +188,9 @@
                         show_image: true,
                         show_date: section.settings.article_show_date,
                         show_author: section.settings.article_show_author,
-                        show_badge: true
-                        media_aspect_ratio: 1
+                        show_badge: true,
+                        media_aspect_ratio: 1,
+                        lazy_load: lazy_load
                       %}
                     {%- when 'page' -%}                
                       <div class="card-wrapper underline-links-hover">

--- a/snippets/article-card.liquid
+++ b/snippets/article-card.liquid
@@ -10,6 +10,7 @@
     - show_date: {String} The setting either show the article date or not. If it's not included it will not show the image by default
     - show_author: {String} The setting either show the article author or not. If it's not included it will not show the author by default
     - show_badge: {String} The setting either show the blog badge or not.
+    - lazy_load: {Boolean} Image should be lazy loaded. Default: true (optional)
 
     Usage:
     {% render 'article-card' blog: blog, article: article, show_image: section.settings.show_image %}
@@ -47,10 +48,10 @@
                 src="{{ article.image.src | img_url: '533x' }}"
                 sizes="(min-width: {{ settings.page_width }}px) {{ settings.page_width | minus: 100 | divided_by: 2 }}px, (min-width: 750px) calc((100vw - 130px) / 2), calc((100vw - 50px) / 2)"
                 alt="{{ article.image.src.alt | escape }}"
+                class="motion-reduce"
+                {% unless lazy_load == false %}loading="lazy"{% endunless %}
                 width="{{ article.image.width }}"
                 height="{{ article.image.height }}"
-                loading="lazy"
-                class="motion-reduce"
               >
             </div>
           </div>

--- a/snippets/article-card.liquid
+++ b/snippets/article-card.liquid
@@ -49,7 +49,7 @@
                 sizes="(min-width: {{ settings.page_width }}px) {{ settings.page_width | minus: 100 | divided_by: 2 }}px, (min-width: 750px) calc((100vw - 130px) / 2), calc((100vw - 50px) / 2)"
                 alt="{{ article.image.src.alt | escape }}"
                 class="motion-reduce"
-                {% unless lazy_load == false %}loading="lazy"{% endunless %}
+                {% if lazy_load %}loading="lazy"{% endif %}
                 width="{{ article.image.width }}"
                 height="{{ article.image.height }}"
               >

--- a/snippets/article-card.liquid
+++ b/snippets/article-card.liquid
@@ -49,7 +49,7 @@
                 sizes="(min-width: {{ settings.page_width }}px) {{ settings.page_width | minus: 100 | divided_by: 2 }}px, (min-width: 750px) calc((100vw - 130px) / 2), calc((100vw - 50px) / 2)"
                 alt="{{ article.image.src.alt | escape }}"
                 class="motion-reduce"
-                {% if lazy_load %}loading="lazy"{% endif %}
+                {% unless lazy_load == false %}loading="lazy"{% endunless %}
                 width="{{ article.image.width }}"
                 height="{{ article.image.height }}"
               >

--- a/snippets/card-product.liquid
+++ b/snippets/card-product.liquid
@@ -7,7 +7,8 @@
     - show_secondary_image: {Boolean} Show the secondary image on hover. Default: false (optional)
     - show_vendor: {Boolean} Show the product vendor. Default: false
     - show_rating: {Boolean} Show the product rating. Default: false
-    - extend_height: {Boolean} Card height extends to available container space. Default: false (optional)
+    - extend_height: {Boolean} Card height extends to available container space. Default: true (optional)
+    - lazy_load: {Boolean} Image should be lazy loaded. Default: true (optional)
 
     Usage:
     {% render 'card-product', show_vendor: section.settings.show_vendor %}
@@ -51,8 +52,8 @@
                 src="{{ card_product.featured_media | img_url: '533x' }}"
                 sizes="(min-width: {{ settings.page_width }}px) {{ settings.page_width | minus: 130 | divided_by: 4 }}px, (min-width: 990px) calc((100vw - 130px) / 4), (min-width: 750px) calc((100vw - 120px) / 3), calc((100vw - 35px) / 2)"
                 alt="{{ card_product.featured_media.alt | escape }}"
-                loading="lazy"
                 class="motion-reduce"
+                {% unless lazy_load == false %}loading="lazy"{% endunless %}
                 width="{{ card_product.featured_media.width }}"
                 height="{{ card_product.featured_media.height }}"
               >
@@ -69,10 +70,10 @@
                   src="{{ card_product.media[1] | img_url: '533x' }}"
                   sizes="(min-width: {{ settings.page_width }}px) {{ settings.page_width | minus: 130 | divided_by: 4 }}px, (min-width: 990px) calc((100vw - 130px) / 4), (min-width: 750px) calc((100vw - 120px) / 3), calc((100vw - 35px) / 2)"
                   alt="{{ card_product.media[1].alt | escape }}"
-                  loading="lazy"
                   class="motion-reduce"
-                width="{{ card_product.media[1].width }}"
-                height="{{ card_product.media[1].height }}"
+                  loading="lazy"
+                  width="{{ card_product.media[1].width }}"
+                  height="{{ card_product.media[1].height }}"
                 >
               {%- endif -%}
             </div>

--- a/snippets/card-product.liquid
+++ b/snippets/card-product.liquid
@@ -53,7 +53,7 @@
                 sizes="(min-width: {{ settings.page_width }}px) {{ settings.page_width | minus: 130 | divided_by: 4 }}px, (min-width: 990px) calc((100vw - 130px) / 4), (min-width: 750px) calc((100vw - 120px) / 3), calc((100vw - 35px) / 2)"
                 alt="{{ card_product.featured_media.alt | escape }}"
                 class="motion-reduce"
-                {% if lazy_load %}loading="lazy"{% endif %}
+                {% unless lazy_load == false %}loading="lazy"{% endunless %}
                 width="{{ card_product.featured_media.width }}"
                 height="{{ card_product.featured_media.height }}"
               >

--- a/snippets/card-product.liquid
+++ b/snippets/card-product.liquid
@@ -53,7 +53,7 @@
                 sizes="(min-width: {{ settings.page_width }}px) {{ settings.page_width | minus: 130 | divided_by: 4 }}px, (min-width: 990px) calc((100vw - 130px) / 4), (min-width: 750px) calc((100vw - 120px) / 3), calc((100vw - 35px) / 2)"
                 alt="{{ card_product.featured_media.alt | escape }}"
                 class="motion-reduce"
-                {% unless lazy_load == false %}loading="lazy"{% endunless %}
+                {% if lazy_load %}loading="lazy"{% endif %}
                 width="{{ card_product.featured_media.width }}"
                 height="{{ card_product.featured_media.height }}"
               >

--- a/snippets/product-thumbnail.liquid
+++ b/snippets/product-thumbnail.liquid
@@ -8,6 +8,7 @@
     - modal_id: {String} The product modal that will be shown by clicking the thumbnail
     - xr_button: {Boolean} Renders the "View in your space" button (shopify-xr-button) if the media is a 3D Model
     - media_width: {Float} The width percentage that the media column occupies on desktop.
+    - lazy_load: {Boolean} Image should be lazy loaded. Default: true (optional)
 
     Usage:
     {% render 'product-thumbnail',
@@ -37,7 +38,7 @@
           {{ media.preview_image | img_url: 'master' }} {{ media.preview_image.width }}w"
         src="{{ media | img_url: '1946x' }}"
         sizes="(min-width: {{ settings.page_width }}px) {{ settings.page_width | minus: 100 | times: media_width | round }}px, (min-width: 990px) calc({{ media_width | times: 100 }}vw - 10rem), (min-width: 750px) calc((100vw - 11.5rem) / 2), calc(100vw - 4rem)"
-        loading="lazy"
+        {% unless lazy_load == false %}loading="lazy"{% endunless %}
         width="973"
         height="{{ 973 | divided_by: media.preview_image.aspect_ratio | ceil }}"
         alt="{{ media.preview_image.alt | escape }}"
@@ -63,7 +64,7 @@
           {{ media.preview_image | img_url: 'master' }} {{ media.preview_image.width }}w"
         src="{{ media | img_url: '1946x' }}"
         sizes="(min-width: {{ settings.page_width }}px) {{ settings.page_width | minus: 100 | times: media_width | round }}px, (min-width: 990px) calc({{ media_width | times: 100 }}vw - 10rem), (min-width: 750px) calc((100vw - 11.5rem) / 2), calc(100vw - 4rem)"
-        loading="lazy"
+        {% unless lazy_load == false %}loading="lazy"{% endunless %}
         width="973"
         height="{{ 973 | divided_by: media.preview_image.aspect_ratio | ceil }}"
         alt="{{ media.preview_image.alt | escape }}"
@@ -102,7 +103,7 @@
         {{ media.preview_image | img_url: 'master' }} {{ media.preview_image.width }}w"
       src="{{ media | img_url: '1946x' }}"
       sizes="(min-width: {{ settings.page_width }}px) {{ settings.page_width | minus: 100 | times: media_width | round }}px, (min-width: 990px) calc({{ media_width | times: 100 }}vw - 10rem), (min-width: 750px) calc((100vw - 11.5rem) / 2), calc(100vw - 4rem)"
-      loading="lazy"
+      {% unless lazy_load == false %}loading="lazy"{% endunless %}
       width="973"
       height="{{ 973 | divided_by: media.preview_image.aspect_ratio | ceil }}"
       alt="{{ media.preview_image.alt | escape }}"
@@ -146,7 +147,7 @@
         {{ media.preview_image | img_url: 'master' }} {{ media.preview_image.width }}w"
       src="{{ media | img_url: '1946x' }}"
       sizes="(min-width: {{ settings.page_width }}px) {{ settings.page_width | minus: 100 | times: media_width | round }}px, (min-width: 990px) calc({{ media_width | times: 100 }}vw - 10rem), (min-width: 750px) calc((100vw - 11.5rem) / 2), calc(100vw - 4rem)"
-      loading="lazy"
+      {% unless lazy_load == false %}loading="lazy"{% endunless %}
       width="973"
       height="{{ 973 | divided_by: media.preview_image.aspect_ratio | ceil }}"
       alt="{{ media.preview_image.alt | escape }}"

--- a/snippets/product-thumbnail.liquid
+++ b/snippets/product-thumbnail.liquid
@@ -38,7 +38,7 @@
           {{ media.preview_image | img_url: 'master' }} {{ media.preview_image.width }}w"
         src="{{ media | img_url: '1946x' }}"
         sizes="(min-width: {{ settings.page_width }}px) {{ settings.page_width | minus: 100 | times: media_width | round }}px, (min-width: 990px) calc({{ media_width | times: 100 }}vw - 10rem), (min-width: 750px) calc((100vw - 11.5rem) / 2), calc(100vw - 4rem)"
-        {% if lazy_load %}loading="lazy"{% endif %}
+        {% unless lazy_load == false %}loading="lazy"{% endunless %}
         width="973"
         height="{{ 973 | divided_by: media.preview_image.aspect_ratio | ceil }}"
         alt="{{ media.preview_image.alt | escape }}"
@@ -64,7 +64,7 @@
           {{ media.preview_image | img_url: 'master' }} {{ media.preview_image.width }}w"
         src="{{ media | img_url: '1946x' }}"
         sizes="(min-width: {{ settings.page_width }}px) {{ settings.page_width | minus: 100 | times: media_width | round }}px, (min-width: 990px) calc({{ media_width | times: 100 }}vw - 10rem), (min-width: 750px) calc((100vw - 11.5rem) / 2), calc(100vw - 4rem)"
-        {% if lazy_load %}loading="lazy"{% endif %}
+        {% unless lazy_load == false %}loading="lazy"{% endunless %}
         width="973"
         height="{{ 973 | divided_by: media.preview_image.aspect_ratio | ceil }}"
         alt="{{ media.preview_image.alt | escape }}"
@@ -103,7 +103,7 @@
         {{ media.preview_image | img_url: 'master' }} {{ media.preview_image.width }}w"
       src="{{ media | img_url: '1946x' }}"
       sizes="(min-width: {{ settings.page_width }}px) {{ settings.page_width | minus: 100 | times: media_width | round }}px, (min-width: 990px) calc({{ media_width | times: 100 }}vw - 10rem), (min-width: 750px) calc((100vw - 11.5rem) / 2), calc(100vw - 4rem)"
-      {% if lazy_load %}loading="lazy"{% endif %}
+      {% unless lazy_load == false %}loading="lazy"{% endunless %}
       width="973"
       height="{{ 973 | divided_by: media.preview_image.aspect_ratio | ceil }}"
       alt="{{ media.preview_image.alt | escape }}"
@@ -147,7 +147,7 @@
         {{ media.preview_image | img_url: 'master' }} {{ media.preview_image.width }}w"
       src="{{ media | img_url: '1946x' }}"
       sizes="(min-width: {{ settings.page_width }}px) {{ settings.page_width | minus: 100 | times: media_width | round }}px, (min-width: 990px) calc({{ media_width | times: 100 }}vw - 10rem), (min-width: 750px) calc((100vw - 11.5rem) / 2), calc(100vw - 4rem)"
-      {% if lazy_load %}loading="lazy"{% endif %}
+      {% unless lazy_load == false %}loading="lazy"{% endunless %}
       width="973"
       height="{{ 973 | divided_by: media.preview_image.aspect_ratio | ceil }}"
       alt="{{ media.preview_image.alt | escape }}"

--- a/snippets/product-thumbnail.liquid
+++ b/snippets/product-thumbnail.liquid
@@ -38,7 +38,7 @@
           {{ media.preview_image | img_url: 'master' }} {{ media.preview_image.width }}w"
         src="{{ media | img_url: '1946x' }}"
         sizes="(min-width: {{ settings.page_width }}px) {{ settings.page_width | minus: 100 | times: media_width | round }}px, (min-width: 990px) calc({{ media_width | times: 100 }}vw - 10rem), (min-width: 750px) calc((100vw - 11.5rem) / 2), calc(100vw - 4rem)"
-        {% unless lazy_load == false %}loading="lazy"{% endunless %}
+        {% if lazy_load %}loading="lazy"{% endif %}
         width="973"
         height="{{ 973 | divided_by: media.preview_image.aspect_ratio | ceil }}"
         alt="{{ media.preview_image.alt | escape }}"
@@ -64,7 +64,7 @@
           {{ media.preview_image | img_url: 'master' }} {{ media.preview_image.width }}w"
         src="{{ media | img_url: '1946x' }}"
         sizes="(min-width: {{ settings.page_width }}px) {{ settings.page_width | minus: 100 | times: media_width | round }}px, (min-width: 990px) calc({{ media_width | times: 100 }}vw - 10rem), (min-width: 750px) calc((100vw - 11.5rem) / 2), calc(100vw - 4rem)"
-        {% unless lazy_load == false %}loading="lazy"{% endunless %}
+        {% if lazy_load %}loading="lazy"{% endif %}
         width="973"
         height="{{ 973 | divided_by: media.preview_image.aspect_ratio | ceil }}"
         alt="{{ media.preview_image.alt | escape }}"
@@ -103,7 +103,7 @@
         {{ media.preview_image | img_url: 'master' }} {{ media.preview_image.width }}w"
       src="{{ media | img_url: '1946x' }}"
       sizes="(min-width: {{ settings.page_width }}px) {{ settings.page_width | minus: 100 | times: media_width | round }}px, (min-width: 990px) calc({{ media_width | times: 100 }}vw - 10rem), (min-width: 750px) calc((100vw - 11.5rem) / 2), calc(100vw - 4rem)"
-      {% unless lazy_load == false %}loading="lazy"{% endunless %}
+      {% if lazy_load %}loading="lazy"{% endif %}
       width="973"
       height="{{ 973 | divided_by: media.preview_image.aspect_ratio | ceil }}"
       alt="{{ media.preview_image.alt | escape }}"
@@ -147,7 +147,7 @@
         {{ media.preview_image | img_url: 'master' }} {{ media.preview_image.width }}w"
       src="{{ media | img_url: '1946x' }}"
       sizes="(min-width: {{ settings.page_width }}px) {{ settings.page_width | minus: 100 | times: media_width | round }}px, (min-width: 990px) calc({{ media_width | times: 100 }}vw - 10rem), (min-width: 750px) calc((100vw - 11.5rem) / 2), calc(100vw - 4rem)"
-      {% unless lazy_load == false %}loading="lazy"{% endunless %}
+      {% if lazy_load %}loading="lazy"{% endif %}
       width="973"
       height="{{ 973 | divided_by: media.preview_image.aspect_ratio | ceil }}"
       alt="{{ media.preview_image.alt | escape }}"


### PR DESCRIPTION
**Why are these changes introduced?**

I was doing some performance testing with all of our most recent changes and noticed a drop in performance for both the collection page and the product page.  Looking at the Lighthouse score, a major part of the issue was the fact that we were lazy loading the above-the-fold images.

**What approach did you take?**

Originally, our thought was that because of Sections Everywhere, we can't have any guarantees that certain images are above the fold.  However, I think we can make a reasonable assumption about a vast majority of merchants - for places like the product page or collection page, they want to get to the meat of the page as quickly as possible.

On the collection page, this will mean the collection banner and/or the first product images.  On the product page, this will mean the first piece of media in the gallery.

**Other considerations**

* Other pages, like the article page, would benefit from treatment like this as well.  For now, I kept it to the critical path and only dealt with the product pages, but I'd like to do a follow-up to consider the other pages as well.
* We can't do this with non-template sections because we can't know which ones are on the page first.  I'd love a solution to this so that we can do things like not lazy load the first slideshow image if it's the first section on the page, etc...

**Demo links**

- [Store](url)
- [Editor](url)

**Checklist**
- [ ] Followed [theme code principles](https://github.com/Shopify/dawn/blob/main/.github/CONTRIBUTING.md#theme-code-principles)
- [ ] Linted with [Theme Check](https://github.com/Shopify/theme-check)
- [ ] Tested on [mobile](https://shopify.dev/themes/store/requirements#mobile-browser-requirements)
- [ ] Tested on [multiple browsers](https://shopify.dev/themes/store/requirements#desktop-browser-requirements)
- [ ] Tested for [accessibility](https://shopify.dev/themes/best-practices/accessibility)
