### PR TITLE
Re-apply mobile padding overrides to sliders

### DIFF
--- a/assets/section-collection-list.css
+++ b/assets/section-collection-list.css
@@ -13,6 +13,11 @@
     padding-right: 0;
   }
 
+  .section-collection-list .page-width {
+    padding-left: 0;
+    padding-right: 0;
+  }
+
   .section-collection-list .collection-list:not(.slider) {
     padding-left: 1.5rem;
     padding-right: 1.5rem;

--- a/assets/section-multicolumn.css
+++ b/assets/section-multicolumn.css
@@ -14,6 +14,11 @@
   .multicolumn .title-wrapper-with-link {
     margin-bottom: 3rem;
   }
+
+  .multicolumn .page-width {
+    padding-left: 0;
+    padding-right: 0;
+  }
 }
 
 .multicolumn-card__image-wrapper--third-width {


### PR DESCRIPTION
**Why are these changes introduced?**

Fixes #1072 

Only noticed the issue on Multicolumn and Collection List.

**What approach did you take?**

Collection list and multicolumn rely on overriding the left/right padding from the `page-width` class on mobile. They're each configured to manage their own padding so they can deal with the slider being enable or disabled. Presumably these overrides were removed in another PR so I've just added them back in.

There's almost certainly a more general global rule we can implement here to account for these types of cases, but reapplying the original solution here is fine for now.

**Other considerations**

For testing..
- Multicolumn, no slider, mobile/tablet breakpoints
- Multicolumn, slider, mobile/tablet breakpoints
- Collection list, no slider, mobile/tablet breakpoints
- Collection list, slider, mobile/tablet breakpoints (note: uses slider up to tablet)

**Demo links**

- [Editor](https://os2-demo.myshopify.com/admin/themes/127102124054/editor)

**Checklist**
- [ ] Followed [theme code principles](https://github.com/Shopify/dawn/blob/main/.github/CONTRIBUTING.md#theme-code-principles)
- [ ] Linted with [Theme Check](https://github.com/Shopify/theme-check)
- [ ] Tested on [mobile](https://shopify.dev/themes/store/requirements#mobile-browser-requirements)
- [ ] Tested on [multiple browsers](https://shopify.dev/themes/store/requirements#desktop-browser-requirements)
- [ ] Tested for [accessibility](https://shopify.dev/themes/best-practices/accessibility)
