### PR TITLE
Collapsible row setting reordering to match section

### DIFF
--- a/sections/main-product.liquid
+++ b/sections/main-product.liquid
@@ -785,16 +785,6 @@
           "label": "t:sections.main-product.blocks.collapsible_tab.settings.heading.label"
         },
         {
-          "type": "richtext",
-          "id": "content",
-          "label": "t:sections.main-product.blocks.collapsible_tab.settings.content.label"
-        },
-        {
-          "type": "page",
-          "id": "page",
-          "label": "t:sections.main-product.blocks.collapsible_tab.settings.page.label"
-        },
-        {
           "type": "select",
           "id": "icon",
           "options": [
@@ -897,6 +887,16 @@
           ],
           "default": "check_mark",
           "label": "t:sections.main-product.blocks.collapsible_tab.settings.icon.label"
+        },
+        {
+          "type": "richtext",
+          "id": "content",
+          "label": "t:sections.main-product.blocks.collapsible_tab.settings.content.label"
+        },
+        {
+          "type": "page",
+          "id": "page",
+          "label": "t:sections.main-product.blocks.collapsible_tab.settings.page.label"
         }
       ]
     },


### PR DESCRIPTION
**Why are these changes introduced?**

Fixes https://github.com/Shopify/dawn/issues/1101.

**What approach did you take?**

I move the setting to be after the heading to match latest decisions that were made for the section.

**Other considerations**

Look at both `Collapsible row` block setting from the `Product information`  and  `Collapsible content` sections to witness the change.

**Demo links**

- [Editor](https://os2-demo.myshopify.com/admin/themes/127105073174/editor?previewPath=%2Fproducts%2Fbo-soft-strap-brown&section=template--15108905533462__main&block=template--15108905533462__main%2Fa6cb225f-531a-4fec-82c7-feee9e8a4351)

cc. @katycobb for visibility

-  [ ]  I  need to update the Figma settings to reflect the latest order.
