### PR TITLE
Added caret rotation + underline when menu item is open

### DIFF
--- a/assets/base.css
+++ b/assets/base.css
@@ -2359,6 +2359,10 @@ details[open] > .header__menu-item {
   text-decoration: underline;
 }
 
+details[open]:hover > .header__menu-item {
+  text-decoration-thickness: 0.2rem;
+}
+
 details[open] > .header__menu-item .icon-caret {
   transform: rotate(180deg);
 }

--- a/assets/base.css
+++ b/assets/base.css
@@ -2355,6 +2355,14 @@ details[open] > .header__icon--menu .icon-hamburger {
   text-underline-offset: 0.3rem;
 }
 
+details[open] > .header__menu-item {
+  text-decoration: underline;
+}
+
+details[open] > .header__menu-item .icon-caret {
+  transform: rotate(180deg);
+}
+
 .header__active-menu-item {
   transition: text-decoration-thickness var(--duration-short) ease;
   color: rgb(var(--color-foreground));

--- a/assets/component-list-menu.css
+++ b/assets/component-list-menu.css
@@ -19,6 +19,10 @@
   text-underline-offset: 0.3rem;
 }
 
+.list-menu__item--active:hover {
+  text-decoration-thickness: 0.2rem;
+}
+
 .list-menu--disclosure.localization-selector {
   max-height: 18rem;
   overflow: auto;


### PR DESCRIPTION
**Why are these changes introduced?**

Fixes #1190.

**What approach did you take?**

Added some CSS dependent on the direct parent details element being `[open]`.  This affects the header nav on desktop only.

**Other considerations**

We should check throughout the theme and decide whether or not to create consistent behaviours throughout for these things.  Some decisions to make around the caret flipping as well as whether any of this should be animated.  For later consideration, though @melissaperreault 

**Demo links**

- [Store](https://os2-demo.myshopify.com/?_ab=0&_fd=0&_sc=1&preview_theme_id=127107432470)
- [Editor](https://os2-demo.myshopify.com/admin/themes/127107432470/editor)

**Checklist**
- [ ] Followed [theme code principles](https://github.com/Shopify/dawn/blob/main/.github/CONTRIBUTING.md#theme-code-principles)
- [ ] Linted with [Theme Check](https://github.com/Shopify/theme-check)
- [ ] Tested on [mobile](https://shopify.dev/themes/store/requirements#mobile-browser-requirements)
- [ ] Tested on [multiple browsers](https://shopify.dev/themes/store/requirements#desktop-browser-requirements)
- [ ] Tested for [accessibility](https://shopify.dev/themes/best-practices/accessibility)
