### PR TITLE
Fixed JS error - featured product section on product page

### DIFF
--- a/sections/main-product.liquid
+++ b/sections/main-product.liquid
@@ -559,7 +559,7 @@
     }
   }
 
-  customElements.define('product-modal', ProductModal);
+  if (!customElements.get('product-modal')) customElements.define('product-modal', ProductModal);
 {% endjavascript %}
 
 {% if product.media.size > 0 %}


### PR DESCRIPTION
**Why are these changes introduced?**

Fixes a bug I noticed where custom elements were being redefined if there was a featured product section on the main product page.

To test you can add a featured product section on the main product page.  Note that multiple featured product sections being together didn't cause this bug because they already checked prior to defining the custom element using this same method.

**What approach did you take?**

Used the amazing `customElements.get()` to check whether or not it's defined.

**Other considerations**

I think we can use this a **lot** more to be able to inline smaller custom elements or at least allow them to be loaded only when they are needed, drastically reducing the size of the `global.js` file.

**Demo links**

- [Store](https://os2-demo.myshopify.com/?_ab=0&_fd=0&_sc=1&preview_theme_id=127107563542)
- [Editor](https://os2-demo.myshopify.com/admin/themes/127107563542/editor)

**Checklist**
- [ ] Followed [theme code principles](https://github.com/Shopify/dawn/blob/main/.github/CONTRIBUTING.md#theme-code-principles)
- [ ] Linted with [Theme Check](https://github.com/Shopify/theme-check)
- [ ] Tested on [mobile](https://shopify.dev/themes/store/requirements#mobile-browser-requirements)
- [ ] Tested on [multiple browsers](https://shopify.dev/themes/store/requirements#desktop-browser-requirements)
- [ ] Tested for [accessibility](https://shopify.dev/themes/best-practices/accessibility)
