### PR TITLE
Added calc so cart notificaiton comes up correctly w/header margin

### DIFF
--- a/sections/header.liquid
+++ b/sections/header.liquid
@@ -67,21 +67,13 @@
 </style>
 
 {%- style -%}
-  .header-wrapper {
+  .section-header {
     margin-bottom: {{ section.settings.margin_bottom | times: 0.75 | round: 0 }}px;
   }
 
-  .cart-notification {
-    top: calc(100% - {{ section.settings.margin_bottom | times: 0.75 | round: 0 }}px);
-  }
-
   @media screen and (min-width: 750px) {
-    .header-wrapper {
+    .section-header {
       margin-bottom: {{ section.settings.margin_bottom }}px;
-    }
-
-    .cart-notification {
-      top: calc(100% - {{ section.settings.margin_bottom }}px);
     }
   }
 {%- endstyle -%}
@@ -669,6 +661,7 @@
 {% schema %}
 {
   "name": "t:sections.header.name",
+  "class": "section-header",
   "settings": [
     {
       "type": "select",

--- a/sections/header.liquid
+++ b/sections/header.liquid
@@ -71,9 +71,17 @@
     margin-bottom: {{ section.settings.margin_bottom | times: 0.75 | round: 0 }}px;
   }
 
+  .cart-notification {
+    top: calc(100% - {{ section.settings.margin_bottom | times: 0.75 | round: 0 }}px);
+  }
+
   @media screen and (min-width: 750px) {
     .header-wrapper {
       margin-bottom: {{ section.settings.margin_bottom }}px;
+    }
+
+    .cart-notification {
+      top: calc(100% - {{ section.settings.margin_bottom }}px);
     }
   }
 {%- endstyle -%}


### PR DESCRIPTION
**Update**

Refactored to put the margin on a different element, thus negating the need for a calc. Thanks @KaichenWang for the idea.

**Why are these changes introduced?**

Fixes a small bug where the cart notification would not emerge from the header properly if there was a margin set in the header settings.

To test, change the margin setting in the header and notice that the Cart Notification is always properly positioned.  Before, it would be X pixels too low, where X is the value of the setting.

Test both Desktop and Mobile because the setting is applied at a fraction on mobile.

**What approach did you take?**

Added a calc that accounts for the setting.

**Demo links**

- [Store](https://os2-demo.myshopify.com/?_ab=0&_fd=0&_sc=1&preview_theme_id=127107629078)
- [Editor](https://os2-demo.myshopify.com/admin/themes/127107629078/editor)

**Checklist**
- [ ] Followed [theme code principles](https://github.com/Shopify/dawn/blob/main/.github/CONTRIBUTING.md#theme-code-principles)
- [ ] Linted with [Theme Check](https://github.com/Shopify/theme-check)
- [ ] Tested on [mobile](https://shopify.dev/themes/store/requirements#mobile-browser-requirements)
- [ ] Tested on [multiple browsers](https://shopify.dev/themes/store/requirements#desktop-browser-requirements)
- [ ] Tested for [accessibility](https://shopify.dev/themes/best-practices/accessibility)
