### PR TITLE
Add app block support to the feat. product section

### DIFF
--- a/sections/featured-product.liquid
+++ b/sections/featured-product.liquid
@@ -81,6 +81,8 @@
 
           {%- for block in section.blocks -%}
             {%- case block.type -%}
+            {%- when '@app' -%}
+              {% render block %}
             {%- when 'text' -%}
               <p class="product__text{% if block.settings.text_style == 'uppercase' %} caption-with-letter-spacing{% elsif block.settings.text_style == 'subtitle' %} subtitle{% endif %}" {{ block.shopify_attributes }}>
                 {{- block.settings.text -}}
@@ -495,6 +497,9 @@
   "tag": "section",
   "class": "section section-featured-product",
   "blocks": [
+    {
+      "type": "@app"
+    },
     {
       "type": "text",
       "name": "t:sections.featured-product.blocks.text.name",


### PR DESCRIPTION
**Why are these changes introduced?**

Fixes #1198 

**What approach did you take?**

Added the app block to the feat. product section

**Other considerations**

**Demo links**

- [Store](https://os2-demo.myshopify.com/?preview_theme_id=127114280982)
- [Editor](https://os2-demo.myshopify.com/admin/themes/127114280982/editor)

**Testing**

I added an app so you can see an option come up in `app blocks`. There isn't anything outputted, I'm not sure why but it must depending on the app and their implementation. 

I double checked and tested the same app on another os2.0 theme and the result was the same.

**Checklist**
- [ ] Followed [theme code principles](https://github.com/Shopify/dawn/blob/main/.github/CONTRIBUTING.md#theme-code-principles)
- [ ] Linted with [Theme Check](https://github.com/Shopify/theme-check)
- [ ] Tested on [mobile](https://shopify.dev/themes/store/requirements#mobile-browser-requirements)
- [ ] Tested on [multiple browsers](https://shopify.dev/themes/store/requirements#desktop-browser-requirements)
- [ ] Tested for [accessibility](https://shopify.dev/themes/best-practices/accessibility)
