### PR TITLE
Update padding input

### DIFF
--- a/assets/base.css
+++ b/assets/base.css
@@ -1717,7 +1717,7 @@ details[open] > .share-button__fallback {
 .customer .field input {
   flex-grow: 1;
   text-align: left;
-  padding: 1.5rem 2rem;
+  padding: 1.5rem;
   margin: var(--inputs-border-width);
   transition: box-shadow var(--duration-short) ease;
 }
@@ -1725,7 +1725,7 @@ details[open] > .share-button__fallback {
 .field__label,
 .customer .field label {
   font-size: 1.6rem;
-  left: calc(var(--inputs-border-width) + 1.5rem);
+  left: calc(var(--inputs-border-width) + 2rem);
   top: calc(1rem + var(--inputs-border-width));
   margin-bottom: 0;
   pointer-events: none;

--- a/assets/base.css
+++ b/assets/base.css
@@ -1745,7 +1745,7 @@ details[open] > .share-button__fallback {
 .customer .field input:-webkit-autofill ~ label {
   font-size: 1rem;
   top: calc(var(--inputs-border-width) + 0.5rem);
-  left: calc(var(--inputs-border-width) + 1.5rem);
+  left: calc(var(--inputs-border-width) + 2rem);
   letter-spacing: 0.04rem;
 }
 
@@ -1755,7 +1755,7 @@ details[open] > .share-button__fallback {
 .customer .field input:focus,
 .customer .field input:not(:placeholder-shown),
 .customer .field input:-webkit-autofill {
-  padding: 2.2rem 1.5rem 0.8rem;
+  padding: 2.2rem 1.5rem 0.8rem 2rem;
   margin: var(--inputs-border-width);
 }
 

--- a/assets/base.css
+++ b/assets/base.css
@@ -1717,7 +1717,7 @@ details[open] > .share-button__fallback {
 .customer .field input {
   flex-grow: 1;
   text-align: left;
-  padding: 1.5rem;
+  padding: 1.5rem 2rem;
   margin: var(--inputs-border-width);
   transition: box-shadow var(--duration-short) ease;
 }

--- a/assets/base.css
+++ b/assets/base.css
@@ -1745,6 +1745,7 @@ details[open] > .share-button__fallback {
 .customer .field input:-webkit-autofill ~ label {
   font-size: 1rem;
   top: calc(var(--inputs-border-width) + 0.5rem);
+  left: calc(var(--inputs-border-width) + 1.5rem);
   letter-spacing: 0.04rem;
 }
 

--- a/assets/base.css
+++ b/assets/base.css
@@ -1691,7 +1691,7 @@ details[open] > .share-button__fallback {
 .customer select {
   cursor: pointer;
   line-height: calc(1 + 0.6 / var(--font-body-scale));
-  padding: 0 1.5rem;
+  padding: 0 2rem;
   margin: var(--inputs-border-width);
   min-height: calc(var(--inputs-border-width) * 2);
 }

--- a/assets/component-cart.css
+++ b/assets/component-cart.css
@@ -103,7 +103,7 @@ cart-items {
   height: 100%;
   position: relative;
   border-radius: var(--inputs-radius);
-  padding: 1rem;
+  padding: 1rem 2rem;
 }
 
 .cart__note .text-area {

--- a/assets/section-footer.css
+++ b/assets/section-footer.css
@@ -313,7 +313,7 @@
 }
 
 .disclosure__button.localization-form__select {
-  padding: calc(1.5rem + var(--inputs-border-width));
+  padding: calc(2rem + var(--inputs-border-width));
   background: rgb(var(--color-background));
 }
 


### PR DESCRIPTION
**Why are these changes introduced?**

Fixes #981.

**What approach did you take?**
Update the padding on the right/left for inputs
Following this: https://screenshot.click/21-12-w9quo-ltwpm.png

**Other considerations**
The buttons were already fixed in a previous PR: 
https://screenshot.click/17-30-tatid-z9m6u.png

**Demo links**

- [Editor](https://os2-demo.myshopify.com/admin/themes/127114575894/editor)

**Checklist**
- [ ] Followed [theme code principles](https://github.com/Shopify/dawn/blob/main/.github/CONTRIBUTING.md#theme-code-principles)
- [ ] Linted with [Theme Check](https://github.com/Shopify/theme-check)
- [ ] Tested on [mobile](https://shopify.dev/themes/store/requirements#mobile-browser-requirements)
- [ ] Tested on [multiple browsers](https://shopify.dev/themes/store/requirements#desktop-browser-requirements)
- [ ] Tested for [accessibility](https://shopify.dev/themes/best-practices/accessibility)
