### PR TITLE
fix password input box shadow and password modal input focus

### DIFF
--- a/assets/section-password.css
+++ b/assets/section-password.css
@@ -107,7 +107,6 @@ body {
 }
 
 .password-field.field {
-  display: block;
   flex: 1 20rem;
 }
 

--- a/layout/password.liquid
+++ b/layout/password.liquid
@@ -86,7 +86,7 @@
         --card-shadow-vertical-offset: {{ settings.card_shadow_vertical_offset | divided_by: 10.0 }}rem;
         --card-shadow-blur-radius: {{ settings.card_shadow_blur | divided_by: 10.0 }}rem;
 
-        --badge-corner-radius: {{ settings.badge_corner_radius | divided_by: 10.0 }}rem;  
+        --badge-corner-radius: {{ settings.badge_corner_radius | divided_by: 10.0 }}rem;
 
         --spacing-sections-desktop: {{ settings.spacing_sections }}px;
         --spacing-sections-mobile: {% if settings.spacing_sections < 24 %}{{ settings.spacing_sections }}{% else %}{{ settings.spacing_sections | times: 0.7 | round | at_least: 20 }}{% endif %}px;
@@ -105,6 +105,7 @@
         --text-boxes-shadow-blur-radius: {{ settings.text_boxes_shadow_blur }}px;
 
         --buttons-radius: {{ settings.buttons_radius }}px;
+        --buttons-radius-outset: {% if settings.buttons_radius > 0 %}{{ settings.buttons_radius | plus: settings.buttons_border_thickness }}{% else %}0{% endif %}px;
         --buttons-border-width: {% if settings.buttons_border_opacity > 0 %}{{ settings.buttons_border_thickness }}{% else %}0{% endif %}px;
         --buttons-border-opacity: {{ settings.buttons_border_opacity | divided_by: 100.0 }};
         --buttons-shadow-opacity: {{ settings.buttons_shadow_opacity | divided_by: 100.0 }};
@@ -118,8 +119,10 @@
         --inputs-border-opacity: {{ settings.inputs_border_opacity | divided_by: 100.0 }};
         --inputs-shadow-opacity: {{ settings.inputs_shadow_opacity | divided_by: 100.0 }};
         --inputs-shadow-horizontal-offset: {{ settings.inputs_shadow_horizontal_offset }}px;
+        --inputs-margin-offset: {% if settings.inputs_shadow_vertical_offset != 0 and settings.inputs_shadow_opacity > 0 %}{{ settings.inputs_shadow_vertical_offset | abs }}{% else %}0{% endif %}px;
         --inputs-shadow-vertical-offset: {{ settings.inputs_shadow_vertical_offset }}px;
         --inputs-shadow-blur-radius: {{ settings.inputs_shadow_blur }}px;
+        --inputs-radius-outset: {% if settings.inputs_radius > 0 %}{{ settings.inputs_radius | plus: settings.inputs_border_thickness }}{% else %}0{% endif %}px;
 
         --variant-pills-radius: {{ settings.variant_pills_radius }}px;
         --variant-pills-border-width: {{ settings.variant_pills_border_thickness }}px;


### PR DESCRIPTION
**Why are these changes introduced?**
1. After the latest input update, the styles were not added to the password page for input and button outset/offset. 
2. The password input field `:focus` state was also not behaving correctly. 

<img width="753" alt="password page" src="https://user-images.githubusercontent.com/26778637/149965513-42812f70-f9bb-4deb-8c15-a745e14a06e5.png">

<img width="589" alt="password page modal" src="https://user-images.githubusercontent.com/26778637/149965546-6ad7e115-2ccb-4718-93ee-b743c465e9b4.png">


**What approach did you take?**
1. I added the three css variables to `password.liquid` 
```
--buttons-radius-outset
--inputs-margin-offset
--inputs-radius-outset
```

2. The password modal input was wrapped in a `div` whose `display` was set to `block`. I removed the `display` property so that it remains `flex` as that's what the `field` class is. 

**Testing**
- [ ] Test Mobile, Tablet, Desktop
- [ ] Password modal input `:focus`
- [ ] Password modal button styles are properly inherited 
- [ ] Password modal input looks correct - no straight border bottom 
- [ ] Password page email banner input looks correct - no straight border bottom 
- [ ] Password page email banner input button inherits correct styles 
- [ ] Safari 
- [ ] Chrome 
- [ ] Firefox  

**Demo links**
- [Editor](https://os2-demo.myshopify.com/admin/themes/127118213142/editor?previewPath=%2Fpassword)

**Checklist**
- [ ] Followed [theme code principles](https://github.com/Shopify/dawn/blob/main/.github/CONTRIBUTING.md#theme-code-principles)
- [ ] Linted with [Theme Check](https://github.com/Shopify/theme-check)
- [ ] Tested on [mobile](https://shopify.dev/themes/store/requirements#mobile-browser-requirements)
- [ ] Tested on [multiple browsers](https://shopify.dev/themes/store/requirements#desktop-browser-requirements)
- [ ] Tested for [accessibility](https://shopify.dev/themes/best-practices/accessibility)
