### PR TITLE
Replace zindex with isolate

### DIFF
--- a/assets/base.css
+++ b/assets/base.css
@@ -2771,3 +2771,7 @@ details-disclosure > details {
     }
   }
 }
+
+.isolate {
+  isolation: isolate;
+}

--- a/assets/collage.css
+++ b/assets/collage.css
@@ -5,8 +5,6 @@
 
 .collage {
   display: grid;
-  position: relative;
-  z-index: 0;
 }
 
 .collage__item > * {

--- a/assets/component-card.css
+++ b/assets/component-card.css
@@ -37,8 +37,6 @@
 
 .card .card__inner .card__media {
   overflow: hidden;
-  /* Fix for Safari border bug on hover */
-  z-index: 0;
   border-radius: calc(var(--card-corner-radius) - var(--card-border-width) - var(--card-image-padding));
 }
 

--- a/assets/component-facets.css
+++ b/assets/component-facets.css
@@ -781,7 +781,6 @@ input.mobile-facets__checkbox {
   position: absolute;
   width: 1.6rem;
   height: 1.6rem;
-  position: absolute;
   left: 2.1rem;
   top: 1.2rem;
   z-index: 0;

--- a/assets/component-newsletter.css
+++ b/assets/component-newsletter.css
@@ -23,10 +23,6 @@
   padding-right: 5rem;
 }
 
-.newsletter-form__field-wrapper .field {
-  z-index: 0;
-}
-
 .newsletter-form__message {
   justify-content: center;
   margin-bottom: 0;

--- a/assets/section-collection-list.css
+++ b/assets/section-collection-list.css
@@ -1,8 +1,3 @@
-.collection-list-wrapper {
-  position: relative;
-  z-index: 0;
-}
-
 .collection-list {
   margin-top: 0;
   margin-bottom: 0;

--- a/assets/section-contact-form.css
+++ b/assets/section-contact-form.css
@@ -1,8 +1,3 @@
-.contact-form {
-  z-index: 0;
-  position: relative;
-}
-
 .contact img {
   max-width: 100%;
 }

--- a/assets/section-featured-blog.css
+++ b/assets/section-featured-blog.css
@@ -1,8 +1,3 @@
-.blog {
-  position: relative;
-  z-index: 0;
-}
-
 .blog-placeholder {
   margin: 0 1.5rem;
   background: rgb(var(--color-background));

--- a/assets/section-featured-product.css
+++ b/assets/section-featured-product.css
@@ -1,8 +1,3 @@
-.featured-product {
-  z-index: 0;
-  position: relative;
-}
-
 .featured-product .product__media-list {
   width: 100%;
   margin: 0;

--- a/assets/section-footer.css
+++ b/assets/section-footer.css
@@ -245,10 +245,6 @@
   color: rgba(var(--color-foreground), 0.75);
 }
 
-.footer__localization {
-  z-index: 0;
-}
-
 @media screen and (min-width: 750px) {
   .footer__localization {
     padding: 0.4rem 0;

--- a/assets/section-multicolumn.css
+++ b/assets/section-multicolumn.css
@@ -1,8 +1,3 @@
-.multicolumn {
-  position: relative;
-  z-index: 0;
-}
-
 .multicolumn .title {
   margin: 0;
 }

--- a/assets/section-product-recommendations.css
+++ b/assets/section-product-recommendations.css
@@ -1,7 +1,5 @@
 .product-recommendations {
   display: block;
-  position: relative;
-  z-index: 0;
 }
 
 .product-recommendations:not(.product-recommendations--loaded) {

--- a/assets/template-collection.css
+++ b/assets/template-collection.css
@@ -1,8 +1,3 @@
-.collection {
-  position: relative;
-  z-index: 0;
-}
-
 @media screen and (max-width: 749px) {
   .collection .grid__item:only-child {
     flex: 0 0 100%;

--- a/sections/collage.liquid
+++ b/sections/collage.liquid
@@ -22,7 +22,7 @@
 <div class="color-{{ section.settings.color_scheme }} gradient">
   <div class="page-width{% if section.settings.heading == blank %} no-heading{% endif %} section-{{ section.id }}-padding">
     <h2 class="collage-wrapper-title">{{ section.settings.heading | escape }}</h2>
-    <div class="collage{% if section.settings.mobile_layout == 'collage' %} collage--mobile{% endif %} isolate">
+    <div class="collage isolate{% if section.settings.mobile_layout == 'collage' %} collage--mobile{% endif %}">
       {%- for block in section.blocks -%}
         <div class="collage__item collage__item--{{ block.type }} collage__item--{{ section.settings.desktop_layout }}" {{ block.shopify_attributes }}>
           {%- case block.type -%}

--- a/sections/collage.liquid
+++ b/sections/collage.liquid
@@ -22,7 +22,7 @@
 <div class="color-{{ section.settings.color_scheme }} gradient">
   <div class="page-width{% if section.settings.heading == blank %} no-heading{% endif %} section-{{ section.id }}-padding">
     <h2 class="collage-wrapper-title">{{ section.settings.heading | escape }}</h2>
-    <div class="collage{% if section.settings.mobile_layout == 'collage' %} collage--mobile{% endif %}">
+    <div class="collage{% if section.settings.mobile_layout == 'collage' %} collage--mobile{% endif %} isolate">
       {%- for block in section.blocks -%}
         <div class="collage__item collage__item--{{ block.type }} collage__item--{{ section.settings.desktop_layout }}" {{ block.shopify_attributes }}>
           {%- case block.type -%}

--- a/sections/collection-list.liquid
+++ b/sections/collection-list.liquid
@@ -19,7 +19,7 @@
 {%- endstyle -%}
 
 <div class="color-{{ section.settings.color_scheme }} gradient">
-  <div class="collection-list-wrapper page-width{% if section.settings.swipe_on_mobile == true %} page-width-desktop{% endif %}{% if section.settings.title == blank %} no-heading{% endif %}{% if section.settings.show_view_all == false or section.blocks.size > collections.size %} no-mobile-link{% endif %} section-{{ section.id }}-padding isolate">
+  <div class="collection-list-wrapper page-width section-{{ section.id }}-padding isolate{% if section.settings.swipe_on_mobile == true %} page-width-desktop{% endif %}{% if section.settings.title == blank %} no-heading{% endif %}{% if section.settings.show_view_all == false or section.blocks.size > collections.size %} no-mobile-link{% endif %}">
     {% unless section.settings.title == blank %}
       <div class="title-wrapper-with-link{% if section.settings.swipe_on_mobile == true %} title-wrapper--self-padded-tablet-down{% else %} title-wrapper--self-padded-mobile{% endif %}{% if section.settings.title == blank %} title-wrapper-with-link--no-heading{% endif %} title-wrapper--no-top-margin">
         <h2 class="collection-list-title">{{ section.settings.title | escape }}</h2>

--- a/sections/collection-list.liquid
+++ b/sections/collection-list.liquid
@@ -19,7 +19,7 @@
 {%- endstyle -%}
 
 <div class="color-{{ section.settings.color_scheme }} gradient">
-  <div class="collection-list-wrapper page-width{% if section.settings.swipe_on_mobile == true %} page-width-desktop{% endif %}{% if section.settings.title == blank %} no-heading{% endif %}{% if section.settings.show_view_all == false or section.blocks.size > collections.size %} no-mobile-link{% endif %} section-{{ section.id }}-padding">
+  <div class="collection-list-wrapper page-width{% if section.settings.swipe_on_mobile == true %} page-width-desktop{% endif %}{% if section.settings.title == blank %} no-heading{% endif %}{% if section.settings.show_view_all == false or section.blocks.size > collections.size %} no-mobile-link{% endif %} section-{{ section.id }}-padding isolate">
     {% unless section.settings.title == blank %}
       <div class="title-wrapper-with-link{% if section.settings.swipe_on_mobile == true %} title-wrapper--self-padded-tablet-down{% else %} title-wrapper--self-padded-mobile{% endif %}{% if section.settings.title == blank %} title-wrapper-with-link--no-heading{% endif %} title-wrapper--no-top-margin">
         <h2 class="collection-list-title">{{ section.settings.title | escape }}</h2>

--- a/sections/contact-form.liquid
+++ b/sections/contact-form.liquid
@@ -17,7 +17,7 @@
 <div class="color-{{ section.settings.color_scheme }} gradient">
   <div class="contact page-width page-width--narrow section-{{ section.id }}-padding">
     <h2 class="title title-wrapper--no-top-margin">{{ section.settings.heading | escape }}</h2>
-    {%- form 'contact', id: 'ContactForm' -%}
+    {%- form 'contact', id: 'ContactForm', class: 'isolate' -%}
       {%- if form.posted_successfully? -%}
         <div class="form-status form-status-list form__message" tabindex="-1" autofocus>{% render 'icon-success' %} {{ 'templates.contact.form.post_success' | t }}</div>
       {%- elsif form.errors -%}

--- a/sections/email-signup-banner.liquid
+++ b/sections/email-signup-banner.liquid
@@ -67,7 +67,7 @@
               {% form 'customer', class: 'newsletter-form' %}
                 <input type="hidden" name="contact[tags]" value="newsletter">
                 <div class="newsletter-form__field-wrapper">
-                  <div class="field">
+                  <div class="field isolate">
                     <input
                       id="NewsletterForm--{{ section.id }}"
                       type="email"

--- a/sections/featured-blog.liquid
+++ b/sections/featured-blog.liquid
@@ -30,7 +30,7 @@
     assign posts_displayed = section.settings.post_limit
   endif
 -%}
-<div class="blog color-{{ section.settings.color_scheme }} gradient{% if section.settings.heading == blank %} no-heading{% endif %} isolate">
+<div class="blog color-{{ section.settings.color_scheme }} gradient isolate{% if section.settings.heading == blank %} no-heading{% endif %}">
   <div class="page-width-desktop{% if posts_displayed < 3 %} page-width-tablet{% endif %} section-{{ section.id }}-padding">
     <div class="title-wrapper-with-link{% if section.settings.heading == blank %} title-wrapper-with-link--no-heading{% endif %} {% if posts_displayed > 2 %}title-wrapper--self-padded-tablet-down{% else %}title-wrapper--self-padded-mobile{% endif %} title-wrapper--no-top-margin">
       <h2 class="blog__title">{{ section.settings.heading | escape }}</h2>

--- a/sections/featured-blog.liquid
+++ b/sections/featured-blog.liquid
@@ -30,7 +30,7 @@
     assign posts_displayed = section.settings.post_limit
   endif
 -%}
-<div class="blog color-{{ section.settings.color_scheme }} gradient{% if section.settings.heading == blank %} no-heading{% endif %}">
+<div class="blog color-{{ section.settings.color_scheme }} gradient{% if section.settings.heading == blank %} no-heading{% endif %} isolate">
   <div class="page-width-desktop{% if posts_displayed < 3 %} page-width-tablet{% endif %} section-{{ section.id }}-padding">
     <div class="title-wrapper-with-link{% if section.settings.heading == blank %} title-wrapper-with-link--no-heading{% endif %} {% if posts_displayed > 2 %}title-wrapper--self-padded-tablet-down{% else %}title-wrapper--self-padded-mobile{% endif %} title-wrapper--no-top-margin">
       <h2 class="blog__title">{{ section.settings.heading | escape }}</h2>

--- a/sections/featured-collection.liquid
+++ b/sections/featured-collection.liquid
@@ -31,7 +31,7 @@
 -%}
 
 <div class="color-{{ section.settings.color_scheme }} gradient">
-  <div class="collection page-width{% if section.settings.swipe_on_mobile == true and section.settings.collection.all_products_count > 2 and section.settings.products_to_show > 2 %} page-width-desktop{% endif %} section-{{ section.id }}-padding">
+  <div class="collection page-width{% if section.settings.swipe_on_mobile == true and section.settings.collection.all_products_count > 2 and section.settings.products_to_show > 2 %} page-width-desktop{% endif %} section-{{ section.id }}-padding isolate">
     {% unless section.settings.title == blank %}
       <div class="title-wrapper-with-link{% if section.settings.title == blank %} title-wrapper-with-link--no-heading{% endif %}{% if section.settings.collection.all_products_count > 2 and section.settings.swipe_on_mobile and section.settings.products_to_show > 2 %} title-wrapper--self-padded-tablet-down{% endif %} title-wrapper--no-top-margin">
         <h2 class="title{% if section.settings.title == blank %} title--no-heading{% endif %}">{{ section.settings.title | escape }}</h2>

--- a/sections/featured-collection.liquid
+++ b/sections/featured-collection.liquid
@@ -31,7 +31,7 @@
 -%}
 
 <div class="color-{{ section.settings.color_scheme }} gradient">
-  <div class="collection page-width{% if section.settings.swipe_on_mobile == true and section.settings.collection.all_products_count > 2 and section.settings.products_to_show > 2 %} page-width-desktop{% endif %} section-{{ section.id }}-padding isolate">
+  <div class="collection page-width section-{{ section.id }}-padding isolate{% if section.settings.swipe_on_mobile == true and section.settings.collection.all_products_count > 2 and section.settings.products_to_show > 2 %} page-width-desktop{% endif %}">
     {% unless section.settings.title == blank %}
       <div class="title-wrapper-with-link{% if section.settings.title == blank %} title-wrapper-with-link--no-heading{% endif %}{% if section.settings.collection.all_products_count > 2 and section.settings.swipe_on_mobile and section.settings.products_to_show > 2 %} title-wrapper--self-padded-tablet-down{% endif %} title-wrapper--no-top-margin">
         <h2 class="title{% if section.settings.title == blank %} title--no-heading{% endif %}">{{ section.settings.title | escape }}</h2>

--- a/sections/featured-product.liquid
+++ b/sections/featured-product.liquid
@@ -32,7 +32,7 @@
 
 <section class="color-{{ section.settings.color_scheme }} {% if section.settings.secondary_background %}background-secondary{% else %}gradient{% endif %}">
   <div class="page-width section-{{ section.id }}-padding">
-    <div class="featured-product product grid grid--1-col gradient color-{{ section.settings.color_scheme }} {% if product.media.size > 0 %}grid--2-col-tablet{% else %}product--no-media{% endif %} isolate">
+    <div class="featured-product product grid grid--1-col gradient color-{{ section.settings.color_scheme }} isolate {% if product.media.size > 0 %}grid--2-col-tablet{% else %}product--no-media{% endif %}">
       <div class="grid__item product__media-wrapper">
         <media-gallery id="MediaGallery-{{ section.id }}" role="region" aria-label="{{ 'products.product.media.gallery_viewer' | t }}" data-desktop-layout="stacked">
           <a class="skip-to-content-link button visually-hidden" href="#ProductInfo-{{ section.id }}">

--- a/sections/featured-product.liquid
+++ b/sections/featured-product.liquid
@@ -32,7 +32,7 @@
 
 <section class="color-{{ section.settings.color_scheme }} {% if section.settings.secondary_background %}background-secondary{% else %}gradient{% endif %}">
   <div class="page-width section-{{ section.id }}-padding">
-    <div class="featured-product product grid grid--1-col gradient color-{{ section.settings.color_scheme }} {% if product.media.size > 0 %}grid--2-col-tablet{% else %}product--no-media{% endif %}">
+    <div class="featured-product product grid grid--1-col gradient color-{{ section.settings.color_scheme }} {% if product.media.size > 0 %}grid--2-col-tablet{% else %}product--no-media{% endif %} isolate">
       <div class="grid__item product__media-wrapper">
         <media-gallery id="MediaGallery-{{ section.id }}" role="region" aria-label="{{ 'products.product.media.gallery_viewer' | t }}" data-desktop-layout="stacked">
           <a class="skip-to-content-link button visually-hidden" href="#ProductInfo-{{ section.id }}">

--- a/sections/footer.liquid
+++ b/sections/footer.liquid
@@ -105,7 +105,7 @@
             {%- form 'customer', id: 'ContactFooter', class: 'footer__newsletter newsletter-form' -%}
               <input type="hidden" name="contact[tags]" value="newsletter">
               <div class="newsletter-form__field-wrapper">
-                <div class="field">
+                <div class="field isolate">
                   <input
                     id="NewsletterForm--{{ section.id }}"
                     type="email"
@@ -226,7 +226,7 @@
 
   <div class="footer__content-bottom">
     <div class="footer__content-bottom-wrapper page-width">
-      <div class="footer__column footer__localization">
+      <div class="footer__column footer__localization isolate">
         {%- if section.settings.enable_country_selector and localization.available_countries.size > 1 -%}
           <noscript>
             {%- form 'localization', id: 'FooterCountryFormNoScript', class: 'localization-form' -%}

--- a/sections/main-cart-footer.liquid
+++ b/sections/main-cart-footer.liquid
@@ -52,7 +52,7 @@
                 </small>
               </div>
             {%- else -%}
-              <div class="cart__ctas" {{ block.shopify_attributes }}>
+              <div class="cart__ctas isolate" {{ block.shopify_attributes }}>
                 <noscript>
                   <button type="submit" class="cart__update-button button button--secondary" form="cart">
                     {{ 'sections.cart.update' | t }}

--- a/sections/multicolumn.liquid
+++ b/sections/multicolumn.liquid
@@ -16,7 +16,7 @@
   }
 {%- endstyle -%}
 
-<div class="multicolumn color-{{ section.settings.color_scheme }} gradient{% unless section.settings.background_style == 'none' and settings.text_boxes_border_thickness > 0 or settings.text_boxes_shadow_opacity > 0 %} background-{{ section.settings.background_style }}{% endunless %}{% if section.settings.title == blank %} no-heading{% endif %} isolate">
+<div class="multicolumn color-{{ section.settings.color_scheme }} gradient isolate{% unless section.settings.background_style == 'none' and settings.text_boxes_border_thickness > 0 or settings.text_boxes_shadow_opacity > 0 %} background-{{ section.settings.background_style }}{% endunless %}{% if section.settings.title == blank %} no-heading{% endif %}">
   <div class="page-width section-{{ section.id }}-padding">
     {% unless section.settings.title == blank %}
       <div class="title-wrapper-with-link title-wrapper--self-padded-mobile title-wrapper--no-top-margin{% if section.settings.title == blank %} title-wrapper-with-link--no-heading{% endif %}">

--- a/sections/multicolumn.liquid
+++ b/sections/multicolumn.liquid
@@ -16,7 +16,7 @@
   }
 {%- endstyle -%}
 
-<div class="multicolumn color-{{ section.settings.color_scheme }} gradient{% unless section.settings.background_style == 'none' and settings.text_boxes_border_thickness > 0 or settings.text_boxes_shadow_opacity > 0 %} background-{{ section.settings.background_style }}{% endunless %}{% if section.settings.title == blank %} no-heading{% endif %}">
+<div class="multicolumn color-{{ section.settings.color_scheme }} gradient{% unless section.settings.background_style == 'none' and settings.text_boxes_border_thickness > 0 or settings.text_boxes_shadow_opacity > 0 %} background-{{ section.settings.background_style }}{% endunless %}{% if section.settings.title == blank %} no-heading{% endif %} isolate">
   <div class="page-width section-{{ section.id }}-padding">
     {% unless section.settings.title == blank %}
       <div class="title-wrapper-with-link title-wrapper--self-padded-mobile title-wrapper--no-top-margin{% if section.settings.title == blank %} title-wrapper-with-link--no-heading{% endif %}">

--- a/sections/newsletter.liquid
+++ b/sections/newsletter.liquid
@@ -29,7 +29,7 @@
           <div {{ block.shopify_attributes }}>
             {% form 'customer', class: 'newsletter-form' %}
               <input type="hidden" name="contact[tags]" value="newsletter">
-              <div class="newsletter-form__field-wrapper">
+              <div class="newsletter-form__field-wrapper isolate">
                 <div class="field">
                   <input
                     id="NewsletterForm--{{ section.id }}"

--- a/sections/product-recommendations.liquid
+++ b/sections/product-recommendations.liquid
@@ -21,7 +21,7 @@
 {%- endstyle -%}
 
 <div class="color-{{ section.settings.color_scheme }} gradient">
-  <product-recommendations class="product-recommendations page-width section-{{ section.id }}-padding" data-url="{{ routes.product_recommendations_url }}?section_id={{ section.id }}&product_id={{ product.id }}&limit=4">
+  <product-recommendations class="product-recommendations page-width section-{{ section.id }}-padding isolate" data-url="{{ routes.product_recommendations_url }}?section_id={{ section.id }}&product_id={{ product.id }}&limit=4">
     {% if recommendations.performed and recommendations.products_count > 0 %}
       <h2 class="product-recommendations__heading">{{ section.settings.heading | escape }}</h2>
       <ul class="grid grid--2-col product-grid{% if recommendations.products_count > 3 %} grid--4-col-desktop grid--quarter-max{% else %} grid--{{ recommendations.products_count }}-col-tablet{% endif %}" role="list">

--- a/snippets/article-card.liquid
+++ b/snippets/article-card.liquid
@@ -35,7 +35,7 @@
     >
       <div class="card__inner {% if settings.card_style == 'standard' %} color-{{ settings.card_color_scheme }}{% endif %}{% if article.image and show_image or settings.card_style == 'standard' %} ratio{% endif %}" style="--ratio-percent: {{ 1 | divided_by: ratio | times: 100 }}%;">
         {%- if show_image == true and article.image -%}
-          <div class="article-card__image-wrapper card__media">
+          <div class="article-card__image-wrapper card__media isolate">
             <div class="article-card__image media media--hover-effect" {% if section.settings.media_height == 'adapt' %} style="padding-bottom: {{ 1 | divided_by: article.image.aspect_ratio | times: 100 }}%;"{% endif %}>
               <img
                 srcset="{%- if article.image.src.width >= 165 -%}{{ article.image.src | img_url: '165x' }} 165w,{%- endif -%}

--- a/snippets/card-collection.liquid
+++ b/snippets/card-collection.liquid
@@ -34,7 +34,7 @@
   >
     <div class="card__inner {% if settings.card_style == 'standard' %}color-{{ settings.card_color_scheme }}{% endif %}{% if card_collection.featured_image or settings.card_style == 'standard' %} ratio{% endif %}" style="--ratio-percent: {{ 1 | divided_by: ratio | times: 100 }}%;">
       {%- if card_collection.featured_image -%}
-        <div class="card__media">
+        <div class="card__media isolate">
           <div class="media media--transparent media--hover-effect">
             <img
               srcset="{%- if card_collection.featured_image.width >= 165 -%}{{ card_collection.featured_image | img_url: '165x' }} 165w,{%- endif -%}

--- a/snippets/card-product.liquid
+++ b/snippets/card-product.liquid
@@ -39,7 +39,7 @@
     >
       <div class="card__inner {% if settings.card_style == 'standard' %}color-{{ settings.card_color_scheme }}{% endif %}{% if card_product.featured_media or settings.card_style == 'standard' %} ratio{% endif %}" style="--ratio-percent: {{ 1 | divided_by: ratio | times: 100 }}%;">
         {%- if card_product.featured_media -%}
-          <div class="card__media">
+          <div class="card__media isolate">
             <div class="media media--transparent media--hover-effect">
               <img
                 srcset="{%- if card_product.featured_media.width >= 165 -%}{{ card_product.featured_media | img_url: '165x' }} 165w,{%- endif -%}


### PR DESCRIPTION
**Why are these changes introduced?**
I am replacing `z-index: 0` and `position: relative` with `isolate`. Where to test (add shadow to the buttons and inputs in global settings):

- Collage (button)
- Newsletter (input)
- Collection list (button)
- Contact form (input)
- Featured blog (button)
- Featured product (button and input)
- Footer (localization dropdown)
- Multicolumn (button)
- Product recommendation (button)
- Collection (button)
- Cards (card shadows)

Example: https://screenshot.click/18-18-chunj-13oy1.mp4

Fixes #1206 .

Original comment: https://github.com/Shopify/dawn/pull/1205#discussion_r786878616

**What approach did you take?**
By doing this we are removing 40+ lines of code! More on `isolate` here: https://developer.mozilla.org/en-US/docs/Web/CSS/isolation

**Other considerations**

**Demo links**

- [Editor](https://os2-demo.myshopify.com/admin/themes/127453888534/editor)

**Checklist**
- [ ] Followed [theme code principles](https://github.com/Shopify/dawn/blob/main/.github/CONTRIBUTING.md#theme-code-principles)
- [ ] Linted with [Theme Check](https://github.com/Shopify/theme-check)
- [ ] Tested on [mobile](https://shopify.dev/themes/store/requirements#mobile-browser-requirements)
- [ ] Tested on [multiple browsers](https://shopify.dev/themes/store/requirements#desktop-browser-requirements)
- [ ] Tested for [accessibility](https://shopify.dev/themes/best-practices/accessibility)
