### PR TITLE
Fix drop shadow issue in Safari for menu and filter

### DIFF
--- a/assets/base.css
+++ b/assets/base.css
@@ -2557,6 +2557,8 @@ details[open] > .header__menu-item .icon-caret {
     var(--popup-shadow-blur-radius)
     rgba(var(--color-shadow), var(--popup-shadow-opacity))
   );
+  /* fix drop-shadow issue in Safari */
+  will-change: filter;
 }
 
 .header__submenu.list-menu {

--- a/assets/base.css
+++ b/assets/base.css
@@ -2551,14 +2551,7 @@ details[open] > .header__menu-item .icon-caret {
   border-color: rgba(var(--color-foreground), var(--popup-border-opacity));
   border-style: solid;
   border-width: var(--popup-border-width);
-  filter: drop-shadow(
-    var(--popup-shadow-horizontal-offset)
-    var(--popup-shadow-vertical-offset)
-    var(--popup-shadow-blur-radius)
-    rgba(var(--color-shadow), var(--popup-shadow-opacity))
-  );
-  /* fix drop-shadow issue in Safari */
-  will-change: filter;
+  box-shadow: var(--popup-shadow-horizontal-offset) var(--popup-shadow-vertical-offset) var(--popup-shadow-blur-radius) rgba(var(--color-shadow), var(--popup-shadow-opacity));
 }
 
 .header__submenu.list-menu {

--- a/assets/component-facets.css
+++ b/assets/component-facets.css
@@ -78,7 +78,7 @@
 
 .facet-filters__field .select:after,
 .facet-filters__field .select:before,
-.mobile-facets__sort .select:after, 
+.mobile-facets__sort .select:after,
 .mobile-facets__sort .select:before {
   content: none;
 }
@@ -251,6 +251,8 @@
   width: 35rem;
   max-height: 55rem;
   overflow-y: auto;
+  /* fix drop-shadow issue in Safari */
+  will-change: filter;
 }
 
 .facets__header {

--- a/assets/component-facets.css
+++ b/assets/component-facets.css
@@ -238,12 +238,7 @@
   border-style: solid;
   border-color: rgba(var(--color-foreground), var(--popup-border-opacity));
   border-radius: var(--popup-corner-radius);
-  filter: drop-shadow(
-    var(--popup-shadow-horizontal-offset)
-    var(--popup-shadow-vertical-offset)
-    var(--popup-shadow-blur-radius)
-    rgba(var(--color-shadow), var(--popup-shadow-opacity))
-  );
+  box-shadow: var(--popup-shadow-horizontal-offset) var(--popup-shadow-vertical-offset) var(--popup-shadow-blur-radius) rgba(var(--color-shadow), var(--popup-shadow-opacity));
   background-color: rgb(var(--color-background));
   position: absolute;
   top: calc(100% + 0.5rem);
@@ -251,8 +246,6 @@
   width: 35rem;
   max-height: 55rem;
   overflow-y: auto;
-  /* fix drop-shadow issue in Safari */
-  will-change: filter;
 }
 
 .facets__header {

--- a/assets/component-predictive-search.css
+++ b/assets/component-predictive-search.css
@@ -10,14 +10,7 @@
   z-index: 3;
   border-bottom-right-radius: var(--popup-corner-radius);
   border-bottom-left-radius: var(--popup-corner-radius);
-  filter: drop-shadow(
-    var(--popup-shadow-horizontal-offset)
-    var(--popup-shadow-vertical-offset)
-    var(--popup-shadow-blur-radius)
-    rgba(var(--color-shadow), var(--popup-shadow-opacity))
-  );
-  /* fix drop-shadow issue in Safari */
-  transform: translateZ(0);
+  box-shadow: var(--popup-shadow-horizontal-offset) var(--popup-shadow-vertical-offset) var(--popup-shadow-blur-radius) rgba(var(--color-shadow), var(--popup-shadow-opacity));
 }
 
 .predictive-search--search-template {

--- a/assets/component-predictive-search.css
+++ b/assets/component-predictive-search.css
@@ -16,6 +16,8 @@
     var(--popup-shadow-blur-radius)
     rgba(var(--color-shadow), var(--popup-shadow-opacity))
   );
+  /* fix drop-shadow issue in Safari */
+  transform: translateZ(0);
 }
 
 .predictive-search--search-template {

--- a/assets/disclosure.css
+++ b/assets/disclosure.css
@@ -32,12 +32,7 @@
   z-index: 2;
   background-color: rgb(var(--color-background));
   border-radius: var(--popup-corner-radius);
-  filter: drop-shadow(
-    var(--popup-shadow-horizontal-offset)
-    var(--popup-shadow-vertical-offset)
-    var(--popup-shadow-blur-radius)
-    rgba(var(--color-shadow), var(--popup-shadow-opacity))
-  );
+  box-shadow: var(--popup-shadow-horizontal-offset) var(--popup-shadow-vertical-offset) var(--popup-shadow-blur-radius) rgba(var(--color-shadow), var(--popup-shadow-opacity));
 }
 
 .disclosure__item {

--- a/assets/section-main-product.css
+++ b/assets/section-main-product.css
@@ -832,6 +832,12 @@ a.product__text {
   var(--popup-shadow-horizontal-offset) var(--popup-shadow-vertical-offset) var(--popup-shadow-blur-radius) rgba(var(--color-shadow), var(--popup-shadow-opacity));
 }
 
+.product-popup-modal__content:focus-visible{
+  box-shadow: 0 0 0 0.3rem rgb(var(--color-background)),
+  0 0 0.5rem 0.4rem rgba(var(--color-foreground), 0.3),
+  var(--popup-shadow-horizontal-offset) var(--popup-shadow-vertical-offset) var(--popup-shadow-blur-radius) rgba(var(--color-shadow), var(--popup-shadow-opacity));
+}
+
 @media screen and (min-width: 750px) {
   .product-popup-modal__content {
     padding-right: 1.5rem;

--- a/assets/section-main-product.css
+++ b/assets/section-main-product.css
@@ -829,6 +829,8 @@ a.product__text {
     var(--popup-shadow-blur-radius)
     rgba(var(--color-foreground), var(--popup-shadow-opacity))
   );
+  /* Fix for safari shadow */
+  will-change: filter;
 }
 
 @media screen and (min-width: 750px) {

--- a/assets/section-main-product.css
+++ b/assets/section-main-product.css
@@ -823,14 +823,13 @@ a.product__text {
   border-color: rgba(var(--color-foreground), var(--popup-border-opacity));
   border-style: solid;
   border-width: var(--popup-border-width);
-  filter: drop-shadow(
-    var(--popup-shadow-horizontal-offset)
-    var(--popup-shadow-vertical-offset)
-    var(--popup-shadow-blur-radius)
-    rgba(var(--color-foreground), var(--popup-shadow-opacity))
-  );
-  /* Fix for safari shadow */
-  will-change: filter;
+  box-shadow: var(--popup-shadow-horizontal-offset) var(--popup-shadow-vertical-offset) var(--popup-shadow-blur-radius) rgba(var(--color-shadow), var(--popup-shadow-opacity));
+}
+
+.product-popup-modal__content.focused {
+  box-shadow: 0 0 0 0.3rem rgb(var(--color-background)),
+  0 0 0.5rem 0.4rem rgba(var(--color-foreground), 0.3),
+  var(--popup-shadow-horizontal-offset) var(--popup-shadow-vertical-offset) var(--popup-shadow-blur-radius) rgba(var(--color-shadow), var(--popup-shadow-opacity));
 }
 
 @media screen and (min-width: 750px) {


### PR DESCRIPTION
**Why are these changes introduced?**

Fixes #1213 issue with drop shadow on the menu dropdown and filter in Safari: [video](https://screenshot.click/22-01-732uy-lcn0h.mp4)

**What approach did you take?**

On predictive search, the `transform` approach work but not on the dropdown/popup of the filter and header menu.

**Other considerations**

Not super stoked to use will-change like this as it's meant to be used sparingly
Could also take a bit more time and see if it'd be worth tackling those box shadows with pseudo elements like in other part of the theme. 

**Testing**

To test you can follow the steps in the video shared above. Basically:
- add shadow on popups and check in Safari to make sure there isn't anything weird happening on : 
    - predictive search
    - filter drop down
    - and menu popup/dropdown

**Demo links**

- [Store](https://os2-demo.myshopify.com/?preview_theme_id=127455035414)
- [Editor](https://os2-demo.myshopify.com/admin/themes/127455035414/editor)

**Checklist**
- [ ] Followed [theme code principles](https://github.com/Shopify/dawn/blob/main/.github/CONTRIBUTING.md#theme-code-principles)
- [ ] Linted with [Theme Check](https://github.com/Shopify/theme-check)
- [ ] Tested on [mobile](https://shopify.dev/themes/store/requirements#mobile-browser-requirements)
- [ ] Tested on [multiple browsers](https://shopify.dev/themes/store/requirements#desktop-browser-requirements)
- [ ] Tested for [accessibility](https://shopify.dev/themes/best-practices/accessibility)
