### PR TITLE
Fixed password alignment

### DIFF
--- a/assets/section-password.css
+++ b/assets/section-password.css
@@ -329,4 +329,5 @@ details.modal .modal__toggle-open {
 
 password-modal {
   justify-self: flex-end;
+  grid-column: 3;
 }


### PR DESCRIPTION
**Why are these changes introduced?**

Fixes #1109

To test - go to the password page and ensure the password link is always aligned to the right.  Try without any content in the second container and ensure things are still aligned.

**What approach did you take?**

Added a grid column to ensure the password is always in the third column.

**Other considerations**

**Demo links**

- [Store](https://os2-demo.myshopify.com/?_ab=0&_fd=0&_sc=1&preview_theme_id=127456149526)
- [Editor](https://os2-demo.myshopify.com/admin/themes/127456149526/editor)

**Checklist**
- [ ] Followed [theme code principles](https://github.com/Shopify/dawn/blob/main/.github/CONTRIBUTING.md#theme-code-principles)
- [ ] Linted with [Theme Check](https://github.com/Shopify/theme-check)
- [ ] Tested on [mobile](https://shopify.dev/themes/store/requirements#mobile-browser-requirements)
- [ ] Tested on [multiple browsers](https://shopify.dev/themes/store/requirements#desktop-browser-requirements)
- [ ] Tested for [accessibility](https://shopify.dev/themes/best-practices/accessibility)
