### PR TITLE
Fix product thumbnail active state

### DIFF
--- a/assets/section-main-product.css
+++ b/assets/section-main-product.css
@@ -1068,7 +1068,7 @@ a.product__text {
 
 .thumbnail[aria-current]:focus:not(:focus-visible) {
   outline: 0;
-  box-shadow: none;
+  box-shadow: 0 0 0 0.1rem rgb(var(--color-foreground));
 }
 
 .thumbnail img {


### PR DESCRIPTION
**Why are these changes introduced?**
When updating media on the product page, I accidentally removed the box shadow when selecting the active thumbnail.

Fixes #1216 

**What approach did you take?**
I replaced `box-shadow: none` with the active state box shadow styling
This means, when a user uses the mouse to select the thumbnail, the border should increase in size, but should not show the focus state.

**Testing**
- [ ] Firefox
- [ ] Safari
- [ ] iOS safari (touch)
- [ ] Chrome 
- [ ] Mobile
- [ ] Desktop
- [ ] Click on a thumbnail - border should increase without showing focus ring
- [ ] Tab through media thumbnails - focus ring should be shown. Active border will reduce while focus ring is shown.

**Demo links**
- [Editor](https://os2-demo.myshopify.com/admin/themes/127459328022/editor?previewPath=%2Fproducts%2Fbo-soft-strap-brown)

**Checklist**
- [x] Followed [theme code principles](https://github.com/Shopify/dawn/blob/main/.github/CONTRIBUTING.md#theme-code-principles)
- [x] Linted with [Theme Check](https://github.com/Shopify/theme-check)
- [x] Tested on [mobile](https://shopify.dev/themes/store/requirements#mobile-browser-requirements)
- [x] Tested on [multiple browsers](https://shopify.dev/themes/store/requirements#desktop-browser-requirements)
- [x] Tested for [accessibility](https://shopify.dev/themes/best-practices/accessibility)
