### PR TITLE
Fix collection list overlap with one item

### DIFF
--- a/assets/section-collection-list.css
+++ b/assets/section-collection-list.css
@@ -34,10 +34,6 @@
   width: 100%;
 }
 
-.collection-list__item:only-child .media {
-  height: 35rem;
-}
-
 @media screen and (max-width: 749px) {
   .collection-list .collection-list__item {
     width: calc(100% - 3rem);
@@ -58,14 +54,6 @@
 }
 
 @media screen and (min-width: 750px) {
-  .collection-list__item:only-child > *:not(.card--media) {
-    height: 320px;
-  }
-
-  .collection-list__item:only-child .media {
-    height: 47rem;
-  }
-
   .collection-list__item a:hover {
     box-shadow: none;
   }


### PR DESCRIPTION
**Why are these changes introduced?**

Fixes #1211 

**What approach did you take?**

Removed some specific sizing that was in place when there was only one collection in the section. 

**Other considerations**

I can see how big the collection might seem when you have 1 only but if the settings mentions square/portrait then I think it should respect that. Adapt to image could work if the collection image is a landscape one I think. 

**Demo links**

- [Store](https://os2-demo.myshopify.com/?preview_theme_id=127459393558)
- [Editor](https://os2-demo.myshopify.com/admin/themes/127459393558/editor)

**To test**

Toggle visibility on the collections added in the collection list section and try the different format options from the secction.

**Checklist**
- [ ] Followed [theme code principles](https://github.com/Shopify/dawn/blob/main/.github/CONTRIBUTING.md#theme-code-principles)
- [ ] Linted with [Theme Check](https://github.com/Shopify/theme-check)
- [ ] Tested on [mobile](https://shopify.dev/themes/store/requirements#mobile-browser-requirements)
- [ ] Tested on [multiple browsers](https://shopify.dev/themes/store/requirements#desktop-browser-requirements)
- [ ] Tested for [accessibility](https://shopify.dev/themes/best-practices/accessibility)
