### PR TITLE
Added a padding setting to page and fixed article bottom margin

### DIFF
--- a/assets/section-blog-post.css
+++ b/assets/section-blog-post.css
@@ -175,3 +175,7 @@
     margin: 5rem 0 8rem;
   }
 }
+
+.article-template__back:last-child {
+  margin-bottom: 2.5rem;
+}

--- a/assets/section-blog-post.css
+++ b/assets/section-blog-post.css
@@ -177,5 +177,5 @@
 }
 
 .article-template__back:last-child {
-  margin-bottom: 2.5rem;
+  margin-bottom: 3.2rem;
 }

--- a/assets/section-blog-post.css
+++ b/assets/section-blog-post.css
@@ -13,12 +13,6 @@
   margin: 0 auto;
 }
 
-@media screen and (min-width: 1320px) {
-  .article-template__hero-container:first-child {
-    margin-top: calc(5rem + var(--page-width-margin));
-  }
-}
-
 .article-template__hero-small {
   height: 11rem;
 }

--- a/sections/main-article.liquid
+++ b/sections/main-article.liquid
@@ -92,7 +92,7 @@
     {%- endcase -%}
   {%- endfor -%}
 
-  <div class="element-margin-top center">
+  <div class="article-template__back element-margin-top center">
     <a href="{{ blog.url }}" class="article-template__link link animate-arrow">
       <span class="icon-wrap">{% render 'icon-arrow' %}</span>
       {{ 'blogs.article.back_to_blog' | t: title: blog.title }}

--- a/sections/main-page.liquid
+++ b/sections/main-page.liquid
@@ -4,7 +4,21 @@
 <noscript>{{ 'section-main-page.css' | asset_url | stylesheet_tag }}</noscript>
 <noscript>{{ 'component-rte.css' | asset_url | stylesheet_tag }}</noscript>
 
-<div class="page-width page-width--narrow">
+{%- style -%}
+  .section-{{ section.id }}-padding {
+    padding-top: {{ section.settings.padding_top | times: 0.75 | round: 0 }}px;
+    padding-bottom: {{ section.settings.padding_bottom | times: 0.75 | round: 0 }}px;
+  }
+
+  @media screen and (min-width: 750px) {
+    .section-{{ section.id }}-padding {
+      padding-top: {{ section.settings.padding_top }}px;
+      padding-bottom: {{ section.settings.padding_bottom }}px;
+    }
+  }
+{%- endstyle -%}
+
+<div class="page-width page-width--narrow section-{{ section.id }}-padding">
   <h1 class="main-page-title page-title h0">
     {{ page.title | escape }}
   </h1>
@@ -17,6 +31,32 @@
 {
   "name": "t:sections.main-page.name",
   "tag": "section",
-  "class": "section"
+  "class": "section",
+  "settings": [
+    {
+      "type": "header",
+      "content": "t:sections.all.padding.section_padding_heading"
+    },
+    {
+      "type": "range",
+      "id": "padding_top",
+      "min": 0,
+      "max": 100,
+      "step": 4,
+      "unit": "px",
+      "label": "t:sections.all.padding.padding_top",
+      "default": 36
+    },
+    {
+      "type": "range",
+      "id": "padding_bottom",
+      "min": 0,
+      "max": 100,
+      "step": 4,
+      "unit": "px",
+      "label": "t:sections.all.padding.padding_bottom",
+      "default": 36
+    }
+  ]
 }
 {% endschema %}


### PR DESCRIPTION
**Why are these changes introduced?**

The page template was missing controls for the top and bottom padding which was limiting potential layouts, so I've added it there.

I also added some hard-coded margin to the bottom of the article template when comments are disabled to ensure the "back to blog" link isn't stuck to the footer when the margin above the footer is set to 0.  We will revisit how to properly handle padding on the article page as it's a bit of a weird one.

**What approach did you take?**

**Other considerations**

**Demo links**

- [Store](https://os2-demo.myshopify.com/?_ab=0&_fd=0&_sc=1&preview_theme_id=127460474902)
- [Editor](https://os2-demo.myshopify.com/admin/themes/127460474902/editor)

**Checklist**
- [ ] Followed [theme code principles](https://github.com/Shopify/dawn/blob/main/.github/CONTRIBUTING.md#theme-code-principles)
- [ ] Linted with [Theme Check](https://github.com/Shopify/theme-check)
- [ ] Tested on [mobile](https://shopify.dev/themes/store/requirements#mobile-browser-requirements)
- [ ] Tested on [multiple browsers](https://shopify.dev/themes/store/requirements#desktop-browser-requirements)
- [ ] Tested for [accessibility](https://shopify.dev/themes/best-practices/accessibility)
