### PR TITLE
Re-apply slider shadow padding

### DIFF
--- a/assets/base.css
+++ b/assets/base.css
@@ -157,6 +157,7 @@
 
 .product-grid,
 .collection-list,
+.blog__posts,
 .card {
   --border-radius: var(--card-corner-radius);
   --border-width: var(--card-border-width);

--- a/assets/component-slider.css
+++ b/assets/component-slider.css
@@ -24,9 +24,6 @@ slider-component {
     scroll-padding-left: 1rem;
     -webkit-overflow-scrolling: touch;
     margin-bottom: 1rem;
-  }
-
-  .slider--mobile.product__media-list {
     padding-top: calc(var(--shadow-vertical-offset) * -1 + var(--shadow-blur-radius));
     padding-bottom: calc(var(--shadow-vertical-offset) + var(--shadow-blur-radius));
   }

--- a/assets/component-slider.css
+++ b/assets/component-slider.css
@@ -24,8 +24,8 @@ slider-component {
     scroll-padding-left: 1rem;
     -webkit-overflow-scrolling: touch;
     margin-bottom: 1rem;
-    padding-top: calc(var(--shadow-vertical-offset) * -1 + var(--shadow-blur-radius));
-    padding-bottom: calc(var(--shadow-vertical-offset) + var(--shadow-blur-radius));
+    padding-top: max(0.5rem, calc(var(--shadow-vertical-offset) * -1 + var(--shadow-blur-radius)));
+    padding-bottom: max(0.5rem, calc(var(--shadow-vertical-offset) + var(--shadow-blur-radius)));
   }
 
   .slider.slider--mobile .slider__slide {
@@ -61,8 +61,8 @@ slider-component {
     scroll-padding-left: 1rem;
     -webkit-overflow-scrolling: touch;
     margin-bottom: 1rem;
-    padding-top: calc(var(--shadow-vertical-offset) * -1 + var(--shadow-blur-radius));
-    padding-bottom: calc(var(--shadow-vertical-offset) + var(--shadow-blur-radius));
+    padding-top: max(0.5rem, calc(var(--shadow-vertical-offset) * -1 + var(--shadow-blur-radius)));
+    padding-bottom: max(0.5rem, calc(var(--shadow-vertical-offset) + var(--shadow-blur-radius)));
   }
 
   .slider.slider--tablet .slider__slide {


### PR DESCRIPTION
**Why are these changes introduced?**

Refs #1217 
Fixes https://github.com/Shopify/dawn/issues/1157

- Fixes slider shadow padding on non-product media sliders
- Adds some additional padding to the same logic for focus outlines

**What approach did you take?**

Reverted a change from a previous commit that limited the scope of the shadow padding styles.
Also noticed that the blogs slider may have been prevented from receiving the proper shadow offset values.

**Other considerations**

There are other improvements we can make to this logic, but this commit just aims to get it back to working for all sliders in the theme.

Testing notes:
- Collection list (tablet/mobile)
- Featured collection (tablet/mobile)
- Multicolumn (mobile)
- Featured blog (tablet/mobile)
- Product media gallery (mobile)

**Demo links**

- [Editor](https://os2-demo.myshopify.com/admin/themes/127460999190/editor)

**Checklist**
- [ ] Followed [theme code principles](https://github.com/Shopify/dawn/blob/main/.github/CONTRIBUTING.md#theme-code-principles)
- [ ] Linted with [Theme Check](https://github.com/Shopify/theme-check)
- [ ] Tested on [mobile](https://shopify.dev/themes/store/requirements#mobile-browser-requirements)
- [ ] Tested on [multiple browsers](https://shopify.dev/themes/store/requirements#desktop-browser-requirements)
- [ ] Tested for [accessibility](https://shopify.dev/themes/best-practices/accessibility)
