### PR TITLE
Collapsible content media with global settings

### DIFF
--- a/assets/base.css
+++ b/assets/base.css
@@ -252,6 +252,11 @@ html.no-js .no-js-hidden {
   }
 }
 
+.isolate {
+  position: relative;
+  z-index: 0;
+}
+
 .section + .section {
   margin-top: var(--spacing-sections-mobile);
 }

--- a/assets/collapsible-content.css
+++ b/assets/collapsible-content.css
@@ -10,8 +10,9 @@
   }
 }
 
-.collapsible-content__media {
-  background-color: transparent;
+.collapsible-content {
+  position: relative;
+  z-index: 0;
 }
 
 .collapsible-content__media--small {

--- a/assets/collapsible-content.css
+++ b/assets/collapsible-content.css
@@ -10,11 +10,6 @@
   }
 }
 
-.collapsible-content {
-  position: relative;
-  z-index: 0;
-}
-
 .collapsible-content__media--small {
   height: 19.4rem;
 }

--- a/sections/collapsible-content.liquid
+++ b/sections/collapsible-content.liquid
@@ -31,7 +31,7 @@
       <div class="grid grid--1-col grid--2-col-tablet collapsible-content__grid{% if section.settings.desktop_layout == 'image_second' %} collapsible-content__grid--reverse{% endif %}">
         {%- if section.settings.image != blank -%}
           <div class="grid__item collapsible-content__grid-item">
-            <div class="collapsible-content__media collapsible-content__media--{{ section.settings.image_ratio }} media"
+            <div class="collapsible-content__media collapsible-content__media--{{ section.settings.image_ratio }} media global-media-settings gradient"
               {% if section.settings.image_ratio == 'adapt' %} style="padding-bottom: {{ 1 | divided_by: section.settings.image.aspect_ratio | times: 100 }}%;"{% endif %}
             >
               <img

--- a/sections/collapsible-content.liquid
+++ b/sections/collapsible-content.liquid
@@ -15,7 +15,7 @@
   }
 {%- endstyle -%}
 
-<div class="collapsible-content collapsible-{{ section.settings.layout }}-layout color-{{ section.settings.color_scheme }} gradient{% if section.settings.layout == 'section' %} page-width{% endif %}">
+<div class="collapsible-content collapsible-{{ section.settings.layout }}-layout color-{{ section.settings.color_scheme }} gradient isolate{% if section.settings.layout == 'section' %} page-width{% endif %}">
   <div class="collapsible-content__wrapper section-{{ section.id }}-padding{% if section.settings.layout == 'section' %} color-{{ section.settings.container_color_scheme }} gradient{% endif %}">
     <div class="{% if section.settings.image == blank %}collapsible-content-wrapper-narrow{% else %}page-width{% endif %}">
       <div class="collapsible-content__header" style="text-align: {{ section.settings.heading_alignment }};">


### PR DESCRIPTION
**Why are these changes introduced?**

Tackles part of #1043 

**What approach did you take?**

Added the `global-media-settings` class on the media wrapper and applied on the section, this styling: 
```css
position: relative;
z-index: 0;
```
So that the shadow could come up. Same fix is applied on other sections and there is a PR looking into refactoring that approach: https://github.com/Shopify/dawn/pull/1209

**To test**

Go to the editor and play around with the global media settings

**Demo links**

- [Store](https://os2-demo.myshopify.com/?preview_theme_id=127461195798)
- [Editor](https://os2-demo.myshopify.com/admin/themes/127461195798/editor)

**Checklist**
- [ ] Followed [theme code principles](https://github.com/Shopify/dawn/blob/main/.github/CONTRIBUTING.md#theme-code-principles)
- [ ] Linted with [Theme Check](https://github.com/Shopify/theme-check)
- [ ] Tested on [mobile](https://shopify.dev/themes/store/requirements#mobile-browser-requirements)
- [ ] Tested on [multiple browsers](https://shopify.dev/themes/store/requirements#desktop-browser-requirements)
- [ ] Tested for [accessibility](https://shopify.dev/themes/best-practices/accessibility)
