### PR TITLE
Change page width setting to use range

### DIFF
--- a/assets/section-main-product.css
+++ b/assets/section-main-product.css
@@ -34,6 +34,10 @@
     padding-left: 5rem;
   }
 
+  .product__info-wrapper--extra-padding {
+    padding-left: 8rem;
+  }
+
   .product__media-container .slider-buttons {
     display: none;
   }
@@ -343,6 +347,10 @@ a.product__text {
 }
 
 @media screen and (min-width: 750px) {
+  .product__info-container {
+    max-width: 60rem;
+  }
+  
   .product__info-container .price--on-sale .price-item--regular {
     font-size: 1.6rem;
   }
@@ -416,6 +424,10 @@ a.product__text {
 .product--no-media fieldset.product-form__input {
   flex-wrap: wrap;
   margin: 0 auto 1.2rem auto;
+}
+
+.product-form__buttons {
+  max-width: 44rem;
 }
 
 .product--no-media .product__info-container > modal-opener {

--- a/config/settings_schema.json
+++ b/config/settings_schema.json
@@ -137,21 +137,15 @@
     "name": "t:settings_schema.layout.name",
     "settings": [
       {
-        "type": "select",
+        "type": "range",
         "id": "page_width",
-        "options": [
-          {
-            "value": "1200",
-            "label": "t:settings_schema.layout.settings.page_width.options__1.label"
-          },
-          {
-            "value": "1600",
-            "label": "t:settings_schema.layout.settings.page_width.options__2.label"
-          }
-        ],
-        "default": "1600",
+        "min": 1000,
+        "max": 1600,
+        "step": 100,
+        "default": 1600,
+        "unit": "px",
         "label": "t:settings_schema.layout.settings.page_width.label"
-        },
+      },
       {
         "type": "range",
         "id": "spacing_sections",

--- a/locales/en.default.schema.json
+++ b/locales/en.default.schema.json
@@ -305,13 +305,7 @@
       "name": "Layout",
       "settings": {
         "page_width": {
-          "label": "Page width",
-          "options__1": {
-            "label": "1200px"
-          },
-          "options__2": {
-            "label": "1600px"
-          }
+          "label": "Page width"
         },
         "spacing_sections": {
           "label": "Vertical space between sections"

--- a/sections/main-product.liquid
+++ b/sections/main-product.liquid
@@ -184,7 +184,7 @@
         {%- endif -%}
       </media-gallery>
     </div>
-    <div class="product__info-wrapper grid__item">
+    <div class="product__info-wrapper grid__item{% if settings.page_width > 1400 and section.settings.media_size == "small" %} product__info-wrapper--extra-padding{% endif %}">
       <div id="ProductInfo-{{ section.id }}" class="product__info-container{% if section.settings.enable_sticky_info %} product__info-container--sticky{% endif %}">
         {%- assign product_form_id = 'product-form-' | append: section.id -%}
 


### PR DESCRIPTION
**Why are these changes introduced?**

Attempting to use a range setting rather than a dropdown for page width.

There are now 6 distinct sizes the merchant can use - 1000 to 1600 in increments of 100.  We can adjust this.

We need to test a number of things to validate these new ranges

* Different settings - things like gap, section specific settings, the media settings on the product page, etc...
* Images - are they rendering at the correct size in each section?  The way we implemented it, they should, be we need to test.  There may be some sizes missing.
* This should have no changes to mobile

**What approach did you take?**

**Other considerations**

**Demo links**

- [Store](https://os2-demo.myshopify.com/?_ab=0&_fd=0&_sc=1&preview_theme_id=127464472598)
- [Editor](https://os2-demo.myshopify.com/admin/themes/127464472598/editor)

**Checklist**
- [ ] Followed [theme code principles](https://github.com/Shopify/dawn/blob/main/.github/CONTRIBUTING.md#theme-code-principles)
- [ ] Linted with [Theme Check](https://github.com/Shopify/theme-check)
- [ ] Tested on [mobile](https://shopify.dev/themes/store/requirements#mobile-browser-requirements)
- [ ] Tested on [multiple browsers](https://shopify.dev/themes/store/requirements#desktop-browser-requirements)
- [ ] Tested for [accessibility](https://shopify.dev/themes/best-practices/accessibility)
