### PR TITLE
Fix  menu drawer - enable body click to close menu

### DIFF
--- a/assets/global.js
+++ b/assets/global.js
@@ -367,7 +367,7 @@ class MenuDrawer extends HTMLElement {
   closeSubmenu(detailsElement) {
     detailsElement.classList.remove('menu-opening');
     detailsElement.querySelector('summary').setAttribute('aria-expanded', false);
-    removeTrapFocus();
+    removeTrapFocus(detailsElement.querySelector('summary'));
     this.closeAnimation(detailsElement);
   }
 

--- a/assets/global.js
+++ b/assets/global.js
@@ -343,16 +343,14 @@ class MenuDrawer extends HTMLElement {
   }
 
   closeMenuDrawer(event, elementToFocus = false) {
-    if (event !== undefined) {
-      this.mainDetailsToggle.classList.remove('menu-opening');
-      this.mainDetailsToggle.querySelectorAll('details').forEach(details =>  {
-        details.removeAttribute('open');
-        details.classList.remove('menu-opening');
-      });
-      document.body.classList.remove(`overflow-hidden-${this.dataset.breakpoint}`);
-      removeTrapFocus(elementToFocus);
-      this.closeAnimation(this.mainDetailsToggle);
-    }
+    this.mainDetailsToggle.classList.remove('menu-opening');
+    this.mainDetailsToggle.querySelectorAll('details').forEach(details =>  {
+      details.removeAttribute('open');
+      details.classList.remove('menu-opening');
+    });
+    document.body.classList.remove(`overflow-hidden-${this.dataset.breakpoint}`);
+    removeTrapFocus(elementToFocus);
+    this.closeAnimation(this.mainDetailsToggle);
   }
 
   onFocusOut(event) {


### PR DESCRIPTION
### Why are these changes introduced?

Fixes #1188

### What approach did you take?

#### Root cause 

1. In `closeMenuDrawer()` function, [a condition was added to skip execution when `event` param is `undefined`](https://github.com/Shopify/dawn-internal/commit/468b9dadf422670a73e24976121638a3fa9d00aa).
2. The condition was added to fix [another issue](https://github.com/Shopify/dawn-internal/pull/466#issuecomment-852365945)
3. As a result, calling `closeMenuDrawer()` with no params does not result in menu closing


#### Fix

1. Remove the condition mentioned in _Root cause # 1_
2. Fix the issue mentioned in  _Root cause # 2_ by passing the summary element as param to `removeTrapFocus()` when closing submenus

### Other considerations

Noticed while testing that trapFocus() for menu does not work as expected. Created [separate issue](https://github.com/Shopify/dawn/issues/1244).

### Demo links

- [Store](https://os2-demo.myshopify.com/?preview_theme_id=127464767510)
- [Editor](https://os2-demo.myshopify.com/admin/themes/127464767510/editor)

### What to test

- [ ] 1. Mobile/tablet menu drawer
- [ ] 2. Closing menu by clicking/tapping outside of menu
- [ ] 3. Opening submenu and closing submenu

### Checklist
- [ ] Followed [theme code principles](https://github.com/Shopify/dawn/blob/main/.github/CONTRIBUTING.md#theme-code-principles)
- [ ] Linted with [Theme Check](https://github.com/Shopify/theme-check)
- [ ] Tested on [mobile](https://shopify.dev/themes/store/requirements#mobile-browser-requirements)
- [ ] Tested on [multiple browsers](https://shopify.dev/themes/store/requirements#desktop-browser-requirements)
- [ ] Tested for [accessibility](https://shopify.dev/themes/best-practices/accessibility)
