### PR TITLE
Only show login in cart if customer is logged out

### DIFF
--- a/sections/main-cart-items.liquid
+++ b/sections/main-cart-items.liquid
@@ -33,7 +33,7 @@
       {{ 'general.continue_shopping' | t }}
     </a>
 
-    {%- if shop.customer_accounts_enabled -%}
+    {%- if shop.customer_accounts_enabled and customer == nil -%}
       <h2 class="cart__login-title">{{ 'sections.cart.login.title' | t }}</h2>
       <p class="cart__login-paragraph">
         {{ 'sections.cart.login.paragraph_html' | t: link: routes.account_login_url }}


### PR DESCRIPTION
**Why are these changes introduced?**

Fixes #923.

**What approach did you take?**
I am checking if the customer object is there and only showing the login in the cart when the customer isn't logged in

https://shopify.dev/api/liquid/objects/customer?shpxid=78ceb4af-3F25-48A6-7B78-AA641C7A87A0

**Other considerations**

**Demo links**

- [Editor](https://os2-demo.myshopify.com/admin/themes/127465029654/editor)

**Checklist**
- [ ] Followed [theme code principles](https://github.com/Shopify/dawn/blob/main/.github/CONTRIBUTING.md#theme-code-principles)
- [ ] Linted with [Theme Check](https://github.com/Shopify/theme-check)
- [ ] Tested on [mobile](https://shopify.dev/themes/store/requirements#mobile-browser-requirements)
- [ ] Tested on [multiple browsers](https://shopify.dev/themes/store/requirements#desktop-browser-requirements)
- [ ] Tested for [accessibility](https://shopify.dev/themes/best-practices/accessibility)
