### PR TITLE
Prevent excess padding on standard card sliders

### DIFF
--- a/assets/base.css
+++ b/assets/base.css
@@ -155,9 +155,8 @@
   --color-icon: rgb(var(--color-base-outline-button-labels));
 }
 
-.product-grid,
-.collection-list,
-.blog__posts,
+.contains-card--standard,
+.contains-card--card,
 .card {
   --border-radius: var(--card-corner-radius);
   --border-width: var(--card-border-width);
@@ -168,8 +167,8 @@
   --shadow-opacity: var(--card-shadow-opacity);
 }
 
-.multicolumn-list,
-.multicolumn-card {
+.contains-content-container,
+.content-container {
   --border-radius: var(--text-boxes-radius);
   --border-width: var(--text-boxes-border-width);
   --border-opacity: var(--text-boxes-border-opacity);

--- a/assets/component-slider.css
+++ b/assets/component-slider.css
@@ -3,6 +3,12 @@ slider-component {
   display: block;
 }
 
+.slider {
+  --focus-outline-padding: 0.5rem;
+  --shadow-padding-top: calc(var(--shadow-vertical-offset) * -1 + var(--shadow-blur-radius));
+  --shadow-padding-bottom: calc(var(--shadow-vertical-offset) + var(--shadow-blur-radius));
+}
+
 @media screen and (max-width: 989px) {
   .no-js slider-component .slider {
     padding-bottom: 3rem;
@@ -24,8 +30,16 @@ slider-component {
     scroll-padding-left: 1.5rem;
     -webkit-overflow-scrolling: touch;
     margin-bottom: 1rem;
-    padding-top: max(0.5rem, calc(var(--shadow-vertical-offset) * -1 + var(--shadow-blur-radius)));
-    padding-bottom: max(0.5rem, calc(var(--shadow-vertical-offset) + var(--shadow-blur-radius)));
+    padding-top: max(var(--focus-outline-padding), var(--shadow-padding-top));
+    padding-bottom: max(var(--focus-outline-padding), var(--shadow-padding-bottom));
+  }
+
+  .slider.slider--mobile.contains-card--standard {
+    padding-bottom: var(--focus-outline-padding);
+  }
+
+  .slider.slider--mobile.contains-content-container {
+    --focus-outline-padding: 0rem;
   }
 
   .slider.slider--mobile .slider__slide {
@@ -61,8 +75,16 @@ slider-component {
     scroll-padding-left: 1.5rem;
     -webkit-overflow-scrolling: touch;
     margin-bottom: 1rem;
-    padding-top: max(0.5rem, calc(var(--shadow-vertical-offset) * -1 + var(--shadow-blur-radius)));
-    padding-bottom: max(0.5rem, calc(var(--shadow-vertical-offset) + var(--shadow-blur-radius)));
+    padding-top: max(var(--focus-outline-padding), var(--shadow-padding-top));
+    padding-bottom: max(var(--focus-outline-padding), var(--shadow-padding-bottom));
+  }
+  
+  .slider.slider--tablet.contains-card--standard {
+    padding-bottom: var(--focus-outline-padding);
+  }
+
+  .slider.slider--tablet.contains-content-container {
+    --focus-outline-padding: 0rem;
   }
 
   .slider.slider--tablet .slider__slide {

--- a/sections/collection-list.liquid
+++ b/sections/collection-list.liquid
@@ -31,7 +31,7 @@
     {% endunless %}
   
     <slider-component class="slider-mobile-gutter">
-      <ul class="collection-list grid grid--1-col{% if section.blocks.size < 5 %} grid--{{ section.blocks.size }}-col-tablet{% else %} grid--3-col-tablet{% endif %}{% if section.settings.swipe_on_mobile %} slider slider--tablet grid--peek{% endif %} collection-list--{{ section.blocks.size }}-items"
+      <ul class="collection-list contains-card--{{ settings.card_style }} grid grid--1-col{% if section.blocks.size < 5 %} grid--{{ section.blocks.size }}-col-tablet{% else %} grid--3-col-tablet{% endif %}{% if section.settings.swipe_on_mobile %} slider slider--tablet grid--peek{% endif %} collection-list--{{ section.blocks.size }}-items"
         id="Slider-{{ section.id }}"
         role="list"
       >

--- a/sections/featured-blog.liquid
+++ b/sections/featured-blog.liquid
@@ -46,7 +46,7 @@
     {%- if section.settings.blog != blank and section.settings.blog.articles_count > 0 -%}
       <slider-component class="slider-mobile-gutter">
         <ul id="Slider-{{ section.id }}"
-          class="blog__posts articles-wrapper grid grid--peek grid--2-col-tablet grid--4-col-desktop slider {% if posts_displayed > 2 %}slider--tablet{% else %}slider--mobile{% endif %}"
+          class="blog__posts articles-wrapper contains-card--{{ settings.card_style }} grid grid--peek grid--2-col-tablet grid--4-col-desktop slider {% if posts_displayed > 2 %}slider--tablet{% else %}slider--mobile{% endif %}"
           role="list"
         >
           {%- for article in section.settings.blog.articles limit: section.settings.post_limit -%}

--- a/sections/featured-collection.liquid
+++ b/sections/featured-collection.liquid
@@ -43,7 +43,7 @@
     {% endunless %}
   
     <slider-component class="slider-mobile-gutter">
-      <ul id="Slider-{{ section.id }}" class="grid grid--2-col product-grid{% if products_to_display == 4 or section.settings.collection == blank %} grid--2-col-tablet grid--4-col-desktop{% else %} grid--3-col-tablet{% endif %}{% if products_to_display > 5 %} grid--one-third-max grid--4-col-desktop grid--quarter-max{% endif %}{% if section.settings.collection.all_products_count > 2 and section.settings.swipe_on_mobile and section.settings.products_to_show > 2 %} slider slider--tablet grid--peek{% endif %}" role="list">
+      <ul id="Slider-{{ section.id }}" class="grid grid--2-col product-grid contains-card--{{ settings.card_style }}{% if products_to_display == 4 or section.settings.collection == blank %} grid--2-col-tablet grid--4-col-desktop{% else %} grid--3-col-tablet{% endif %}{% if products_to_display > 5 %} grid--one-third-max grid--4-col-desktop grid--quarter-max{% endif %}{% if section.settings.collection.all_products_count > 2 and section.settings.swipe_on_mobile and section.settings.products_to_show > 2 %} slider slider--tablet grid--peek{% endif %}" role="list">
         {%- for product in section.settings.collection.products limit: section.settings.products_to_show -%}
           <li id="Slide-{{ section.id }}-{{ forloop.index }}" class="grid__item{% if section.settings.collection.all_products_count > 2 and section.settings.swipe_on_mobile and section.settings.products_to_show > 2 %} slider__slide{% endif %}">
             {% render 'card-product',

--- a/sections/multicolumn.liquid
+++ b/sections/multicolumn.liquid
@@ -29,7 +29,7 @@
       </div>
     {% endunless %}
     <slider-component class="slider-mobile-gutter">
-      <ul class="multicolumn-list grid grid--1-col{% if section.blocks.size > 3 and section.settings.image_width != 'full' %} grid--2-col-tablet grid--4-col-desktop{% elsif section.blocks.size > 3 and section.settings.image_width == 'full' %} grid--2-col-tablet{% else %} grid--3-col-tablet{% endif %}{% if section.settings.swipe_on_mobile and section.blocks.size > 1 %} slider slider--mobile grid--peek{% endif %}"
+      <ul class="multicolumn-list contains-content-container grid grid--1-col{% if section.blocks.size > 3 and section.settings.image_width != 'full' %} grid--2-col-tablet grid--4-col-desktop{% elsif section.blocks.size > 3 and section.settings.image_width == 'full' %} grid--2-col-tablet{% else %} grid--3-col-tablet{% endif %}{% if section.settings.swipe_on_mobile and section.blocks.size > 1 %} slider slider--mobile grid--peek{% endif %}"
         id="Slider-{{ section.id }}"
         role="list"
       >


### PR DESCRIPTION
**Why are these changes introduced?**

Fixes #1217 

We previously added additional padding above and below sliders to compensate for shadow offset. This change removes the additional bottom padding specifically for sliders that contain standard style cards.

**What approach did you take?**

Created new classes to describe the type of children a slider/grid contains. I think this could be useful to apply everywhere, but for now I've scoped this to only what was needed for this change.

Using the same method, I also added an exception that prevents the previously added .5rem for focus outlines on content-container sliders, which don't receive focus.

**Other considerations**

Struggled naming these classes. Other ideas welcome.

Testing notes:
- Collection list
- Featured collections
- Featured blog
- Multicolumn

**Demo links**

- [Editor](https://os2-demo.myshopify.com/admin/themes/127468929046/editor)

**Checklist**
- [ ] Followed [theme code principles](https://github.com/Shopify/dawn/blob/main/.github/CONTRIBUTING.md#theme-code-principles)
- [ ] Linted with [Theme Check](https://github.com/Shopify/theme-check)
- [ ] Tested on [mobile](https://shopify.dev/themes/store/requirements#mobile-browser-requirements)
- [ ] Tested on [multiple browsers](https://shopify.dev/themes/store/requirements#desktop-browser-requirements)
- [ ] Tested for [accessibility](https://shopify.dev/themes/best-practices/accessibility)
