### PR TITLE
Fixed collection banner shadow colour

### DIFF
--- a/assets/component-collection-hero.css
+++ b/assets/component-collection-hero.css
@@ -77,7 +77,7 @@
   box-shadow: var(--media-shadow-horizontal-offset)
     var(--media-shadow-vertical-offset)
     var(--media-shadow-blur-radius)
-    rgba(var(--color-foreground), var(--media-shadow-opacity));
+    rgba(var(--color-shadow), var(--media-shadow-opacity));
 }
 
 @media screen and (max-width: 749px) {


### PR DESCRIPTION
**Why are these changes introduced?**

Shadow colour for collection was changing depending on colour scheme. Changed the colour to use the --color-shadow var.

**What approach did you take?**

**Other considerations**

**Demo links**

- [Editor](https://os2-demo.myshopify.com/admin/themes/127492980758/editor)

**Checklist**
- [ ] Followed [theme code principles](https://github.com/Shopify/dawn/blob/main/.github/CONTRIBUTING.md#theme-code-principles)
- [ ] Linted with [Theme Check](https://github.com/Shopify/theme-check)
- [ ] Tested on [mobile](https://shopify.dev/themes/store/requirements#mobile-browser-requirements)
- [ ] Tested on [multiple browsers](https://shopify.dev/themes/store/requirements#desktop-browser-requirements)
- [ ] Tested for [accessibility](https://shopify.dev/themes/best-practices/accessibility)
