### PR TITLE
Fix view details for feat. product section on safari

### DIFF
--- a/assets/section-featured-product.css
+++ b/assets/section-featured-product.css
@@ -48,6 +48,7 @@
 .share-button + .product__view-details {
   display: inline-flex;
   float: right;
+  align-items: center;
 }
 
 .share-button + .product__view-details::after {


### PR DESCRIPTION
**Why are these changes introduced?**

Fixes an issue where the `view details` isn't aligned with the arrorw `->`
![](https://screenshot.click/22-01-8h76a-i6w40.png) 

**What approach did you take?**

I added a `align-items: center;` to the wrapper so that the text and icon are vertically aligned. 

**Testing**

Open the store link in safari, desktop or mobile and confirm that view details isn't wonky like in the screenshot above.
You might want to test: 
- different languages so to make sure nothing weird happen with longer sentences
- confirm it's still working as expected in Chrome and Firefox

**Demo links**

- [Store](https://os2-demo.myshopify.com/?preview_theme_id=127498453014)
- [Editor](https://os2-demo.myshopify.com/admin/themes/127498453014/editor)

**Checklist**
- [ ] Followed [theme code principles](https://github.com/Shopify/dawn/blob/main/.github/CONTRIBUTING.md#theme-code-principles)
- [ ] Linted with [Theme Check](https://github.com/Shopify/theme-check)
- [ ] Tested on [mobile](https://shopify.dev/themes/store/requirements#mobile-browser-requirements)
- [ ] Tested on [multiple browsers](https://shopify.dev/themes/store/requirements#desktop-browser-requirements)
- [ ] Tested for [accessibility](https://shopify.dev/themes/best-practices/accessibility)
