### PR TITLE
Fix word breaks

### DIFF
--- a/assets/base.css
+++ b/assets/base.css
@@ -386,6 +386,7 @@ h5,
   letter-spacing: calc(var(--font-heading-scale) * 0.06rem);
   color: rgb(var(--color-foreground));
   line-height: calc(1 + 0.3 / max(1, var(--font-heading-scale)));
+  word-break: break-word;
 }
 
 .h0 {

--- a/assets/component-image-with-text.css
+++ b/assets/component-image-with-text.css
@@ -311,13 +311,11 @@
 
 .image-with-text__heading {
   word-break: break-word;
-  hyphens: auto;
   margin-bottom: 0;
 }
 
 .image-with-text__text p {
   word-break: break-word;
-  hyphens: auto;
   margin-top: 0;
   margin-bottom: 1rem;
 }

--- a/snippets/card-collection.liquid
+++ b/snippets/card-collection.liquid
@@ -61,7 +61,7 @@
       {%- endif -%}
       <div class="card__content">        
         <div class="card__information">
-          <h3 class="card__heading h1">
+          <h3 class="card__heading">
             <a href="{{ card_collection.url }}" class="full-unstyled-link">
               {%- if card_collection.title != blank -%}
                 {{- card_collection.title | escape -}}
@@ -82,7 +82,7 @@
     {% if settings.card_style == 'card' or card_collection.featured_image %} 
       <div class="card__content">
         <div class="card__information">
-          <h3 class="card__heading{% if card_collection.featured_image == nil %} h1{% endif %}">
+          <h3 class="card__heading">
             <a href="{{ card_collection.url }}" class="full-unstyled-link">
               {%- if card_collection.title != blank -%}
                 {{- card_collection.title | escape -}}


### PR DESCRIPTION
**Why are these changes introduced?**

Mitigate visual issues caused by headings overflowing containers and word breaks

**What approach did you take?**

### 1. Remove usage of `hyphens` CSS property
Some fonts (example: Americana) do not properly support `hyphens: auto`, resulting in unnecessary breaks in words with no actual hyphen rendered.

### 2. Add `word-break: break-word;` for all headings
This prevents headings (which are typically set to larger font-sizes) from overflowing containers.

### 3. Change collection card headings to `H3` style instead of `H1` style

**Other considerations**

**Demo links**

- [Store](https://os2-demo.myshopify.com/?preview_theme_id=127499010070)
- [Editor](https://os2-demo.myshopify.com/admin/themes/127499010070/editor)

**Checklist**
- [ ] Followed [theme code principles](https://github.com/Shopify/dawn/blob/main/.github/CONTRIBUTING.md#theme-code-principles)
- [ ] Linted with [Theme Check](https://github.com/Shopify/theme-check)
- [ ] Tested on [mobile](https://shopify.dev/themes/store/requirements#mobile-browser-requirements)
- [ ] Tested on [multiple browsers](https://shopify.dev/themes/store/requirements#desktop-browser-requirements)
- [ ] Tested for [accessibility](https://shopify.dev/themes/best-practices/accessibility)
