### PR TITLE
revert badges IDs

### DIFF
--- a/config/settings_schema.json
+++ b/config/settings_schema.json
@@ -957,7 +957,7 @@
       },
       {
         "type": "select",
-        "id": "badge_sale_color_scheme",
+        "id": "sale_badge_color_scheme",
         "options": [
           {
             "value": "accent-1",
@@ -973,11 +973,11 @@
           }
         ],
         "default": "accent-2",
-        "label": "t:settings_schema.badges.settings.badge_sale_color_scheme.label"
+        "label": "t:settings_schema.badges.settings.sale_badge_color_scheme.label"
       },
       {
         "type": "select",
-        "id": "badge_sold_out_color_scheme",
+        "id": "sold_out_badge_color_scheme",
         "options": [
           {
             "value": "background-1",
@@ -989,7 +989,7 @@
           }
         ],
         "default": "inverse",
-        "label": "t:settings_schema.badges.settings.badge_sold_out_color_scheme.label"
+        "label": "t:settings_schema.badges.settings.sold_out_badge_color_scheme.label"
       }
     ]
   },

--- a/locales/cs.schema.json
+++ b/locales/cs.schema.json
@@ -294,10 +294,10 @@
           },
           "label": "Pozice karty produktu"
         },
-        "badge_sale_color_scheme": {
+        "sale_badge_color_scheme": {
           "label": "Barevné schéma odznaku Sleva"
         },
-        "badge_sold_out_color_scheme": {
+        "sold_out_badge_color_scheme": {
           "label": "Barevné schéma odznaku Vyprodáno"
         }
       }

--- a/locales/da.schema.json
+++ b/locales/da.schema.json
@@ -294,10 +294,10 @@
           },
           "label": "Position for produktkort"
         },
-        "badge_sale_color_scheme": {
+        "sale_badge_color_scheme": {
           "label": "Farveskema for salgsbadges"
         },
-        "badge_sold_out_color_scheme": {
+        "sold_out_badge_color_scheme": {
           "label": "Farveskema for udsolgt-badges"
         }
       }

--- a/locales/de.schema.json
+++ b/locales/de.schema.json
@@ -294,10 +294,10 @@
           },
           "label": "Position der Produktkarte"
         },
-        "badge_sale_color_scheme": {
+        "sale_badge_color_scheme": {
           "label": "Farbschema für Sale-Badges"
         },
-        "badge_sold_out_color_scheme": {
+        "sold_out_badge_color_scheme": {
           "label": "Farbschema für Ausverkauft-Badges"
         }
       }

--- a/locales/en.default.schema.json
+++ b/locales/en.default.schema.json
@@ -96,10 +96,10 @@
           },
           "label": "Product card position"
         },
-        "badge_sale_color_scheme": {
+        "sale_badge_color_scheme": {
           "label": "Sale badge color scheme"
         },
-        "badge_sold_out_color_scheme": {
+        "sold_out_badge_color_scheme": {
           "label": "Sold out badge color scheme"
         }
       }

--- a/locales/es.schema.json
+++ b/locales/es.schema.json
@@ -294,10 +294,10 @@
           },
           "label": "Posición de tarjeta de producto"
         },
-        "badge_sale_color_scheme": {
+        "sale_badge_color_scheme": {
           "label": "Esquema de color de distintivo de oferta"
         },
-        "badge_sold_out_color_scheme": {
+        "sold_out_badge_color_scheme": {
           "label": "Esquema de color de emblema de agotado"
         }
       }

--- a/locales/fi.schema.json
+++ b/locales/fi.schema.json
@@ -294,10 +294,10 @@
           },
           "label": "Tuotekortin sijainti"
         },
-        "badge_sale_color_scheme": {
+        "sale_badge_color_scheme": {
           "label": "Alennusmyynti-tunnuksen värimalli"
         },
-        "badge_sold_out_color_scheme": {
+        "sold_out_badge_color_scheme": {
           "label": "Loppuunmyyty-tunnuksen värimalli"
         }
       }

--- a/locales/fr.schema.json
+++ b/locales/fr.schema.json
@@ -294,10 +294,10 @@
           },
           "label": "Position de la carte de produit"
         },
-        "badge_sale_color_scheme": {
+        "sale_badge_color_scheme": {
           "label": "Combinaison de couleurs du badge de vente"
         },
-        "badge_sold_out_color_scheme": {
+        "sold_out_badge_color_scheme": {
           "label": "Combinaison de couleurs du badge de rupture de stock"
         }
       }

--- a/locales/it.schema.json
+++ b/locales/it.schema.json
@@ -294,10 +294,10 @@
           },
           "label": "Posizione scheda prodotto"
         },
-        "badge_sale_color_scheme": {
+        "sale_badge_color_scheme": {
           "label": "Schema colori per badge vendita"
         },
-        "badge_sold_out_color_scheme": {
+        "sold_out_badge_color_scheme": {
           "label": "Schema colori per badge esaurito"
         }
       }

--- a/locales/ja.schema.json
+++ b/locales/ja.schema.json
@@ -294,10 +294,10 @@
           },
           "label": "商品カードの位置"
         },
-        "badge_sale_color_scheme": {
+        "sale_badge_color_scheme": {
           "label": "販売バッジの配色"
         },
-        "badge_sold_out_color_scheme": {
+        "sold_out_badge_color_scheme": {
           "label": "完売バッジの配色"
         }
       }

--- a/locales/ko.schema.json
+++ b/locales/ko.schema.json
@@ -294,10 +294,10 @@
           },
           "label": "제품 카드 위치"
         },
-        "badge_sale_color_scheme": {
+        "sale_badge_color_scheme": {
           "label": "할인 배지 색상 체계"
         },
-        "badge_sold_out_color_scheme": {
+        "sold_out_badge_color_scheme": {
           "label": "품절 배지 색상 체계"
         }
       }

--- a/locales/nb.schema.json
+++ b/locales/nb.schema.json
@@ -294,10 +294,10 @@
           },
           "label": "Posisjon for produktkort"
         },
-        "badge_sale_color_scheme": {
+        "sale_badge_color_scheme": {
           "label": "Fargetema for salgsmerke"
         },
-        "badge_sold_out_color_scheme": {
+        "sold_out_badge_color_scheme": {
           "label": "Fargetema for utsolgt-merker"
         }
       }

--- a/locales/nl.schema.json
+++ b/locales/nl.schema.json
@@ -294,10 +294,10 @@
           },
           "label": "Positie productkaart"
         },
-        "badge_sale_color_scheme": {
+        "sale_badge_color_scheme": {
           "label": "Kleurschema uitverkoopbadge"
         },
-        "badge_sold_out_color_scheme": {
+        "sold_out_badge_color_scheme": {
           "label": "Kleurschema uitverkocht-badge"
         }
       }

--- a/locales/pl.schema.json
+++ b/locales/pl.schema.json
@@ -294,10 +294,10 @@
           },
           "label": "Położenie karty produktu"
         },
-        "badge_sale_color_scheme": {
+        "sale_badge_color_scheme": {
           "label": "Kolorystyka znaczków Wyprzedaż"
         },
-        "badge_sold_out_color_scheme": {
+        "sold_out_badge_color_scheme": {
           "label": "Kolorystyka znaczków Wyprzedane"
         }
       }

--- a/locales/pt-BR.schema.json
+++ b/locales/pt-BR.schema.json
@@ -294,10 +294,10 @@
           },
           "label": "Posição do cartão do produto"
         },
-        "badge_sale_color_scheme": {
+        "sale_badge_color_scheme": {
           "label": "Esquema de cores do selo de promoção"
         },
-        "badge_sold_out_color_scheme": {
+        "sold_out_badge_color_scheme": {
           "label": "Esquema de cores do selo de esgotado"
         }
       }

--- a/locales/pt-PT.schema.json
+++ b/locales/pt-PT.schema.json
@@ -294,10 +294,10 @@
           },
           "label": "Posição do cartão de produto"
         },
-        "badge_sale_color_scheme": {
+        "sale_badge_color_scheme": {
           "label": "Esquema de cor do selo de venda"
         },
-        "badge_sold_out_color_scheme": {
+        "sold_out_badge_color_scheme": {
           "label": "Cor de esquema de selo esgotado"
         }
       }

--- a/locales/sv.schema.json
+++ b/locales/sv.schema.json
@@ -294,10 +294,10 @@
           },
           "label": "Position för produktkort"
         },
-        "badge_sale_color_scheme": {
+        "sale_badge_color_scheme": {
           "label": "Färgschema för försäljningsbricka"
         },
-        "badge_sold_out_color_scheme": {
+        "sold_out_badge_color_scheme": {
           "label": "Utsålt färgschema för bricka"
         }
       }

--- a/locales/th.schema.json
+++ b/locales/th.schema.json
@@ -294,10 +294,10 @@
           },
           "label": "ตำแหน่งบัตรสินค้า"
         },
-        "badge_sale_color_scheme": {
+        "sale_badge_color_scheme": {
           "label": "รูปแบบสีของเครื่องหมายการค้า"
         },
-        "badge_sold_out_color_scheme": {
+        "sold_out_badge_color_scheme": {
           "label": "รูปแบบสีของเครื่องหมายสินค้าที่ขายหมด"
         }
       }

--- a/locales/tr.schema.json
+++ b/locales/tr.schema.json
@@ -294,10 +294,10 @@
           },
           "label": "Ürün kartı konumu"
         },
-        "badge_sale_color_scheme": {
+        "sale_badge_color_scheme": {
           "label": "İndirim rozeti renk şeması"
         },
-        "badge_sold_out_color_scheme": {
+        "sold_out_badge_color_scheme": {
           "label": "Tükendi rozeti renk şeması"
         }
       }

--- a/locales/vi.schema.json
+++ b/locales/vi.schema.json
@@ -294,10 +294,10 @@
           },
           "label": "Vị trí thẻ sản phẩm"
         },
-        "badge_sale_color_scheme": {
+        "sale_badge_color_scheme": {
           "label": "Bảng màu huy hiệu giảm giá"
         },
-        "badge_sold_out_color_scheme": {
+        "sold_out_badge_color_scheme": {
           "label": "Bảng màu huy hiệu đã hết hàng"
         }
       }

--- a/locales/zh-CN.schema.json
+++ b/locales/zh-CN.schema.json
@@ -294,10 +294,10 @@
           },
           "label": "产品卡位置"
         },
-        "badge_sale_color_scheme": {
+        "sale_badge_color_scheme": {
           "label": "促销徽章配色方案"
         },
-        "badge_sold_out_color_scheme": {
+        "sold_out_badge_color_scheme": {
           "label": "售罄徽章配色方案"
         }
       }

--- a/locales/zh-TW.schema.json
+++ b/locales/zh-TW.schema.json
@@ -294,10 +294,10 @@
           },
           "label": "產品卡片位置"
         },
-        "badge_sale_color_scheme": {
+        "sale_badge_color_scheme": {
           "label": "銷售徽章顏色配置"
         },
-        "badge_sold_out_color_scheme": {
+        "sold_out_badge_color_scheme": {
           "label": "售罄徽章顏色佈景主題"
         }
       }

--- a/snippets/card-product.liquid
+++ b/snippets/card-product.liquid
@@ -79,25 +79,25 @@
             </div>
           </div>
         {%- endif -%}
-        <div class="card__content">        
+        <div class="card__content">
           <div class="card__information">
             <h3 class="card__heading">
               <a href="{{ card_product.url | default: '#' }}" class="full-unstyled-link">
                 {{ card_product.title | escape }}
               </a>
             </h3>
-          </div>      
-          <div class="card__badge {{ settings.badge_position }}"> 
+          </div>
+          <div class="card__badge {{ settings.badge_position }}">
             {%- if card_product.available == false -%}
-              <span class="badge badge--bottom-left color-{{ settings.badge_sold_out_color_scheme }}">{{ 'products.product.sold_out' | t }}</span>
+              <span class="badge badge--bottom-left color-{{ settings.sold_out_badge_color_scheme }}">{{ 'products.product.sold_out' | t }}</span>
             {%- elsif card_product.compare_at_price > card_product.price and card_product.available -%}
-              <span class="badge badge--bottom-left color-{{ settings.badge_sale_color_scheme }}">{{ 'products.product.on_sale' | t }}</span>
+              <span class="badge badge--bottom-left color-{{ settings.sale_badge_color_scheme }}">{{ 'products.product.on_sale' | t }}</span>
             {%- endif -%}
           </div>
         </div>
       </div>
       <div class="card__content">
-        <div class="card__information">  
+        <div class="card__information">
           <h3 class="card__heading{% if card_product.featured_media or settings.card_style == 'standard' %} h5{% endif %}">
             <a href="{{ card_product.url | default: '#' }}" class="full-unstyled-link">
               {{ card_product.title | escape }}
@@ -107,19 +107,19 @@
             {%- if show_vendor -%}
               <span class="visually-hidden">{{ 'accessibility.vendor' | t }}</span>
               <div class="caption-with-letter-spacing light">{{ card_product.vendor }}</div>
-            {%- endif -%}    
-            
+            {%- endif -%}
+
             <span class="caption-large light">{{ block.settings.description | escape }}</span>
 
             {%- if show_rating and card_product.metafields.reviews.rating.value != blank -%}
               {% liquid
-                assign rating_decimal = 0 
-                assign decimal = card_product.metafields.reviews.rating.value.rating | modulo: 1 
+                assign rating_decimal = 0
+                assign decimal = card_product.metafields.reviews.rating.value.rating | modulo: 1
                 if decimal >= 0.3 and decimal <= 0.7
                   assign rating_decimal = 0.5
                 elsif decimal > 0.7
                   assign rating_decimal = 1
-                endif 
+                endif
               %}
               <div class="rating" role="img" aria-label="{{ 'accessibility.star_reviews_info' | t: rating_value: card_product.metafields.reviews.rating.value, rating_max: card_product.metafields.reviews.rating.value.scale_max }}">
                 <span aria-hidden="true" class="rating-star color-icon-{{ settings.accent_icons }}" style="--rating: {{ card_product.metafields.reviews.rating.value.rating | floor }}; --rating-max: {{ card_product.metafields.reviews.rating.value.scale_max }}; --rating-decimal: {{ rating_decimal }};"></span>
@@ -132,15 +132,15 @@
                 <span class="visually-hidden">{{ card_product.metafields.reviews.rating_count }} {{ "accessibility.total_reviews" | t }}</span>
               </p>
             {%- endif -%}
-            
+
             {% render 'price', product: card_product, price_class: '' %}
           </div>
-        </div>     
+        </div>
         <div class="card__badge {{ settings.badge_position }}">
           {%- if card_product.available == false -%}
-            <span class="badge badge--bottom-left color-{{ settings.badge_sold_out_color_scheme }}">{{ 'products.product.sold_out' | t }}</span>
+            <span class="badge badge--bottom-left color-{{ settings.sold_out_badge_color_scheme }}">{{ 'products.product.sold_out' | t }}</span>
           {%- elsif card_product.compare_at_price > card_product.price and card_product.available -%}
-            <span class="badge badge--bottom-left color-{{ settings.badge_sale_color_scheme }}">{{ 'products.product.on_sale' | t }}</span>
+            <span class="badge badge--bottom-left color-{{ settings.sale_badge_color_scheme }}">{{ 'products.product.on_sale' | t }}</span>
           {%- endif -%}
         </div>
       </div>
@@ -157,14 +157,14 @@
       style="--ratio-percent: 100%;"
     >
       <div class="card__inner {% if settings.card_style == 'standard' %}color-{{ settings.card_color_scheme }}{% endif %}{% if settings.card_style == 'standard' %} ratio{% endif %}" style="--ratio-percent: 100%;">
-        <div class="card__content">        
+        <div class="card__content">
           <div class="card__information">
             <h3 class="card__heading">
               <a href="#" class="full-unstyled-link">
                 {{ 'onboarding.product_title' | t }}
               </a>
             </h3>
-          </div>  
+          </div>
         </div>
       </div>
       <div class="card__content">

--- a/snippets/price.liquid
+++ b/snippets/price.liquid
@@ -82,11 +82,11 @@
     </small>
   </div>
   {%- if show_badges -%}
-    <span class="badge price__badge-sale color-{{ settings.badge_sale_color_scheme }}">
+    <span class="badge price__badge-sale color-{{ settings.sale_badge_color_scheme }}">
       {{ 'products.product.on_sale' | t }}
     </span>
 
-    <span class="badge price__badge-sold-out color-{{ settings.badge_sold_out_color_scheme }}">
+    <span class="badge price__badge-sold-out color-{{ settings.sold_out_badge_color_scheme }}">
       {{ 'products.product.sold_out' | t }}
     </span>
   {%- endif -%}

--- a/templates/gift_card.liquid
+++ b/templates/gift_card.liquid
@@ -108,7 +108,7 @@
           {% endif %}
         </p>
         {%- if gift_card.enabled == false or gift_card.expired -%}
-          <p class="gift-card__label badge badge--{{ settings.badge_sold_out_color_scheme }}">{{ 'gift_cards.issued.expired' | t }}</p>
+          <p class="gift-card__label badge badge--{{ settings.sold_out_badge_color_scheme }}">{{ 'gift_cards.issued.expired' | t }}</p>
         {%- endif -%}
       </div>
 


### PR DESCRIPTION
**Why are these changes introduced?**

Fixes IDs for badges that were changed but that would mean merchant updating to the newer version of the theme would need to re assign the colors set for their sold out and sales badge. 

**What approach did you take?**

I did a replace all to replace even in language files. 

**To test**

Change the colors of the badges in the general color settings. 

**Demo links**

- [Store](https://os2-demo.myshopify.com/?preview_theme_id=127499468822)
- [Editor](https://os2-demo.myshopify.com/admin/themes/127499468822/editor)

**Checklist**
- [ ] Followed [theme code principles](https://github.com/Shopify/dawn/blob/main/.github/CONTRIBUTING.md#theme-code-principles)
- [ ] Linted with [Theme Check](https://github.com/Shopify/theme-check)
- [ ] Tested on [mobile](https://shopify.dev/themes/store/requirements#mobile-browser-requirements)
- [ ] Tested on [multiple browsers](https://shopify.dev/themes/store/requirements#desktop-browser-requirements)
- [ ] Tested for [accessibility](https://shopify.dev/themes/best-practices/accessibility)
