### PR TITLE
Revert "Version bump 3.0.0"

### DIFF
--- a/config/settings_schema.json
+++ b/config/settings_schema.json
@@ -2,7 +2,7 @@
   {
     "name": "theme_info",
     "theme_name": "Dawn",
-    "theme_version": "3.0.0",
+    "theme_version": "2.5.0",
     "theme_author": "Shopify",
     "theme_documentation_url": "https://help.shopify.com/en/manual/online-store/themes",
     "theme_support_url": "https://support.shopify.com/"


### PR DESCRIPTION
Reverts Shopify/dawn#1275
We need to push an update before we can create our new release. 