### PR TITLE
Update slider shadow padding implementation

### DIFF
--- a/assets/base.css
+++ b/assets/base.css
@@ -155,9 +155,8 @@
   --color-icon: rgb(var(--color-base-outline-button-labels));
 }
 
-.product-grid,
-.collection-list,
-.blog__posts,
+.contains-card--standard,
+.contains-card--card,
 .card {
   --border-radius: var(--card-corner-radius);
   --border-width: var(--card-border-width);
@@ -168,8 +167,8 @@
   --shadow-opacity: var(--card-shadow-opacity);
 }
 
-.multicolumn-list,
-.multicolumn-card {
+.contains-content-container,
+.content-container {
   --border-radius: var(--text-boxes-radius);
   --border-width: var(--text-boxes-border-width);
   --border-opacity: var(--text-boxes-border-opacity);

--- a/assets/base.css
+++ b/assets/base.css
@@ -155,6 +155,7 @@
   --color-icon: rgb(var(--color-base-outline-button-labels));
 }
 
+.contains-card,
 .contains-card--standard,
 .contains-card--card,
 .card {

--- a/assets/base.css
+++ b/assets/base.css
@@ -156,8 +156,6 @@
 }
 
 .contains-card,
-.contains-card--standard,
-.contains-card--card,
 .card {
   --border-radius: var(--card-corner-radius);
   --border-width: var(--card-border-width);

--- a/assets/component-slider.css
+++ b/assets/component-slider.css
@@ -10,8 +10,12 @@ slider-component {
 }
 
 .slider__slide {
+  --focus-outline-padding: 0.5rem;
+  --shadow-padding-top: calc(var(--shadow-vertical-offset) * -1 + var(--shadow-blur-radius));
+  --shadow-padding-bottom: calc(var(--shadow-vertical-offset) + var(--shadow-blur-radius));
   scroll-snap-align: start;
   flex-shrink: 0;
+  padding-bottom: 0;
 }
 
 @media screen and (max-width: 749px) {
@@ -24,13 +28,20 @@ slider-component {
     scroll-padding-left: 1.5rem;
     -webkit-overflow-scrolling: touch;
     margin-bottom: 1rem;
-    padding-top: max(0.5rem, calc(var(--shadow-vertical-offset) * -1 + var(--shadow-blur-radius)));
-    padding-bottom: max(0.5rem, calc(var(--shadow-vertical-offset) + var(--shadow-blur-radius)));
   }
 
   .slider.slider--mobile .slider__slide {
     margin-bottom: 0;
-    padding-bottom: 0;
+    padding-top: max(var(--focus-outline-padding), var(--shadow-padding-top));
+    padding-bottom: max(var(--focus-outline-padding), var(--shadow-padding-bottom));
+  }
+
+  .slider.slider--mobile.contains-card--standard .slider__slide:not(.collection-list__item--no-media) {
+    padding-bottom: var(--focus-outline-padding);
+  }
+
+  .slider.slider--mobile.contains-content-container .slider__slide {
+    --focus-outline-padding: 0rem;
   }
 }
 
@@ -47,7 +58,6 @@ slider-component {
 
   .slider.slider--tablet-up .slider__slide {
     margin-bottom: 0;
-    padding-bottom: 0;
   }
 }
 
@@ -61,13 +71,20 @@ slider-component {
     scroll-padding-left: 1.5rem;
     -webkit-overflow-scrolling: touch;
     margin-bottom: 1rem;
-    padding-top: max(0.5rem, calc(var(--shadow-vertical-offset) * -1 + var(--shadow-blur-radius)));
-    padding-bottom: max(0.5rem, calc(var(--shadow-vertical-offset) + var(--shadow-blur-radius)));
   }
 
   .slider.slider--tablet .slider__slide {
     margin-bottom: 0;
-    padding-bottom: 0;
+    padding-top: max(var(--focus-outline-padding), var(--shadow-padding-top));
+    padding-bottom: max(var(--focus-outline-padding), var(--shadow-padding-bottom));
+  }
+
+  .slider.slider--tablet.contains-card--standard .slider__slide:not(.collection-list__item--no-media) {
+    padding-bottom: var(--focus-outline-padding);
+  }
+
+  .slider.slider--tablet.contains-content-container .slider__slide {
+    --focus-outline-padding: 0rem;
   }
 }
 
@@ -89,7 +106,6 @@ slider-component {
 
 .slider.slider--everywhere .slider__slide {
   margin-bottom: 0;
-  padding-bottom: 0;
   scroll-snap-align: center;
 }
 

--- a/sections/collection-list.liquid
+++ b/sections/collection-list.liquid
@@ -31,7 +31,7 @@
     {% endunless %}
   
     <slider-component class="slider-mobile-gutter">
-      <ul class="collection-list grid grid--1-col{% if section.blocks.size < 5 %} grid--{{ section.blocks.size }}-col-tablet{% else %} grid--3-col-tablet{% endif %}{% if section.settings.swipe_on_mobile %} slider slider--tablet grid--peek{% endif %} collection-list--{{ section.blocks.size }}-items"
+      <ul class="collection-list contains-card--{{ settings.card_style }} grid grid--1-col{% if section.blocks.size < 5 %} grid--{{ section.blocks.size }}-col-tablet{% else %} grid--3-col-tablet{% endif %}{% if section.settings.swipe_on_mobile %} slider slider--tablet grid--peek{% endif %} collection-list--{{ section.blocks.size }}-items"
         id="Slider-{{ section.id }}"
         role="list"
       >
@@ -42,7 +42,7 @@
           endif
         -%}
         {%- for block in section.blocks -%}
-          <li id="Slide-{{ section.id }}-{{ forloop.index }}" class="collection-list__item grid__item{% if section.settings.swipe_on_mobile %} slider__slide{% endif %}" {{ block.shopify_attributes }}>
+          <li id="Slide-{{ section.id }}-{{ forloop.index }}" class="collection-list__item grid__item{% if section.settings.swipe_on_mobile %} slider__slide{% endif %}{% if block.settings.collection.featured_image == nil %} collection-list__item--no-media{% endif %}" {{ block.shopify_attributes }}>
             {% render 'card-collection', card_collection: block.settings.collection , media_aspect_ratio: section.settings.image_ratio, columns: columns %}
           </li>
         {%- endfor -%}

--- a/sections/collection-list.liquid
+++ b/sections/collection-list.liquid
@@ -31,7 +31,7 @@
     {% endunless %}
   
     <slider-component class="slider-mobile-gutter">
-      <ul class="collection-list contains-card--{{ settings.card_style }} grid grid--1-col{% if section.blocks.size < 5 %} grid--{{ section.blocks.size }}-col-tablet{% else %} grid--3-col-tablet{% endif %}{% if section.settings.swipe_on_mobile %} slider slider--tablet grid--peek{% endif %} collection-list--{{ section.blocks.size }}-items"
+      <ul class="collection-list contains-card contains-card--{{ settings.card_style }} grid grid--1-col{% if section.blocks.size < 5 %} grid--{{ section.blocks.size }}-col-tablet{% else %} grid--3-col-tablet{% endif %}{% if section.settings.swipe_on_mobile %} slider slider--tablet grid--peek{% endif %} collection-list--{{ section.blocks.size }}-items"
         id="Slider-{{ section.id }}"
         role="list"
       >

--- a/sections/collection-list.liquid
+++ b/sections/collection-list.liquid
@@ -31,7 +31,7 @@
     {% endunless %}
   
     <slider-component class="slider-mobile-gutter">
-      <ul class="collection-list contains-card contains-card--{{ settings.card_style }} grid grid--1-col{% if section.blocks.size < 5 %} grid--{{ section.blocks.size }}-col-tablet{% else %} grid--3-col-tablet{% endif %}{% if section.settings.swipe_on_mobile %} slider slider--tablet grid--peek{% endif %} collection-list--{{ section.blocks.size }}-items"
+      <ul class="collection-list contains-card{% if settings.card_style == 'standard' %} contains-card--standard{% endif %} grid grid--1-col{% if section.blocks.size < 5 %} grid--{{ section.blocks.size }}-col-tablet{% else %} grid--3-col-tablet{% endif %}{% if section.settings.swipe_on_mobile %} slider slider--tablet grid--peek{% endif %} collection-list--{{ section.blocks.size }}-items"
         id="Slider-{{ section.id }}"
         role="list"
       >

--- a/sections/featured-blog.liquid
+++ b/sections/featured-blog.liquid
@@ -46,7 +46,7 @@
     {%- if section.settings.blog != blank and section.settings.blog.articles_count > 0 -%}
       <slider-component class="slider-mobile-gutter">
         <ul id="Slider-{{ section.id }}"
-          class="blog__posts articles-wrapper contains-card contains-card--{{ settings.card_style }} grid grid--peek grid--2-col-tablet grid--4-col-desktop slider {% if posts_displayed > 2 %}slider--tablet{% else %}slider--mobile{% endif %}"
+          class="blog__posts articles-wrapper contains-card{% if settings.card_style == 'standard' %} contains-card--standard{% endif %} grid grid--peek grid--2-col-tablet grid--4-col-desktop slider {% if posts_displayed > 2 %}slider--tablet{% else %}slider--mobile{% endif %}"
           role="list"
         >
           {%- for article in section.settings.blog.articles limit: section.settings.post_limit -%}

--- a/sections/featured-blog.liquid
+++ b/sections/featured-blog.liquid
@@ -46,7 +46,7 @@
     {%- if section.settings.blog != blank and section.settings.blog.articles_count > 0 -%}
       <slider-component class="slider-mobile-gutter">
         <ul id="Slider-{{ section.id }}"
-          class="blog__posts articles-wrapper contains-card--{{ settings.card_style }} grid grid--peek grid--2-col-tablet grid--4-col-desktop slider {% if posts_displayed > 2 %}slider--tablet{% else %}slider--mobile{% endif %}"
+          class="blog__posts articles-wrapper contains-card contains-card--{{ settings.card_style }} grid grid--peek grid--2-col-tablet grid--4-col-desktop slider {% if posts_displayed > 2 %}slider--tablet{% else %}slider--mobile{% endif %}"
           role="list"
         >
           {%- for article in section.settings.blog.articles limit: section.settings.post_limit -%}

--- a/sections/featured-blog.liquid
+++ b/sections/featured-blog.liquid
@@ -30,8 +30,8 @@
     assign posts_displayed = section.settings.post_limit
   endif
 -%}
-<div class="blog isolate color-{{ section.settings.color_scheme }} gradient{% if section.settings.heading == blank %} no-heading{% endif %}">
-  <div class="page-width-desktop{% if posts_displayed < 3 %} page-width-tablet{% endif %} section-{{ section.id }}-padding">
+<div class="blog color-{{ section.settings.color_scheme }} gradient{% if section.settings.heading == blank %} no-heading{% endif %}">
+  <div class="page-width-desktop isolate{% if posts_displayed < 3 %} page-width-tablet{% endif %} section-{{ section.id }}-padding">
     <div class="title-wrapper-with-link{% if section.settings.heading == blank %} title-wrapper-with-link--no-heading{% endif %} {% if posts_displayed > 2 %}title-wrapper--self-padded-tablet-down{% else %}title-wrapper--self-padded-mobile{% endif %} title-wrapper--no-top-margin">
       <h2 class="blog__title">{{ section.settings.heading | escape }}</h2>
 

--- a/sections/featured-blog.liquid
+++ b/sections/featured-blog.liquid
@@ -46,7 +46,7 @@
     {%- if section.settings.blog != blank and section.settings.blog.articles_count > 0 -%}
       <slider-component class="slider-mobile-gutter">
         <ul id="Slider-{{ section.id }}"
-          class="blog__posts articles-wrapper grid grid--peek grid--2-col-tablet grid--4-col-desktop slider {% if posts_displayed > 2 %}slider--tablet{% else %}slider--mobile{% endif %}"
+          class="blog__posts articles-wrapper contains-card--{{ settings.card_style }} grid grid--peek grid--2-col-tablet grid--4-col-desktop slider {% if posts_displayed > 2 %}slider--tablet{% else %}slider--mobile{% endif %}"
           role="list"
         >
           {%- for article in section.settings.blog.articles limit: section.settings.post_limit -%}

--- a/sections/featured-collection.liquid
+++ b/sections/featured-collection.liquid
@@ -43,7 +43,7 @@
     {% endunless %}
   
     <slider-component class="slider-mobile-gutter">
-      <ul id="Slider-{{ section.id }}" class="grid grid--2-col product-grid contains-card--{{ settings.card_style }}{% if products_to_display == 4 or section.settings.collection == blank %} grid--2-col-tablet grid--4-col-desktop{% else %} grid--3-col-tablet{% endif %}{% if products_to_display > 5 %} grid--one-third-max grid--4-col-desktop grid--quarter-max{% endif %}{% if section.settings.collection.all_products_count > 2 and section.settings.swipe_on_mobile and section.settings.products_to_show > 2 %} slider slider--tablet grid--peek{% endif %}" role="list">
+      <ul id="Slider-{{ section.id }}" class="grid grid--2-col product-grid contains-card contains-card--{{ settings.card_style }}{% if products_to_display == 4 or section.settings.collection == blank %} grid--2-col-tablet grid--4-col-desktop{% else %} grid--3-col-tablet{% endif %}{% if products_to_display > 5 %} grid--one-third-max grid--4-col-desktop grid--quarter-max{% endif %}{% if section.settings.collection.all_products_count > 2 and section.settings.swipe_on_mobile and section.settings.products_to_show > 2 %} slider slider--tablet grid--peek{% endif %}" role="list">
         {%- for product in section.settings.collection.products limit: section.settings.products_to_show -%}
           <li id="Slide-{{ section.id }}-{{ forloop.index }}" class="grid__item{% if section.settings.collection.all_products_count > 2 and section.settings.swipe_on_mobile and section.settings.products_to_show > 2 %} slider__slide{% endif %}">
             {% render 'card-product',

--- a/sections/featured-collection.liquid
+++ b/sections/featured-collection.liquid
@@ -43,7 +43,7 @@
     {% endunless %}
   
     <slider-component class="slider-mobile-gutter">
-      <ul id="Slider-{{ section.id }}" class="grid grid--2-col product-grid{% if products_to_display == 4 or section.settings.collection == blank %} grid--2-col-tablet grid--4-col-desktop{% else %} grid--3-col-tablet{% endif %}{% if products_to_display > 5 %} grid--one-third-max grid--4-col-desktop grid--quarter-max{% endif %}{% if section.settings.collection.all_products_count > 2 and section.settings.swipe_on_mobile and section.settings.products_to_show > 2 %} slider slider--tablet grid--peek{% endif %}" role="list">
+      <ul id="Slider-{{ section.id }}" class="grid grid--2-col product-grid contains-card--{{ settings.card_style }}{% if products_to_display == 4 or section.settings.collection == blank %} grid--2-col-tablet grid--4-col-desktop{% else %} grid--3-col-tablet{% endif %}{% if products_to_display > 5 %} grid--one-third-max grid--4-col-desktop grid--quarter-max{% endif %}{% if section.settings.collection.all_products_count > 2 and section.settings.swipe_on_mobile and section.settings.products_to_show > 2 %} slider slider--tablet grid--peek{% endif %}" role="list">
         {%- for product in section.settings.collection.products limit: section.settings.products_to_show -%}
           <li id="Slide-{{ section.id }}-{{ forloop.index }}" class="grid__item{% if section.settings.collection.all_products_count > 2 and section.settings.swipe_on_mobile and section.settings.products_to_show > 2 %} slider__slide{% endif %}">
             {% render 'card-product',

--- a/sections/featured-collection.liquid
+++ b/sections/featured-collection.liquid
@@ -43,7 +43,7 @@
     {% endunless %}
   
     <slider-component class="slider-mobile-gutter">
-      <ul id="Slider-{{ section.id }}" class="grid grid--2-col product-grid contains-card contains-card--{{ settings.card_style }}{% if products_to_display == 4 or section.settings.collection == blank %} grid--2-col-tablet grid--4-col-desktop{% else %} grid--3-col-tablet{% endif %}{% if products_to_display > 5 %} grid--one-third-max grid--4-col-desktop grid--quarter-max{% endif %}{% if section.settings.collection.all_products_count > 2 and section.settings.swipe_on_mobile and section.settings.products_to_show > 2 %} slider slider--tablet grid--peek{% endif %}" role="list">
+      <ul id="Slider-{{ section.id }}" class="grid grid--2-col product-grid contains-card{% if settings.card_style == 'standard' %} contains-card--standard{% endif %}{% if products_to_display == 4 or section.settings.collection == blank %} grid--2-col-tablet grid--4-col-desktop{% else %} grid--3-col-tablet{% endif %}{% if products_to_display > 5 %} grid--one-third-max grid--4-col-desktop grid--quarter-max{% endif %}{% if section.settings.collection.all_products_count > 2 and section.settings.swipe_on_mobile and section.settings.products_to_show > 2 %} slider slider--tablet grid--peek{% endif %}" role="list">
         {%- for product in section.settings.collection.products limit: section.settings.products_to_show -%}
           <li id="Slide-{{ section.id }}-{{ forloop.index }}" class="grid__item{% if section.settings.collection.all_products_count > 2 and section.settings.swipe_on_mobile and section.settings.products_to_show > 2 %} slider__slide{% endif %}">
             {% render 'card-product',

--- a/sections/multicolumn.liquid
+++ b/sections/multicolumn.liquid
@@ -29,7 +29,7 @@
       </div>
     {% endunless %}
     <slider-component class="slider-mobile-gutter">
-      <ul class="multicolumn-list grid grid--1-col{% if section.blocks.size > 3 and section.settings.image_width != 'full' %} grid--2-col-tablet grid--4-col-desktop{% elsif section.blocks.size > 3 and section.settings.image_width == 'full' %} grid--2-col-tablet{% else %} grid--3-col-tablet{% endif %}{% if section.settings.swipe_on_mobile and section.blocks.size > 1 %} slider slider--mobile grid--peek{% endif %}"
+      <ul class="multicolumn-list contains-content-container grid grid--1-col{% if section.blocks.size > 3 and section.settings.image_width != 'full' %} grid--2-col-tablet grid--4-col-desktop{% elsif section.blocks.size > 3 and section.settings.image_width == 'full' %} grid--2-col-tablet{% else %} grid--3-col-tablet{% endif %}{% if section.settings.swipe_on_mobile and section.blocks.size > 1 %} slider slider--mobile grid--peek{% endif %}"
         id="Slider-{{ section.id }}"
         role="list"
       >


### PR DESCRIPTION
**Why are these changes introduced?**

Fixes #1217 

We previously added additional padding above and below sliders to compensate for shadow offset. This change makes it possible to remove the additional bottom padding specifically for sliders that contain standard style cards.

<img src="https://screenshot.click/31-19-9c3qy-kainf.png" width="300"/>

**What approach did you take?**

Previously, slider shadow padding was applied to the `<ul class="slider">` element. I've changed the approach to put this padding on the `<li class="slider__slide">` elements instead. This was mostly to accommodate a case in collection list where empty collection cards still need the bottom padding regardless of which card style is used ([see here](https://screenshot.click/31-54-tk052-4ij2t.png))

In order to better scope generic shadow variables and account for exception cases I've created new classes to describe the type of children a slider/grid contains. I think these could be utilized more to further simplify global setting variable inheritance, but for now I'm using only where relevant to this issue.

Using the same method, I also added an exception that prevents the previously added .5rem for focus outlines on content-container sliders, which don't receive focus.

**Other considerations**

Probably a UX decision, but instead of just removing bottom padding we could add it between the card image and the title. I don't think the further separation of these two elements looks particularly good, but maybe for preserving contrast we should consider it. Perhaps this is better solved by providing a title spacing setting or something.

Struggled naming the new contains classes. Other ideas welcome.

This PR doesn't modify the actual shadow offset/blur calculations we're using for the padding. We can probably still do more to improve this but should be considered separately from this PR.

Testing notes:

- Check for padding/margin related regressions in all slider sections
- Check with positive and negative vertical shadow offsets

**Demo links**

- [Editor](https://os2-demo.myshopify.com/admin/themes/127526731798/editor)

**Checklist**
- [ ] Followed [theme code principles](https://github.com/Shopify/dawn/blob/main/.github/CONTRIBUTING.md#theme-code-principles)
- [ ] Linted with [Theme Check](https://github.com/Shopify/theme-check)
- [ ] Tested on [mobile](https://shopify.dev/themes/store/requirements#mobile-browser-requirements)
- [ ] Tested on [multiple browsers](https://shopify.dev/themes/store/requirements#desktop-browser-requirements)
- [ ] Tested for [accessibility](https://shopify.dev/themes/best-practices/accessibility)
