### PR TITLE
Use `og:type=website` for collection

### DIFF
--- a/snippets/meta-tags.liquid
+++ b/snippets/meta-tags.liquid
@@ -8,8 +8,6 @@
     assign og_type = 'product'
   elsif request.page_type == 'article'
     assign og_type = 'article'
-  elsif request.page_type == 'collection'
-    assign og_type = 'product.group'
   elsif request.page_type == 'password'
     assign og_url = shop.url
   endif


### PR DESCRIPTION
`<meta property="og:type" content="product.group" />` is not actually a valid value. Collection page should default to `<meta property="og:type" content="website" />` instead.

cc: @jackson-lo

**Why are these changes introduced?**

Fixes #0.

**What approach did you take?**

**Other considerations**

**Demo links**

- [Store](url)
- [Editor](url)

**Checklist**
- [ ] Followed [theme code principles](https://github.com/Shopify/dawn/blob/main/.github/CONTRIBUTING.md#theme-code-principles)
- [ ] Linted with [Theme Check](https://github.com/Shopify/theme-check)
- [ ] Tested on [mobile](https://shopify.dev/themes/store/requirements#mobile-browser-requirements)
- [ ] Tested on [multiple browsers](https://shopify.dev/themes/store/requirements#desktop-browser-requirements)
- [ ] Tested for [accessibility](https://shopify.dev/themes/best-practices/accessibility)
