### PR TITLE
Add header full width setting

### DIFF
--- a/assets/base.css
+++ b/assets/base.css
@@ -2181,6 +2181,10 @@ input[type='checkbox'] {
   .header:not(.header--middle-left) .header__inline-menu {
     margin-top: 1.05rem;
   }
+
+  .header--full-width {
+    max-width: none;
+  }
 }
 
 .header *[tabindex='-1']:focus {

--- a/locales/en.default.schema.json
+++ b/locales/en.default.schema.json
@@ -875,6 +875,9 @@
           "label": "Enable sticky header",
           "info": "Header shows on the screen as customers scroll up."
         },
+        "full_width": {
+          "label": "Make header content full width"
+        },
         "margin_bottom": {
           "label": "Bottom margin"
         }

--- a/sections/header.liquid
+++ b/sections/header.liquid
@@ -92,7 +92,7 @@
   </symbol>
 </svg>
 <{% if section.settings.enable_sticky_header %}sticky-header{% else %}div{% endif %} class="header-wrapper color-{{ section.settings.color_scheme }} gradient{% if section.settings.show_line_separator %} header-wrapper--border-bottom{% endif %}">
-  <header class="header header--{{ section.settings.logo_position }} page-width{% if section.settings.menu != blank %} header--has-menu{% endif %}">
+  <header class="header header--{{ section.settings.logo_position }} page-width{% if section.settings.full_width %} header--full-width{% endif %}{% if section.settings.menu != blank %} header--has-menu{% endif %}">
     {%- if section.settings.menu != blank -%}
       <header-drawer data-breakpoint="tablet">
         <details id="Details-menu-drawer-container" class="menu-drawer-container">
@@ -745,6 +745,12 @@
       "default": true,
       "label": "t:sections.header.settings.enable_sticky_header.label",
       "info": "t:sections.header.settings.enable_sticky_header.info"
+    },
+    {
+      "type": "checkbox",
+      "id": "full_width",
+      "default": false,
+      "label": "t:sections.header.settings.full_width.label"
     },
     {
       "type": "header",


### PR DESCRIPTION
**Why are these changes introduced?**

Adds a header setting similar to `Make section full width` settings that prevent the header logo/nav from being constrained by the page width.

**What approach did you take?**

**Other considerations**

**Testing steps/scenarios**
- [ ] _List all the testing tasks that applies to your fix and help peers to review your work._

**Demo links**
_Please include a link to a demo store that includes preconfigured sections and settings to allow reviewers to easily test the features you are working on._

- [Editor](https://os2-demo.myshopify.com/admin/themes/127532138518/editor)

**Checklist**
- [ ] Followed [theme code principles](https://github.com/Shopify/dawn/blob/main/.github/CONTRIBUTING.md#theme-code-principles)
- [ ] Linted with [Theme Check](https://github.com/Shopify/theme-check)
- [ ] Tested on [mobile](https://shopify.dev/themes/store/requirements#mobile-browser-requirements)
- [ ] Tested on [multiple browsers](https://shopify.dev/themes/store/requirements#desktop-browser-requirements)
- [ ] Tested for [accessibility](https://shopify.dev/themes/best-practices/accessibility)
