### PR TITLE
Add missing gradient support

### DIFF
--- a/assets/base.css
+++ b/assets/base.css
@@ -1920,6 +1920,7 @@ input[type='checkbox'] {
 
 /* component-quantity */
 .quantity {
+  background: rgb(var(--color-background));
   color: rgba(var(--color-foreground));
   position: relative;
   width: calc(14rem / var(--font-body-scale) + var(--inputs-border-width) * 2);

--- a/assets/base.css
+++ b/assets/base.css
@@ -1472,7 +1472,6 @@ details[open] > .share-button__fallback {
 }
 
 .share-button__fallback {
-  background: rgb(var(--color-background));
   display: flex;
   align-items: center;
   position: absolute;
@@ -1501,6 +1500,7 @@ details[open] > .share-button__fallback {
 }
 
 .share-button__fallback:before {
+  background: rgb(var(--color-background));
   pointer-events: none;
   content: '';
   position: absolute;
@@ -1920,7 +1920,6 @@ input[type='checkbox'] {
 
 /* component-quantity */
 .quantity {
-  background: rgb(var(--color-background));
   color: rgba(var(--color-foreground));
   position: relative;
   width: calc(14rem / var(--font-body-scale) + var(--inputs-border-width) * 2);
@@ -1945,6 +1944,7 @@ input[type='checkbox'] {
 }
 
 .quantity:before {
+  background: rgb(var(--color-background));
   pointer-events: none;
   content: '';
   position: absolute;

--- a/assets/component-cart-notification.css
+++ b/assets/component-cart-notification.css
@@ -9,7 +9,6 @@
 .cart-notification {
   border-bottom-right-radius: var(--popup-corner-radius);
   border-bottom-left-radius: var(--popup-corner-radius);
-  background-color: rgb(var(--color-background));
   border-color: rgba(var(--color-foreground), var(--popup-border-opacity));
   border-style: solid;
   border-width: 0 0 var(--popup-border-width);

--- a/assets/component-facets.css
+++ b/assets/component-facets.css
@@ -566,7 +566,6 @@ a.active-facets__button.focused .active-facets__button-inner,
 }
 
 .mobile-facets__header {
-  background-color: rgb(var(--color-background));
   border-bottom: 0.1rem solid rgba(var(--color-foreground), 0.08);
   padding: 1rem 2.5rem;
   text-align: center;
@@ -823,7 +822,6 @@ input.mobile-facets__checkbox {
 }
 
 .mobile-facets__footer {
-  background-color: rgb(var(--color-background));
   border-top: 0.1rem solid rgba(var(--color-foreground), 0.08);
   padding: 2rem;
   bottom: 0;

--- a/assets/component-facets.css
+++ b/assets/component-facets.css
@@ -697,6 +697,7 @@ details.menu-opening .mobile-facets__close svg {
   flex-grow: 1;
   display: flex;
   flex-direction: column;
+  overflow-y: auto;
 }
 
 .mobile-facets__details[open] .icon-caret {
@@ -744,7 +745,6 @@ details.menu-opening .mobile-facets__close svg {
   width: 100%;
   bottom: 0;
   left: 0;
-  background-color: rgb(var(--color-background));
   z-index: 3;
   transform: translateX(100%);
   visibility: hidden;
@@ -786,7 +786,6 @@ input.mobile-facets__checkbox {
 .mobile-facets__label {
   padding: 1.5rem 2rem 1.5rem 2.5rem;
   width: 100%;
-  background-color: rgb(var(--color-background));
   transition: background-color 0.2s ease;
   word-break: break-word;
   display: flex;

--- a/assets/component-list-menu.css
+++ b/assets/component-list-menu.css
@@ -7,7 +7,6 @@
   min-width: 100%;
   width: 20rem;
   border: 1px solid rgba(var(--color-foreground), 0.2);
-  background-color: rgb(var(--color-background));
 }
 
 .list-menu--disclosure:focus {

--- a/sections/email-signup-banner.liquid
+++ b/sections/email-signup-banner.liquid
@@ -55,7 +55,7 @@
     </div>
   {%- endif -%}
   <div class="banner__content banner__content--{{ section.settings.desktop_content_position }} page-width">
-    <div class="email-signup-banner__box banner__box newsletter newsletter__wrapper isolate{% if section.settings.show_background_image == false %} email-signup-banner__box--no-image{% endif %} content-container color-{{ section.settings.color_scheme }} content-container--full-width-mobile">
+    <div class="email-signup-banner__box banner__box newsletter newsletter__wrapper isolate{% if section.settings.show_background_image == false %} email-signup-banner__box--no-image{% endif %} content-container color-{{ section.settings.color_scheme }} gradient content-container--full-width-mobile">
       {%- for block in section.blocks -%}
         {%- case block.type -%}
           {%- when 'heading' -%}

--- a/sections/featured-product.liquid
+++ b/sections/featured-product.liquid
@@ -348,7 +348,7 @@
       <div class="product-media-modal__dialog" role="dialog" aria-label="{{ 'products.modal.label' | t }}" aria-modal="true" tabindex="-1">
         <button id="ModalClose-{{ section.id }}" type="button" class="product-media-modal__toggle" aria-label="{{ 'accessibility.close' | t }}">{% render 'icon-close' %}</button>
 
-        <div class="product-media-modal__content" role="document" aria-label="{{ 'products.modal.label' | t }}" tabindex="0">
+        <div class="product-media-modal__content color-background-1 gradient" role="document" aria-label="{{ 'products.modal.label' | t }}" tabindex="0">
           {%- liquid
             if product.selected_or_first_available_variant.featured_media != null
               assign media = product.selected_or_first_available_variant.featured_media

--- a/sections/header.liquid
+++ b/sections/header.liquid
@@ -104,7 +104,7 @@
           </summary>
           <div id="menu-drawer" class="menu-drawer motion-reduce" tabindex="-1">
             <div class="menu-drawer__inner-container">
-              <div class="menu-drawer__navigation-container">
+              <div class="menu-drawer__navigation-container color-{{ section.settings.color_scheme }} gradient">
                 <nav class="menu-drawer__navigation">
                   <ul class="menu-drawer__menu list-menu" role="list">
                     {%- for link in section.settings.menu.links -%}
@@ -276,7 +276,7 @@
               </svg>
             </span>
           </summary>
-          <div class="search-modal modal__content" role="dialog" aria-modal="true" aria-label="{{ 'general.search.search' | t }}">
+          <div class="search-modal modal__content color-{{ section.settings.color_scheme }} gradient" role="dialog" aria-modal="true" aria-label="{{ 'general.search.search' | t }}">
             <div class="modal-overlay"></div>
             <div class="search-modal__content{% if settings.inputs_shadow_vertical_offset != 0 and settings.inputs_shadow_vertical_offset < 0 %} search-modal__content-top{% else %} search-modal__content-bottom{% endif %}" tabindex="-1">
               {%- if settings.predictive_search_enabled -%}
@@ -313,7 +313,7 @@
                   </div>
 
                   {%- if settings.predictive_search_enabled -%}
-                    <div class="predictive-search predictive-search--header" tabindex="-1" data-predictive-search>
+                    <div class="predictive-search predictive-search--header color-{{ section.settings.color_scheme }} gradient" tabindex="-1" data-predictive-search>
                       <div class="predictive-search__loading-state">
                         <svg aria-hidden="true" focusable="false" role="presentation" class="spinner" viewBox="0 0 66 66" xmlns="http://www.w3.org/2000/svg">
                           <circle class="path" fill="none" stroke-width="6" cx="33" cy="33" r="30"></circle>
@@ -425,7 +425,7 @@
               </svg>
             </span>
           </summary>
-          <div class="search-modal modal__content" role="dialog" aria-modal="true" aria-label="{{ 'general.search.search' | t }}">
+          <div class="search-modal modal__content color-{{ section.settings.color_scheme }} gradient" role="dialog" aria-modal="true" aria-label="{{ 'general.search.search' | t }}">
             <div class="modal-overlay"></div>
             <div class="search-modal__content{% if settings.inputs_shadow_vertical_offset != 0 and settings.inputs_shadow_vertical_offset < 0 %} search-modal__content-top{% else %} search-modal__content-bottom{% endif %}" tabindex="-1">
               {%- if settings.predictive_search_enabled -%}
@@ -462,7 +462,7 @@
                   </div>
 
                   {%- if settings.predictive_search_enabled -%}
-                    <div class="predictive-search predictive-search--header" tabindex="-1" data-predictive-search>
+                    <div class="predictive-search predictive-search--header color-{{ section.settings.color_scheme }} gradient" tabindex="-1" data-predictive-search>
                       <div class="predictive-search__loading-state">
                         <svg aria-hidden="true" focusable="false" role="presentation" class="spinner" viewBox="0 0 66 66" xmlns="http://www.w3.org/2000/svg">
                           <circle class="path" fill="none" stroke-width="6" cx="33" cy="33" r="30"></circle>

--- a/sections/header.liquid
+++ b/sections/header.liquid
@@ -117,7 +117,7 @@
                               {% render 'icon-caret' %}
                             </summary>
                             <div id="link-{{ link.title | escape }}" class="menu-drawer__submenu motion-reduce" tabindex="-1">
-                              <div class="menu-drawer__inner-submenu">
+                              <div class="menu-drawer__inner-submenu color-{{ section.settings.color_scheme }} gradient">
                                 <button class="menu-drawer__close-button link link--text focus-inset" aria-expanded="true">
                                   {% render 'icon-arrow' %}
                                   {{ link.title | escape }}
@@ -372,7 +372,7 @@
                       <span {%- if link.child_active %} class="header__active-menu-item"{% endif %}>{{ link.title | escape }}</span>
                       {% render 'icon-caret' %}
                     </summary>
-                    <ul id="HeaderMenu-MenuList-{{ forloop.index }}" class="header__submenu list-menu list-menu--disclosure caption-large motion-reduce" role="list" tabindex="-1">
+                    <ul id="HeaderMenu-MenuList-{{ forloop.index }}" class="header__submenu list-menu list-menu--disclosure color-{{ section.settings.color_scheme }} gradient caption-large motion-reduce" role="list" tabindex="-1">
                       {%- for childlink in link.links -%}
                         <li>
                           {%- if childlink.links == blank -%}

--- a/sections/header.liquid
+++ b/sections/header.liquid
@@ -313,7 +313,7 @@
                   </div>
 
                   {%- if settings.predictive_search_enabled -%}
-                    <div class="predictive-search predictive-search--header color-{{ section.settings.color_scheme }} gradient" tabindex="-1" data-predictive-search>
+                    <div class="predictive-search predictive-search--header" tabindex="-1" data-predictive-search>
                       <div class="predictive-search__loading-state">
                         <svg aria-hidden="true" focusable="false" role="presentation" class="spinner" viewBox="0 0 66 66" xmlns="http://www.w3.org/2000/svg">
                           <circle class="path" fill="none" stroke-width="6" cx="33" cy="33" r="30"></circle>
@@ -462,7 +462,7 @@
                   </div>
 
                   {%- if settings.predictive_search_enabled -%}
-                    <div class="predictive-search predictive-search--header color-{{ section.settings.color_scheme }} gradient" tabindex="-1" data-predictive-search>
+                    <div class="predictive-search predictive-search--header" tabindex="-1" data-predictive-search>
                       <div class="predictive-search__loading-state">
                         <svg aria-hidden="true" focusable="false" role="presentation" class="spinner" viewBox="0 0 66 66" xmlns="http://www.w3.org/2000/svg">
                           <circle class="path" fill="none" stroke-width="6" cx="33" cy="33" r="30"></circle>

--- a/sections/header.liquid
+++ b/sections/header.liquid
@@ -102,7 +102,7 @@
               {% render 'icon-close' %}
             </span>
           </summary>
-          <div id="menu-drawer" class="color-{{ section.settings.color_scheme }} gradient menu-drawer motion-reduce" tabindex="-1">
+          <div id="menu-drawer" class="gradient menu-drawer motion-reduce" tabindex="-1">
             <div class="menu-drawer__inner-container">
               <div class="menu-drawer__navigation-container">
                 <nav class="menu-drawer__navigation">
@@ -372,7 +372,7 @@
                       <span {%- if link.child_active %} class="header__active-menu-item"{% endif %}>{{ link.title | escape }}</span>
                       {% render 'icon-caret' %}
                     </summary>
-                    <ul id="HeaderMenu-MenuList-{{ forloop.index }}" class="header__submenu list-menu list-menu--disclosure color-{{ section.settings.color_scheme }} gradient caption-large motion-reduce" role="list" tabindex="-1">
+                    <ul id="HeaderMenu-MenuList-{{ forloop.index }}" class="header__submenu list-menu list-menu--disclosure gradient caption-large motion-reduce" role="list" tabindex="-1">
                       {%- for childlink in link.links -%}
                         <li>
                           {%- if childlink.links == blank -%}

--- a/sections/header.liquid
+++ b/sections/header.liquid
@@ -102,9 +102,9 @@
               {% render 'icon-close' %}
             </span>
           </summary>
-          <div id="menu-drawer" class="menu-drawer motion-reduce" tabindex="-1">
+          <div id="menu-drawer" class="color-{{ section.settings.color_scheme }} gradient menu-drawer motion-reduce" tabindex="-1">
             <div class="menu-drawer__inner-container">
-              <div class="menu-drawer__navigation-container color-{{ section.settings.color_scheme }} gradient">
+              <div class="menu-drawer__navigation-container">
                 <nav class="menu-drawer__navigation">
                   <ul class="menu-drawer__menu list-menu" role="list">
                     {%- for link in section.settings.menu.links -%}
@@ -116,8 +116,8 @@
                               {% render 'icon-arrow' %}
                               {% render 'icon-caret' %}
                             </summary>
-                            <div id="link-{{ link.title | escape }}" class="menu-drawer__submenu motion-reduce" tabindex="-1">
-                              <div class="menu-drawer__inner-submenu color-{{ section.settings.color_scheme }} gradient">
+                            <div id="link-{{ link.title | escape }}" class="menu-drawer__submenu gradient motion-reduce" tabindex="-1">
+                              <div class="menu-drawer__inner-submenu">
                                 <button class="menu-drawer__close-button link link--text focus-inset" aria-expanded="true">
                                   {% render 'icon-arrow' %}
                                   {{ link.title | escape }}
@@ -136,7 +136,7 @@
                                             {% render 'icon-arrow' %}
                                             {% render 'icon-caret' %}
                                           </summary>
-                                          <div id="childlink-{{ childlink.title | escape }}" class="menu-drawer__submenu motion-reduce">
+                                          <div id="childlink-{{ childlink.title | escape }}" class="menu-drawer__submenu gradient motion-reduce">
                                             <button class="menu-drawer__close-button link link--text focus-inset" aria-expanded="true">
                                               {% render 'icon-arrow' %}
                                               {{ childlink.title | escape }}
@@ -276,7 +276,7 @@
               </svg>
             </span>
           </summary>
-          <div class="search-modal modal__content color-{{ section.settings.color_scheme }} gradient" role="dialog" aria-modal="true" aria-label="{{ 'general.search.search' | t }}">
+          <div class="search-modal modal__content gradient" role="dialog" aria-modal="true" aria-label="{{ 'general.search.search' | t }}">
             <div class="modal-overlay"></div>
             <div class="search-modal__content{% if settings.inputs_shadow_vertical_offset != 0 and settings.inputs_shadow_vertical_offset < 0 %} search-modal__content-top{% else %} search-modal__content-bottom{% endif %}" tabindex="-1">
               {%- if settings.predictive_search_enabled -%}
@@ -425,7 +425,7 @@
               </svg>
             </span>
           </summary>
-          <div class="search-modal modal__content color-{{ section.settings.color_scheme }} gradient" role="dialog" aria-modal="true" aria-label="{{ 'general.search.search' | t }}">
+          <div class="search-modal modal__content gradient" role="dialog" aria-modal="true" aria-label="{{ 'general.search.search' | t }}">
             <div class="modal-overlay"></div>
             <div class="search-modal__content{% if settings.inputs_shadow_vertical_offset != 0 and settings.inputs_shadow_vertical_offset < 0 %} search-modal__content-top{% else %} search-modal__content-bottom{% endif %}" tabindex="-1">
               {%- if settings.predictive_search_enabled -%}

--- a/sections/image-banner.liquid
+++ b/sections/image-banner.liquid
@@ -80,7 +80,7 @@
     </div>
   {%- endif -%}
   <div class="banner__content banner__content--{{ section.settings.desktop_content_position }} page-width">
-    <div class="banner__box content-container content-container--full-width-mobile color-{{ section.settings.color_scheme }}">
+    <div class="banner__box content-container content-container--full-width-mobile color-{{ section.settings.color_scheme }} gradient">
       {%- for block in section.blocks -%}
         {%- case block.type -%}
           {%- when 'heading' -%}

--- a/sections/main-product.liquid
+++ b/sections/main-product.liquid
@@ -485,7 +485,7 @@
     <div class="product-media-modal__dialog" role="dialog" aria-label="{{ 'products.modal.label' | t }}" aria-modal="true" tabindex="-1">
       <button id="ModalClose-{{ section.id }}" type="button" class="product-media-modal__toggle" aria-label="{{ 'accessibility.close' | t }}">{% render 'icon-close' %}</button>
 
-      <div class="product-media-modal__content" role="document" aria-label="{{ 'products.modal.label' | t }}" tabindex="0">
+      <div class="product-media-modal__content color-background-1 gradient" role="document" aria-label="{{ 'products.modal.label' | t }}" tabindex="0">
         {%- liquid
           if product.selected_or_first_available_variant.featured_media != null
             assign media = product.selected_or_first_available_variant.featured_media

--- a/sections/main-product.liquid
+++ b/sections/main-product.liquid
@@ -485,7 +485,7 @@
     <div class="product-media-modal__dialog" role="dialog" aria-label="{{ 'products.modal.label' | t }}" aria-modal="true" tabindex="-1">
       <button id="ModalClose-{{ section.id }}" type="button" class="product-media-modal__toggle" aria-label="{{ 'accessibility.close' | t }}">{% render 'icon-close' %}</button>
 
-      <div class="product-media-modal__content color-background-1 gradient" role="document" aria-label="{{ 'products.modal.label' | t }}" tabindex="0">
+      <div class="product-media-modal__content gradient" role="document" aria-label="{{ 'products.modal.label' | t }}" tabindex="0">
         {%- liquid
           if product.selected_or_first_available_variant.featured_media != null
             assign media = product.selected_or_first_available_variant.featured_media

--- a/sections/pickup-availability.liquid
+++ b/sections/pickup-availability.liquid
@@ -31,7 +31,7 @@
     </div>
   </pickup-availability-preview>
 
-  <pickup-availability-drawer tabindex="-1" role="dialog" aria-modal="true" aria-labelledby="PickupAvailabilityHeading">
+  <pickup-availability-drawer class="color-background-1 gradient" tabindex="-1" role="dialog" aria-modal="true" aria-labelledby="PickupAvailabilityHeading">
     <div class="pickup-availability-header">
       <h2 class="h3 pickup-availability-drawer-title" id="PickupAvailabilityHeading">{{ product_variant.product.title | escape }}</h2>
       <button class="pickup-availability-drawer-button" type="button" aria-label="{{ 'accessibility.close' | t }}">{%- render 'icon-close' -%}</button>

--- a/sections/pickup-availability.liquid
+++ b/sections/pickup-availability.liquid
@@ -31,7 +31,7 @@
     </div>
   </pickup-availability-preview>
 
-  <pickup-availability-drawer class="color-background-1 gradient" tabindex="-1" role="dialog" aria-modal="true" aria-labelledby="PickupAvailabilityHeading">
+  <pickup-availability-drawer class="gradient" tabindex="-1" role="dialog" aria-modal="true" aria-labelledby="PickupAvailabilityHeading">
     <div class="pickup-availability-header">
       <h2 class="h3 pickup-availability-drawer-title" id="PickupAvailabilityHeading">{{ product_variant.product.title | escape }}</h2>
       <button class="pickup-availability-drawer-button" type="button" aria-label="{{ 'accessibility.close' | t }}">{%- render 'icon-close' -%}</button>

--- a/sections/slideshow.liquid
+++ b/sections/slideshow.liquid
@@ -73,7 +73,7 @@
           {%- endif -%}
         </div>
         <div class="slideshow__text-wrapper banner__content banner__content--{{ block.settings.box_align }} page-width{% if block.settings.show_text_box == false %} banner--desktop-transparent{% endif %}">
-          <div class="slideshow__text banner__box content-container content-container--full-width-mobile color-{{ block.settings.color_scheme }} slideshow__text--{{ block.settings.text_alignment }} slideshow__text-mobile--{{ block.settings.text_alignment_mobile }}">
+          <div class="slideshow__text banner__box content-container content-container--full-width-mobile color-{{ block.settings.color_scheme }} gradient slideshow__text--{{ block.settings.text_alignment }} slideshow__text-mobile--{{ block.settings.text_alignment_mobile }}">
             {%- if block.settings.heading != blank -%}
               <h2 class="banner__heading {{ block.settings.heading_size }}">{{ block.settings.heading | escape }}</h2>
             {%- endif -%}

--- a/snippets/article-card.liquid
+++ b/snippets/article-card.liquid
@@ -29,11 +29,11 @@
       card--{{ settings.card_style }}
       {% if media_height and media_height != 'adapt' %} article-card__image--{{ media_height }}{% endif %}
       {% if article.image and show_image %} card--media{% else %} card--text{% endif %}
-      {% if settings.card_style == 'card' %} color-{{ settings.card_color_scheme }}{% endif %}
+      {% if settings.card_style == 'card' %} color-{{ settings.card_color_scheme }} gradient{% endif %}
       {% if settings.card_style == 'card' and media_height == nil and article.image == empty or show_image == false %} ratio{% endif %}"
       style="--ratio-percent: {{ 1 | divided_by: ratio | times: 100 }}%;"
     >
-      <div class="card__inner {% if settings.card_style == 'standard' %} color-{{ settings.card_color_scheme }}{% endif %}{% if article.image and show_image or settings.card_style == 'standard' %} ratio{% endif %}" style="--ratio-percent: {{ 1 | divided_by: ratio | times: 100 }}%;">
+      <div class="card__inner {% if settings.card_style == 'standard' %} color-{{ settings.card_color_scheme }} gradient{% endif %}{% if article.image and show_image or settings.card_style == 'standard' %} ratio{% endif %}" style="--ratio-percent: {{ 1 | divided_by: ratio | times: 100 }}%;">
         {%- if show_image == true and article.image -%}
           <div class="article-card__image-wrapper card__media">
             <div class="article-card__image media media--hover-effect" {% if section.settings.media_height == 'adapt' %} style="padding-bottom: {{ 1 | divided_by: article.image.aspect_ratio | times: 100 }}%;"{% endif %}>

--- a/snippets/card-collection.liquid
+++ b/snippets/card-collection.liquid
@@ -27,12 +27,12 @@
   <div class="card
     card--{{ settings.card_style }}
     {% if card_collection.featured_image %} card--media{% else %} card--text{% endif %}
-    {% if settings.card_style == 'card' %} color-{{ settings.card_color_scheme }}{% endif %}
+    {% if settings.card_style == 'card' %} color-{{ settings.card_color_scheme }} gradient{% endif %}
     {% if extend_height %} card--extend-height{% endif %}
     {% if card_collection.featured_image == nil and settings.card_style == 'card' %} ratio{% endif %}"
     style="--ratio-percent: {{ 1 | divided_by: ratio | times: 100 }}%;"
   >
-    <div class="card__inner {% if settings.card_style == 'standard' %}color-{{ settings.card_color_scheme }}{% endif %}{% if card_collection.featured_image or settings.card_style == 'standard' %} ratio{% endif %}" style="--ratio-percent: {{ 1 | divided_by: ratio | times: 100 }}%;">
+    <div class="card__inner {% if settings.card_style == 'standard' %}color-{{ settings.card_color_scheme }} gradient{% endif %}{% if card_collection.featured_image or settings.card_style == 'standard' %} ratio{% endif %}" style="--ratio-percent: {{ 1 | divided_by: ratio | times: 100 }}%;">
       {%- if card_collection.featured_image -%}
         <div class="card__media">
           <div class="media media--transparent media--hover-effect">

--- a/snippets/card-product.liquid
+++ b/snippets/card-product.liquid
@@ -32,12 +32,12 @@
     <div class="card
       card--{{ settings.card_style }}
       {% if card_product.featured_media %} card--media{% else %} card--text{% endif %}
-      {% if settings.card_style == 'card' %} color-{{ settings.card_color_scheme }}{% endif %}
+      {% if settings.card_style == 'card' %} color-{{ settings.card_color_scheme }} gradient{% endif %}
       {% if extend_height %} card--extend-height{% endif %}
       {% if card_product.featured_media == nil and settings.card_style == 'card' %} ratio{% endif %}"
       style="--ratio-percent: {{ 1 | divided_by: ratio | times: 100 }}%;"
     >
-      <div class="card__inner {% if settings.card_style == 'standard' %}color-{{ settings.card_color_scheme }}{% endif %}{% if card_product.featured_media or settings.card_style == 'standard' %} ratio{% endif %}" style="--ratio-percent: {{ 1 | divided_by: ratio | times: 100 }}%;">
+      <div class="card__inner {% if settings.card_style == 'standard' %}color-{{ settings.card_color_scheme }} gradient{% endif %}{% if card_product.featured_media or settings.card_style == 'standard' %} ratio{% endif %}" style="--ratio-percent: {{ 1 | divided_by: ratio | times: 100 }}%;">
         {%- if card_product.featured_media -%}
           <div class="card__media">
             <div class="media media--transparent media--hover-effect">
@@ -152,11 +152,11 @@
       card--{{ settings.card_style }}
       card--text
       {% if extend_height %} card--extend-height{% endif %}
-      {% if settings.card_style == 'card' %} color-{{ settings.card_color_scheme }}{% endif %}
+      {% if settings.card_style == 'card' %} color-{{ settings.card_color_scheme }} gradient{% endif %}
       {% if card_product.featured_media == nil and settings.card_style == 'card' %} ratio{% endif %}"
       style="--ratio-percent: 100%;"
     >
-      <div class="card__inner {% if settings.card_style == 'standard' %}color-{{ settings.card_color_scheme }}{% endif %}{% if settings.card_style == 'standard' %} ratio{% endif %}" style="--ratio-percent: 100%;">
+      <div class="card__inner {% if settings.card_style == 'standard' %}color-{{ settings.card_color_scheme }} gradient{% endif %}{% if settings.card_style == 'standard' %} ratio{% endif %}" style="--ratio-percent: 100%;">
         <div class="card__content">
           <div class="card__information">
             <h3 class="card__heading">

--- a/snippets/cart-notification.liquid
+++ b/snippets/cart-notification.liquid
@@ -9,8 +9,8 @@
 {% endcomment %}
 
 <cart-notification>
-  <div class="cart-notification-wrapper page-width{% if color_scheme %} color-{{ color_scheme }}{% endif %}">
-    <div id="cart-notification" class="cart-notification focus-inset" aria-modal="true" aria-label="{{ 'general.cart.item_added' | t }}" role="dialog" tabindex="-1">
+  <div class="cart-notification-wrapper page-width">
+    <div id="cart-notification" class="cart-notification focus-inset{% if color_scheme %} color-{{ color_scheme }} gradient{% endif %}" aria-modal="true" aria-label="{{ 'general.cart.item_added' | t }}" role="dialog" tabindex="-1">
       <div class="cart-notification__header">
         <h2 class="cart-notification__heading caption-large text-body">{%- render 'icon-checkmark' -%} {{ 'general.cart.item_added' | t }}</h2>
         <button type="button" class="cart-notification__close modal__close-button link link--text focus-inset" aria-label="{{ 'accessibility.close' | t }}">

--- a/snippets/facets.liquid
+++ b/snippets/facets.liquid
@@ -269,7 +269,7 @@
       </summary>
       <facet-filters-form>
         <form id="FacetFiltersFormMobile" class="mobile-facets">
-          <div class="mobile-facets__inner">
+          <div class="mobile-facets__inner color-background-1 gradient">
             <div class="mobile-facets__header">
               <div class="mobile-facets__header-inner">
                 <h2 class="mobile-facets__heading">

--- a/snippets/facets.liquid
+++ b/snippets/facets.liquid
@@ -269,8 +269,8 @@
       </summary>
       <facet-filters-form>
         <form id="FacetFiltersFormMobile" class="mobile-facets">
-          <div class="mobile-facets__inner color-background-1 gradient">
-            <div class="mobile-facets__header">
+          <div class="mobile-facets__inner">
+            <div class="mobile-facets__header color-background-1 gradient">
               <div class="mobile-facets__header-inner">
                 <h2 class="mobile-facets__heading">
                   {%- if enable_filtering and enable_sorting -%}
@@ -292,7 +292,7 @@
                 </p>
               </div>
             </div>
-            <div class="mobile-facets__main">
+            <div class="mobile-facets__main color-background-1 gradient">
               {%- for filter in results.filters -%}
                 {% case filter.type %}
                 {% when 'list' %}
@@ -304,7 +304,7 @@
                         <noscript>{% render 'icon-caret' %}</noscript>
                       </div>
                     </summary>
-                    <div id="FacetMobile-{{ forloop.index }}-{{ section.id }}" class="mobile-facets__submenu">
+                    <div id="FacetMobile-{{ forloop.index }}-{{ section.id }}" class="mobile-facets__submenu color-background-1 gradient">
                       <button class="mobile-facets__close-button link link--text focus-inset" aria-expanded="true" type="button">
                         {% render 'icon-arrow' %}
                         {{ filter.label | escape }}
@@ -334,7 +334,7 @@
                         {%- endfor -%}
                       </ul>
 
-                      <div class="no-js-hidden mobile-facets__footer">
+                      <div class="no-js-hidden mobile-facets__footer color-background-1 gradient">
                         <facet-remove class="mobile-facets__clear-wrapper">
                           <a href="{{ results_url }}" class="mobile-facets__clear underlined-link">{{ 'products.facets.clear' | t }}</a>
                         </facet-remove>
@@ -352,7 +352,7 @@
                         <noscript>{% render 'icon-caret' %}</noscript>
                       </div>
                     </summary>
-                    <div id="FacetMobile-{{ forloop.index }}-{{ section.id }}" class="mobile-facets__submenu">
+                    <div id="FacetMobile-{{ forloop.index }}-{{ section.id }}" class="mobile-facets__submenu color-background-1 gradient">
                       <button class="mobile-facets__close-button link link--text focus-inset" aria-expanded="true" type="button">
                         {% render 'icon-arrow' %}
                         {{ filter.label | escape }}

--- a/snippets/facets.liquid
+++ b/snippets/facets.liquid
@@ -269,8 +269,8 @@
       </summary>
       <facet-filters-form>
         <form id="FacetFiltersFormMobile" class="mobile-facets">
-          <div class="mobile-facets__inner">
-            <div class="mobile-facets__header color-background-1 gradient">
+          <div class="mobile-facets__inner gradient">
+            <div class="mobile-facets__header">
               <div class="mobile-facets__header-inner">
                 <h2 class="mobile-facets__heading">
                   {%- if enable_filtering and enable_sorting -%}
@@ -292,7 +292,7 @@
                 </p>
               </div>
             </div>
-            <div class="mobile-facets__main color-background-1 gradient">
+            <div class="mobile-facets__main gradient">
               {%- for filter in results.filters -%}
                 {% case filter.type %}
                 {% when 'list' %}
@@ -304,7 +304,7 @@
                         <noscript>{% render 'icon-caret' %}</noscript>
                       </div>
                     </summary>
-                    <div id="FacetMobile-{{ forloop.index }}-{{ section.id }}" class="mobile-facets__submenu color-background-1 gradient">
+                    <div id="FacetMobile-{{ forloop.index }}-{{ section.id }}" class="mobile-facets__submenu gradient">
                       <button class="mobile-facets__close-button link link--text focus-inset" aria-expanded="true" type="button">
                         {% render 'icon-arrow' %}
                         {{ filter.label | escape }}
@@ -334,7 +334,7 @@
                         {%- endfor -%}
                       </ul>
 
-                      <div class="no-js-hidden mobile-facets__footer color-background-1 gradient">
+                      <div class="no-js-hidden mobile-facets__footer gradient">
                         <facet-remove class="mobile-facets__clear-wrapper">
                           <a href="{{ results_url }}" class="mobile-facets__clear underlined-link">{{ 'products.facets.clear' | t }}</a>
                         </facet-remove>
@@ -352,7 +352,7 @@
                         <noscript>{% render 'icon-caret' %}</noscript>
                       </div>
                     </summary>
-                    <div id="FacetMobile-{{ forloop.index }}-{{ section.id }}" class="mobile-facets__submenu color-background-1 gradient">
+                    <div id="FacetMobile-{{ forloop.index }}-{{ section.id }}" class="mobile-facets__submenu gradient">
                       <button class="mobile-facets__close-button link link--text focus-inset" aria-expanded="true" type="button">
                         {% render 'icon-arrow' %}
                         {{ filter.label | escape }}


### PR DESCRIPTION
**Why are these changes introduced?**

Fixes #1265 
Fixes #1106 

Added gradient support to..
- Product cards, collection cards, and article cards
- Cart notification
- Search bar
- Search results popup
- Mobile menu
- Header subnav
- Slideshow content
- Image banner content
- Facet filter popups
- Product media modal
- Email signup banner
- Pickup availability drawer

Also.. 
- Added a solid background to quantity input to match other inputs ([see here](https://screenshot.click/02-26-n8vk2-v6v99.png))

**What approach did you take?**

I feel if text inputs and buttons aren't transparent (and thus may show a background gradient) then things like the quantity input and variant pills shouldn't be either. But we can certainly discuss and adjust as needed.

<details>
<summary>This looks right to me</summary>
<img src="https://screenshot.click/02-34-nvcms-zb2uq.png" width="400"/>
</details>

<details>
<summary>This doesn't</summary>
<img src="https://screenshot.click/02-37-brm5d-71gvs.png" width="400"/>
</details>

**Other considerations**

**Testing steps/scenarios**
Test all sections noted above

**Demo links**

- [Editor](https://os2-demo.myshopify.com/admin/themes/127539249174/editor)

**Checklist**
- [ ] Followed [theme code principles](https://github.com/Shopify/dawn/blob/main/.github/CONTRIBUTING.md#theme-code-principles)
- [ ] Linted with [Theme Check](https://github.com/Shopify/theme-check)
- [ ] Tested on [mobile](https://shopify.dev/themes/store/requirements#mobile-browser-requirements)
- [ ] Tested on [multiple browsers](https://shopify.dev/themes/store/requirements#desktop-browser-requirements)
- [ ] Tested for [accessibility](https://shopify.dev/themes/best-practices/accessibility)
