### PR TITLE
Fix facet filters on mobile. Add overlay to HeaderDrawer.

### DIFF
--- a/assets/base.css
+++ b/assets/base.css
@@ -2314,6 +2314,17 @@ input[type='checkbox'] {
   }
 }
 
+.header__icon--menu[aria-expanded="true"]::before {
+  content: "";
+  top: 100%;
+  left: 0;
+  height: calc(var(--viewport-height, 100vh) - (var(--header-bottom-position, 100%)));
+  width: 100%;
+  display: block;
+  position: absolute;
+  background: rgba(var(--color-foreground), 0.5);
+}
+
 /* Search */
 menu-drawer + .header__search {
   display: none;

--- a/assets/global.js
+++ b/assets/global.js
@@ -343,6 +343,8 @@ class MenuDrawer extends HTMLElement {
   }
 
   closeMenuDrawer(event, elementToFocus = false) {
+    if (event === undefined) return;
+
     this.mainDetailsToggle.classList.remove('menu-opening');
     this.mainDetailsToggle.querySelectorAll('details').forEach(details =>  {
       details.removeAttribute('open');


### PR DESCRIPTION
**Why are these changes introduced?**

Fixes #1346 and adds an overlay to Header, like suggested by @melissaperreault in #1242.

**What approach did you take?**
- Revert the change made in #1242 by adding back the check if `event === undefined`.
- Added an overlay to Header navigation on mobile. This overlay prevents accidental navigation when the user taps to exit the drawer, but ends up clicking a link.

**Testing steps/scenarios**
- [ ] Test Facet Filters on **mobile**, **desktop (mouse)**, and **desktop (mouse) with mobile viewport size**.
    - [ ] Click outside the drawer to close it.
    - [ ] Check if navigating categories and toggling filters works with no unexpected closing.
- [ ] Test Navigation Menus on **mobile**, **desktop (mouse)**, and **desktop (mouse) with mobile viewport size**.
    - [ ] Click outside the drawer to close it.
    - [ ] Check if navigating menus and submenus still work with no unexpected closing.

**Demo links**
_Please include a link to a demo store that includes preconfigured sections and settings to allow reviewers to easily test the features you are working on._

- [Store](https://os2-demo.myshopify.com/?preview_theme_id=127583780886)
- [Editor](https://os2-demo.myshopify.com/admin/themes/127583780886/editor)

**Checklist**
- [x] Followed [theme code principles](https://github.com/Shopify/dawn/blob/main/.github/CONTRIBUTING.md#theme-code-principles)
- [x] Linted with [Theme Check](https://github.com/Shopify/theme-check)
- [x] Tested on [mobile](https://shopify.dev/themes/store/requirements#mobile-browser-requirements)
- [x] Tested on [multiple browsers](https://shopify.dev/themes/store/requirements#desktop-browser-requirements)
- [x] Tested for [accessibility](https://shopify.dev/themes/best-practices/accessibility)