### PR TITLE
Fix slideshow content container borders

### DIFF
--- a/assets/component-slideshow.css
+++ b/assets/component-slideshow.css
@@ -43,9 +43,11 @@ slideshow-component .slideshow.banner {
   max-width: 54.5rem;
 }
 
-slideshow-component.page-width .slideshow__text {
-  border-right: var(--text-boxes-border-width) solid rgba(var(--color-foreground), var(--text-boxes-border-opacity));
-  border-left: var(--text-boxes-border-width) solid rgba(var(--color-foreground), var(--text-boxes-border-opacity));
+@media screen and (max-width: 749px) {
+  slideshow-component.page-width .slideshow__text {
+    border-right: var(--text-boxes-border-width) solid rgba(var(--color-foreground), var(--text-boxes-border-opacity));
+    border-left: var(--text-boxes-border-width) solid rgba(var(--color-foreground), var(--text-boxes-border-opacity));
+  }
 }
 
 .slideshow__text > * {


### PR DESCRIPTION
**Why are these changes introduced?**

Fixes #1288 

**What approach did you take?**

**Slideshow section**

For slideshow section image bocks, when the [Show container on desktop](https://user-images.githubusercontent.com/28404165/153647716-f9773d6f-6c35-4782-aae9-51cb35865f4d.png) setting is unchecked/disabled, the content container shows left and right borders. These borders show up when using [global Content container > Border settings](https://user-images.githubusercontent.com/28404165/153648056-63a089a3-e0c8-409f-a258-e91121136b22.png)

Currently, in the `component.slideshow.css`, the following rule applies to the slideshow content container when the [Grid layout setting](https://user-images.githubusercontent.com/28404165/153649271-ead556ea-c4cb-4ba7-a9a5-6cf769921cee.png) is enabled:

```css
slideshow-component.page-width .slideshow__text {
  border-right: var(--text-boxes-border-width) solid rgba(var(--color-foreground), var(--text-boxes-border-opacity));
  border-left: var(--text-boxes-border-width) solid rgba(var(--color-foreground), var(--text-boxes-border-opacity));
}
```

Wrapping the above in a media query fixes this issue:

```css
@media screen and (max-width: 749px) {
  slideshow-component.page-width .slideshow__text {
    border-right: var(--text-boxes-border-width) solid rgba(var(--color-foreground), var(--text-boxes-border-opacity));
    border-left: var(--text-boxes-border-width) solid rgba(var(--color-foreground), var(--text-boxes-border-opacity));
  }
}
```

- Tested with Chrome, FireFox, and Safari

**Other considerations**

As noted here: https://github.com/Shopify/dawn/issues/1288#issuecomment-1035582311, I initially thought removing the `slideshow-component.page-width .slideshow__text` rule entirely from `component-slideshow.css` would fix the issue but I didn't account for left and right borders on mobile, which is being handled here:

https://github.com/Shopify/dawn/blob/ad989e67cb728242b47cf95c59cb7be7f38fd719/assets/base.css#L2708-L2711

**Testing steps/scenarios**
- [ ] Add a slideshow section with the [Grid layout setting](https://user-images.githubusercontent.com/28404165/153649271-ead556ea-c4cb-4ba7-a9a5-6cf769921cee.png) enabled
- [ ] Add an image slide with the [Show container on desktop](https://user-images.githubusercontent.com/28404165/153647716-f9773d6f-6c35-4782-aae9-51cb35865f4d.png) setting disabled.
- [ ] Add a second image slide with Show container on desktop enabled to compare.
- [ ] Make sure to test mobile with the [Show content below images on mobile setting](https://user-images.githubusercontent.com/28404165/153650135-58b01552-5692-434a-9c97-1acc2e461756.png) enabled.

**Demo links**

- [Store](https://os2-demo.myshopify.com/?preview_theme_id=127586664470)
- [Editor](https://os2-demo.myshopify.com/admin/themes/127586664470/editor)

**Checklist**
- [ ] Followed [theme code principles](https://github.com/Shopify/dawn/blob/main/.github/CONTRIBUTING.md#theme-code-principles)
- [ ] Linted with [Theme Check](https://github.com/Shopify/theme-check)
- [ ] Tested on [mobile](https://shopify.dev/themes/store/requirements#mobile-browser-requirements)
- [ ] Tested on [multiple browsers](https://shopify.dev/themes/store/requirements#desktop-browser-requirements)
- [ ] Tested for [accessibility](https://shopify.dev/themes/best-practices/accessibility)
