### PR TITLE
Added required to blog comments

### DIFF
--- a/sections/main-article.liquid
+++ b/sections/main-article.liquid
@@ -175,6 +175,7 @@
                   autocomplete="name"
                   value="{{ form.author }}"
                   aria-required="true"
+                  required
                   {% if form.errors contains 'author' %}
                     aria-invalid="true"
                     aria-describedby="CommentForm-author-error"
@@ -199,6 +200,7 @@
                   autocorrect="off"
                   autocapitalize="off"
                   aria-required="true"
+                  required
                   {% if form.errors contains 'email' %}
                     aria-invalid="true"
                     aria-describedby="CommentForm-email-error"
@@ -220,6 +222,7 @@
                 id="CommentForm-body"
                 class="text-area field__input"
                 aria-required="true"
+                required
                 {% if form.errors contains 'body' %}
                   aria-invalid="true"
                   aria-describedby="CommentForm-body-error"


### PR DESCRIPTION
**Why are these changes introduced?**

Fixes #1131. (mostly)

There **is** still a platform issue that blows up the rendering of the page, however this will stop most folks from getting to it.

**What approach did you take?**

Added the `required` attribute to the form inputs so that the form can't be submitted on any browser that supports them (most browsers do).

**Other considerations**

**Testing steps/scenarios**
* Try submitting a blog comment with any or all fields unfilled
* You should now see your browser's native warning regarding missing fields rather than submission being allowed.

**Demo links**

- [Store](url)
- [Editor](url)

**Checklist**
- [ ] Followed [theme code principles](https://github.com/Shopify/dawn/blob/main/.github/CONTRIBUTING.md#theme-code-principles)
- [ ] Linted with [Theme Check](https://github.com/Shopify/theme-check)
- [ ] Tested on [mobile](https://shopify.dev/themes/store/requirements#mobile-browser-requirements)
- [ ] Tested on [multiple browsers](https://shopify.dev/themes/store/requirements#desktop-browser-requirements)
- [ ] Tested for [accessibility](https://shopify.dev/themes/best-practices/accessibility)
