### PR TITLE
`{{ shop.url }}` → `{{ request.origin }}` when building absolute URLs on the current domain

### DIFF
--- a/layout/theme.liquid
+++ b/layout/theme.liquid
@@ -227,7 +227,7 @@
     </ul>
 
     <script>
-      window.shopUrl = '{{ shop.url }}';
+      window.shopUrl = '{{ request.origin }}';
       window.routes = {
         cart_add_url: '{{ routes.cart_add_url }}',
         cart_change_url: '{{ routes.cart_change_url }}',

--- a/sections/featured-product.liquid
+++ b/sections/featured-product.liquid
@@ -160,7 +160,7 @@
                       <input type="text"
                             class="field__input"
                             id="url"
-                            value="{{ product.selected_variant.url | default: product.url | prepend: shop.url }}"
+                            value="{{ product.selected_variant.url | default: product.url | prepend: request.origin }}"
                             placeholder="{{ 'general.share.share_url' | t }}"
                             onclick="this.select();"
                             readonly
@@ -432,7 +432,7 @@
     "@context": "http://schema.org/",
     "@type": "Product",
     "name": {{ product.title | json }},
-    "url": {{ shop.url | append: product.url | json }},
+    "url": {{ request.origin | append: product.url | json }},
     {% if seo_media -%}
       {%- assign media_size = seo_media.preview_image.width | append: 'x' -%}
       "image": [
@@ -457,7 +457,7 @@
           "availability" : "http://schema.org/{% if variant.available %}InStock{% else %}OutOfStock{% endif %}",
           "price" : {{ variant.price | divided_by: 100.00 | json }},
           "priceCurrency" : {{ cart.currency.iso_code | json }},
-          "url" : {{ shop.url | append: variant.url | json }}
+          "url" : {{ request.origin | append: variant.url | json }}
         }{% unless forloop.last %},{% endunless %}
       {%- endfor -%}
     ]

--- a/sections/header.liquid
+++ b/sections/header.liquid
@@ -637,12 +637,12 @@
       {{ settings.social_youtube_link | json }},
       {{ settings.social_vimeo_link | json }}
     ],
-    "url": {{ shop.url | append: page.url | json }}
+    "url": {{ request.origin | append: page.url | json }}
   }
 </script>
 
 {%- if request.page_type == 'index' -%}
-  {% assign potential_action_target = shop.url | append: routes.search_url | append: "?q={search_term_string}" %}
+  {% assign potential_action_target = request.origin | append: routes.search_url | append: "?q={search_term_string}" %}
   <script type="application/ld+json">
     {
       "@context": "http://schema.org",
@@ -653,7 +653,7 @@
         "target": {{ potential_action_target | json }},
         "query-input": "required name=search_term_string"
       },
-      "url": {{ shop.url | append: page.url | json }}
+      "url": {{ request.origin | append: page.url | json }}
     }
   </script>
 {%- endif -%}

--- a/sections/main-article.liquid
+++ b/sections/main-article.liquid
@@ -69,7 +69,7 @@
                     <input type="text"
                           class="field__input"
                           id="url"
-                          value="{{ shop.url | append: article.url }}"
+                          value="{{ request.origin | append: article.url }}"
                           placeholder="{{ 'general.share.share_url' | t }}"
                           onclick="this.select();"
                           readonly
@@ -254,7 +254,7 @@
     "articleBody": {{ article.content | strip_html | json }},
     "mainEntityOfPage": {
       "@type": "WebPage",
-      "@id": {{ shop.url | append: page.url | json }}
+      "@id": {{ request.origin | append: page.url | json }}
     },
     "headline": {{ article.title | json }},
     {% if article.excerpt != blank %}

--- a/sections/main-product.liquid
+++ b/sections/main-product.liquid
@@ -294,7 +294,7 @@
                     <input type="text"
                           class="field__input"
                           id="url"
-                          value="{{ product.selected_variant.url | default: product.url | prepend: shop.url }}"
+                          value="{{ product.selected_variant.url | default: product.url | prepend: request.origin }}"
                           placeholder="{{ 'general.share.share_url' | t }}"
                           onclick="this.select();"
                           readonly
@@ -610,7 +610,7 @@
     "@context": "http://schema.org/",
     "@type": "Product",
     "name": {{ product.title | json }},
-    "url": {{ shop.url | append: product.url | json }},
+    "url": {{ request.origin | append: product.url | json }},
     {% if seo_media -%}
       {%- assign media_size = seo_media.preview_image.width | append: 'x' -%}
       "image": [
@@ -635,7 +635,7 @@
           "availability" : "http://schema.org/{% if variant.available %}InStock{% else %}OutOfStock{% endif %}",
           "price" : {{ variant.price | divided_by: 100.00 | json }},
           "priceCurrency" : {{ cart.currency.iso_code | json }},
-          "url" : {{ shop.url | append: variant.url | json }}
+          "url" : {{ request.origin | append: variant.url | json }}
         }{% unless forloop.last %},{% endunless %}
       {%- endfor -%}
     ]

--- a/snippets/meta-tags.liquid
+++ b/snippets/meta-tags.liquid
@@ -1,6 +1,6 @@
 {%- liquid
   assign og_title = page_title | default: shop.name
-  assign og_url = canonical_url | default: shop.url
+  assign og_url = canonical_url | default: request.origin
   assign og_type = 'website'
   assign og_description = page_description | default: shop.description | default: shop.name
 
@@ -11,7 +11,7 @@
   elsif request.page_type == 'collection'
     assign og_type = 'product.group'
   elsif request.page_type == 'password'
-    assign og_url = shop.url
+    assign og_url = request.origin
   endif
 %}
 

--- a/templates/gift_card.liquid
+++ b/templates/gift_card.liquid
@@ -149,7 +149,7 @@
         {%- endif -%}
         <div class="gift-card__buttons no-print">
           <a
-            href="{{ shop.url }}"
+            href="{{ request.origin }}"
             class="button"
             target="_blank"
             rel="noopener"


### PR DESCRIPTION
**Why are these changes introduced?**

`{{ shop.url }}` always returns the shop's primary domain, but it's used to generate `Share` links and structured data. When visiting a shop on a non-primary domain, they result in the wrong url.

<img width="457" alt="image" src="https://user-images.githubusercontent.com/4642599/154714943-75771e36-4646-430c-a659-b696e4c641cf.png">

The behavior of `{{ shop.url }}` cannot change without potentially breaking shops which are relying on it as a reference to the primary domain. So `{{ request.origin }}` was recently added as an alternative for use cases like this.

**What approach did you take?**

Replaced all instances of `{{ shop.url }}` with `{{ request.origin }}`.

**Other considerations**

Are there any cases where we should always be using the shop's primary domain? Gift cards for example, although I'm not sure why that one makes me suspicious.

**Demo links**
_Please include a link to a demo store that includes preconfigured sections and settings to allow reviewers to easily test the features you are working on._

- Store: https://ca.catleaves.com/products/basic-cat-leaf?preview_theme_id=127614287894
- Editor: https://cat-leaves.myshopify.com/admin/themes/127614287894/editor

**Checklist**
- [x] Followed [theme code principles](https://github.com/Shopify/dawn/blob/main/.github/CONTRIBUTING.md#theme-code-principles)
- [x] Linted with [Theme Check](https://github.com/Shopify/theme-check)
- [ ] Tested on [mobile](https://shopify.dev/themes/store/requirements#mobile-browser-requirements)
- [ ] Tested on [multiple browsers](https://shopify.dev/themes/store/requirements#desktop-browser-requirements)
- [ ] Tested for [accessibility](https://shopify.dev/themes/best-practices/accessibility)
