### PR TITLE
Add binding to catch block to prevent syntax error in browsers that don't support es2019

### DIFF
--- a/assets/global.js
+++ b/assets/global.js
@@ -73,7 +73,7 @@ function trapFocus(container, elementToFocus = container) {
 // Here run the querySelector to figure out if the browser supports :focus-visible or not and run code based on it.
 try {
   document.querySelector(":focus-visible");
-} catch {
+} catch(e) {
   focusVisiblePolyfill();
 }
 


### PR DESCRIPTION
**Why are these changes introduced?**

Partially addresses https://github.com/Shopify/dawn/issues/1376

**What approach did you take?**

Add binding to catch block

**Other considerations**

- [Optional binding for catch blocks was introduced in es2019](https://github.com/tc39/proposal-optional-catch-binding)
- Omitting the binding causes syntax error in older browsers (including Safari in iOS 11)
- Although we don't officially support iOS 11, reasoning for fixing this:
  - Although we aren’t officially supporting it, it would allow older browsers to benefit without bloating the code.
  - If a change to support an older browser doesn’t add significant complexity and doesn’t cause any negative effects for the browsers we do support, then we should make the change.

**Testing steps/scenarios**

- [ ] Use preview on Browserstack, Simulator or iOS 11 device on mobile
- [ ] Open main mobile menu

**Demo links**

- [Store](https://os2-demo.myshopify.com/?preview_theme_id=127614943254)
- [Editor](https://os2-demo.myshopify.com/admin/themes/127614943254/editor)

**Checklist**
- [ ] Followed [theme code principles](https://github.com/Shopify/dawn/blob/main/.github/CONTRIBUTING.md#theme-code-principles)
- [ ] Linted with [Theme Check](https://github.com/Shopify/theme-check)
- [ ] Tested on [mobile](https://shopify.dev/themes/store/requirements#mobile-browser-requirements)
- [ ] Tested on [multiple browsers](https://shopify.dev/themes/store/requirements#desktop-browser-requirements)
- [ ] Tested for [accessibility](https://shopify.dev/themes/best-practices/accessibility)
