### PR TITLE
Product media zoom option

### DIFF
--- a/locales/en.default.schema.json
+++ b/locales/en.default.schema.json
@@ -1838,6 +1838,15 @@
             "label": "Large"
           }
         },
+        "media_zoom": {
+          "label": "Media zoom",
+          "options__1": {
+            "label": "Enable zoom"
+          },
+          "options__2": {
+            "label": "Disable zoom"
+          }
+        },
         "mobile_thumbnails": {
           "label": "Mobile layout",
           "options__1": {

--- a/sections/featured-product.liquid
+++ b/sections/featured-product.liquid
@@ -42,7 +42,7 @@
             {%- if product.selected_or_first_available_variant.featured_media != null -%}
               {%- assign media = product.selected_or_first_available_variant.featured_media -%}
               <div class="product__media-item" data-media-id="{{ section.id }}-{{ media.id }}">
-                {% render 'product-thumbnail', media: media, position: 'featured', loop: section.settings.enable_video_looping, modal_id: section.id, xr_button: false, media_width: 0.5 %}
+                {% render 'product-thumbnail', media: media, position: 'featured', loop: section.settings.enable_video_looping, modal_id: section.id, xr_button: false, media_width: 0.5, media_zoom: section.settings.media_zoom %}
               </div>
             {%- endif -%}
             {%- liquid
@@ -54,7 +54,7 @@
             {%- for media in product.media -%}
               {%- if media_to_render contains media.id and media.id != product.selected_or_first_available_variant.featured_media.id -%}
                 <div class="product__media-item" data-media-id="{{ section.id }}-{{ media.id }}">
-                  {% render 'product-thumbnail', media: media, position: forloop.index, loop: section.settings.enable_video_looping, modal_id: section.id, xr_button: false, media_width: 0.5 %}
+                  {% render 'product-thumbnail', media: media, position: forloop.index, loop: section.settings.enable_video_looping, modal_id: section.id, xr_button: false, media_width: 0.5, media_zoom: section.settings.media_zoom %}
                 </div>
               {%- endif -%}
             {%- endfor -%}
@@ -344,34 +344,36 @@
         </div>
       </div>
     </div>
-    <product-modal id="ProductModal-{{ section.id }}" class="product-media-modal media-modal">
-      <div class="product-media-modal__dialog" role="dialog" aria-label="{{ 'products.modal.label' | t }}" aria-modal="true" tabindex="-1">
-        <button id="ModalClose-{{ section.id }}" type="button" class="product-media-modal__toggle" aria-label="{{ 'accessibility.close' | t }}">{% render 'icon-close' %}</button>
+    {%- if section.settings.media_zoom -%}
+      <product-modal id="ProductModal-{{ section.id }}" class="product-media-modal media-modal">
+        <div class="product-media-modal__dialog" role="dialog" aria-label="{{ 'products.modal.label' | t }}" aria-modal="true" tabindex="-1">
+          <button id="ModalClose-{{ section.id }}" type="button" class="product-media-modal__toggle" aria-label="{{ 'accessibility.close' | t }}">{% render 'icon-close' %}</button>
 
-        <div class="product-media-modal__content" role="document" aria-label="{{ 'products.modal.label' | t }}" tabindex="0">
-          {%- liquid
-            if product.selected_or_first_available_variant.featured_media != null
-              assign media = product.selected_or_first_available_variant.featured_media
-              render 'product-media', media: media, loop: section.settings.enable_video_looping, variant_image: section.settings.hide_variants
-            endif
-          -%}
-
-          {%- for media in product.media -%}
+          <div class="product-media-modal__content" role="document" aria-label="{{ 'products.modal.label' | t }}" tabindex="0">
             {%- liquid
-              if section.settings.hide_variants and media_to_render contains media.id
-                assign variant_image = true
-              else
-                assign variant_image = false
+              if product.selected_or_first_available_variant.featured_media != null
+                assign media = product.selected_or_first_available_variant.featured_media
+                render 'product-media', media: media, loop: section.settings.enable_video_looping, variant_image: section.settings.hide_variants
               endif
-
-              unless media.id == product.selected_or_first_available_variant.featured_media.id
-                render 'product-media', media: media, loop: section.settings.enable_video_looping, variant_image: variant_image
-              endunless
             -%}
-          {%- endfor -%}
+
+            {%- for media in product.media -%}
+              {%- liquid
+                if section.settings.hide_variants and media_to_render contains media.id
+                  assign variant_image = true
+                else
+                  assign variant_image = false
+                endif
+
+                unless media.id == product.selected_or_first_available_variant.featured_media.id
+                  render 'product-media', media: media, loop: section.settings.enable_video_looping, variant_image: variant_image
+                endunless
+              -%}
+            {%- endfor -%}
+          </div>
         </div>
-      </div>
-    </product-modal>
+      </product-modal>
+    {%- endif -%}
   </div>
 </section>
 
@@ -678,6 +680,22 @@
       "id": "hide_variants",
       "default": false,
       "label": "t:sections.main-product.settings.hide_variants.label"
+    },
+    {
+      "type": "select",
+      "id": "media_zoom",
+      "options": [
+        {
+          "value": "enable",
+          "label": "t:sections.main-product.settings.media_zoom.options__1.label"
+        },
+        {
+          "value": "disable",
+          "label": "t:sections.main-product.settings.media_zoom.options__2.label"
+        }
+      ],
+      "default": "enable",
+      "label": "t:sections.main-product.settings.media_zoom.label"
     },
     {
       "type": "checkbox",

--- a/sections/main-product.liquid
+++ b/sections/main-product.liquid
@@ -61,14 +61,14 @@
               {%- assign featured_media = product.selected_or_first_available_variant.featured_media -%}
               <li id="Slide-{{ section.id }}-{{ featured_media.id }}" class="product__media-item grid__item slider__slide is-active{% if featured_media.media_type != 'image' %} product__media-item--full{% endif %}{% if section.settings.hide_variants and variant_images contains featured_media.src %} product__media-item--variant{% endif %}" data-media-id="{{ section.id }}-{{ featured_media.id }}">
                 {%- assign media_position = 1 -%}
-                {% render 'product-thumbnail', media: featured_media, position: media_position, loop: section.settings.enable_video_looping, modal_id: section.id, xr_button: true, media_width: media_width, lazy_load: false %}
+                {% render 'product-thumbnail', media: featured_media, position: media_position, loop: section.settings.enable_video_looping, modal_id: section.id, xr_button: true, media_width: media_width, lazy_load: false, media_zoom: section.settings.media_zoom %}
               </li>
             {%- endif -%}
             {%- for media in product.media -%}
               {%- unless media.id == product.selected_or_first_available_variant.featured_media.id -%}
                 <li id="Slide-{{ section.id }}-{{ media.id }}" class="product__media-item grid__item slider__slide{% if product.selected_or_first_available_variant.featured_media == null and forloop.index == 1 %} is-active{% endif %}{% if media.media_type != 'image' %} product__media-item--full{% endif %}{% if section.settings.hide_variants and variant_images contains media.src %} product__media-item--variant{% endif %}" data-media-id="{{ section.id }}-{{ media.id }}">
                   {%- assign media_position = media_position | default: 0 | plus: 1 -%}
-                  {% render 'product-thumbnail', media: media, position: media_position, loop: section.settings.enable_video_looping, modal_id: section.id, xr_button: true, media_width: media_width, lazy_load: true %}
+                  {% render 'product-thumbnail', media: media, position: media_position, loop: section.settings.enable_video_looping, modal_id: section.id, xr_button: true, media_width: media_width, lazy_load: true, media_zoom: section.settings.media_zoom %}
                 </li>
               {%- endunless -%}
             {%- endfor -%}
@@ -482,34 +482,36 @@
     </div>
   </div>
 
-  <product-modal id="ProductModal-{{ section.id }}" class="product-media-modal media-modal">
-    <div class="product-media-modal__dialog" role="dialog" aria-label="{{ 'products.modal.label' | t }}" aria-modal="true" tabindex="-1">
-      <button id="ModalClose-{{ section.id }}" type="button" class="product-media-modal__toggle" aria-label="{{ 'accessibility.close' | t }}">{% render 'icon-close' %}</button>
+  {%- if section.settings.media_zoom == "enable" -%}
+    <product-modal id="ProductModal-{{ section.id }}" class="product-media-modal media-modal">
+      <div class="product-media-modal__dialog" role="dialog" aria-label="{{ 'products.modal.label' | t }}" aria-modal="true" tabindex="-1">
+        <button id="ModalClose-{{ section.id }}" type="button" class="product-media-modal__toggle" aria-label="{{ 'accessibility.close' | t }}">{% render 'icon-close' %}</button>
 
-      <div class="product-media-modal__content" role="document" aria-label="{{ 'products.modal.label' | t }}" tabindex="0">
-        {%- liquid
-          if product.selected_or_first_available_variant.featured_media != null
-            assign media = product.selected_or_first_available_variant.featured_media
-            render 'product-media', media: media, loop: section.settings.enable_video_looping, variant_image: section.settings.hide_variants
-          endif
-        -%}
-
-        {%- for media in product.media -%}
+        <div class="product-media-modal__content" role="document" aria-label="{{ 'products.modal.label' | t }}" tabindex="0">
           {%- liquid
-            if section.settings.hide_variants and variant_images contains media.src
-              assign variant_image = true
-            else
-              assign variant_image = false
+            if product.selected_or_first_available_variant.featured_media != null
+              assign media = product.selected_or_first_available_variant.featured_media
+              render 'product-media', media: media, loop: section.settings.enable_video_looping, variant_image: section.settings.hide_variants
             endif
-
-            unless media.id == product.selected_or_first_available_variant.featured_media.id
-              render 'product-media', media: media, loop: section.settings.enable_video_looping, variant_image: variant_image
-            endunless
           -%}
-        {%- endfor -%}
+
+          {%- for media in product.media -%}
+            {%- liquid
+              if section.settings.hide_variants and variant_images contains media.src
+                assign variant_image = true
+              else
+                assign variant_image = false
+              endif
+
+              unless media.id == product.selected_or_first_available_variant.featured_media.id
+                render 'product-media', media: media, loop: section.settings.enable_video_looping, variant_image: variant_image
+              endunless
+            -%}
+          {%- endfor -%}
+        </div>
       </div>
-    </div>
-  </product-modal>
+    </product-modal>
+  {%- endif -%}
 
   {% assign popups = section.blocks | where: "type", "popup" %}
   {%- for block in popups -%}
@@ -1064,7 +1066,7 @@
     },
     {
       "type": "select",
-      "id": "media_zoomn",
+      "id": "media_zoom",
       "options": [
         {
           "value": "enable",

--- a/sections/main-product.liquid
+++ b/sections/main-product.liquid
@@ -1064,6 +1064,22 @@
     },
     {
       "type": "select",
+      "id": "media_zoomn",
+      "options": [
+        {
+          "value": "enable",
+          "label": "t:sections.main-product.settings.media_zoom.options__1.label"
+        },
+        {
+          "value": "disable",
+          "label": "t:sections.main-product.settings.media_zoom.options__2.label"
+        }
+      ],
+      "default": "enable",
+      "label": "t:sections.main-product.settings.media_zoom.label"
+    },
+    {
+      "type": "select",
       "id": "mobile_thumbnails",
       "options": [
         {

--- a/snippets/product-thumbnail.liquid
+++ b/snippets/product-thumbnail.liquid
@@ -9,12 +9,14 @@
     - xr_button: {Boolean} Renders the "View in your space" button (shopify-xr-button) if the media is a 3D Model
     - media_width: {Float} The width percentage that the media column occupies on desktop.
     - lazy_load: {Boolean} Image should be lazy loaded. Default: true (optional)
+    - media_zoom: {String} Zoom option for media type image
 
     Usage:
     {% render 'product-thumbnail',
       media: media,
       position: forloop.index,
       loop: section.settings.enable_video_looping,
+      media_zoom: section.settings.media_zoom,
       modal_id: section.id
     %}
 {% endcomment %}
@@ -73,48 +75,107 @@
   {%- endif -%}
 </noscript>
 
-<modal-opener class="product__modal-opener product__modal-opener--{{ media.media_type }} no-js-hidden" data-modal="#ProductModal-{{ modal_id }}">
-  <span class="product__media-icon motion-reduce" aria-hidden="true">
-    {%- liquid
-      case media.media_type
-      when 'video' or 'external_video'
-        render 'icon-play'
-      when 'model'
-        render 'icon-3d-model'
-      else
-        render 'icon-zoom'
-      endcase
-    -%}
-  </span>
-
-  <div class="product__media media media--transparent gradient global-media-settings" style="padding-top: {{ 1 | divided_by: media.preview_image.aspect_ratio | times: 100 }}%;">
-    <img
-      srcset="{% if media.preview_image.width >= 493 %}{{ media.preview_image | img_url: '493x' }} 493w,{% endif %}
-        {% if media.preview_image.width >= 600 %}{{ media.preview_image | img_url: '600x' }} 600w,{% endif %}
-        {% if media.preview_image.width >= 713 %}{{ media.preview_image | img_url: '713x' }} 713w,{% endif %}
-        {% if media.preview_image.width >= 823 %}{{ media.preview_image | img_url: '823x' }} 823w,{% endif %}
-        {% if media.preview_image.width >= 990 %}{{ media.preview_image | img_url: '990x' }} 990w,{% endif %}
-        {% if media.preview_image.width >= 1100 %}{{ media.preview_image | img_url: '1100x' }} 1100w,{% endif %}
-        {% if media.preview_image.width >= 1206 %}{{ media.preview_image | img_url: '1206x' }} 1206w,{% endif %}
-        {% if media.preview_image.width >= 1346 %}{{ media.preview_image | img_url: '1346x' }} 1346w,{% endif %}
-        {% if media.preview_image.width >= 1426 %}{{ media.preview_image | img_url: '1426x' }} 1426w,{% endif %}
-        {% if media.preview_image.width >= 1646 %}{{ media.preview_image | img_url: '1646x' }} 1646w,{% endif %}
-        {% if media.preview_image.width >= 1946 %}{{ media.preview_image | img_url: '1946x' }} 1946w,{% endif %}
-        {{ media.preview_image | img_url: 'master' }} {{ media.preview_image.width }}w"
-      src="{{ media | img_url: '1946x' }}"
-      sizes="(min-width: {{ settings.page_width }}px) {{ settings.page_width | minus: 100 | times: media_width | round }}px, (min-width: 990px) calc({{ media_width | times: 100 }}vw - 10rem), (min-width: 750px) calc((100vw - 11.5rem) / 2), calc(100vw - 4rem)"
-      {% unless lazy_load == false %}loading="lazy"{% endunless %}
-      width="973"
-      height="{{ 973 | divided_by: media.preview_image.aspect_ratio | ceil }}"
-      alt="{{ media.preview_image.alt | escape }}"
-    >
-  </div>
-  <button class="product__media-toggle" type="button" aria-haspopup="dialog" data-media-id="{{ media.id }}">
-    <span class="visually-hidden">
-      {{ 'products.product.media.open_media' | t: index: position }}
+{%- if media.media_type == 'image' -%}
+  {%- if media_zoom == 'enable' -%}
+    <modal-opener class="product__modal-opener product__modal-opener--{{ media.media_type }} no-js-hidden" data-modal="#ProductModal-{{ modal_id }}">
+      <span class="product__media-icon motion-reduce" aria-hidden="true">
+        {% render 'icon-zoom' %}
+      </span>
+    
+      <div class="product__media media media--transparent gradient global-media-settings" style="padding-top: {{ 1 | divided_by: media.preview_image.aspect_ratio | times: 100 }}%;">
+        <img
+          srcset="{% if media.preview_image.width >= 493 %}{{ media.preview_image | img_url: '493x' }} 493w,{% endif %}
+            {% if media.preview_image.width >= 600 %}{{ media.preview_image | img_url: '600x' }} 600w,{% endif %}
+            {% if media.preview_image.width >= 713 %}{{ media.preview_image | img_url: '713x' }} 713w,{% endif %}
+            {% if media.preview_image.width >= 823 %}{{ media.preview_image | img_url: '823x' }} 823w,{% endif %}
+            {% if media.preview_image.width >= 990 %}{{ media.preview_image | img_url: '990x' }} 990w,{% endif %}
+            {% if media.preview_image.width >= 1100 %}{{ media.preview_image | img_url: '1100x' }} 1100w,{% endif %}
+            {% if media.preview_image.width >= 1206 %}{{ media.preview_image | img_url: '1206x' }} 1206w,{% endif %}
+            {% if media.preview_image.width >= 1346 %}{{ media.preview_image | img_url: '1346x' }} 1346w,{% endif %}
+            {% if media.preview_image.width >= 1426 %}{{ media.preview_image | img_url: '1426x' }} 1426w,{% endif %}
+            {% if media.preview_image.width >= 1646 %}{{ media.preview_image | img_url: '1646x' }} 1646w,{% endif %}
+            {% if media.preview_image.width >= 1946 %}{{ media.preview_image | img_url: '1946x' }} 1946w,{% endif %}
+            {{ media.preview_image | img_url: 'master' }} {{ media.preview_image.width }}w"
+          src="{{ media | img_url: '1946x' }}"
+          sizes="(min-width: {{ settings.page_width }}px) {{ settings.page_width | minus: 100 | times: media_width | round }}px, (min-width: 990px) calc({{ media_width | times: 100 }}vw - 10rem), (min-width: 750px) calc((100vw - 11.5rem) / 2), calc(100vw - 4rem)"
+          {% unless lazy_load == false %}loading="lazy"{% endunless %}
+          width="973"
+          height="{{ 973 | divided_by: media.preview_image.aspect_ratio | ceil }}"
+          alt="{{ media.preview_image.alt | escape }}"
+        >
+      </div>
+      <button class="product__media-toggle" type="button" aria-haspopup="dialog" data-media-id="{{ media.id }}">
+        <span class="visually-hidden">
+          {{ 'products.product.media.open_media' | t: index: position }}
+        </span>
+      </button>
+    </modal-opener>
+  {%- else -%}
+    <div class="product__media media gradient global-media-settings" style="padding-top: {{ 1 | divided_by: media.preview_image.aspect_ratio | times: 100 }}%;">
+      <img
+        srcset="{% if media.preview_image.width >= 493 %}{{ media.preview_image | img_url: '493x' }} 493w,{% endif %}
+          {% if media.preview_image.width >= 600 %}{{ media.preview_image | img_url: '600x' }} 600w,{% endif %}
+          {% if media.preview_image.width >= 713 %}{{ media.preview_image | img_url: '713x' }} 713w,{% endif %}
+          {% if media.preview_image.width >= 823 %}{{ media.preview_image | img_url: '823x' }} 823w,{% endif %}
+          {% if media.preview_image.width >= 990 %}{{ media.preview_image | img_url: '990x' }} 990w,{% endif %}
+          {% if media.preview_image.width >= 1100 %}{{ media.preview_image | img_url: '1100x' }} 1100w,{% endif %}
+          {% if media.preview_image.width >= 1206 %}{{ media.preview_image | img_url: '1206x' }} 1206w,{% endif %}
+          {% if media.preview_image.width >= 1346 %}{{ media.preview_image | img_url: '1346x' }} 1346w,{% endif %}
+          {% if media.preview_image.width >= 1426 %}{{ media.preview_image | img_url: '1426x' }} 1426w,{% endif %}
+          {% if media.preview_image.width >= 1646 %}{{ media.preview_image | img_url: '1646x' }} 1646w,{% endif %}
+          {% if media.preview_image.width >= 1946 %}{{ media.preview_image | img_url: '1946x' }} 1946w,{% endif %}
+          {{ media.preview_image | img_url: 'master' }} {{ media.preview_image.width }}w"
+        src="{{ media | img_url: '1946x' }}"
+        sizes="(min-width: {{ settings.page_width }}px) {{ settings.page_width | minus: 100 | times: media_width | round }}px, (min-width: 990px) calc({{ media_width | times: 100 }}vw - 10rem), (min-width: 750px) calc((100vw - 11.5rem) / 2), calc(100vw - 4rem)"
+        {% unless lazy_load == false %}loading="lazy"{% endunless %}
+        width="973"
+        height="{{ 973 | divided_by: media.preview_image.aspect_ratio | ceil }}"
+        alt="{{ media.preview_image.alt | escape }}"
+      >
+    </div>
+  {%- endif -%}
+{%- else -%}
+  <modal-opener class="product__modal-opener product__modal-opener--{{ media.media_type }} no-js-hidden" data-modal="#ProductModal-{{ modal_id }}">
+    <span class="product__media-icon motion-reduce" aria-hidden="true">
+      {%- liquid
+        case media.media_type
+        when 'video' or 'external_video'
+          render 'icon-play'
+        else
+          render 'icon-3d-model'
+        endcase
+      -%}
     </span>
-  </button>
-</modal-opener>
+
+    <div class="product__media media media--transparent gradient global-media-settings" style="padding-top: {{ 1 | divided_by: media.preview_image.aspect_ratio | times: 100 }}%;">
+      <img
+        srcset="{% if media.preview_image.width >= 493 %}{{ media.preview_image | img_url: '493x' }} 493w,{% endif %}
+          {% if media.preview_image.width >= 600 %}{{ media.preview_image | img_url: '600x' }} 600w,{% endif %}
+          {% if media.preview_image.width >= 713 %}{{ media.preview_image | img_url: '713x' }} 713w,{% endif %}
+          {% if media.preview_image.width >= 823 %}{{ media.preview_image | img_url: '823x' }} 823w,{% endif %}
+          {% if media.preview_image.width >= 990 %}{{ media.preview_image | img_url: '990x' }} 990w,{% endif %}
+          {% if media.preview_image.width >= 1100 %}{{ media.preview_image | img_url: '1100x' }} 1100w,{% endif %}
+          {% if media.preview_image.width >= 1206 %}{{ media.preview_image | img_url: '1206x' }} 1206w,{% endif %}
+          {% if media.preview_image.width >= 1346 %}{{ media.preview_image | img_url: '1346x' }} 1346w,{% endif %}
+          {% if media.preview_image.width >= 1426 %}{{ media.preview_image | img_url: '1426x' }} 1426w,{% endif %}
+          {% if media.preview_image.width >= 1646 %}{{ media.preview_image | img_url: '1646x' }} 1646w,{% endif %}
+          {% if media.preview_image.width >= 1946 %}{{ media.preview_image | img_url: '1946x' }} 1946w,{% endif %}
+          {{ media.preview_image | img_url: 'master' }} {{ media.preview_image.width }}w"
+        src="{{ media | img_url: '1946x' }}"
+        sizes="(min-width: {{ settings.page_width }}px) {{ settings.page_width | minus: 100 | times: media_width | round }}px, (min-width: 990px) calc({{ media_width | times: 100 }}vw - 10rem), (min-width: 750px) calc((100vw - 11.5rem) / 2), calc(100vw - 4rem)"
+        {% unless lazy_load == false %}loading="lazy"{% endunless %}
+        width="973"
+        height="{{ 973 | divided_by: media.preview_image.aspect_ratio | ceil }}"
+        alt="{{ media.preview_image.alt | escape }}"
+      >
+    </div>
+    <button class="product__media-toggle" type="button" aria-haspopup="dialog" data-media-id="{{ media.id }}">
+      <span class="visually-hidden">
+        {{ 'products.product.media.open_media' | t: index: position }}
+      </span>
+    </button>
+  </modal-opener>
+{%- endif -%}
 
 {%- if media.media_type != 'image' -%}
   {%- if media.media_type == 'model' -%}

--- a/snippets/product-thumbnail.liquid
+++ b/snippets/product-thumbnail.liquid
@@ -111,27 +111,29 @@
       </button>
     </modal-opener>
   {%- else -%}
-    <div class="product__media media gradient global-media-settings" style="padding-top: {{ 1 | divided_by: media.preview_image.aspect_ratio | times: 100 }}%;">
-      <img
-        srcset="{% if media.preview_image.width >= 493 %}{{ media.preview_image | img_url: '493x' }} 493w,{% endif %}
-          {% if media.preview_image.width >= 600 %}{{ media.preview_image | img_url: '600x' }} 600w,{% endif %}
-          {% if media.preview_image.width >= 713 %}{{ media.preview_image | img_url: '713x' }} 713w,{% endif %}
-          {% if media.preview_image.width >= 823 %}{{ media.preview_image | img_url: '823x' }} 823w,{% endif %}
-          {% if media.preview_image.width >= 990 %}{{ media.preview_image | img_url: '990x' }} 990w,{% endif %}
-          {% if media.preview_image.width >= 1100 %}{{ media.preview_image | img_url: '1100x' }} 1100w,{% endif %}
-          {% if media.preview_image.width >= 1206 %}{{ media.preview_image | img_url: '1206x' }} 1206w,{% endif %}
-          {% if media.preview_image.width >= 1346 %}{{ media.preview_image | img_url: '1346x' }} 1346w,{% endif %}
-          {% if media.preview_image.width >= 1426 %}{{ media.preview_image | img_url: '1426x' }} 1426w,{% endif %}
-          {% if media.preview_image.width >= 1646 %}{{ media.preview_image | img_url: '1646x' }} 1646w,{% endif %}
-          {% if media.preview_image.width >= 1946 %}{{ media.preview_image | img_url: '1946x' }} 1946w,{% endif %}
-          {{ media.preview_image | img_url: 'master' }} {{ media.preview_image.width }}w"
-        src="{{ media | img_url: '1946x' }}"
-        sizes="(min-width: {{ settings.page_width }}px) {{ settings.page_width | minus: 100 | times: media_width | round }}px, (min-width: 990px) calc({{ media_width | times: 100 }}vw - 10rem), (min-width: 750px) calc((100vw - 11.5rem) / 2), calc(100vw - 4rem)"
-        {% unless lazy_load == false %}loading="lazy"{% endunless %}
-        width="973"
-        height="{{ 973 | divided_by: media.preview_image.aspect_ratio | ceil }}"
-        alt="{{ media.preview_image.alt | escape }}"
-      >
+    <div style="width: 100%;"> 
+      <div class="product__media media media--transparent gradient global-media-settings" style="padding-top: {{ 1 | divided_by: media.preview_image.aspect_ratio | times: 100 }}%;">
+        <img
+          srcset="{% if media.preview_image.width >= 493 %}{{ media.preview_image | img_url: '493x' }} 493w,{% endif %}
+            {% if media.preview_image.width >= 600 %}{{ media.preview_image | img_url: '600x' }} 600w,{% endif %}
+            {% if media.preview_image.width >= 713 %}{{ media.preview_image | img_url: '713x' }} 713w,{% endif %}
+            {% if media.preview_image.width >= 823 %}{{ media.preview_image | img_url: '823x' }} 823w,{% endif %}
+            {% if media.preview_image.width >= 990 %}{{ media.preview_image | img_url: '990x' }} 990w,{% endif %}
+            {% if media.preview_image.width >= 1100 %}{{ media.preview_image | img_url: '1100x' }} 1100w,{% endif %}
+            {% if media.preview_image.width >= 1206 %}{{ media.preview_image | img_url: '1206x' }} 1206w,{% endif %}
+            {% if media.preview_image.width >= 1346 %}{{ media.preview_image | img_url: '1346x' }} 1346w,{% endif %}
+            {% if media.preview_image.width >= 1426 %}{{ media.preview_image | img_url: '1426x' }} 1426w,{% endif %}
+            {% if media.preview_image.width >= 1646 %}{{ media.preview_image | img_url: '1646x' }} 1646w,{% endif %}
+            {% if media.preview_image.width >= 1946 %}{{ media.preview_image | img_url: '1946x' }} 1946w,{% endif %}
+            {{ media.preview_image | img_url: 'master' }} {{ media.preview_image.width }}w"
+          src="{{ media | img_url: '1946x' }}"
+          sizes="(min-width: {{ settings.page_width }}px) {{ settings.page_width | minus: 100 | times: media_width | round }}px, (min-width: 990px) calc({{ media_width | times: 100 }}vw - 10rem), (min-width: 750px) calc((100vw - 11.5rem) / 2), calc(100vw - 4rem)"
+          {% unless lazy_load == false %}loading="lazy"{% endunless %}
+          width="973"
+          height="{{ 973 | divided_by: media.preview_image.aspect_ratio | ceil }}"
+          alt="{{ media.preview_image.alt | escape }}"
+        >
+      </div>
     </div>
   {%- endif -%}
 {%- else -%}


### PR DESCRIPTION
**Why are these changes introduced?**

Fixes #733

**What approach did you take?**

- add zoom options（enable or disable）to main product
- add zoom options（enable or disable）to featured product
- edit product thumbnail
   - add media zoom argument
   - ` if media zoom == 'disable'` show product__media without modal-opener

I have to improve code more in product thumbnail（line: 114）
```
    <div style="width: 100%;"> 
      <div class="product__media media media--transparent gradient global-media-settings" style="padding-top: {{ 1 | divided_by: media.preview_image.aspect_ratio | times: 100 }}%;">
```
I think it would be class. 
how should I name the element that has `widht: 100%` style?

**Other considerations**

I think it would be able to disable zoom by remove or invalidate javascript 


**Testing steps/scenarios**
- [ ] able to disable zoom on main product (desktop and mobile)
- [ ] able to disable zoom on featured product (desktop and mobile)

**Demo links**
_Please include a link to a demo store that includes preconfigured sections and settings to allow reviewers to easily test the features you are working on._

- [Store](https://thesense-dev.myshopify.com/?preview_theme_id=129465057465)
- [Editor](https://thesense-dev.myshopify.com/admin/themes/129465057465/editor)

**Checklist**
- [ ] Followed [theme code principles](https://github.com/Shopify/dawn/blob/main/.github/CONTRIBUTING.md#theme-code-principles)
- [ ] Linted with [Theme Check](https://github.com/Shopify/theme-check)
- [ ] Tested on [mobile](https://shopify.dev/themes/store/requirements#mobile-browser-requirements)
- [ ] Tested on [multiple browsers](https://shopify.dev/themes/store/requirements#desktop-browser-requirements)
- [ ] Tested for [accessibility](https://shopify.dev/themes/best-practices/accessibility)
