### PR TITLE
Update pull request template with release notes TLDR

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,4 +1,7 @@
-**TLDR;** Please include a short description (1-2 sentences) about the changes you are introducing. This content will be used in our release notes for Dawn on [themes.shopify.com](https://themes.shopify.com/themes/dawn/styles/default#ReleaseNotes).
+**PR Summary:** 
+
+_Please include a short description (using non-technical terms, 1-2 sentences) about the changes you are introducing, what problem is being fixed and/or describe the benefit to merchants. This content will be used in our release notes for Dawn on [themes.shopify.com](https://themes.shopify.com/themes/dawn/styles/default#ReleaseNotes)._
+
 
 **Why are these changes introduced?**
 
@@ -18,9 +21,9 @@ _Please include a link to a demo store that includes preconfigured sections and 
 - [Editor](url)
 
 **Checklist**
+- [ ] Added PR summary for [release notes](https://themes.shopify.com/themes/dawn/styles/default#ReleaseNotes)
 - [ ] Followed [theme code principles](https://github.com/Shopify/dawn/blob/main/.github/CONTRIBUTING.md#theme-code-principles)
 - [ ] Linted with [Theme Check](https://github.com/Shopify/theme-check)
 - [ ] Tested on [mobile](https://shopify.dev/themes/store/requirements#mobile-browser-requirements)
 - [ ] Tested on [multiple browsers](https://shopify.dev/themes/store/requirements#desktop-browser-requirements)
 - [ ] Tested for [accessibility](https://shopify.dev/themes/best-practices/accessibility)
-- [ ] Add a short PR description at the top of your PR for the [release notes](https://themes.shopify.com/themes/dawn/styles/default#ReleaseNotes)

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,3 +1,5 @@
+**TLDR;** Please include a short description (1-2 sentences) about the changes you are introducing. This content will be used in our release notes for Dawn on [themes.shopify.com](https://themes.shopify.com/themes/dawn/styles/default#ReleaseNotes).
+
 **Why are these changes introduced?**
 
 Fixes #0.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -23,3 +23,4 @@ _Please include a link to a demo store that includes preconfigured sections and 
 - [ ] Tested on [mobile](https://shopify.dev/themes/store/requirements#mobile-browser-requirements)
 - [ ] Tested on [multiple browsers](https://shopify.dev/themes/store/requirements#desktop-browser-requirements)
 - [ ] Tested for [accessibility](https://shopify.dev/themes/best-practices/accessibility)
+- [ ] Add a short PR description at the top of your PR for the [release notes](https://themes.shopify.com/themes/dawn/styles/default#ReleaseNotes)


### PR DESCRIPTION
**Why are these changes introduced?**
The theme store now offers a Release notes section for themes. 
It should be the responsibility of each contributor to provide a TLDR (Too long don't read) about the changes that they are introducing. This way, the person creating the release notes and/or release does not need to read the PR content to obtain the right context. Instead, the dev who created the PR can create the short description, and content can modify it, as needed.