### PR TITLE
Change theme settings default values to improve merchant UX

### DIFF
--- a/config/settings_schema.json
+++ b/config/settings_schema.json
@@ -255,7 +255,7 @@
         "step": 2,
         "unit": "px",
         "label": "t:settings_schema.global.settings.vertical_offset.label",
-        "default": 0
+        "default": 4
       },
       {
         "type": "range",
@@ -265,7 +265,7 @@
         "step": 5,
         "unit": "px",
         "label": "t:settings_schema.global.settings.blur.label",
-        "default": 0
+        "default": 5
       }
     ]
   },
@@ -338,7 +338,7 @@
         "step": 2,
         "unit": "px",
         "label": "t:settings_schema.global.settings.vertical_offset.label",
-        "default": 0
+        "default": 4
       },
       {
         "type": "range",
@@ -348,7 +348,7 @@
         "step": 5,
         "unit": "px",
         "label": "t:settings_schema.global.settings.blur.label",
-        "default": 0
+        "default": 5
       }
     ]
   },
@@ -421,7 +421,7 @@
         "step": 2,
         "unit": "px",
         "label": "t:settings_schema.global.settings.vertical_offset.label",
-        "default": 0
+        "default": 4
       },
       {
         "type": "range",
@@ -431,7 +431,7 @@
         "step": 5,
         "unit": "px",
         "label": "t:settings_schema.global.settings.blur.label",
-        "default": 0
+        "default": 5
       }
     ]
   },
@@ -534,7 +534,7 @@
         "step": 5,
         "unit": "%",
         "label": "t:settings_schema.global.settings.opacity.label",
-        "default": 0
+        "default": 10
       },
       {
         "type": "range",
@@ -558,7 +558,7 @@
         "step": 5,
         "unit": "%",
         "label": "t:settings_schema.global.settings.opacity.label",
-        "default": 10
+        "default": 0
       },
       {
         "type": "range",
@@ -578,7 +578,7 @@
         "step": 2,
         "unit": "px",
         "label": "t:settings_schema.global.settings.vertical_offset.label",
-        "default": 0
+        "default": 4
       },
       {
         "type": "range",
@@ -588,7 +588,7 @@
         "step": 5,
         "unit": "px",
         "label": "t:settings_schema.global.settings.blur.label",
-        "default": 0
+        "default": 5
       }
     ]
   },
@@ -617,7 +617,7 @@
         "step": 5,
         "unit": "%",
         "label": "t:settings_schema.global.settings.opacity.label",
-        "default": 0
+        "default": 10
       },
       {
         "type": "range",
@@ -661,7 +661,7 @@
         "step": 2,
         "unit": "px",
         "label": "t:settings_schema.global.settings.vertical_offset.label",
-        "default": 0
+        "default": 4
       },
       {
         "type": "range",
@@ -671,7 +671,7 @@
         "step": 5,
         "unit": "px",
         "label": "t:settings_schema.global.settings.blur.label",
-        "default": 0
+        "default": 5
       }
     ]
   },
@@ -744,7 +744,7 @@
         "step": 2,
         "unit": "px",
         "label": "t:settings_schema.global.settings.vertical_offset.label",
-        "default": 0
+        "default": 4
       },
       {
         "type": "range",
@@ -754,7 +754,7 @@
         "step": 5,
         "unit": "px",
         "label": "t:settings_schema.global.settings.blur.label",
-        "default": 0
+        "default": 5
       }
     ]
   },
@@ -831,7 +831,7 @@
         "step": 2,
         "unit": "px",
         "label": "t:settings_schema.global.settings.vertical_offset.label",
-        "default": 0
+        "default": 4
       },
       {
         "type": "range",
@@ -841,7 +841,7 @@
         "step": 5,
         "unit": "px",
         "label": "t:settings_schema.global.settings.blur.label",
-        "default": 0
+        "default": 5
       }
     ]
   },
@@ -904,7 +904,7 @@
         "step": 2,
         "unit": "px",
         "label": "t:settings_schema.global.settings.vertical_offset.label",
-        "default": 0
+        "default": 4
       },
       {
         "type": "range",
@@ -914,7 +914,7 @@
         "step": 5,
         "unit": "px",
         "label": "t:settings_schema.global.settings.blur.label",
-        "default": 0
+        "default": 5
       }
     ]
   },


### PR DESCRIPTION
**TLDR; Why are these changes introduced?**

Change theme settings default values to reduce the amount of steps merchants go through to discover what theme settings are doing in the editor preview.

**What approach did you take?**

Applied the safe smart defaults where needed to follow this rule:

- If `Border thickness` default = `0`
   - Make the `Border opacity` default = `10`
      - EXCEPTION, if `Button's Border thickness` is set to `0`, make it to `1` and have the opacity to `100`, this will ensure the secondary button style outline is visible.
- If `Shadow opacity` default = `0`
   - Make `Shadow vertical offset` default = `4`
   - Make `Shadow blur` default = `5`

**Other considerations**

**Testing steps/scenarios**
- [ ] Stress test defaults are well applied and don't conflict with other styles/settings.
- [ ] Areas to stress test if this system works
   - [ ] Increase the Shadow opacity to notice the fewer steps it takes to preview the style
      - [ ] Buttons
      - [ ] Variant pills
      - [ ] Inputs
      - [ ] Cards
      - [ ] Content containers
      - [ ] Media
      - [ ] Dropdown and pop-ups
      - [ ] Drawers
   - [ ] Increase the border thickness to notice the fewer steps in previewing the border to appear
      - [ ] Cards
      - [ ] Content containers

**Demo links**

- [Editor](https://os2-demo.myshopify.com/admin/themes/127629459478/editor)

**Checklist**
- [ ] Followed [theme code principles](https://github.com/Shopify/dawn/blob/main/.github/CONTRIBUTING.md#theme-code-principles)
- [ ] Linted with [Theme Check](https://github.com/Shopify/theme-check)
- [ ] Tested on [mobile](https://shopify.dev/themes/store/requirements#mobile-browser-requirements)
- [ ] Tested on [multiple browsers](https://shopify.dev/themes/store/requirements#desktop-browser-requirements)
- [ ] Tested for [accessibility](https://shopify.dev/themes/best-practices/accessibility)
