### PR TITLE
Fix default amount of columns on product page for multicolumn section

### DIFF
--- a/templates/product.json
+++ b/templates/product.json
@@ -133,7 +133,8 @@
       "settings": {
         "title": "",
         "background_style": "none",
-        "button_label": ""
+        "button_label": "",
+        "columns_desktop": 2
       }
     },
     "product-recommendations": {


### PR DESCRIPTION
**Why are these changes introduced?**

When introducing a new setting to pick the amount of columns we want in a section, we forgot to update the multicolumn section on the product page in `product.json`. 

It's looking like this atm. So the fix is to make it 2 columns again: 
![](https://screenshot.click/23-38-gcc97-9j50a.png)

**What approach did you take?**

I'm just adding an entry to set the amount of columns to 2 on the product page's section.

**Other considerations**

**Testing steps/scenarios**
- [ ] Go to the product page and confirm that there are 2 block in the multicolumn section and that it's using a 2 columns layout.

**Demo links**
_Please include a link to a demo store that includes preconfigured sections and settings to allow reviewers to easily test the features you are working on._

- [Store](https://os2-demo.myshopify.com/?preview_theme_id=127638732822)
- [Editor](https://os2-demo.myshopify.com/admin/themes/127638732822/editor)

**Checklist**
- [ ] Followed [theme code principles](https://github.com/Shopify/dawn/blob/main/.github/CONTRIBUTING.md#theme-code-principles)
- [ ] Linted with [Theme Check](https://github.com/Shopify/theme-check)
- [ ] Tested on [mobile](https://shopify.dev/themes/store/requirements#mobile-browser-requirements)
- [ ] Tested on [multiple browsers](https://shopify.dev/themes/store/requirements#desktop-browser-requirements)
- [ ] Tested for [accessibility](https://shopify.dev/themes/best-practices/accessibility)
