### PR TITLE
Add variant picker sold out UI [temporary solution]

### DIFF
--- a/assets/global.js
+++ b/assets/global.js
@@ -832,8 +832,11 @@ class VariantSelects extends HTMLElement {
         const html = new DOMParser().parseFromString(responseText, 'text/html')
         const destination = document.getElementById(id);
         const source = html.getElementById(id);
+        const variantPickerDestination = document.querySelector('variant-radios') || document.querySelector('variant-selects');
+        const variantPickerSource = html.querySelector('variant-radios') || html.querySelector('variant-selects');
 
         if (source && destination) destination.innerHTML = source.innerHTML;
+        if (variantPickerSource && variantPickerDestination) variantPickerDestination.innerHTML = variantPickerSource.innerHTML;
 
         const price = document.getElementById(`price-${this.dataset.section}`);
 

--- a/assets/section-main-product.css
+++ b/assets/section-main-product.css
@@ -199,7 +199,9 @@ fieldset.product-form__input .form__label {
   cursor: pointer;
   position: relative;
 }
-
+.product-form__input input[type='radio'].disabled + label {
+  opacity: 0.5;
+}
 .product-form__input input[type='radio'] + label:before {
   content: '';
   position: absolute;

--- a/assets/section-main-product.css
+++ b/assets/section-main-product.css
@@ -199,9 +199,6 @@ fieldset.product-form__input .form__label {
   cursor: pointer;
   position: relative;
 }
-.product-form__input input[type='radio'].disabled + label {
-  opacity: 0.5;
-}
 .product-form__input input[type='radio'] + label:before {
   content: '';
   position: absolute;
@@ -233,10 +230,13 @@ fieldset.product-form__input .form__label {
   background-color: rgba(var(--color-background), 0.3);
 }
 
-.product-form__input input[type='radio']:disabled + label {
+.product-form__input input[type='radio']:disabled + label, .product-form__input input[type='radio'].disabled + label {
   border-color: rgba(var(--color-foreground), 0.1);
   color: rgba(var(--color-foreground), 0.4);
   text-decoration: line-through;
+}
+.product-form__input input[type='radio'].disabled:checked + label, .product-form__input input[type='radio']:disabled:checked + label {
+  color: rgba(var(--color-background),.4);
 }
 .product-form__input input[type='radio']:focus-visible + label {
   box-shadow: 0 0 0 0.3rem rgb(var(--color-background)),

--- a/locales/en.default.schema.json
+++ b/locales/en.default.schema.json
@@ -1594,6 +1594,18 @@
               "options__2": {
                 "label": "Pills"
               }
+            },
+            "select_soldout_type": {
+              "label": "Soldout select type",
+              "options__1": {
+                "label": "None"
+              },
+              "options__2": {
+                "label": "Disabled"
+              },
+              "options__3": {
+                "label": "Append"
+              }
             }
           }
         },

--- a/sections/main-product.liquid
+++ b/sections/main-product.liquid
@@ -391,8 +391,8 @@
                                   {% endif %}
                               {% endcase %}
                             {% endfor %}
-                            <option value="{{ value | escape }}" {% if option.selected_value == value %}selected="selected"{% endif %}>
-                              {{ value }}{% if option_disabled %} [{{ 'products.product.unavailable' | t }}]{% endif %}
+                            <option value="{{ value | escape }}" {% if option.selected_value == value %}selected="selected"{% endif %}{% if option_disabled and 'disabled' == block.settings.select_soldout_type %} disabled{% endif %}>
+                              {{ value }}{% if option_disabled and 'append' == block.settings.select_soldout_type %} [{{ 'products.product.unavailable' | t }}]{% endif %}
                             </option>
                           {%- endfor -%}
                         </select>
@@ -758,6 +758,26 @@
           ],
           "default": "button",
           "label": "t:sections.main-product.blocks.variant_picker.settings.picker_type.label"
+        },
+        {
+          "type": "select",
+          "id": "select_soldout_type",
+          "options": [
+            {
+              "value": "none",
+              "label": "t:sections.main-product.blocks.variant_picker.settings.select_soldout_type.options__1.label"
+            },
+            {
+              "value": "disabled",
+              "label": "t:sections.main-product.blocks.variant_picker.settings.select_soldout_type.options__2.label"
+            },
+            {
+              "value": "append",
+              "label": "t:sections.main-product.blocks.variant_picker.settings.select_soldout_type.options__3.label"
+            }
+          ],
+          "default": "none",
+          "label": "t:sections.main-product.blocks.variant_picker.settings.select_soldout_type.label"
         }
       ]
     },

--- a/sections/main-product.liquid
+++ b/sections/main-product.liquid
@@ -25,6 +25,11 @@
 
 <script src="{{ 'product-form.js' | asset_url }}" defer="defer"></script>
 
+{%- assign variants_available_arr = product.variants | map: 'available' -%}
+{%- assign variants_option1_arr = product.variants | map: 'option1' -%}
+{%- assign variants_option2_arr = product.variants | map: 'option2' -%}
+{%- assign variants_option3_arr = product.variants | map: 'option3' -%}
+
 {%- assign first_3d_model = product.media | where: "media_type", "model" | first -%}
 {%- if first_3d_model -%}
   {{ 'component-product-model.css' | asset_url | stylesheet_tag }}
@@ -318,20 +323,38 @@
               {%- if block.settings.picker_type == 'button' -%}
                 <variant-radios class="no-js-hidden" data-section="{{ section.id }}" data-url="{{ product.url }}" {{ block.shopify_attributes }}>
                   {%- for option in product.options_with_values -%}
-                      <fieldset class="js product-form__input">
-                        <legend class="form__label">{{ option.name }}</legend>
-                        {%- for value in option.values -%}
-                          <input type="radio" id="{{ section.id }}-{{ option.position }}-{{ forloop.index0 }}"
-                                name="{{ option.name }}"
-                                value="{{ value | escape }}"
-                                form="{{ product_form_id }}"
-                                {% if option.selected_value == value %}checked{% endif %}
-                          >
-                          <label for="{{ section.id }}-{{ option.position }}-{{ forloop.index0 }}">
-                            {{ value }}
-                          </label>
-                        {%- endfor -%}
-                      </fieldset>
+                    <fieldset class="js product-form__input">
+                      <legend class="form__label">{{ option.name }}</legend>
+                      {%- for value in option.values -%}
+                        {%- assign option_disabled = true -%}
+                        {% for option1_name in variants_option1_arr %}
+                          {% case option.position %}
+                            {% when 1 %}
+                              {% if variants_option1_arr[forloop.index0] == value and variants_available_arr[forloop.index0] == true %}
+                                {%- assign option_disabled = false -%}
+                              {% endif %}
+                            {% when 2 %}
+                              {% if option1_name == product.selected_or_first_available_variant.option1 and variants_option2_arr[forloop.index0] == value and variants_available_arr[forloop.index0] == true %}
+                                {%- assign option_disabled = false -%}
+                              {% endif %}
+                            {% when 3 %}
+                              {% if option1_name == product.selected_or_first_available_variant.option1 and variants_option2_arr[forloop.index0] == product.selected_or_first_available_variant.option2 and variants_option3_arr[forloop.index0] == value and variants_available_arr[forloop.index0] == true %}
+                                {%- assign option_disabled = false -%}
+                              {% endif %}
+                          {% endcase %}
+                        {% endfor %}
+                        <input type="radio" id="{{ section.id }}-{{ option.position }}-{{ forloop.index0 }}"
+                              name="{{ option.name }}"
+                              value="{{ value | escape }}"
+                              form="{{ product_form_id }}"
+                              {% if option.selected_value == value %}checked{% endif %}
+                              {% if option_disabled %}class="disabled"{% endif %}
+                        >
+                        <label for="{{ section.id }}-{{ option.position }}-{{ forloop.index0 }}">
+                          {{ value }}
+                        </label>
+                      {%- endfor -%}
+                    </fieldset>
                   {%- endfor -%}
                   <script type="application/json">
                     {{ product.variants | json }}
@@ -351,8 +374,25 @@
                           form="{{ product_form_id }}"
                         >
                           {%- for value in option.values -%}
+                            {%- assign option_disabled = true -%}
+                            {% for option1_name in variants_option1_arr %}
+                              {% case option.position %}
+                                {% when 1 %}
+                                  {% if variants_option1_arr[forloop.index0] == value and variants_available_arr[forloop.index0] == true %}
+                                    {%- assign option_disabled = false -%}
+                                  {% endif %}
+                                {% when 2 %}
+                                  {% if option1_name == product.selected_or_first_available_variant.option1 and variants_option2_arr[forloop.index0] == value and variants_available_arr[forloop.index0] == true %}
+                                    {%- assign option_disabled = false -%}
+                                  {% endif %}
+                                {% when 3 %}
+                                  {% if option1_name == product.selected_or_first_available_variant.option1 and variants_option2_arr[forloop.index0] == product.selected_or_first_available_variant.option2 and variants_option3_arr[forloop.index0] == value and variants_available_arr[forloop.index0] == true %}
+                                    {%- assign option_disabled = false -%}
+                                  {% endif %}
+                              {% endcase %}
+                            {% endfor %}
                             <option value="{{ value | escape }}" {% if option.selected_value == value %}selected="selected"{% endif %}>
-                              {{ value }}
+                              {{ value }}{% if option_disabled %} [{{ 'products.product.unavailable' | t }}]{% endif %}
                             </option>
                           {%- endfor -%}
                         </select>


### PR DESCRIPTION
This is getting more attention so here's a temporary solution that relies on some JavaScript (and Liquid).

**Why are these changes introduced?**

Temporarily fixes #45 (Variant picker) and #105 (Add variant picker sold out UI).

**What approach did you take?**

Style radio buttons with `disabled` class; sold out select options can either be disabled, appended, or ignored via block settings.

**Demo links**
Password: `fleomo`
- [Product with one option](https://cfx-theme-playground.myshopify.com/products/billowing-glade)
- [Product with two options](https://cfx-theme-playground.myshopify.com/products/ancient-water)
- [Product with three options](https://cfx-theme-playground.myshopify.com/products/autumn-hill)

**Checklist**
- [x] Followed [theme code principles](https://github.com/Shopify/dawn/blob/main/.github/CONTRIBUTING.md#theme-code-principles)
- [x] Linted with [Theme Check](https://github.com/Shopify/theme-check)
- [ ] Tested on [mobile](https://shopify.dev/themes/store/requirements#mobile-browser-requirements)
- [ ] Tested on [multiple browsers](https://shopify.dev/themes/store/requirements#desktop-browser-requirements)
- [ ] Tested for [accessibility](https://shopify.dev/themes/best-practices/accessibility)
