### PR TITLE
Fix iOS14 cart image bug

### DIFF
--- a/assets/component-cart-items.css
+++ b/assets/component-cart-items.css
@@ -25,6 +25,7 @@
 
 .cart-item__image-container {
   display: inline-flex;
+  align-items: flex-start;
 }
 
 .cart-item__image-container:after {


### PR DESCRIPTION
**Why are these changes introduced?**

Fixes #1409 

**What approach did you take?**

Added an `align-items: flex-start;` property to prevent the image from stretching.

**Other considerations**

**Testing steps/scenarios**
- [ ] Using browser stack and/or and iOS device running Safari version 14, go to the home page, click on a product (the dog one is a good example) from the feat. collection section, and add it to the cart. Then check the cart page and confirm that the image is using the right size. No weirdness.
- [ ] Test in other browsers on desktop to make sure it didn't break any of the original layout/sizing.

**Demo links**
_Please include a link to a demo store that includes preconfigured sections and settings to allow reviewers to easily test the features you are working on._

- [Store](https://os2-demo.myshopify.com/?preview_theme_id=127642042390)
- [Editor](https://os2-demo.myshopify.com/admin/themes/127642042390/editor)

**Checklist**
- [ ] Followed [theme code principles](https://github.com/Shopify/dawn/blob/main/.github/CONTRIBUTING.md#theme-code-principles)
- [ ] Linted with [Theme Check](https://github.com/Shopify/theme-check)
- [ ] Tested on [mobile](https://shopify.dev/themes/store/requirements#mobile-browser-requirements)
- [ ] Tested on [multiple browsers](https://shopify.dev/themes/store/requirements#desktop-browser-requirements)
- [ ] Tested for [accessibility](https://shopify.dev/themes/best-practices/accessibility)
