### PR TITLE
Fix bad CLS score on main product when video is the featured media

### DIFF
--- a/sections/main-product.liquid
+++ b/sections/main-product.liquid
@@ -6,8 +6,7 @@
 {{ 'component-slider.css' | asset_url | stylesheet_tag }}
 {{ 'component-rating.css' | asset_url | stylesheet_tag }}
 {{ 'component-loading-overlay.css' | asset_url | stylesheet_tag }}
-
-<link rel="stylesheet" href="{{ 'component-deferred-media.css' | asset_url }}" media="print" onload="this.media='all'">
+{{ 'component-deferred-media.css' | asset_url | stylesheet_tag }}
 
 {%- style -%}
   .section-{{ section.id }}-padding {


### PR DESCRIPTION
**Why are these changes introduced?**

Fixes #1165 

**What approach did you take?**

There are 80 lines of CSS in `component-deferred-media.css` which were loaded asynchronously on `main-product.iquid` and a few other files. 

I've changed it so the asset is loaded right away so that if some of the first medias are videos then it won't cause any CLS issues. 

Before and after lighthouse scores on mobile: 
![](https://screenshot.click/24-33-aigql-zcd8k.png)

**Other considerations**

A few other files do call that file asynchronously, so that problem might happen there as well but because it's section it's not possible for us to say if they're going to be the first thing loading at the top of the page or not. 

Here is the list of places: 
- collage.liquid
- featured-product.liquid

**Testing steps/scenarios**
- [ ] You can try and load main locally, remove the dynamic checkout button and go to the `Test 3D models, video` product which is showing on the home page and feat. collection, using lighthouse in the inspect tool. Test for mobile and desktop. 
- [ ] Then do the same thing on this test theme/branch to compare the results.
- [ ] Test other products to make sure it hasn't impacted in any way their performance.

**Demo links**

- [Store](https://os2-demo.myshopify.com/?preview_theme_id=127643353110)
- [Editor](https://os2-demo.myshopify.com/admin/themes/127643353110/editor)

**Checklist**
- [ ] Followed [theme code principles](https://github.com/Shopify/dawn/blob/main/.github/CONTRIBUTING.md#theme-code-principles)
- [ ] Linted with [Theme Check](https://github.com/Shopify/theme-check)
- [ ] Tested on [mobile](https://shopify.dev/themes/store/requirements#mobile-browser-requirements)
- [ ] Tested on [multiple browsers](https://shopify.dev/themes/store/requirements#desktop-browser-requirements)
- [ ] Tested for [accessibility](https://shopify.dev/themes/best-practices/accessibility)
