### PR TITLE
Update color list order and simplify section string

### DIFF
--- a/config/settings_schema.json
+++ b/config/settings_schema.json
@@ -490,27 +490,27 @@
         "options": [
           {
             "value": "accent-1",
-            "label": "t:settings_schema.global.settings.color_scheme.options__1.label"
+            "label": "t:sections.all.colors.accent_1.label"
           },
           {
             "value": "accent-2",
-            "label": "t:settings_schema.global.settings.color_scheme.options__2.label"
+            "label": "t:sections.all.colors.accent_2.label"
           },
           {
             "value": "background-1",
-            "label": "t:settings_schema.global.settings.color_scheme.options__3.label"
+            "label": "t:sections.all.colors.background_1.label"
           },
           {
             "value": "background-2",
-            "label": "t:settings_schema.global.settings.color_scheme.options__4.label"
+            "label": "t:sections.all.colors.background_2.label"
           },
           {
             "value": "inverse",
-            "label": "t:settings_schema.global.settings.color_scheme.options__5.label"
+            "label": "t:sections.all.colors.inverse.label"
           }
         ],
         "default": "background-2",
-        "label": "t:settings_schema.global.settings.color_scheme.label"
+        "label": "t:sections.all.colors.label"
       },
       {
         "type": "header",
@@ -961,15 +961,15 @@
         "options": [
           {
             "value": "accent-1",
-            "label": "t:settings_schema.global.settings.color_scheme.options__1.label"
+            "label": "t:sections.all.colors.accent_1.label"
           },
           {
             "value": "accent-2",
-            "label": "t:settings_schema.global.settings.color_scheme.options__2.label"
+            "label": "t:sections.all.colors.accent_2.label"
           },
           {
             "value": "background-2",
-            "label": "t:settings_schema.global.settings.color_scheme.options__4.label"
+            "label": "t:sections.all.colors.background_2.label"
           }
         ],
         "default": "accent-2",
@@ -981,11 +981,11 @@
         "options": [
           {
             "value": "background-1",
-            "label": "t:settings_schema.global.settings.color_scheme.options__3.label"
+            "label": "t:sections.all.colors.background_1.label"
           },
           {
             "value": "inverse",
-            "label": "t:settings_schema.global.settings.color_scheme.options__5.label"
+            "label": "t:sections.all.colors.inverse.label"
           }
         ],
         "default": "inverse",
@@ -1002,11 +1002,11 @@
         "options": [
           {
             "value": "accent-1",
-            "label": "t:settings_schema.styles.settings.accent_icons.options__1.label"
+            "label": "t:sections.all.colors.accent_1.label"
           },
           {
             "value": "accent-2",
-            "label": "t:settings_schema.styles.settings.accent_icons.options__2.label"
+            "label": "t:sections.all.colors.accent_2.label"
           },
           {
             "value": "outline-button",

--- a/locales/cs.schema.json
+++ b/locales/cs.schema.json
@@ -77,12 +77,6 @@
       "name": "Ikony",
       "settings": {
         "accent_icons": {
-          "options__1": {
-            "label": "Zvýraznění 1"
-          },
-          "options__2": {
-            "label": "Zvýraznění 2"
-          },
           "options__3": {
             "label": "Tlačítko s obrysem"
           },
@@ -238,24 +232,6 @@
             "label": "Doprava"
           },
           "label": "Zarovnání textu"
-        },
-        "color_scheme": {
-          "options__1": {
-            "label": "Zvýraznění 1"
-          },
-          "options__2": {
-            "label": "Zvýraznění 2"
-          },
-          "options__3": {
-            "label": "Pozadí 1"
-          },
-          "options__4": {
-            "label": "Pozadí 2"
-          },
-          "options__5": {
-            "label": "Inverze"
-          },
-          "label": "Barevné schéma"
         }
       }
     },
@@ -361,24 +337,6 @@
           "settings": {
             "text": {
               "label": "Text"
-            },
-            "color_scheme": {
-              "label": "Barevné schéma",
-              "options__1": {
-                "label": "Pozadí 1"
-              },
-              "options__2": {
-                "label": "Pozadí 2"
-              },
-              "options__3": {
-                "label": "Inverze"
-              },
-              "options__4": {
-                "label": "Zvýraznění 1"
-              },
-              "options__5": {
-                "label": "Zvýraznění 2"
-              }
             },
             "link": {
               "label": "Odkaz"
@@ -647,24 +605,6 @@
         }
       },
       "settings": {
-        "color_scheme": {
-          "options__1": {
-            "label": "Zvýraznění 1"
-          },
-          "options__2": {
-            "label": "Zvýraznění 2"
-          },
-          "options__3": {
-            "label": "Pozadí 1"
-          },
-          "options__4": {
-            "label": "Pozadí 2"
-          },
-          "options__5": {
-            "label": "Inverze"
-          },
-          "label": "Barevné schéma"
-        },
         "newsletter_enable": {
           "label": "Zobrazit přihlášení k odběru e-mailů"
         },
@@ -744,24 +684,6 @@
           "label": "Zobrazit plovoucí záhlaví",
           "info": "Záhlaví zůstane zobrazené na obrazovce, přestože zákazníci skrolují dál."
         },
-        "color_scheme": {
-          "options__1": {
-            "label": "Zvýraznění 1"
-          },
-          "options__2": {
-            "label": "Zvýraznění 2"
-          },
-          "options__3": {
-            "label": "Pozadí 1"
-          },
-          "options__4": {
-            "label": "Pozadí 2"
-          },
-          "options__5": {
-            "label": "Inverze"
-          },
-          "label": "Barevné schéma"
-        },
         "margin_bottom": {
           "label": "Dolní okraj"
         }
@@ -777,22 +699,6 @@
           "label": "Druhý obrázek"
         },
         "color_scheme": {
-          "options__1": {
-            "label": "Zvýraznění 1"
-          },
-          "options__2": {
-            "label": "Zvýraznění 2"
-          },
-          "options__3": {
-            "label": "Pozadí 1"
-          },
-          "options__4": {
-            "label": "Pozadí 2"
-          },
-          "options__5": {
-            "label": "Inverze"
-          },
-          "label": "Barevné schéma",
           "info": "Zobrazuje se v případě, že se zobrazuje kontejner."
         },
         "stack_images_on_mobile": {
@@ -967,24 +873,6 @@
             "label": "Velká"
           },
           "label": "Výška obrázku"
-        },
-        "color_scheme": {
-          "options__1": {
-            "label": "Pozadí 1"
-          },
-          "options__2": {
-            "label": "Pozadí 2"
-          },
-          "options__3": {
-            "label": "Inverze"
-          },
-          "options__4": {
-            "label": "Zvýraznění 1"
-          },
-          "options__5": {
-            "label": "Zvýraznění 2"
-          },
-          "label": "Barevné schéma"
         },
         "layout": {
           "options__1": {
@@ -1377,27 +1265,7 @@
       "name": "Stránka"
     },
     "main-password-footer": {
-      "name": "Zápatí hesla",
-      "settings": {
-        "color_scheme": {
-          "options__1": {
-            "label": "Zvýraznění 1"
-          },
-          "options__2": {
-            "label": "Zvýraznění 2"
-          },
-          "options__3": {
-            "label": "Pozadí 1"
-          },
-          "options__4": {
-            "label": "Pozadí 2"
-          },
-          "options__5": {
-            "label": "Inverze"
-          },
-          "label": "Barevné schéma"
-        }
-      }
+      "name": "Zápatí hesla"
     },
     "main-password-header": {
       "name": "Záhlaví hesla",
@@ -1408,24 +1276,6 @@
         "logo_max_width": {
           "label": "Šířka vlastního loga",
           "unit": "px"
-        },
-        "color_scheme": {
-          "options__1": {
-            "label": "Zvýraznění 1"
-          },
-          "options__2": {
-            "label": "Zvýraznění 2"
-          },
-          "options__3": {
-            "label": "Pozadí 1"
-          },
-          "options__4": {
-            "label": "Pozadí 2"
-          },
-          "options__5": {
-            "label": "Inverze"
-          },
-          "label": "Barevné schéma"
         }
       }
     },
@@ -1868,24 +1718,6 @@
     "newsletter": {
       "name": "Přihlášení k odběru e-mailů",
       "settings": {
-        "color_scheme": {
-          "label": "Barevné schéma",
-          "options__1": {
-            "label": "Zvýraznění 1"
-          },
-          "options__2": {
-            "label": "Zvýraznění 2"
-          },
-          "options__3": {
-            "label": "Pozadí 1"
-          },
-          "options__4": {
-            "label": "Pozadí 2"
-          },
-          "options__5": {
-            "label": "Inverze"
-          }
-        },
         "full_width": {
           "label": "Nastavit plnou šířku sekce"
         },
@@ -1971,24 +1803,6 @@
     "rich-text": {
       "name": "Formát RTF",
       "settings": {
-        "color_scheme": {
-          "options__1": {
-            "label": "Zvýraznění 1"
-          },
-          "options__2": {
-            "label": "Zvýraznění 2"
-          },
-          "options__3": {
-            "label": "Pozadí 1"
-          },
-          "options__4": {
-            "label": "Pozadí 2"
-          },
-          "options__5": {
-            "label": "Inverze"
-          },
-          "label": "Barevné schéma"
-        },
         "full_width": {
           "label": "Nastavit plnou šířku sekce"
         }
@@ -2212,22 +2026,6 @@
           "label": "Neprůhlednost překryvu obrázku"
         },
         "color_scheme": {
-          "options__1": {
-            "label": "Zvýraznění 1"
-          },
-          "options__2": {
-            "label": "Zvýraznění 2"
-          },
-          "options__3": {
-            "label": "Pozadí 1"
-          },
-          "options__4": {
-            "label": "Pozadí 2"
-          },
-          "options__5": {
-            "label": "Inverzní"
-          },
-          "label": "Barevné schéma",
           "info": "Zobrazuje se v případě, že se zobrazuje kontejner."
         },
         "show_text_below": {
@@ -2484,23 +2282,7 @@
               "label": "Neprůhlednost překryvu obrázku"
             },
             "color_scheme": {
-              "info": "Zobrazuje se v případě, že se zobrazuje kontejner.",
-              "options__1": {
-                "label": "Zvýraznění 1"
-              },
-              "options__2": {
-                "label": "Zvýraznění 2"
-              },
-              "options__3": {
-                "label": "Pozadí 1"
-              },
-              "options__4": {
-                "label": "Pozadí 2"
-              },
-              "options__5": {
-                "label": "Inverze"
-              },
-              "label": "Barevné schéma"
+              "info": "Zobrazuje se v případě, že se zobrazuje kontejner."
             },
             "text_alignment_mobile": {
               "label": "Zarovnání obsahu v mobilním prostředí",
@@ -2554,24 +2336,6 @@
             "label": "Kontejner sekcí"
           }
         },
-        "color_scheme": {
-          "label": "Barevné schéma",
-          "options__1": {
-            "label": "Pozadí 1"
-          },
-          "options__2": {
-            "label": "Pozadí 2"
-          },
-          "options__3": {
-            "label": "Inverze"
-          },
-          "options__4": {
-            "label": "Zvýraznění 1"
-          },
-          "options__5": {
-            "label": "Zvýraznění 2"
-          }
-        },
         "open_first_collapsible_row": {
           "label": "Otevřít první sbalitelný řádek"
         },
@@ -2605,21 +2369,6 @@
         },
         "container_color_scheme": {
           "label": "Barevné schéma kontejneru",
-          "options__1": {
-            "label": "Pozadí 1"
-          },
-          "options__2": {
-            "label": "Pozadí 2"
-          },
-          "options__3": {
-            "label": "Inverze"
-          },
-          "options__4": {
-            "label": "Zvýraznění 1"
-          },
-          "options__5": {
-            "label": "Zvýraznění 2"
-          },
           "info": "Zobrazí se v případě, že je rozvržení nastaveno na kontejner řádků nebo sekcí."
         }
       },

--- a/locales/da.schema.json
+++ b/locales/da.schema.json
@@ -77,12 +77,6 @@
       "name": "Ikoner",
       "settings": {
         "accent_icons": {
-          "options__1": {
-            "label": "Markering 1"
-          },
-          "options__2": {
-            "label": "Markering 2"
-          },
           "options__3": {
             "label": "Rammeknap"
           },
@@ -238,24 +232,6 @@
             "label": "Højre"
           },
           "label": "Tekstjustering"
-        },
-        "color_scheme": {
-          "options__1": {
-            "label": "Markering 1"
-          },
-          "options__2": {
-            "label": "Markering 2"
-          },
-          "options__3": {
-            "label": "Baggrund 1"
-          },
-          "options__4": {
-            "label": "Baggrund 2"
-          },
-          "options__5": {
-            "label": "Omvendt"
-          },
-          "label": "Farveskema"
         }
       }
     },
@@ -361,24 +337,6 @@
           "settings": {
             "text": {
               "label": "Tekstfarve"
-            },
-            "color_scheme": {
-              "label": "Farveskema",
-              "options__1": {
-                "label": "Baggrund 1"
-              },
-              "options__2": {
-                "label": "Baggrund 2"
-              },
-              "options__3": {
-                "label": "Omvendt"
-              },
-              "options__4": {
-                "label": "Markering 1"
-              },
-              "options__5": {
-                "label": "Markering 2"
-              }
             },
             "link": {
               "label": "Link"
@@ -647,24 +605,6 @@
         }
       },
       "settings": {
-        "color_scheme": {
-          "options__1": {
-            "label": "Markering 1"
-          },
-          "options__2": {
-            "label": "Markering 2"
-          },
-          "options__3": {
-            "label": "Baggrund 1"
-          },
-          "options__4": {
-            "label": "Baggrund 2"
-          },
-          "options__5": {
-            "label": "Omvendt"
-          },
-          "label": "Farveskema"
-        },
         "newsletter_enable": {
           "label": "Vis tilmelding med mail"
         },
@@ -744,24 +684,6 @@
           "label": "Aktivér fastgjort sidehoved",
           "info": "Sidehovedet vises på skærmen, når kunderne ruller op."
         },
-        "color_scheme": {
-          "options__1": {
-            "label": "Markering 1"
-          },
-          "options__2": {
-            "label": "Markering 2"
-          },
-          "options__3": {
-            "label": "Baggrund 1"
-          },
-          "options__4": {
-            "label": "Baggrund 2"
-          },
-          "options__5": {
-            "label": "Omvendt"
-          },
-          "label": "Farveskema"
-        },
         "margin_bottom": {
           "label": "Nederste margen"
         }
@@ -777,22 +699,6 @@
           "label": "Andet billede"
         },
         "color_scheme": {
-          "options__1": {
-            "label": "Markering 1"
-          },
-          "options__2": {
-            "label": "Markering 2"
-          },
-          "options__3": {
-            "label": "Baggrund 1"
-          },
-          "options__4": {
-            "label": "Baggrund 2"
-          },
-          "options__5": {
-            "label": "Omvendt"
-          },
-          "label": "Farveskema",
           "info": "Synlig, når containeren vises."
         },
         "stack_images_on_mobile": {
@@ -967,24 +873,6 @@
             "label": "Stor"
           },
           "label": "Billedhøjde"
-        },
-        "color_scheme": {
-          "options__1": {
-            "label": "Baggrund 1"
-          },
-          "options__2": {
-            "label": "Baggrund 2"
-          },
-          "options__3": {
-            "label": "Omvendt"
-          },
-          "options__4": {
-            "label": "Markering 1"
-          },
-          "options__5": {
-            "label": "Markering 2"
-          },
-          "label": "Farveskema"
         },
         "layout": {
           "options__1": {
@@ -1377,27 +1265,7 @@
       "name": "Side"
     },
     "main-password-footer": {
-      "name": "Sidefod på adgangskodeside",
-      "settings": {
-        "color_scheme": {
-          "options__1": {
-            "label": "Markering 1"
-          },
-          "options__2": {
-            "label": "Markering 2"
-          },
-          "options__3": {
-            "label": "Baggrund 1"
-          },
-          "options__4": {
-            "label": "Baggrund 2"
-          },
-          "options__5": {
-            "label": "Omvendt"
-          },
-          "label": "Farveskema"
-        }
-      }
+      "name": "Sidefod på adgangskodeside"
     },
     "main-password-header": {
       "name": "Sidehoved på adgangskodesiden",
@@ -1408,24 +1276,6 @@
         "logo_max_width": {
           "label": "Tilpasset logobredde",
           "unit": "px"
-        },
-        "color_scheme": {
-          "options__1": {
-            "label": "Markering 1"
-          },
-          "options__2": {
-            "label": "Markering 2"
-          },
-          "options__3": {
-            "label": "Baggrund 1"
-          },
-          "options__4": {
-            "label": "Baggrund 2"
-          },
-          "options__5": {
-            "label": "Omvendt"
-          },
-          "label": "Farveskema"
         }
       }
     },
@@ -1868,24 +1718,6 @@
     "newsletter": {
       "name": "Tilmelding med mail",
       "settings": {
-        "color_scheme": {
-          "label": "Farveskema",
-          "options__1": {
-            "label": "Markering 1"
-          },
-          "options__2": {
-            "label": "Markering 2"
-          },
-          "options__3": {
-            "label": "Baggrund 1"
-          },
-          "options__4": {
-            "label": "Baggrund 2"
-          },
-          "options__5": {
-            "label": "Omvendt"
-          }
-        },
         "full_width": {
           "label": "Gør afsnittet til fuld bredde"
         },
@@ -1971,24 +1803,6 @@
     "rich-text": {
       "name": "RTF",
       "settings": {
-        "color_scheme": {
-          "options__1": {
-            "label": "Markering 1"
-          },
-          "options__2": {
-            "label": "Markering 2"
-          },
-          "options__3": {
-            "label": "Baggrund 1"
-          },
-          "options__4": {
-            "label": "Baggrund 2"
-          },
-          "options__5": {
-            "label": "Omvendt"
-          },
-          "label": "Farveskema"
-        },
         "full_width": {
           "label": "Gør afsnittet til fuld bredde"
         }
@@ -2212,22 +2026,6 @@
           "label": "Billedoverlejringens uigennemsigtighed"
         },
         "color_scheme": {
-          "options__1": {
-            "label": "Markering 1"
-          },
-          "options__2": {
-            "label": "Markering 2"
-          },
-          "options__3": {
-            "label": "Baggrund 1"
-          },
-          "options__4": {
-            "label": "Baggrund 2"
-          },
-          "options__5": {
-            "label": "Omvendt"
-          },
-          "label": "Farveskema",
           "info": "Synlig, når containeren vises"
         },
         "show_text_below": {
@@ -2484,23 +2282,7 @@
               "label": "Billedoverlejringens uigennemsigtighed"
             },
             "color_scheme": {
-              "label": "Farveskema",
-              "info": "Synlig, når containeren vises.",
-              "options__1": {
-                "label": "Markering 1"
-              },
-              "options__2": {
-                "label": "Markering 2"
-              },
-              "options__3": {
-                "label": "Baggrund 1"
-              },
-              "options__4": {
-                "label": "Baggrund 2"
-              },
-              "options__5": {
-                "label": "Omvendt"
-              }
+              "info": "Synlig, når containeren vises."
             },
             "text_alignment_mobile": {
               "label": "Justering af indhold på mobil",
@@ -2554,24 +2336,6 @@
             "label": "Objektbeholder til afsnit"
           }
         },
-        "color_scheme": {
-          "label": "Farveskema",
-          "options__1": {
-            "label": "Baggrund 1"
-          },
-          "options__2": {
-            "label": "Baggrund 2"
-          },
-          "options__3": {
-            "label": "Omvendt"
-          },
-          "options__4": {
-            "label": "Markering 1"
-          },
-          "options__5": {
-            "label": "Markering 2"
-          }
-        },
         "open_first_collapsible_row": {
           "label": "Åbn første række, der kan skjules"
         },
@@ -2605,21 +2369,6 @@
         },
         "container_color_scheme": {
           "label": "Objektbeholder til farveskema",
-          "options__1": {
-            "label": "Baggrund 1"
-          },
-          "options__2": {
-            "label": "Baggrund 2"
-          },
-          "options__3": {
-            "label": "Omvendt"
-          },
-          "options__4": {
-            "label": "Markering 1"
-          },
-          "options__5": {
-            "label": "Markering 2"
-          },
           "info": "Synlig, når Layout er angivet til objektbeholder til Række eller Afsnit."
         }
       },

--- a/locales/de.schema.json
+++ b/locales/de.schema.json
@@ -77,12 +77,6 @@
       "name": "Symbole",
       "settings": {
         "accent_icons": {
-          "options__1": {
-            "label": "Akzent 1"
-          },
-          "options__2": {
-            "label": "Akzent 2"
-          },
           "options__3": {
             "label": "Umriss-Schaltfläche"
           },
@@ -238,24 +232,6 @@
             "label": "Rechts"
           },
           "label": "Textausrichtung"
-        },
-        "color_scheme": {
-          "options__1": {
-            "label": "Akzent 1"
-          },
-          "options__2": {
-            "label": "Akzent 2"
-          },
-          "options__3": {
-            "label": "Hintergrund 1"
-          },
-          "options__4": {
-            "label": "Hintergrund 2"
-          },
-          "options__5": {
-            "label": "Invertiert"
-          },
-          "label": "Farbschema"
         }
       }
     },
@@ -361,24 +337,6 @@
           "settings": {
             "text": {
               "label": "Text"
-            },
-            "color_scheme": {
-              "label": "Farbschema",
-              "options__1": {
-                "label": "Hintergrund 1"
-              },
-              "options__2": {
-                "label": "Hintergrund 2"
-              },
-              "options__3": {
-                "label": "Invertiert"
-              },
-              "options__4": {
-                "label": "Akzent 1"
-              },
-              "options__5": {
-                "label": "Akzent 2"
-              }
             },
             "link": {
               "label": "Link"
@@ -647,24 +605,6 @@
         }
       },
       "settings": {
-        "color_scheme": {
-          "options__1": {
-            "label": "Akzent 1"
-          },
-          "options__2": {
-            "label": "Akzent 2"
-          },
-          "options__3": {
-            "label": "Hintergrund 1"
-          },
-          "options__4": {
-            "label": "Hintergrund 2"
-          },
-          "options__5": {
-            "label": "Invertiert"
-          },
-          "label": "Farbschema"
-        },
         "newsletter_enable": {
           "label": "E-Mail-Anmeldung anzeigen"
         },
@@ -744,24 +684,6 @@
           "label": "Fixierten Header aktivieren",
           "info": "Der Header wird auf dem Bildschirm angezeigt, wenn der Kunde nach oben scrollt."
         },
-        "color_scheme": {
-          "options__1": {
-            "label": "Akzent 1"
-          },
-          "options__2": {
-            "label": "Akzent 2"
-          },
-          "options__3": {
-            "label": "Hintergrund 1"
-          },
-          "options__4": {
-            "label": "Hintergrund 2"
-          },
-          "options__5": {
-            "label": "Invertiert"
-          },
-          "label": "Farbschema"
-        },
         "margin_bottom": {
           "label": "Unterer Rand"
         }
@@ -777,22 +699,6 @@
           "label": "Zweites Bild"
         },
         "color_scheme": {
-          "options__1": {
-            "label": "Akzent 1"
-          },
-          "options__2": {
-            "label": "Akzent 2"
-          },
-          "options__3": {
-            "label": "Hintergrund 1"
-          },
-          "options__4": {
-            "label": "Hintergrund 2"
-          },
-          "options__5": {
-            "label": "Invertiert"
-          },
-          "label": "Farbschema",
           "info": "Sichtbar, wenn Container angezeigt wird."
         },
         "stack_images_on_mobile": {
@@ -967,24 +873,6 @@
             "label": "Groß"
           },
           "label": "Bildhöhe"
-        },
-        "color_scheme": {
-          "options__1": {
-            "label": "Hintergrund 1"
-          },
-          "options__2": {
-            "label": "Hintergrund 2"
-          },
-          "options__3": {
-            "label": "Invertiert"
-          },
-          "options__4": {
-            "label": "Akzent 1"
-          },
-          "options__5": {
-            "label": "Akzent 2"
-          },
-          "label": "Farbschema"
         },
         "layout": {
           "options__1": {
@@ -1377,27 +1265,7 @@
       "name": "Seite"
     },
     "main-password-footer": {
-      "name": "Passwort-Fußzeile",
-      "settings": {
-        "color_scheme": {
-          "options__1": {
-            "label": "Akzent 1"
-          },
-          "options__2": {
-            "label": "Akzent 2"
-          },
-          "options__3": {
-            "label": "Hintergrund 1"
-          },
-          "options__4": {
-            "label": "Hintergrund 2"
-          },
-          "options__5": {
-            "label": "Invertiert"
-          },
-          "label": "Farbschema"
-        }
-      }
+      "name": "Passwort-Fußzeile"
     },
     "main-password-header": {
       "name": "Passwort-Header",
@@ -1408,24 +1276,6 @@
         "logo_max_width": {
           "label": "Breite des benutzerdefinierten Logos",
           "unit": "Pixel"
-        },
-        "color_scheme": {
-          "options__1": {
-            "label": "Akzent 1"
-          },
-          "options__2": {
-            "label": "Akzent 2"
-          },
-          "options__3": {
-            "label": "Hintergrund 1"
-          },
-          "options__4": {
-            "label": "Hintergrund 2"
-          },
-          "options__5": {
-            "label": "Invertiert"
-          },
-          "label": "Farbschema"
         }
       }
     },
@@ -1868,24 +1718,6 @@
     "newsletter": {
       "name": "E-Mail-Anmeldung",
       "settings": {
-        "color_scheme": {
-          "label": "Farbschema",
-          "options__1": {
-            "label": "Akzent 1"
-          },
-          "options__2": {
-            "label": "Akzent 2"
-          },
-          "options__3": {
-            "label": "Hintergrund 1"
-          },
-          "options__4": {
-            "label": "Hintergrund 2"
-          },
-          "options__5": {
-            "label": "Invertiert"
-          }
-        },
         "full_width": {
           "label": "Abschnitt über die gesamte Breite"
         },
@@ -1971,24 +1803,6 @@
     "rich-text": {
       "name": "Rich Text",
       "settings": {
-        "color_scheme": {
-          "options__1": {
-            "label": "Akzent 1"
-          },
-          "options__2": {
-            "label": "Akzent 2"
-          },
-          "options__3": {
-            "label": "Hintergrund 1"
-          },
-          "options__4": {
-            "label": "Hintergrund 2"
-          },
-          "options__5": {
-            "label": "Invertiert"
-          },
-          "label": "Farbschema"
-        },
         "full_width": {
           "label": "Abschnitt über die gesamte Breite"
         }
@@ -2212,22 +2026,6 @@
           "label": "Deckkraft der Bildüberlagerung"
         },
         "color_scheme": {
-          "options__1": {
-            "label": "Akzent 1"
-          },
-          "options__2": {
-            "label": "Akzent 2"
-          },
-          "options__3": {
-            "label": "Hintergrund 1"
-          },
-          "options__4": {
-            "label": "Hintergrund 2"
-          },
-          "options__5": {
-            "label": "Invertiert"
-          },
-          "label": "Farbschema",
           "info": "Sichtbar, wenn Container angezeigt wird"
         },
         "show_text_below": {
@@ -2484,23 +2282,7 @@
               "label": "Deckkraft der Bildüberlagerung"
             },
             "color_scheme": {
-              "label": "Farbschema",
-              "info": "Sichtbar, wenn Container angezeigt wird.",
-              "options__1": {
-                "label": "Akzent 1"
-              },
-              "options__2": {
-                "label": "Akzent 2"
-              },
-              "options__3": {
-                "label": "Hintergrund 1"
-              },
-              "options__4": {
-                "label": "Hintergrund 2"
-              },
-              "options__5": {
-                "label": "Invertiert"
-              }
+              "info": "Sichtbar, wenn Container angezeigt wird."
             },
             "text_alignment_mobile": {
               "label": "Mobile Inhaltsausrichtung",
@@ -2554,24 +2336,6 @@
             "label": "Abschnittscontainer"
           }
         },
-        "color_scheme": {
-          "label": "Farbschema",
-          "options__1": {
-            "label": "Hintergrund 1"
-          },
-          "options__2": {
-            "label": "Hintergrund 2"
-          },
-          "options__3": {
-            "label": "Invertiert"
-          },
-          "options__4": {
-            "label": "Akzent 1"
-          },
-          "options__5": {
-            "label": "Akzent 2"
-          }
-        },
         "open_first_collapsible_row": {
           "label": "Erste einklappbare Reihe öffnen"
         },
@@ -2605,21 +2369,6 @@
         },
         "container_color_scheme": {
           "label": "Farbschema für Container",
-          "options__1": {
-            "label": "Hintergrund 1"
-          },
-          "options__2": {
-            "label": "Hintergrund 2"
-          },
-          "options__3": {
-            "label": "Invertiert"
-          },
-          "options__4": {
-            "label": "Akzent 1"
-          },
-          "options__5": {
-            "label": "Akzent 2"
-          },
           "info": "Wird angezeigt, wenn für das Layout Zeilen- oder Abschnitts-Container festgelegt wird."
         }
       },

--- a/locales/en.default.schema.json
+++ b/locales/en.default.schema.json
@@ -751,24 +751,6 @@
         }
       },
       "settings": {
-        "color_scheme": {
-          "options__1": {
-            "label": "Accent 1"
-          },
-          "options__2": {
-            "label": "Accent 2"
-          },
-          "options__3": {
-            "label": "Background 1"
-          },
-          "options__4": {
-            "label": "Background 2"
-          },
-          "options__5": {
-            "label": "Inverse"
-          },
-          "label": "Color scheme"
-        },
         "newsletter_enable": {
           "label": "Show email signup"
         },

--- a/locales/en.default.schema.json
+++ b/locales/en.default.schema.json
@@ -2071,23 +2071,7 @@
           "label": "Desktop content position"
         },
         "color_scheme": {
-          "options__1": {
-            "label": "Accent 1"
-          },
-          "options__2": {
-            "label": "Accent 2"
-          },
-          "options__3": {
-            "label": "Background 1"
-          },
-          "options__4": {
-            "label": "Background 2"
-          },
-          "options__5": {
-            "label": "Inverse"
-          },
-          "label": "Color scheme",
-          "info": "Visible when container displayed"
+          "info": "Visible when container displayed."
         },
         "image_height": {
           "label": "Banner height",

--- a/locales/en.default.schema.json
+++ b/locales/en.default.schema.json
@@ -2082,24 +2082,6 @@
     "rich-text": {
       "name": "Rich text",
       "settings": {
-        "color_scheme": {
-          "options__1": {
-            "label": "Accent 1"
-          },
-          "options__2": {
-            "label": "Accent 2"
-          },
-          "options__3": {
-            "label": "Background 1"
-          },
-          "options__4": {
-            "label": "Background 2"
-          },
-          "options__5": {
-            "label": "Inverse"
-          },
-          "label": "Color scheme"
-        },
         "full_width": {
           "label": "Make section full width"
         }
@@ -2324,23 +2306,7 @@
               "label": "Image overlay opacity"
             },
             "color_scheme": {
-              "label": "Color scheme",
-              "info": "Visible when container displayed.",
-              "options__1": {
-                "label": "Accent 1"
-              },
-              "options__2": {
-                "label": "Accent 2"
-              },
-              "options__3": {
-                "label": "Background 1"
-              },
-              "options__4": {
-                "label": "Background 2"
-              },
-              "options__5": {
-                "label": "Inverse"
-              }
+              "info": "Visible when container displayed."
             },
             "text_alignment_mobile": {
               "label": "Mobile content alignment",

--- a/locales/en.default.schema.json
+++ b/locales/en.default.schema.json
@@ -906,22 +906,6 @@
           "label": "Desktop content alignment"
         },
         "color_scheme": {
-          "options__1": {
-            "label": "Accent 1"
-          },
-          "options__2": {
-            "label": "Accent 2"
-          },
-          "options__3": {
-            "label": "Background 1"
-          },
-          "options__4": {
-            "label": "Background 2"
-          },
-          "options__5": {
-            "label": "Inverse"
-          },
-          "label": "Color scheme",
           "info": "Visible when container displayed."
         },
         "header": {

--- a/locales/en.default.schema.json
+++ b/locales/en.default.schema.json
@@ -185,12 +185,6 @@
       "name": "Icons",
       "settings": {
         "accent_icons": {
-          "options__1": {
-            "label": "Accent 1"
-          },
-          "options__2": {
-            "label": "Accent 2"
-          },
           "options__3": {
             "label": "Outline button"
           },
@@ -782,24 +776,6 @@
     "header": {
       "name": "Header",
       "settings": {
-        "color_scheme": {
-          "options__1": {
-            "label": "Accent 1"
-          },
-          "options__2": {
-            "label": "Accent 2"
-          },
-          "options__3": {
-            "label": "Background 1"
-          },
-          "options__4": {
-            "label": "Background 2"
-          },
-          "options__5": {
-            "label": "Inverse"
-          },
-          "label": "Color scheme"
-        },
         "logo": {
           "label": "Logo image"
         },

--- a/locales/en.default.schema.json
+++ b/locales/en.default.schema.json
@@ -1411,27 +1411,7 @@
       "name": "Page"
     },
     "main-password-footer": {
-      "name": "Password footer",
-      "settings": {
-        "color_scheme": {
-          "options__1": {
-            "label": "Accent 1"
-          },
-          "options__2": {
-            "label": "Accent 2"
-          },
-          "options__3": {
-            "label": "Background 1"
-          },
-          "options__4": {
-            "label": "Background 2"
-          },
-          "options__5": {
-            "label": "Inverse"
-          },
-          "label": "Color scheme"
-        }
-      }
+      "name": "Password footer"
     },
     "main-password-header": {
       "name": "Password header",
@@ -1442,24 +1422,6 @@
         "logo_max_width": {
           "label": "Custom logo width",
           "unit": "px"
-        },
-        "color_scheme": {
-          "options__1": {
-            "label": "Accent 1"
-          },
-          "options__2": {
-            "label": "Accent 2"
-          },
-          "options__3": {
-            "label": "Background 1"
-          },
-          "options__4": {
-            "label": "Background 2"
-          },
-          "options__5": {
-            "label": "Inverse"
-          },
-          "label": "Color scheme"
         }
       }
     },

--- a/locales/en.default.schema.json
+++ b/locales/en.default.schema.json
@@ -362,24 +362,6 @@
             "text": {
               "label": "Text"
             },
-            "color_scheme": {
-              "label": "Color scheme",
-              "options__1": {
-                "label": "Background 1"
-              },
-              "options__2": {
-                "label": "Background 2"
-              },
-              "options__3": {
-                "label": "Inverse"
-              },
-              "options__4": {
-                "label": "Accent 1"
-              },
-              "options__5": {
-                "label": "Accent 2"
-              }
-            },
             "link": {
               "label": "Link"
             }
@@ -2554,42 +2536,9 @@
             "label": "Section container"
           }
         },
-        "color_scheme": {
-          "label": "Color scheme",
-          "options__1": {
-            "label": "Background 1"
-          },
-          "options__2": {
-            "label": "Background 2"
-          },
-          "options__3": {
-            "label": "Inverse"
-          },
-          "options__4": {
-            "label": "Accent 1"
-          },
-          "options__5": {
-            "label": "Accent 2"
-          }
-        },
         "container_color_scheme": {
           "label": "Container color scheme",
-          "info": "Visible when Layout is set to Row or Section container.",
-          "options__1": {
-            "label": "Background 1"
-          },
-          "options__2": {
-            "label": "Background 2"
-          },
-          "options__3": {
-            "label": "Inverse"
-          },
-          "options__4": {
-            "label": "Accent 1"
-          },
-          "options__5": {
-            "label": "Accent 2"
-          }
+          "info": "Visible when Layout is set to Row or Section container."
         },
         "open_first_collapsible_row": {
           "label": "Open first collapsible row"

--- a/locales/en.default.schema.json
+++ b/locales/en.default.schema.json
@@ -1864,24 +1864,6 @@
     "newsletter": {
       "name": "Email signup",
       "settings": {
-        "color_scheme": {
-          "label": "Color scheme",
-          "options__1": {
-            "label": "Accent 1"
-          },
-          "options__2": {
-            "label": "Accent 2"
-          },
-          "options__3": {
-            "label": "Background 1"
-          },
-          "options__4": {
-            "label": "Background 2"
-          },
-          "options__5": {
-            "label": "Inverse"
-          }
-        },
         "full_width": {
           "label": "Make section full width"
         },

--- a/locales/en.default.schema.json
+++ b/locales/en.default.schema.json
@@ -40,24 +40,6 @@
             "label": "Right"
           },
           "label": "Text alignment"
-        },
-        "color_scheme": {
-          "options__1": {
-            "label": "Accent 1"
-          },
-          "options__2": {
-            "label": "Accent 2"
-          },
-          "options__3": {
-            "label": "Background 1"
-          },
-          "options__4": {
-            "label": "Background 2"
-          },
-          "options__5": {
-            "label": "Inverse"
-          },
-          "label": "Color scheme"
         }
       }
     },

--- a/locales/en.default.schema.json
+++ b/locales/en.default.schema.json
@@ -1033,24 +1033,6 @@
           "label": "Desktop image width",
           "info": "Image is automatically optimized for mobile."
         },
-        "color_scheme": {
-          "options__1": {
-            "label": "Background 1"
-          },
-          "options__2": {
-            "label": "Background 2"
-          },
-          "options__3": {
-            "label": "Inverse"
-          },
-          "options__4": {
-            "label": "Accent 1"
-          },
-          "options__5": {
-            "label": "Accent 2"
-          },
-          "label": "Color scheme"
-        },
         "layout": {
           "options__1": {
             "label": "Image first"

--- a/locales/es.schema.json
+++ b/locales/es.schema.json
@@ -77,12 +77,6 @@
       "name": "Íconos",
       "settings": {
         "accent_icons": {
-          "options__1": {
-            "label": "Acento 1"
-          },
-          "options__2": {
-            "label": "Acento 2"
-          },
           "options__3": {
             "label": "Botón con contorno"
           },
@@ -238,24 +232,6 @@
             "label": "Derecha"
           },
           "label": "Alineación de texto"
-        },
-        "color_scheme": {
-          "options__1": {
-            "label": "Acento 1"
-          },
-          "options__2": {
-            "label": "Acento 2"
-          },
-          "options__3": {
-            "label": "Fondo 1"
-          },
-          "options__4": {
-            "label": "Fondo 2"
-          },
-          "options__5": {
-            "label": "Invertir"
-          },
-          "label": "Esquema de colores"
         }
       }
     },
@@ -361,24 +337,6 @@
           "settings": {
             "text": {
               "label": "Texto"
-            },
-            "color_scheme": {
-              "label": "Esquema de colores",
-              "options__1": {
-                "label": "Fondo 1"
-              },
-              "options__2": {
-                "label": "Fondo 2"
-              },
-              "options__3": {
-                "label": "Invertir"
-              },
-              "options__4": {
-                "label": "Acento 1"
-              },
-              "options__5": {
-                "label": "Acento 2"
-              }
             },
             "link": {
               "label": "Enlace"
@@ -647,24 +605,6 @@
         }
       },
       "settings": {
-        "color_scheme": {
-          "options__1": {
-            "label": "Acento 1"
-          },
-          "options__2": {
-            "label": "Acento 2"
-          },
-          "options__3": {
-            "label": "Fondo 1"
-          },
-          "options__4": {
-            "label": "Fondo 2"
-          },
-          "options__5": {
-            "label": "Invertir"
-          },
-          "label": "Esquema de colores"
-        },
         "newsletter_enable": {
           "label": "Mostrar suscriptor de correo electrónico"
         },
@@ -744,24 +684,6 @@
           "label": "Activar encabezado fijo",
           "info": "El encabezado se muestra en la pantalla mientras los clientes se desplazan hacia arriba."
         },
-        "color_scheme": {
-          "options__1": {
-            "label": "Resaltado 1"
-          },
-          "options__2": {
-            "label": "Resaltado 2"
-          },
-          "options__3": {
-            "label": "Fondo 1"
-          },
-          "options__4": {
-            "label": "Fondo 2"
-          },
-          "options__5": {
-            "label": "Invertir"
-          },
-          "label": "Esquema de colores"
-        },
         "margin_bottom": {
           "label": "Margen inferior"
         }
@@ -777,22 +699,6 @@
           "label": "Segunda imagen"
         },
         "color_scheme": {
-          "options__1": {
-            "label": "Acento 1"
-          },
-          "options__2": {
-            "label": "Acento 2"
-          },
-          "options__3": {
-            "label": "Fondo 1"
-          },
-          "options__4": {
-            "label": "Fondo 2"
-          },
-          "options__5": {
-            "label": "Invertir"
-          },
-          "label": "Esquema de colores",
           "info": "Visible cuando se muestre el contenedor."
         },
         "stack_images_on_mobile": {
@@ -967,24 +873,6 @@
             "label": "Grande"
           },
           "label": "Altura de imagen"
-        },
-        "color_scheme": {
-          "options__1": {
-            "label": "Fondo 1"
-          },
-          "options__2": {
-            "label": "Fondo 2"
-          },
-          "options__3": {
-            "label": "Invertir"
-          },
-          "options__4": {
-            "label": "Acento 1"
-          },
-          "options__5": {
-            "label": "Acento 2"
-          },
-          "label": "Esquema de colores"
         },
         "layout": {
           "options__1": {
@@ -1377,27 +1265,7 @@
       "name": "Página"
     },
     "main-password-footer": {
-      "name": "Pie de página de contraseña",
-      "settings": {
-        "color_scheme": {
-          "options__1": {
-            "label": "Acento 1"
-          },
-          "options__2": {
-            "label": "Acento 2"
-          },
-          "options__3": {
-            "label": "Fondo 1"
-          },
-          "options__4": {
-            "label": "Fondo 2"
-          },
-          "options__5": {
-            "label": "Invertir"
-          },
-          "label": "Esquema de colores"
-        }
-      }
+      "name": "Pie de página de contraseña"
     },
     "main-password-header": {
       "name": "Encabezado de contraseña",
@@ -1408,24 +1276,6 @@
         "logo_max_width": {
           "label": "Ancho del logo personalizado",
           "unit": "px"
-        },
-        "color_scheme": {
-          "options__1": {
-            "label": "Acento 1"
-          },
-          "options__2": {
-            "label": "Acento 2"
-          },
-          "options__3": {
-            "label": "Fondo 1"
-          },
-          "options__4": {
-            "label": "Fondo 2"
-          },
-          "options__5": {
-            "label": "Invertir"
-          },
-          "label": "Esquema de colores"
         }
       }
     },
@@ -1868,24 +1718,6 @@
     "newsletter": {
       "name": "Suscriptor de correo electrónico",
       "settings": {
-        "color_scheme": {
-          "label": "Esquema de colores",
-          "options__1": {
-            "label": "Acento 1"
-          },
-          "options__2": {
-            "label": "Acento 2"
-          },
-          "options__3": {
-            "label": "Fondo 1"
-          },
-          "options__4": {
-            "label": "Fondo 2"
-          },
-          "options__5": {
-            "label": "Invertir"
-          }
-        },
         "full_width": {
           "label": "Definir ancho completo en sección"
         },
@@ -1971,24 +1803,6 @@
     "rich-text": {
       "name": "Texto enriquecido",
       "settings": {
-        "color_scheme": {
-          "options__1": {
-            "label": "Acento 1"
-          },
-          "options__2": {
-            "label": "Acento 2"
-          },
-          "options__3": {
-            "label": "Fondo 1"
-          },
-          "options__4": {
-            "label": "Fondo 2"
-          },
-          "options__5": {
-            "label": "Invertir"
-          },
-          "label": "Esquema de colores"
-        },
         "full_width": {
           "label": "Definir ancho completo en sección"
         }
@@ -2212,22 +2026,6 @@
           "label": "Opacidad de la sobreposición de imagen"
         },
         "color_scheme": {
-          "options__1": {
-            "label": "Acento 1"
-          },
-          "options__2": {
-            "label": "Acento 2"
-          },
-          "options__3": {
-            "label": "Fondo 1"
-          },
-          "options__4": {
-            "label": "Fondo 2"
-          },
-          "options__5": {
-            "label": "Invertir"
-          },
-          "label": "Esquema de colores",
           "info": "Visible cuando se muestre el contenedor"
         },
         "show_text_below": {
@@ -2484,23 +2282,7 @@
               "label": "Opacidad de la sobreposición de imagen"
             },
             "color_scheme": {
-              "label": "Esquema de colores",
-              "info": "Visible cuando se muestre el contenedor.",
-              "options__1": {
-                "label": "Resaltado 1"
-              },
-              "options__2": {
-                "label": "Resaltado 2"
-              },
-              "options__3": {
-                "label": "Fondo 1"
-              },
-              "options__4": {
-                "label": "Fondo 2"
-              },
-              "options__5": {
-                "label": "Invertir"
-              }
+              "info": "Visible cuando se muestre el contenedor."
             },
             "text_alignment_mobile": {
               "label": "Alineación del contenido en dispositivos móviles",
@@ -2554,42 +2336,9 @@
             "label": "Contenedor de sección"
           }
         },
-        "color_scheme": {
-          "label": "Esquema de colores",
-          "options__1": {
-            "label": "Fondo 1"
-          },
-          "options__2": {
-            "label": "Fondo 2"
-          },
-          "options__3": {
-            "label": "Invertir"
-          },
-          "options__4": {
-            "label": "Acento 1"
-          },
-          "options__5": {
-            "label": "Acento 2"
-          }
-        },
         "container_color_scheme": {
           "label": "Esquema de color del contenedor",
-          "info": "Visible cuando el diseño está configurado como fila o contenedor de sección.",
-          "options__1": {
-            "label": "Fondo 1"
-          },
-          "options__2": {
-            "label": "Fondo 2"
-          },
-          "options__3": {
-            "label": "Invertir"
-          },
-          "options__4": {
-            "label": "Acento 1"
-          },
-          "options__5": {
-            "label": "Acento 2"
-          }
+          "info": "Visible cuando el diseño está configurado como fila o contenedor de sección."
         },
         "open_first_collapsible_row": {
           "label": "Abrir primera fila desplegable"

--- a/locales/fi.schema.json
+++ b/locales/fi.schema.json
@@ -77,12 +77,6 @@
       "name": "Kuvakkeet",
       "settings": {
         "accent_icons": {
-          "options__1": {
-            "label": "Korostus 1"
-          },
-          "options__2": {
-            "label": "Korostus 2"
-          },
           "options__3": {
             "label": "Kehyspainike"
           },
@@ -238,24 +232,6 @@
             "label": "Oikea"
           },
           "label": "Tekstin tasaus"
-        },
-        "color_scheme": {
-          "options__1": {
-            "label": "Korostus 1"
-          },
-          "options__2": {
-            "label": "Korostus 2"
-          },
-          "options__3": {
-            "label": "Tausta 1"
-          },
-          "options__4": {
-            "label": "Tausta 2"
-          },
-          "options__5": {
-            "label": "Käänteinen"
-          },
-          "label": "Värimalli"
         }
       }
     },
@@ -361,24 +337,6 @@
           "settings": {
             "text": {
               "label": "Teksti"
-            },
-            "color_scheme": {
-              "label": "Värimalli",
-              "options__1": {
-                "label": "Tausta 1"
-              },
-              "options__2": {
-                "label": "Tausta 2"
-              },
-              "options__3": {
-                "label": "Käänteinen"
-              },
-              "options__4": {
-                "label": "Korostus 1"
-              },
-              "options__5": {
-                "label": "Korostus 2"
-              }
             },
             "link": {
               "label": "Linkki"
@@ -647,24 +605,6 @@
         }
       },
       "settings": {
-        "color_scheme": {
-          "options__1": {
-            "label": "Korostus 1"
-          },
-          "options__2": {
-            "label": "Korostus 2"
-          },
-          "options__3": {
-            "label": "Tausta 1"
-          },
-          "options__4": {
-            "label": "Tausta 2"
-          },
-          "options__5": {
-            "label": "Käänteinen"
-          },
-          "label": "Värimalli"
-        },
         "newsletter_enable": {
           "label": "Näytä sähköpostirekisteröityminen"
         },
@@ -744,24 +684,6 @@
           "label": "Ota paikallaan pysyvä ylätunniste käyttöön",
           "info": "Ylätunniste näkyy näytöllä, kun asiakkaat vierittävät ylöspäin."
         },
-        "color_scheme": {
-          "options__1": {
-            "label": "Korostus 1"
-          },
-          "options__2": {
-            "label": "Korostus 2"
-          },
-          "options__3": {
-            "label": "Tausta 1"
-          },
-          "options__4": {
-            "label": "Tausta 2"
-          },
-          "options__5": {
-            "label": "Käänteinen"
-          },
-          "label": "Värimalli"
-        },
         "margin_bottom": {
           "label": "Alareunus"
         }
@@ -777,22 +699,6 @@
           "label": "Toinen kuva"
         },
         "color_scheme": {
-          "options__1": {
-            "label": "Korostus 1"
-          },
-          "options__2": {
-            "label": "Korostus 2"
-          },
-          "options__3": {
-            "label": "Tausta 1"
-          },
-          "options__4": {
-            "label": "Tausta 2"
-          },
-          "options__5": {
-            "label": "Käänteinen"
-          },
-          "label": "Värimalli",
           "info": "Näkyvillä, kun säilö on esillä."
         },
         "stack_images_on_mobile": {
@@ -967,24 +873,6 @@
             "label": "Suuri"
           },
           "label": "Kuvan korkeus"
-        },
-        "color_scheme": {
-          "options__1": {
-            "label": "Tausta 1"
-          },
-          "options__2": {
-            "label": "Tausta 2"
-          },
-          "options__3": {
-            "label": "Käänteinen"
-          },
-          "options__4": {
-            "label": "Korostus 1"
-          },
-          "options__5": {
-            "label": "Korostus 2"
-          },
-          "label": "Värimalli"
         },
         "layout": {
           "options__1": {
@@ -1377,27 +1265,7 @@
       "name": "Sivu"
     },
     "main-password-footer": {
-      "name": "Salasana-alatunniste",
-      "settings": {
-        "color_scheme": {
-          "options__1": {
-            "label": "Korostus 1"
-          },
-          "options__2": {
-            "label": "Korostus 2"
-          },
-          "options__3": {
-            "label": "Tausta 1"
-          },
-          "options__4": {
-            "label": "Tausta 2"
-          },
-          "options__5": {
-            "label": "Käänteinen"
-          },
-          "label": "Värimalli"
-        }
-      }
+      "name": "Salasana-alatunniste"
     },
     "main-password-header": {
       "name": "Salasanaylätunniste",
@@ -1408,24 +1276,6 @@
         "logo_max_width": {
           "label": "Mukautetun logon leveys",
           "unit": "px"
-        },
-        "color_scheme": {
-          "options__1": {
-            "label": "Korostus 1"
-          },
-          "options__2": {
-            "label": "Korostus 2"
-          },
-          "options__3": {
-            "label": "Tausta 1"
-          },
-          "options__4": {
-            "label": "Tausta 2"
-          },
-          "options__5": {
-            "label": "Käänteinen"
-          },
-          "label": "Värimalli"
         }
       }
     },
@@ -1868,24 +1718,6 @@
     "newsletter": {
       "name": "Sähköpostirekisteröityminen",
       "settings": {
-        "color_scheme": {
-          "label": "Värimalli",
-          "options__1": {
-            "label": "Korostus 1"
-          },
-          "options__2": {
-            "label": "Korostus 2"
-          },
-          "options__3": {
-            "label": "Tausta 1"
-          },
-          "options__4": {
-            "label": "Tausta 2"
-          },
-          "options__5": {
-            "label": "Käänteinen"
-          }
-        },
         "full_width": {
           "label": "Tee osiosta täysleveä"
         },
@@ -1971,24 +1803,6 @@
     "rich-text": {
       "name": "Rich text",
       "settings": {
-        "color_scheme": {
-          "options__1": {
-            "label": "Korostus 1"
-          },
-          "options__2": {
-            "label": "Korostus 2"
-          },
-          "options__3": {
-            "label": "Tausta 1"
-          },
-          "options__4": {
-            "label": "Tausta 2"
-          },
-          "options__5": {
-            "label": "Käänteinen"
-          },
-          "label": "Värimalli"
-        },
         "full_width": {
           "label": "Tee osiosta täysleveä"
         }
@@ -2212,22 +2026,6 @@
           "label": "Peittokuvan läpikuultavuus"
         },
         "color_scheme": {
-          "options__1": {
-            "label": "Korostus 1"
-          },
-          "options__2": {
-            "label": "Korostus 2"
-          },
-          "options__3": {
-            "label": "Tausta 1"
-          },
-          "options__4": {
-            "label": "Tausta 2"
-          },
-          "options__5": {
-            "label": "Käänteinen"
-          },
-          "label": "Värimalli",
           "info": "Näkyvillä, kun säilö on esillä"
         },
         "show_text_below": {
@@ -2484,23 +2282,7 @@
               "label": "Peittokuvan läpikuultavuus"
             },
             "color_scheme": {
-              "info": "Näkyvillä, kun säilö on esillä.",
-              "options__1": {
-                "label": "Korostus 1"
-              },
-              "options__2": {
-                "label": "Korostus 2"
-              },
-              "options__3": {
-                "label": "Tausta 1"
-              },
-              "options__4": {
-                "label": "Tausta 2"
-              },
-              "options__5": {
-                "label": "Käänteinen"
-              },
-              "label": "Värimalli"
+              "info": "Näkyvillä, kun säilö on esillä."
             },
             "text_alignment_mobile": {
               "label": "Mobiilisisällön tasaus",
@@ -2554,24 +2336,6 @@
             "label": "Osiosäiliö"
           }
         },
-        "color_scheme": {
-          "label": "Värimalli",
-          "options__1": {
-            "label": "Tausta 1"
-          },
-          "options__2": {
-            "label": "Tausta 2"
-          },
-          "options__3": {
-            "label": "Käänteinen"
-          },
-          "options__4": {
-            "label": "Korostus 1"
-          },
-          "options__5": {
-            "label": "Korostus 2"
-          }
-        },
         "open_first_collapsible_row": {
           "label": "Avaa ensimmäinen pienenettävä rivi"
         },
@@ -2605,21 +2369,6 @@
         },
         "container_color_scheme": {
           "label": "Säiliön värimalli",
-          "options__1": {
-            "label": "Tausta 1"
-          },
-          "options__2": {
-            "label": "Tausta 2"
-          },
-          "options__3": {
-            "label": "Käänteinen"
-          },
-          "options__4": {
-            "label": "Korostus 1"
-          },
-          "options__5": {
-            "label": "Korostus 2"
-          },
           "info": "Näkyy, kun asetteluna on rivi- tai osiosäiliö."
         }
       },

--- a/locales/fr.schema.json
+++ b/locales/fr.schema.json
@@ -77,12 +77,6 @@
       "name": "Icônes",
       "settings": {
         "accent_icons": {
-          "options__1": {
-            "label": "Accentuation 1"
-          },
-          "options__2": {
-            "label": "Accentuation 2"
-          },
           "options__3": {
             "label": "Bouton en relief"
           },
@@ -238,24 +232,6 @@
             "label": "Droite"
           },
           "label": "Alignement du texte"
-        },
-        "color_scheme": {
-          "options__1": {
-            "label": "Accent 1"
-          },
-          "options__2": {
-            "label": "Accent 2"
-          },
-          "options__3": {
-            "label": "Arrière-plan 1"
-          },
-          "options__4": {
-            "label": "Arrière-plan 2"
-          },
-          "options__5": {
-            "label": "Inverser"
-          },
-          "label": "Combinaison de couleurs"
         }
       }
     },
@@ -361,24 +337,6 @@
           "settings": {
             "text": {
               "label": "Texte"
-            },
-            "color_scheme": {
-              "label": "Combinaison de couleurs",
-              "options__1": {
-                "label": "Arrière-plan 1"
-              },
-              "options__2": {
-                "label": "Arrière-plan 2"
-              },
-              "options__3": {
-                "label": "Inverser"
-              },
-              "options__4": {
-                "label": "Accentuation 1"
-              },
-              "options__5": {
-                "label": "Accentuation 2"
-              }
             },
             "link": {
               "label": "Lien"
@@ -647,24 +605,6 @@
         }
       },
       "settings": {
-        "color_scheme": {
-          "options__1": {
-            "label": "Accentuation 1"
-          },
-          "options__2": {
-            "label": "Accentuation 2"
-          },
-          "options__3": {
-            "label": "Arrière-plan 1"
-          },
-          "options__4": {
-            "label": "Arrière-plan 2"
-          },
-          "options__5": {
-            "label": "Inverser"
-          },
-          "label": "Combinaison de couleurs"
-        },
         "newsletter_enable": {
           "label": "Afficher l'inscription à la liste de diffusion"
         },
@@ -744,24 +684,6 @@
           "label": "Activer l'en-tête collé",
           "info": "L'en-tête s'affiche à l'écran lorsque les clients font défiler vers le haut."
         },
-        "color_scheme": {
-          "options__1": {
-            "label": "Accentuation 1"
-          },
-          "options__2": {
-            "label": "Accentuation 2"
-          },
-          "options__3": {
-            "label": "Arrière-plan 1"
-          },
-          "options__4": {
-            "label": "Arrière-plan 2"
-          },
-          "options__5": {
-            "label": "Inverser"
-          },
-          "label": "Combinaison de couleurs"
-        },
         "margin_bottom": {
           "label": "Marge inférieure"
         }
@@ -777,22 +699,6 @@
           "label": "Deuxième image"
         },
         "color_scheme": {
-          "options__1": {
-            "label": "Accentuation 1"
-          },
-          "options__2": {
-            "label": "Accentuation 2"
-          },
-          "options__3": {
-            "label": "Arrière-plan 1"
-          },
-          "options__4": {
-            "label": "Arrière-plan 2"
-          },
-          "options__5": {
-            "label": "Inverser"
-          },
-          "label": "Combinaison de couleurs",
           "info": "Visible lorsque le conteneur est affiché."
         },
         "stack_images_on_mobile": {
@@ -967,24 +873,6 @@
             "label": "Grand"
           },
           "label": "Hauteur de l'image"
-        },
-        "color_scheme": {
-          "options__1": {
-            "label": "Arrière-plan 1"
-          },
-          "options__2": {
-            "label": "Arrière-plan 2"
-          },
-          "options__3": {
-            "label": "Inverser"
-          },
-          "options__4": {
-            "label": "Accentuation 1"
-          },
-          "options__5": {
-            "label": "Accentuation 2"
-          },
-          "label": "Combinaison de couleurs"
         },
         "layout": {
           "options__1": {
@@ -1377,27 +1265,7 @@
       "name": "Page"
     },
     "main-password-footer": {
-      "name": "Pied de page du mot de passe",
-      "settings": {
-        "color_scheme": {
-          "options__1": {
-            "label": "Accentuation 1"
-          },
-          "options__2": {
-            "label": "Accentuation 2"
-          },
-          "options__3": {
-            "label": "Arrière-plan 1"
-          },
-          "options__4": {
-            "label": "Arrière-plan 2"
-          },
-          "options__5": {
-            "label": "Inverser"
-          },
-          "label": "Combinaison de couleurs"
-        }
-      }
+      "name": "Pied de page du mot de passe"
     },
     "main-password-header": {
       "name": "En-tête du mot de passe",
@@ -1408,24 +1276,6 @@
         "logo_max_width": {
           "label": "Largeur personnalisée du logo",
           "unit": "px"
-        },
-        "color_scheme": {
-          "options__1": {
-            "label": "Accentuation 1"
-          },
-          "options__2": {
-            "label": "Accentuation 2"
-          },
-          "options__3": {
-            "label": "Arrière-plan 1"
-          },
-          "options__4": {
-            "label": "Arrière-plan 2"
-          },
-          "options__5": {
-            "label": "Inverser"
-          },
-          "label": "Combinaison de couleurs"
         }
       }
     },
@@ -1868,24 +1718,6 @@
     "newsletter": {
       "name": "Inscription à la liste de diffusion",
       "settings": {
-        "color_scheme": {
-          "label": "Combinaison de couleurs",
-          "options__1": {
-            "label": "Accentuation 1"
-          },
-          "options__2": {
-            "label": "Accentuation 2"
-          },
-          "options__3": {
-            "label": "Arrière-plan 1"
-          },
-          "options__4": {
-            "label": "Arrière-plan 2"
-          },
-          "options__5": {
-            "label": "Inverser"
-          }
-        },
         "full_width": {
           "label": "Rendre la section pleine largeur"
         },
@@ -1971,24 +1803,6 @@
     "rich-text": {
       "name": "Texte enrichi",
       "settings": {
-        "color_scheme": {
-          "options__1": {
-            "label": "Accentuation 1"
-          },
-          "options__2": {
-            "label": "Accentuation 2"
-          },
-          "options__3": {
-            "label": "Arrière-plan 1"
-          },
-          "options__4": {
-            "label": "Arrière-plan 2"
-          },
-          "options__5": {
-            "label": "Inverser"
-          },
-          "label": "Combinaison de couleurs"
-        },
         "full_width": {
           "label": "Rendre la section pleine largeur"
         }
@@ -2212,22 +2026,6 @@
           "label": "Opacité de la superposition d'images"
         },
         "color_scheme": {
-          "options__1": {
-            "label": "Accentuation 1"
-          },
-          "options__2": {
-            "label": "Accentuation 2"
-          },
-          "options__3": {
-            "label": "Arrière-plan 1"
-          },
-          "options__4": {
-            "label": "Arrière-plan 2"
-          },
-          "options__5": {
-            "label": "Inverser"
-          },
-          "label": "Combinaison de couleurs",
           "info": "Visible lorsque le conteneur est affiché"
         },
         "show_text_below": {
@@ -2484,23 +2282,7 @@
               "label": "Opacité de la superposition d'images"
             },
             "color_scheme": {
-              "label": "Combinaison de couleurs",
-              "info": "Visible lorsque le conteneur est affiché.",
-              "options__1": {
-                "label": "Accent 1"
-              },
-              "options__2": {
-                "label": "Accent 2"
-              },
-              "options__3": {
-                "label": "Arrière-plan 1"
-              },
-              "options__4": {
-                "label": "Arrière-plan 2"
-              },
-              "options__5": {
-                "label": "Inverser"
-              }
+              "info": "Visible lorsque le conteneur est affiché."
             },
             "text_alignment_mobile": {
               "label": "Alignement du contenu sur mobile",
@@ -2554,41 +2336,8 @@
             "label": "Conteneur de section"
           }
         },
-        "color_scheme": {
-          "label": "Combinaison de couleurs",
-          "options__1": {
-            "label": "Arrière-plan 1"
-          },
-          "options__2": {
-            "label": "Arrière-plan 2"
-          },
-          "options__3": {
-            "label": "Inverser"
-          },
-          "options__4": {
-            "label": "Accent 1"
-          },
-          "options__5": {
-            "label": "Accent 2"
-          }
-        },
         "container_color_scheme": {
           "label": "Combinaison de couleurs du conteneur",
-          "options__1": {
-            "label": "Arrière-plan 1"
-          },
-          "options__2": {
-            "label": "Arrière-plan 2"
-          },
-          "options__3": {
-            "label": "Inverser"
-          },
-          "options__4": {
-            "label": "Accent 1"
-          },
-          "options__5": {
-            "label": "Accent 2"
-          },
           "info": "Visible lorsque la Mise en page est définie comme conteneur de Ligne ou de Section."
         },
         "open_first_collapsible_row": {

--- a/locales/it.schema.json
+++ b/locales/it.schema.json
@@ -77,12 +77,6 @@
       "name": "Icone",
       "settings": {
         "accent_icons": {
-          "options__1": {
-            "label": "Elemento in risalto 1"
-          },
-          "options__2": {
-            "label": "Elemento in risalto 2"
-          },
           "options__3": {
             "label": "Contorno pulsante"
           },
@@ -238,24 +232,6 @@
             "label": "A destra"
           },
           "label": "Allineamento testo"
-        },
-        "color_scheme": {
-          "options__1": {
-            "label": "Elemento in risalto 1"
-          },
-          "options__2": {
-            "label": "Elemento in risalto 2"
-          },
-          "options__3": {
-            "label": "Sfondo 1"
-          },
-          "options__4": {
-            "label": "Sfondo 2"
-          },
-          "options__5": {
-            "label": "Inverso"
-          },
-          "label": "Schema colori"
         }
       }
     },
@@ -361,24 +337,6 @@
           "settings": {
             "text": {
               "label": "Testo"
-            },
-            "color_scheme": {
-              "label": "Schema di colori",
-              "options__1": {
-                "label": "Sfondo 1"
-              },
-              "options__2": {
-                "label": "Sfondo 2"
-              },
-              "options__3": {
-                "label": "Inverso"
-              },
-              "options__4": {
-                "label": "Elemento in risalto 1"
-              },
-              "options__5": {
-                "label": "Elemento in risalto 2"
-              }
             },
             "link": {
               "label": "Link"
@@ -647,24 +605,6 @@
         }
       },
       "settings": {
-        "color_scheme": {
-          "options__1": {
-            "label": "Elemento in risalto 1"
-          },
-          "options__2": {
-            "label": "Elemento in risalto 2"
-          },
-          "options__3": {
-            "label": "Sfondo 1"
-          },
-          "options__4": {
-            "label": "Sfondo 2"
-          },
-          "options__5": {
-            "label": "Inverso"
-          },
-          "label": "Schema di colori"
-        },
         "newsletter_enable": {
           "label": "Mostra iscrizione alla newsletter"
         },
@@ -744,24 +684,6 @@
           "label": "Abilita header fisso",
           "info": "L'header viene mostrato sullo schermo quando i clienti scorrono verso l'alto."
         },
-        "color_scheme": {
-          "options__1": {
-            "label": "Elemento in risalto 1"
-          },
-          "options__2": {
-            "label": "Elemento in risalto 2"
-          },
-          "options__3": {
-            "label": "Sfondo 1"
-          },
-          "options__4": {
-            "label": "Sfondo 2"
-          },
-          "options__5": {
-            "label": "Inverso"
-          },
-          "label": "Schema di colori"
-        },
         "margin_bottom": {
           "label": "Margine inferiore"
         }
@@ -777,22 +699,6 @@
           "label": "Seconda immagine"
         },
         "color_scheme": {
-          "options__1": {
-            "label": "Elemento in risalto 1"
-          },
-          "options__2": {
-            "label": "Elemento in risalto 2"
-          },
-          "options__3": {
-            "label": "Sfondo 1"
-          },
-          "options__4": {
-            "label": "Sfondo 2"
-          },
-          "options__5": {
-            "label": "Inverso"
-          },
-          "label": "Schema di colori",
           "info": "Visibile quando è visualizzato il contenitore."
         },
         "stack_images_on_mobile": {
@@ -967,24 +873,6 @@
             "label": "Grande"
           },
           "label": "Altezza immagine"
-        },
-        "color_scheme": {
-          "options__1": {
-            "label": "Sfondo 1"
-          },
-          "options__2": {
-            "label": "Sfondo 2"
-          },
-          "options__3": {
-            "label": "Inverso"
-          },
-          "options__4": {
-            "label": "Elemento in risalto 1"
-          },
-          "options__5": {
-            "label": "Elemento in risalto 2"
-          },
-          "label": "Schema di colori"
         },
         "layout": {
           "options__1": {
@@ -1377,27 +1265,7 @@
       "name": "Pagina"
     },
     "main-password-footer": {
-      "name": "Footer della password",
-      "settings": {
-        "color_scheme": {
-          "options__1": {
-            "label": "Elemento in risalto 1"
-          },
-          "options__2": {
-            "label": "Elemento in risalto 2"
-          },
-          "options__3": {
-            "label": "Sfondo 1"
-          },
-          "options__4": {
-            "label": "Sfondo 2"
-          },
-          "options__5": {
-            "label": "Inverso"
-          },
-          "label": "Schema di colori"
-        }
-      }
+      "name": "Footer della password"
     },
     "main-password-header": {
       "name": "Header della password",
@@ -1408,24 +1276,6 @@
         "logo_max_width": {
           "label": "Larghezza logo personalizzata",
           "unit": "px"
-        },
-        "color_scheme": {
-          "options__1": {
-            "label": "Elemento in risalto 1"
-          },
-          "options__2": {
-            "label": "Elemento in risalto 2"
-          },
-          "options__3": {
-            "label": "Sfondo 1"
-          },
-          "options__4": {
-            "label": "Sfondo 2"
-          },
-          "options__5": {
-            "label": "Inverso"
-          },
-          "label": "Schema di colori"
         }
       }
     },
@@ -1868,24 +1718,6 @@
     "newsletter": {
       "name": "Iscrizione alla newsletter",
       "settings": {
-        "color_scheme": {
-          "label": "Schema di colori",
-          "options__1": {
-            "label": "Elemento in risalto 1"
-          },
-          "options__2": {
-            "label": "Elemento in risalto 2"
-          },
-          "options__3": {
-            "label": "Sfondo 1"
-          },
-          "options__4": {
-            "label": "Sfondo 2"
-          },
-          "options__5": {
-            "label": "Inverso"
-          }
-        },
         "full_width": {
           "label": "Crea sezione a larghezza intera"
         },
@@ -1971,24 +1803,6 @@
     "rich-text": {
       "name": "Rich text",
       "settings": {
-        "color_scheme": {
-          "options__1": {
-            "label": "Elemento in risalto 1"
-          },
-          "options__2": {
-            "label": "Elemento in risalto 2"
-          },
-          "options__3": {
-            "label": "Sfondo 1"
-          },
-          "options__4": {
-            "label": "Sfondo 2"
-          },
-          "options__5": {
-            "label": "Inverso"
-          },
-          "label": "Schema di colori"
-        },
         "full_width": {
           "label": "Crea sezione a larghezza intera"
         }
@@ -2212,22 +2026,6 @@
           "label": "Opacità della sovrapposizione immagine"
         },
         "color_scheme": {
-          "options__1": {
-            "label": "Elemento in risalto 1"
-          },
-          "options__2": {
-            "label": "Elemento in risalto 2"
-          },
-          "options__3": {
-            "label": "Sfondo 1"
-          },
-          "options__4": {
-            "label": "Sfondo 2"
-          },
-          "options__5": {
-            "label": "Inverso"
-          },
-          "label": "Schema di colori",
           "info": "Visibile quando è visualizzato il contenitore"
         },
         "show_text_below": {
@@ -2484,23 +2282,7 @@
               "label": "Opacità della sovrapposizione immagine"
             },
             "color_scheme": {
-              "label": "Schema colori",
-              "info": "Visibile quando è visualizzato il contenitore.",
-              "options__1": {
-                "label": "Elemento in risalto 1"
-              },
-              "options__2": {
-                "label": "Elemento in risalto 2"
-              },
-              "options__3": {
-                "label": "Sfondo 1"
-              },
-              "options__4": {
-                "label": "Sfondo 2"
-              },
-              "options__5": {
-                "label": "Inverso"
-              }
+              "info": "Visibile quando è visualizzato il contenitore."
             },
             "text_alignment_mobile": {
               "label": "Allineamento contenuto su dispositivi mobili",
@@ -2554,42 +2336,9 @@
             "label": "Contenitore sezione"
           }
         },
-        "color_scheme": {
-          "label": "Schema colori",
-          "options__1": {
-            "label": "Sfondo 1"
-          },
-          "options__2": {
-            "label": "Sfondo 2"
-          },
-          "options__3": {
-            "label": "Inverso"
-          },
-          "options__4": {
-            "label": "Elemento in risalto 1"
-          },
-          "options__5": {
-            "label": "Elemento in risalto 2"
-          }
-        },
         "container_color_scheme": {
           "label": "Schema di colori dei contenitori",
-          "info": "Visibile quando il Layout viene impostato a contenitore Riga o Sezione.",
-          "options__1": {
-            "label": "Sfondo 1"
-          },
-          "options__2": {
-            "label": "Sfondo 2"
-          },
-          "options__3": {
-            "label": "Inverso"
-          },
-          "options__4": {
-            "label": "Elemento in risalto 1"
-          },
-          "options__5": {
-            "label": "Elemento in risalto 2"
-          }
+          "info": "Visibile quando il Layout viene impostato a contenitore Riga o Sezione."
         },
         "open_first_collapsible_row": {
           "label": "Apri prima riga comprimibile"

--- a/locales/ja.schema.json
+++ b/locales/ja.schema.json
@@ -77,12 +77,6 @@
       "name": "アイコン",
       "settings": {
         "accent_icons": {
-          "options__1": {
-            "label": "アクセント1"
-          },
-          "options__2": {
-            "label": "アクセント2"
-          },
           "options__3": {
             "label": "アウトラインボタン"
           },
@@ -238,24 +232,6 @@
             "label": "右"
           },
           "label": "テキストアラインメント"
-        },
-        "color_scheme": {
-          "options__1": {
-            "label": "アクセント1"
-          },
-          "options__2": {
-            "label": "アクセント2"
-          },
-          "options__3": {
-            "label": "背景1"
-          },
-          "options__4": {
-            "label": "背景2"
-          },
-          "options__5": {
-            "label": "反転"
-          },
-          "label": "配色"
         }
       }
     },
@@ -360,24 +336,6 @@
           "settings": {
             "text": {
               "label": "テキスト"
-            },
-            "color_scheme": {
-              "label": "配色",
-              "options__1": {
-                "label": "背景1"
-              },
-              "options__2": {
-                "label": "背景2"
-              },
-              "options__3": {
-                "label": "反転"
-              },
-              "options__4": {
-                "label": "アクセント1"
-              },
-              "options__5": {
-                "label": "アクセント2"
-              }
             },
             "link": {
               "label": "リンク"
@@ -647,24 +605,6 @@
         }
       },
       "settings": {
-        "color_scheme": {
-          "options__1": {
-            "label": "アクセント1"
-          },
-          "options__2": {
-            "label": "アクセント2"
-          },
-          "options__3": {
-            "label": "背景1"
-          },
-          "options__4": {
-            "label": "背景2"
-          },
-          "options__5": {
-            "label": "反転"
-          },
-          "label": "配色"
-        },
         "newsletter_enable": {
           "label": "メール登録を表示する"
         },
@@ -744,24 +684,6 @@
           "label": "常時表示のヘッダーを有効にする",
           "info": "お客様が上にスクロールするとヘッダーが画面に表示されます。"
         },
-        "color_scheme": {
-          "options__1": {
-            "label": "アクセント1"
-          },
-          "options__2": {
-            "label": "アクセント2"
-          },
-          "options__3": {
-            "label": "背景1"
-          },
-          "options__4": {
-            "label": "背景2"
-          },
-          "options__5": {
-            "label": "反転"
-          },
-          "label": "配色"
-        },
         "margin_bottom": {
           "label": "下マージン"
         }
@@ -777,22 +699,6 @@
           "label": "2番目の画像"
         },
         "color_scheme": {
-          "options__1": {
-            "label": "アクセント1"
-          },
-          "options__2": {
-            "label": "アクセント2"
-          },
-          "options__3": {
-            "label": "背景1"
-          },
-          "options__4": {
-            "label": "背景2"
-          },
-          "options__5": {
-            "label": "反転"
-          },
-          "label": "配色",
           "info": "コンテナが表示された時に表示。"
         },
         "stack_images_on_mobile": {
@@ -967,24 +873,6 @@
             "label": "大"
           },
           "label": "画像の高さ"
-        },
-        "color_scheme": {
-          "options__1": {
-            "label": "背景1"
-          },
-          "options__2": {
-            "label": "背景2"
-          },
-          "options__3": {
-            "label": "反転"
-          },
-          "options__4": {
-            "label": "アクセント1"
-          },
-          "options__5": {
-            "label": "アクセント2"
-          },
-          "label": "配色"
         },
         "layout": {
           "options__1": {
@@ -1377,27 +1265,7 @@
       "name": "ページ"
     },
     "main-password-footer": {
-      "name": "パスワードフッター",
-      "settings": {
-        "color_scheme": {
-          "options__1": {
-            "label": "アクセント1"
-          },
-          "options__2": {
-            "label": "アクセント2"
-          },
-          "options__3": {
-            "label": "背景1"
-          },
-          "options__4": {
-            "label": "背景2"
-          },
-          "options__5": {
-            "label": "反転"
-          },
-          "label": "配色"
-        }
-      }
+      "name": "パスワードフッター"
     },
     "main-password-header": {
       "name": "パスワードヘッダー",
@@ -1408,24 +1276,6 @@
         "logo_max_width": {
           "label": "ロゴの幅をカスタマイズする",
           "unit": "ピクセル"
-        },
-        "color_scheme": {
-          "options__1": {
-            "label": "アクセント1"
-          },
-          "options__2": {
-            "label": "アクセント2"
-          },
-          "options__3": {
-            "label": "背景1"
-          },
-          "options__4": {
-            "label": "背景2"
-          },
-          "options__5": {
-            "label": "反転"
-          },
-          "label": "配色"
         }
       }
     },
@@ -1868,24 +1718,6 @@
     "newsletter": {
       "name": "メール登録",
       "settings": {
-        "color_scheme": {
-          "label": "配色",
-          "options__1": {
-            "label": "アクセント1"
-          },
-          "options__2": {
-            "label": "アクセント2"
-          },
-          "options__3": {
-            "label": "背景1"
-          },
-          "options__4": {
-            "label": "背景2"
-          },
-          "options__5": {
-            "label": "反転"
-          }
-        },
         "full_width": {
           "label": "セクションを全幅にする"
         },
@@ -1971,24 +1803,6 @@
     "rich-text": {
       "name": "リッチテキスト",
       "settings": {
-        "color_scheme": {
-          "options__1": {
-            "label": "アクセント1"
-          },
-          "options__2": {
-            "label": "アクセント2"
-          },
-          "options__3": {
-            "label": "背景1"
-          },
-          "options__4": {
-            "label": "背景2"
-          },
-          "options__5": {
-            "label": "反転"
-          },
-          "label": "配色"
-        },
         "full_width": {
           "label": "セクションを全幅にする"
         }
@@ -2212,22 +2026,6 @@
           "label": "画像のオーバーレイ不透明率"
         },
         "color_scheme": {
-          "options__1": {
-            "label": "アクセント1"
-          },
-          "options__2": {
-            "label": "アクセント2"
-          },
-          "options__3": {
-            "label": "背景1"
-          },
-          "options__4": {
-            "label": "背景2"
-          },
-          "options__5": {
-            "label": "反転"
-          },
-          "label": "配色",
           "info": "コンテナが表示された時に表示"
         },
         "show_text_below": {
@@ -2484,23 +2282,7 @@
               "label": "画像のオーバーレイ不透明率"
             },
             "color_scheme": {
-              "label": "配色",
-              "info": "コンテナが表示された時に表示。",
-              "options__1": {
-                "label": "アクセント1"
-              },
-              "options__2": {
-                "label": "アクセント2"
-              },
-              "options__3": {
-                "label": "背景1"
-              },
-              "options__4": {
-                "label": "背景2"
-              },
-              "options__5": {
-                "label": "反転"
-              }
+              "info": "コンテナが表示された時に表示。"
             },
             "text_alignment_mobile": {
               "label": "モバイルのコンテンツ配置",
@@ -2554,24 +2336,6 @@
             "label": "セクションのコンテナー"
           }
         },
-        "color_scheme": {
-          "label": "配色",
-          "options__1": {
-            "label": "背景1"
-          },
-          "options__2": {
-            "label": "背景2"
-          },
-          "options__3": {
-            "label": "反転"
-          },
-          "options__4": {
-            "label": "アクセント1"
-          },
-          "options__5": {
-            "label": "アクセント2"
-          }
-        },
         "open_first_collapsible_row": {
           "label": "最初の折りたたみ可能な行を開く"
         },
@@ -2605,21 +2369,6 @@
         },
         "container_color_scheme": {
           "label": "コンテナの配色",
-          "options__1": {
-            "label": "背景1"
-          },
-          "options__2": {
-            "label": "背景2"
-          },
-          "options__3": {
-            "label": "反転"
-          },
-          "options__4": {
-            "label": "アクセント1"
-          },
-          "options__5": {
-            "label": "アクセント2"
-          },
           "info": "レイアウトが行またはセクションのコンテナーに設定されている場合に表示されます。"
         }
       },

--- a/locales/ko.schema.json
+++ b/locales/ko.schema.json
@@ -77,12 +77,6 @@
       "name": "아이콘",
       "settings": {
         "accent_icons": {
-          "options__1": {
-            "label": "강조 1"
-          },
-          "options__2": {
-            "label": "강조 2"
-          },
           "options__3": {
             "label": "윤곽 버튼"
           },
@@ -238,24 +232,6 @@
             "label": "오른쪽"
           },
           "label": "텍스트 정렬"
-        },
-        "color_scheme": {
-          "options__1": {
-            "label": "강조 1"
-          },
-          "options__2": {
-            "label": "강조 2"
-          },
-          "options__3": {
-            "label": "배경 1"
-          },
-          "options__4": {
-            "label": "배경 2"
-          },
-          "options__5": {
-            "label": "서로 바꾸기"
-          },
-          "label": "색상 배합"
         }
       }
     },
@@ -360,24 +336,6 @@
           "settings": {
             "text": {
               "label": "텍스트"
-            },
-            "color_scheme": {
-              "label": "색상 배합",
-              "options__1": {
-                "label": "배경 1"
-              },
-              "options__2": {
-                "label": "배경 2"
-              },
-              "options__3": {
-                "label": "서로 바꾸기"
-              },
-              "options__4": {
-                "label": "강조 1"
-              },
-              "options__5": {
-                "label": "강조 2"
-              }
             },
             "link": {
               "label": "링크"
@@ -647,24 +605,6 @@
         }
       },
       "settings": {
-        "color_scheme": {
-          "options__1": {
-            "label": "강조 1"
-          },
-          "options__2": {
-            "label": "강조 2"
-          },
-          "options__3": {
-            "label": "배경 1"
-          },
-          "options__4": {
-            "label": "배경 2"
-          },
-          "options__5": {
-            "label": "서로 바꾸기"
-          },
-          "label": "색상 배합"
-        },
         "newsletter_enable": {
           "label": "이메일 가입 표시"
         },
@@ -744,24 +684,6 @@
           "label": "고정 머리글 사용",
           "info": "고객이 위쪽으로 스크롤하면 화면에 표시되는 머리글입니다."
         },
-        "color_scheme": {
-          "options__1": {
-            "label": "강조 1"
-          },
-          "options__2": {
-            "label": "강조 2"
-          },
-          "options__3": {
-            "label": "배경 1"
-          },
-          "options__4": {
-            "label": "배경 2"
-          },
-          "options__5": {
-            "label": "서로 바꾸기"
-          },
-          "label": "색상 배합"
-        },
         "margin_bottom": {
           "label": "하단 마진"
         }
@@ -777,22 +699,6 @@
           "label": "두 번째 이미지"
         },
         "color_scheme": {
-          "options__1": {
-            "label": "강조 1"
-          },
-          "options__2": {
-            "label": "강조 2"
-          },
-          "options__3": {
-            "label": "배경 1"
-          },
-          "options__4": {
-            "label": "배경 2"
-          },
-          "options__5": {
-            "label": "서로 바꾸기"
-          },
-          "label": "색상 배합",
           "info": "컨테이너가 표시될 때 볼 수 있습니다."
         },
         "stack_images_on_mobile": {
@@ -967,24 +873,6 @@
             "label": "크게"
           },
           "label": "이미지 높이"
-        },
-        "color_scheme": {
-          "options__1": {
-            "label": "배경 1"
-          },
-          "options__2": {
-            "label": "배경 2"
-          },
-          "options__3": {
-            "label": "서로 바꾸기"
-          },
-          "options__4": {
-            "label": "강조 1"
-          },
-          "options__5": {
-            "label": "강조 2"
-          },
-          "label": "색상 배합"
         },
         "layout": {
           "options__1": {
@@ -1377,27 +1265,7 @@
       "name": "페이지"
     },
     "main-password-footer": {
-      "name": "비밀번호 바닥글",
-      "settings": {
-        "color_scheme": {
-          "options__1": {
-            "label": "강조 1"
-          },
-          "options__2": {
-            "label": "강조 2"
-          },
-          "options__3": {
-            "label": "배경 1"
-          },
-          "options__4": {
-            "label": "배경 2"
-          },
-          "options__5": {
-            "label": "서로 바꾸기"
-          },
-          "label": "색상 배합"
-        }
-      }
+      "name": "비밀번호 바닥글"
     },
     "main-password-header": {
       "name": "비밀번호 머리글",
@@ -1408,24 +1276,6 @@
         "logo_max_width": {
           "label": "사용자 지정 로고 폭",
           "unit": "px"
-        },
-        "color_scheme": {
-          "options__1": {
-            "label": "강조 1"
-          },
-          "options__2": {
-            "label": "강조 2"
-          },
-          "options__3": {
-            "label": "배경 1"
-          },
-          "options__4": {
-            "label": "배경 2"
-          },
-          "options__5": {
-            "label": "서로 바꾸기"
-          },
-          "label": "색상 배합"
         }
       }
     },
@@ -1868,24 +1718,6 @@
     "newsletter": {
       "name": "이메일 가입",
       "settings": {
-        "color_scheme": {
-          "label": "색상 배합",
-          "options__1": {
-            "label": "강조 1"
-          },
-          "options__2": {
-            "label": "강조 2"
-          },
-          "options__3": {
-            "label": "배경 1"
-          },
-          "options__4": {
-            "label": "배경 2"
-          },
-          "options__5": {
-            "label": "서로 바꾸기"
-          }
-        },
         "full_width": {
           "label": "섹션을 전체 폭 사용"
         },
@@ -1971,24 +1803,6 @@
     "rich-text": {
       "name": "서식있는 텍스트",
       "settings": {
-        "color_scheme": {
-          "options__1": {
-            "label": "강조 1"
-          },
-          "options__2": {
-            "label": "강조 2"
-          },
-          "options__3": {
-            "label": "배경 1"
-          },
-          "options__4": {
-            "label": "배경 2"
-          },
-          "options__5": {
-            "label": "서로 바꾸기"
-          },
-          "label": "색상 배합"
-        },
         "full_width": {
           "label": "섹션을 전체 폭 사용"
         }
@@ -2212,22 +2026,6 @@
           "label": "이미지 오버레이 투명도"
         },
         "color_scheme": {
-          "options__1": {
-            "label": "강조 1"
-          },
-          "options__2": {
-            "label": "강조 2"
-          },
-          "options__3": {
-            "label": "배경 1"
-          },
-          "options__4": {
-            "label": "배경 2"
-          },
-          "options__5": {
-            "label": "서로 바꾸기"
-          },
-          "label": "색상 배합",
           "info": "컨테이너가 표시될 때 보이게 하기"
         },
         "show_text_below": {
@@ -2484,23 +2282,7 @@
               "label": "이미지 오버레이 투명도"
             },
             "color_scheme": {
-              "label": "색상 배합",
-              "info": "컨테이너가 표시될 때 볼 수 있습니다.",
-              "options__1": {
-                "label": "강조 1"
-              },
-              "options__2": {
-                "label": "강조 2"
-              },
-              "options__3": {
-                "label": "배경 1"
-              },
-              "options__4": {
-                "label": "배경 2"
-              },
-              "options__5": {
-                "label": "서로 바꾸기"
-              }
+              "info": "컨테이너가 표시될 때 볼 수 있습니다."
             },
             "text_alignment_mobile": {
               "label": "모바일 콘텐츠 정렬",
@@ -2554,24 +2336,6 @@
             "label": "섹션 컨테이너"
           }
         },
-        "color_scheme": {
-          "label": "색상 배합",
-          "options__1": {
-            "label": "배경 1"
-          },
-          "options__2": {
-            "label": "배경 2"
-          },
-          "options__3": {
-            "label": "서로 바꾸기"
-          },
-          "options__4": {
-            "label": "강조 1"
-          },
-          "options__5": {
-            "label": "강조 2"
-          }
-        },
         "open_first_collapsible_row": {
           "label": "첫 번째 축소 가능한 행 열기"
         },
@@ -2605,21 +2369,6 @@
         },
         "container_color_scheme": {
           "label": "컨테이너 색상 배합",
-          "options__1": {
-            "label": "배경 1"
-          },
-          "options__2": {
-            "label": "배경 2"
-          },
-          "options__3": {
-            "label": "서로 바꾸기"
-          },
-          "options__4": {
-            "label": "강조 1"
-          },
-          "options__5": {
-            "label": "강조 2"
-          },
           "info": "행 또는 섹션 컨테이너에 레이아웃이 설정되면 표시됩니다."
         }
       },

--- a/locales/nb.schema.json
+++ b/locales/nb.schema.json
@@ -77,12 +77,6 @@
       "name": "Ikoner",
       "settings": {
         "accent_icons": {
-          "options__1": {
-            "label": "Aksent 1"
-          },
-          "options__2": {
-            "label": "Aksent 2"
-          },
           "options__3": {
             "label": "Omriss rundt knapp"
           },
@@ -238,24 +232,6 @@
             "label": "Høyre"
           },
           "label": "Tekstjustering"
-        },
-        "color_scheme": {
-          "options__1": {
-            "label": "Aksent 1"
-          },
-          "options__2": {
-            "label": "Aksent 2"
-          },
-          "options__3": {
-            "label": "Bakgrunn 1"
-          },
-          "options__4": {
-            "label": "Bakgrunn 2"
-          },
-          "options__5": {
-            "label": "Omvendt"
-          },
-          "label": "Fargepalett"
         }
       }
     },
@@ -361,24 +337,6 @@
           "settings": {
             "text": {
               "label": "Tekst"
-            },
-            "color_scheme": {
-              "label": "Fargepalett",
-              "options__1": {
-                "label": "Bakgrunn 1"
-              },
-              "options__2": {
-                "label": "Bakgrunn 2"
-              },
-              "options__3": {
-                "label": "Omvendt"
-              },
-              "options__4": {
-                "label": "Aksent 1"
-              },
-              "options__5": {
-                "label": "Aksent 2"
-              }
             },
             "link": {
               "label": "Kobling"
@@ -647,24 +605,6 @@
         }
       },
       "settings": {
-        "color_scheme": {
-          "options__1": {
-            "label": "Aksent 1"
-          },
-          "options__2": {
-            "label": "Aksent 2"
-          },
-          "options__3": {
-            "label": "Bakgrunn 1"
-          },
-          "options__4": {
-            "label": "Bakgrunn 2"
-          },
-          "options__5": {
-            "label": "Omvendt"
-          },
-          "label": "Fargepalett"
-        },
         "newsletter_enable": {
           "label": "Vis e-postregistrering"
         },
@@ -744,24 +684,6 @@
           "label": "Aktiver festet overskrift",
           "info": "Overskriften vises på skjermen når kunden blar opp."
         },
-        "color_scheme": {
-          "options__1": {
-            "label": "Aksent 1"
-          },
-          "options__2": {
-            "label": "Aksent 2"
-          },
-          "options__3": {
-            "label": "Bakgrunn 1"
-          },
-          "options__4": {
-            "label": "Bakgrunn 2"
-          },
-          "options__5": {
-            "label": "Omvendt"
-          },
-          "label": "Fargepalett"
-        },
         "margin_bottom": {
           "label": "Bunnmarg"
         }
@@ -777,22 +699,6 @@
           "label": "Andre bilde"
         },
         "color_scheme": {
-          "options__1": {
-            "label": "Aksent 1"
-          },
-          "options__2": {
-            "label": "Aksent 2"
-          },
-          "options__3": {
-            "label": "Bakgrunn 1"
-          },
-          "options__4": {
-            "label": "Bakgrunn 2"
-          },
-          "options__5": {
-            "label": "Omvendt"
-          },
-          "label": "Fargepalett",
           "info": "Synlig når beholderen vises."
         },
         "stack_images_on_mobile": {
@@ -967,24 +873,6 @@
             "label": "Stor"
           },
           "label": "Bildehøyde"
-        },
-        "color_scheme": {
-          "options__1": {
-            "label": "Bakgrunn 1"
-          },
-          "options__2": {
-            "label": "Bakgrunn 2"
-          },
-          "options__3": {
-            "label": "Omvendt"
-          },
-          "options__4": {
-            "label": "Aksent 1"
-          },
-          "options__5": {
-            "label": "Aksent 2"
-          },
-          "label": "Fargepalett"
         },
         "layout": {
           "options__1": {
@@ -1377,27 +1265,7 @@
       "name": "Side"
     },
     "main-password-footer": {
-      "name": "Bunntekst for passord",
-      "settings": {
-        "color_scheme": {
-          "options__1": {
-            "label": "Aksent 1"
-          },
-          "options__2": {
-            "label": "Aksent 2"
-          },
-          "options__3": {
-            "label": "Bakgrunn 1"
-          },
-          "options__4": {
-            "label": "Bakgrunn 2"
-          },
-          "options__5": {
-            "label": "Omvendt"
-          },
-          "label": "Fargepalett"
-        }
-      }
+      "name": "Bunntekst for passord"
     },
     "main-password-header": {
       "name": "Overskrift for passord",
@@ -1408,24 +1276,6 @@
         "logo_max_width": {
           "label": "Egendefinert logobredde",
           "unit": "px"
-        },
-        "color_scheme": {
-          "options__1": {
-            "label": "Aksent 1"
-          },
-          "options__2": {
-            "label": "Aksent 2"
-          },
-          "options__3": {
-            "label": "Bakgrunn 1"
-          },
-          "options__4": {
-            "label": "Bakgrunn 2"
-          },
-          "options__5": {
-            "label": "Omvendt"
-          },
-          "label": "Fargepalett"
         }
       }
     },
@@ -1868,24 +1718,6 @@
     "newsletter": {
       "name": "E-postregistrering",
       "settings": {
-        "color_scheme": {
-          "label": "Fargepalett",
-          "options__1": {
-            "label": "Aksent 1"
-          },
-          "options__2": {
-            "label": "Aksent 2"
-          },
-          "options__3": {
-            "label": "Bakgrunn 1"
-          },
-          "options__4": {
-            "label": "Bakgrunn 2"
-          },
-          "options__5": {
-            "label": "Omvendt"
-          }
-        },
         "full_width": {
           "label": "Gjør seksjonen til full bredde"
         },
@@ -1971,24 +1803,6 @@
     "rich-text": {
       "name": "Rik tekst",
       "settings": {
-        "color_scheme": {
-          "options__1": {
-            "label": "Aksent 1"
-          },
-          "options__2": {
-            "label": "Aksent 2"
-          },
-          "options__3": {
-            "label": "Bakgrunn 1"
-          },
-          "options__4": {
-            "label": "Bakgrunn 2"
-          },
-          "options__5": {
-            "label": "Omvendt"
-          },
-          "label": "Fargepalett"
-        },
         "full_width": {
           "label": "Gjør seksjonen til full bredde"
         }
@@ -2212,22 +2026,6 @@
           "label": "Gjennomsiktighet for bildeoverlegg"
         },
         "color_scheme": {
-          "options__1": {
-            "label": "Aksent 1"
-          },
-          "options__2": {
-            "label": "Aksent 2"
-          },
-          "options__3": {
-            "label": "Bakgrunn 1"
-          },
-          "options__4": {
-            "label": "Bakgrunn 2"
-          },
-          "options__5": {
-            "label": "Omvendt"
-          },
-          "label": "Fargepalett",
           "info": "Synlig når beholderen vises"
         },
         "show_text_below": {
@@ -2484,23 +2282,7 @@
               "label": "Gjennomsiktighet for bildeoverlegg"
             },
             "color_scheme": {
-              "info": "Synlig når beholderen vises.",
-              "options__1": {
-                "label": "Aksent 1"
-              },
-              "options__2": {
-                "label": "Aksent 2"
-              },
-              "options__3": {
-                "label": "Bakgrunn 1"
-              },
-              "options__4": {
-                "label": "Bakgrunn 2"
-              },
-              "options__5": {
-                "label": "Omvendt"
-              },
-              "label": "Fargepalett"
+              "info": "Synlig når beholderen vises."
             },
             "text_alignment_mobile": {
               "label": "Innholdsjustering på mobiltelefon",
@@ -2554,41 +2336,8 @@
             "label": "Seksjonsbeholder"
           }
         },
-        "color_scheme": {
-          "label": "Fargepalett",
-          "options__1": {
-            "label": "Bakgrunn 1"
-          },
-          "options__2": {
-            "label": "Bakgrunn 2"
-          },
-          "options__3": {
-            "label": "Omvendt"
-          },
-          "options__4": {
-            "label": "Aksent 1"
-          },
-          "options__5": {
-            "label": "Aksent 2"
-          }
-        },
         "container_color_scheme": {
           "label": "Fargetema for beholder",
-          "options__1": {
-            "label": "Bakgrunn 1"
-          },
-          "options__2": {
-            "label": "Bakgrunn 2"
-          },
-          "options__3": {
-            "label": "Omvendt"
-          },
-          "options__4": {
-            "label": "Aksent 1"
-          },
-          "options__5": {
-            "label": "Aksent 2"
-          },
           "info": "Synlig når layouten er satt til rad- eller seksjonsbeholder."
         },
         "open_first_collapsible_row": {

--- a/locales/nl.schema.json
+++ b/locales/nl.schema.json
@@ -77,12 +77,6 @@
       "name": "Pictogrammen",
       "settings": {
         "accent_icons": {
-          "options__1": {
-            "label": "Accent 1"
-          },
-          "options__2": {
-            "label": "Accent 2"
-          },
           "options__3": {
             "label": "Knop Omlijnen"
           },
@@ -238,24 +232,6 @@
             "label": "Rechts"
           },
           "label": "Tekstuitlijning"
-        },
-        "color_scheme": {
-          "options__1": {
-            "label": "Accent 1"
-          },
-          "options__2": {
-            "label": "Accent 2"
-          },
-          "options__3": {
-            "label": "Achtergrond 1"
-          },
-          "options__4": {
-            "label": "Achtergrond 2"
-          },
-          "options__5": {
-            "label": "Omkeren"
-          },
-          "label": "Kleurschema"
         }
       }
     },
@@ -361,24 +337,6 @@
           "settings": {
             "text": {
               "label": "Tekst"
-            },
-            "color_scheme": {
-              "label": "Kleurschema",
-              "options__1": {
-                "label": "Achtergrond 1"
-              },
-              "options__2": {
-                "label": "Achtergrond 2"
-              },
-              "options__3": {
-                "label": "Omkeren"
-              },
-              "options__4": {
-                "label": "Accent 1"
-              },
-              "options__5": {
-                "label": "Accent 2"
-              }
             },
             "link": {
               "label": "Link"
@@ -647,24 +605,6 @@
         }
       },
       "settings": {
-        "color_scheme": {
-          "options__1": {
-            "label": "Accent 1"
-          },
-          "options__2": {
-            "label": "Accent 2"
-          },
-          "options__3": {
-            "label": "Achtergrond 1"
-          },
-          "options__4": {
-            "label": "Achtergrond 2"
-          },
-          "options__5": {
-            "label": "Omkeren"
-          },
-          "label": "Kleurschema"
-        },
         "newsletter_enable": {
           "label": "Aanmelding voor het ontvangen van e-mail weergeven"
         },
@@ -744,24 +684,6 @@
           "label": "Sticky header inschakelen",
           "info": "De kop verschijnt op het scherm als de klanten omhoog scrollen."
         },
-        "color_scheme": {
-          "options__1": {
-            "label": "Accent 1"
-          },
-          "options__2": {
-            "label": "Accent 2"
-          },
-          "options__3": {
-            "label": "Achtergrond 1"
-          },
-          "options__4": {
-            "label": "Achtergrond 2"
-          },
-          "options__5": {
-            "label": "Omkeren"
-          },
-          "label": "Kleurschema"
-        },
         "margin_bottom": {
           "label": "Ondermarge"
         }
@@ -777,22 +699,6 @@
           "label": "Tweede afbeelding"
         },
         "color_scheme": {
-          "options__1": {
-            "label": "Accent 1"
-          },
-          "options__2": {
-            "label": "Accent 2"
-          },
-          "options__3": {
-            "label": "Achtergrond 1"
-          },
-          "options__4": {
-            "label": "Achtergrond 2"
-          },
-          "options__5": {
-            "label": "Omkeren"
-          },
-          "label": "Kleurschema",
           "info": "Zichtbaar wanneer de container wordt weergegeven."
         },
         "stack_images_on_mobile": {
@@ -967,24 +873,6 @@
             "label": "Groot"
           },
           "label": "Hoogte afbeelding"
-        },
-        "color_scheme": {
-          "options__1": {
-            "label": "Achtergrond 1"
-          },
-          "options__2": {
-            "label": "Achtergrond 2"
-          },
-          "options__3": {
-            "label": "Omkeren"
-          },
-          "options__4": {
-            "label": "Accent 1"
-          },
-          "options__5": {
-            "label": "Accent 2"
-          },
-          "label": "Kleurschema"
         },
         "layout": {
           "options__1": {
@@ -1377,27 +1265,7 @@
       "name": "Pagina"
     },
     "main-password-footer": {
-      "name": "Wachtwoord voettekst",
-      "settings": {
-        "color_scheme": {
-          "options__1": {
-            "label": "Accent 1"
-          },
-          "options__2": {
-            "label": "Accent 2"
-          },
-          "options__3": {
-            "label": "Achtergrond 1"
-          },
-          "options__4": {
-            "label": "Achtergrond 2"
-          },
-          "options__5": {
-            "label": "Omkeren"
-          },
-          "label": "Kleurschema"
-        }
-      }
+      "name": "Wachtwoord voettekst"
     },
     "main-password-header": {
       "name": "Wachtwoord koptekst",
@@ -1408,24 +1276,6 @@
         "logo_max_width": {
           "label": "Aangepaste logo-breedte",
           "unit": "px"
-        },
-        "color_scheme": {
-          "options__1": {
-            "label": "Accent 1"
-          },
-          "options__2": {
-            "label": "Accent 2"
-          },
-          "options__3": {
-            "label": "Achtergrond 1"
-          },
-          "options__4": {
-            "label": "Achtergrond 2"
-          },
-          "options__5": {
-            "label": "Omkeren"
-          },
-          "label": "Kleurschema"
         }
       }
     },
@@ -1868,24 +1718,6 @@
     "newsletter": {
       "name": "Aanmelding voor het ontvangen van e-mail",
       "settings": {
-        "color_scheme": {
-          "label": "Kleurschema",
-          "options__1": {
-            "label": "Accent 1"
-          },
-          "options__2": {
-            "label": "Accent 2"
-          },
-          "options__3": {
-            "label": "Achtergrond 1"
-          },
-          "options__4": {
-            "label": "Achtergrond 2"
-          },
-          "options__5": {
-            "label": "Omkeren"
-          }
-        },
         "full_width": {
           "label": "Volledige breedte voor sectie gebruiken"
         },
@@ -1971,24 +1803,6 @@
     "rich-text": {
       "name": "Tekst met opmaak",
       "settings": {
-        "color_scheme": {
-          "options__1": {
-            "label": "Accent 1"
-          },
-          "options__2": {
-            "label": "Accent 2"
-          },
-          "options__3": {
-            "label": "Achtergrond 1"
-          },
-          "options__4": {
-            "label": "Achtergrond 2"
-          },
-          "options__5": {
-            "label": "Omkeren"
-          },
-          "label": "Kleurschema"
-        },
         "full_width": {
           "label": "Volledige breedte voor sectie gebruiken"
         }
@@ -2212,22 +2026,6 @@
           "label": "Dekking van afbeeldingsoverlay"
         },
         "color_scheme": {
-          "options__1": {
-            "label": "Accent 1"
-          },
-          "options__2": {
-            "label": "Accent 2"
-          },
-          "options__3": {
-            "label": "Achtergrond 1"
-          },
-          "options__4": {
-            "label": "Achtergrond 2"
-          },
-          "options__5": {
-            "label": "Omkeren"
-          },
-          "label": "Kleurschema",
           "info": "Zichtbaar wanneer de container wordt weergegeven"
         },
         "show_text_below": {
@@ -2484,23 +2282,7 @@
               "label": "Dekking van afbeeldingsoverlay"
             },
             "color_scheme": {
-              "label": "Kleurschema",
-              "info": "Zichtbaar wanneer de container wordt weergegeven.",
-              "options__1": {
-                "label": "Accent 1"
-              },
-              "options__2": {
-                "label": "Accent 2"
-              },
-              "options__3": {
-                "label": "Achtergrond 1"
-              },
-              "options__4": {
-                "label": "Achtergrond 2"
-              },
-              "options__5": {
-                "label": "Omkeren"
-              }
+              "info": "Zichtbaar wanneer de container wordt weergegeven."
             },
             "text_alignment_mobile": {
               "label": "Uitlijning van content op mobiel",
@@ -2554,41 +2336,8 @@
             "label": "Container sectie"
           }
         },
-        "color_scheme": {
-          "label": "Kleurschema",
-          "options__1": {
-            "label": "Achtergrond 1"
-          },
-          "options__2": {
-            "label": "Achtergrond 2"
-          },
-          "options__3": {
-            "label": "Omkeren"
-          },
-          "options__4": {
-            "label": "Accent 1"
-          },
-          "options__5": {
-            "label": "Accent 2"
-          }
-        },
         "container_color_scheme": {
           "label": "Kleurschema van container",
-          "options__1": {
-            "label": "Achtergrond 1"
-          },
-          "options__2": {
-            "label": "Achtergrond 2"
-          },
-          "options__3": {
-            "label": "Omkeren"
-          },
-          "options__4": {
-            "label": "Accent 1"
-          },
-          "options__5": {
-            "label": "Accent 2"
-          },
           "info": "Zichtbaar wanneer de opmaak is ingesteld op rij- of sectiecontainer."
         },
         "open_first_collapsible_row": {

--- a/locales/pl.schema.json
+++ b/locales/pl.schema.json
@@ -77,12 +77,6 @@
       "name": "Ikony",
       "settings": {
         "accent_icons": {
-          "options__1": {
-            "label": "Akcent 1"
-          },
-          "options__2": {
-            "label": "Akcent 2"
-          },
           "options__3": {
             "label": "Przycisk konspektu"
           },
@@ -238,24 +232,6 @@
             "label": "Prawa strona"
           },
           "label": "Wyrównanie tekstu"
-        },
-        "color_scheme": {
-          "options__1": {
-            "label": "Akcent 1"
-          },
-          "options__2": {
-            "label": "Akcent 2"
-          },
-          "options__3": {
-            "label": "Tło 1"
-          },
-          "options__4": {
-            "label": "Tło 2"
-          },
-          "options__5": {
-            "label": "Odwrócone"
-          },
-          "label": "Kolorystyka"
         }
       }
     },
@@ -361,24 +337,6 @@
           "settings": {
             "text": {
               "label": "Tekst"
-            },
-            "color_scheme": {
-              "label": "Kolorystyka",
-              "options__1": {
-                "label": "Tło 1"
-              },
-              "options__2": {
-                "label": "Tło 2"
-              },
-              "options__3": {
-                "label": "Odwrócone"
-              },
-              "options__4": {
-                "label": "Akcent 1"
-              },
-              "options__5": {
-                "label": "Akcent 2"
-              }
             },
             "link": {
               "label": "Link"
@@ -647,24 +605,6 @@
         }
       },
       "settings": {
-        "color_scheme": {
-          "options__1": {
-            "label": "Akcent 1"
-          },
-          "options__2": {
-            "label": "Akcent 2"
-          },
-          "options__3": {
-            "label": "Tło 1"
-          },
-          "options__4": {
-            "label": "Tło 2"
-          },
-          "options__5": {
-            "label": "Odwrócone"
-          },
-          "label": "Kolorystyka"
-        },
         "newsletter_enable": {
           "label": "Pokaż rejestrację w celu otrzymywania e-maili."
         },
@@ -744,24 +684,6 @@
           "label": "Włącz przypięty nagłówek",
           "info": "Nagłówek pojawia się na ekranie, gdy klienci przewijają w górę."
         },
-        "color_scheme": {
-          "options__1": {
-            "label": "Akcent 1"
-          },
-          "options__2": {
-            "label": "Akcent 2"
-          },
-          "options__3": {
-            "label": "Tło 1"
-          },
-          "options__4": {
-            "label": "Tło 2"
-          },
-          "options__5": {
-            "label": "Odwrócone"
-          },
-          "label": "Kolorystyka"
-        },
         "margin_bottom": {
           "label": "Dolna granica"
         }
@@ -777,22 +699,6 @@
           "label": "Drugi obraz"
         },
         "color_scheme": {
-          "options__1": {
-            "label": "Akcent 1"
-          },
-          "options__2": {
-            "label": "Akcent 2"
-          },
-          "options__3": {
-            "label": "Tło 1"
-          },
-          "options__4": {
-            "label": "Tło 2"
-          },
-          "options__5": {
-            "label": "Odwrócone"
-          },
-          "label": "Kolorystyka",
           "info": "Widoczne podczas wyświetlania kontenera."
         },
         "stack_images_on_mobile": {
@@ -967,24 +873,6 @@
             "label": "Duży"
           },
           "label": "Wysokość obrazu"
-        },
-        "color_scheme": {
-          "options__1": {
-            "label": "Tło 1"
-          },
-          "options__2": {
-            "label": "Tło 2"
-          },
-          "options__3": {
-            "label": "Odwrócone"
-          },
-          "options__4": {
-            "label": "Akcent 1"
-          },
-          "options__5": {
-            "label": "Akcent 2"
-          },
-          "label": "Kolorystyka"
         },
         "layout": {
           "options__1": {
@@ -1377,27 +1265,7 @@
       "name": "Strona"
     },
     "main-password-footer": {
-      "name": "Stopka hasła",
-      "settings": {
-        "color_scheme": {
-          "options__1": {
-            "label": "Akcent 1"
-          },
-          "options__2": {
-            "label": "Akcent 2"
-          },
-          "options__3": {
-            "label": "Tło 1"
-          },
-          "options__4": {
-            "label": "Tło 2"
-          },
-          "options__5": {
-            "label": "Odwrócone"
-          },
-          "label": "Kolorystyka"
-        }
-      }
+      "name": "Stopka hasła"
     },
     "main-password-header": {
       "name": "Nagłówek hasła",
@@ -1408,24 +1276,6 @@
         "logo_max_width": {
           "label": "Niestandardowa szerokość logo",
           "unit": "px"
-        },
-        "color_scheme": {
-          "options__1": {
-            "label": "Akcent 1"
-          },
-          "options__2": {
-            "label": "Akcent 2"
-          },
-          "options__3": {
-            "label": "Tło 1"
-          },
-          "options__4": {
-            "label": "Tło 2"
-          },
-          "options__5": {
-            "label": "Odwrócone"
-          },
-          "label": "Kolorystyka"
         }
       }
     },
@@ -1868,24 +1718,6 @@
     "newsletter": {
       "name": "Osoba zarejestrowana w celu otrzymywania e-maili",
       "settings": {
-        "color_scheme": {
-          "label": "Kolorystyka",
-          "options__1": {
-            "label": "Akcent 1"
-          },
-          "options__2": {
-            "label": "Akcent 2"
-          },
-          "options__3": {
-            "label": "Tło 1"
-          },
-          "options__4": {
-            "label": "Tło 2"
-          },
-          "options__5": {
-            "label": "Odwrócone"
-          }
-        },
         "full_width": {
           "label": "Zrób sekcję na całą szerokość"
         },
@@ -1971,24 +1803,6 @@
     "rich-text": {
       "name": "Tekst sformatowany",
       "settings": {
-        "color_scheme": {
-          "options__1": {
-            "label": "Akcent 1"
-          },
-          "options__2": {
-            "label": "Akcent 2"
-          },
-          "options__3": {
-            "label": "Tło 1"
-          },
-          "options__4": {
-            "label": "Tło 2"
-          },
-          "options__5": {
-            "label": "Odwrócone"
-          },
-          "label": "Kolorystyka"
-        },
         "full_width": {
           "label": "Zrób sekcję na całą szerokość"
         }
@@ -2212,22 +2026,6 @@
           "label": "Nieprzezroczystość nakładki obrazu"
         },
         "color_scheme": {
-          "options__1": {
-            "label": "Akcent 1"
-          },
-          "options__2": {
-            "label": "Akcent 2"
-          },
-          "options__3": {
-            "label": "Tło 1"
-          },
-          "options__4": {
-            "label": "Tło 2"
-          },
-          "options__5": {
-            "label": "Odwrócone"
-          },
-          "label": "Kolorystyka",
           "info": "Widoczne podczas wyświetlania kontenera"
         },
         "show_text_below": {
@@ -2484,23 +2282,7 @@
               "label": "Nieprzezroczystość nakładki obrazu"
             },
             "color_scheme": {
-              "info": "Widoczne podczas wyświetlania kontenera.",
-              "options__1": {
-                "label": "Akcent 1"
-              },
-              "options__2": {
-                "label": "Akcent 2"
-              },
-              "options__3": {
-                "label": "Tło 1"
-              },
-              "options__4": {
-                "label": "Tło 2"
-              },
-              "options__5": {
-                "label": "Odwrócone"
-              },
-              "label": "Kolorystyka"
+              "info": "Widoczne podczas wyświetlania kontenera."
             },
             "text_alignment_mobile": {
               "label": "Wyrównanie treści na urządzeniu mobilnym",
@@ -2554,24 +2336,6 @@
             "label": "Kontener sekcji"
           }
         },
-        "color_scheme": {
-          "label": "Kolorystyka",
-          "options__1": {
-            "label": "Tło 1"
-          },
-          "options__2": {
-            "label": "Tło 2"
-          },
-          "options__3": {
-            "label": "Odwrócone"
-          },
-          "options__4": {
-            "label": "Akcent 1"
-          },
-          "options__5": {
-            "label": "Akcent 2"
-          }
-        },
         "open_first_collapsible_row": {
           "label": "Otwórz pierwszy zwijany rząd"
         },
@@ -2605,21 +2369,6 @@
         },
         "container_color_scheme": {
           "label": "Schemat kolorów kontenera",
-          "options__1": {
-            "label": "Tło 1"
-          },
-          "options__2": {
-            "label": "Tło 2"
-          },
-          "options__3": {
-            "label": "Odwrócone"
-          },
-          "options__4": {
-            "label": "Akcent 1"
-          },
-          "options__5": {
-            "label": "Akcent 2"
-          },
           "info": "Widoczny, gdy układ jest ustawiony na Wiersz lub Kontener sekcji."
         }
       },

--- a/locales/pt-BR.schema.json
+++ b/locales/pt-BR.schema.json
@@ -77,12 +77,6 @@
       "name": "Ícones",
       "settings": {
         "accent_icons": {
-          "options__1": {
-            "label": "Destaque 1"
-          },
-          "options__2": {
-            "label": "Destaque 2"
-          },
           "options__3": {
             "label": "Botão com contorno"
           },
@@ -238,24 +232,6 @@
             "label": "Direita"
           },
           "label": "Alinhamento do texto"
-        },
-        "color_scheme": {
-          "options__1": {
-            "label": "Destaque 1"
-          },
-          "options__2": {
-            "label": "Destaque 2"
-          },
-          "options__3": {
-            "label": "Plano de fundo 1"
-          },
-          "options__4": {
-            "label": "Plano de fundo 2"
-          },
-          "options__5": {
-            "label": "Inverso"
-          },
-          "label": "Esquema de cores"
         }
       }
     },
@@ -361,24 +337,6 @@
           "settings": {
             "text": {
               "label": "Texto"
-            },
-            "color_scheme": {
-              "label": "Esquema de cores",
-              "options__1": {
-                "label": "Plano de fundo 1"
-              },
-              "options__2": {
-                "label": "Plano de fundo 2"
-              },
-              "options__3": {
-                "label": "Inverso"
-              },
-              "options__4": {
-                "label": "Destaque 1"
-              },
-              "options__5": {
-                "label": "Destaque 2"
-              }
             },
             "link": {
               "label": "Link"
@@ -647,24 +605,6 @@
         }
       },
       "settings": {
-        "color_scheme": {
-          "options__1": {
-            "label": "Destaque 1"
-          },
-          "options__2": {
-            "label": "Destaque 2"
-          },
-          "options__3": {
-            "label": "Plano de fundo 1"
-          },
-          "options__4": {
-            "label": "Plano de fundo 2"
-          },
-          "options__5": {
-            "label": "Inverso"
-          },
-          "label": "Esquema de cores"
-        },
         "newsletter_enable": {
           "label": "Exibir assinante de e-mail"
         },
@@ -744,24 +684,6 @@
           "label": "Habilitar cabeçalho fixo",
           "info": "O cabeçalho fica na tela quando o cliente rola para cima."
         },
-        "color_scheme": {
-          "options__1": {
-            "label": "Destaque 1"
-          },
-          "options__2": {
-            "label": "Destaque 2"
-          },
-          "options__3": {
-            "label": "Plano de fundo 1"
-          },
-          "options__4": {
-            "label": "Plano de fundo 2"
-          },
-          "options__5": {
-            "label": "Inverso"
-          },
-          "label": "Esquema de cores"
-        },
         "margin_bottom": {
           "label": "Margem inferior"
         }
@@ -777,22 +699,6 @@
           "label": "Segunda imagem"
         },
         "color_scheme": {
-          "options__1": {
-            "label": "Destaque 1"
-          },
-          "options__2": {
-            "label": "Destaque 2"
-          },
-          "options__3": {
-            "label": "Plano de fundo 1"
-          },
-          "options__4": {
-            "label": "Plano de fundo 2"
-          },
-          "options__5": {
-            "label": "Inverso"
-          },
-          "label": "Esquema de cores",
           "info": "Visível quando o contêiner é exibido."
         },
         "stack_images_on_mobile": {
@@ -967,24 +873,6 @@
             "label": "Grande"
           },
           "label": "Altura da imagem"
-        },
-        "color_scheme": {
-          "options__1": {
-            "label": "Plano de fundo 1"
-          },
-          "options__2": {
-            "label": "Plano de fundo 2"
-          },
-          "options__3": {
-            "label": "Inverso"
-          },
-          "options__4": {
-            "label": "Destaque 1"
-          },
-          "options__5": {
-            "label": "Destaque 2"
-          },
-          "label": "Esquema de cores"
         },
         "layout": {
           "options__1": {
@@ -1377,27 +1265,7 @@
       "name": "Página"
     },
     "main-password-footer": {
-      "name": "Rodapé de senha",
-      "settings": {
-        "color_scheme": {
-          "options__1": {
-            "label": "Destaque 1"
-          },
-          "options__2": {
-            "label": "Destaque 2"
-          },
-          "options__3": {
-            "label": "Plano de fundo 1"
-          },
-          "options__4": {
-            "label": "Plano de fundo 2"
-          },
-          "options__5": {
-            "label": "Inverso"
-          },
-          "label": "Esquema de cores"
-        }
-      }
+      "name": "Rodapé de senha"
     },
     "main-password-header": {
       "name": "Cabeçalho de senha",
@@ -1408,24 +1276,6 @@
         "logo_max_width": {
           "label": "Largura personalizada do logo",
           "unit": "px"
-        },
-        "color_scheme": {
-          "options__1": {
-            "label": "Destaque 1"
-          },
-          "options__2": {
-            "label": "Destaque 2"
-          },
-          "options__3": {
-            "label": "Plano de fundo 1"
-          },
-          "options__4": {
-            "label": "Plano de fundo 2"
-          },
-          "options__5": {
-            "label": "Inverso"
-          },
-          "label": "Esquema de cores"
         }
       }
     },
@@ -1868,24 +1718,6 @@
     "newsletter": {
       "name": "Assinante de e-mail",
       "settings": {
-        "color_scheme": {
-          "label": "Esquema de cores",
-          "options__1": {
-            "label": "Destaque 1"
-          },
-          "options__2": {
-            "label": "Destaque 2"
-          },
-          "options__3": {
-            "label": "Plano de fundo 1"
-          },
-          "options__4": {
-            "label": "Plano de fundo 2"
-          },
-          "options__5": {
-            "label": "Inverso"
-          }
-        },
         "full_width": {
           "label": "Definir seção com largura total"
         },
@@ -1971,24 +1803,6 @@
     "rich-text": {
       "name": "Rich text",
       "settings": {
-        "color_scheme": {
-          "options__1": {
-            "label": "Destaque 1"
-          },
-          "options__2": {
-            "label": "Destaque 2"
-          },
-          "options__3": {
-            "label": "Plano de fundo 1"
-          },
-          "options__4": {
-            "label": "Plano de fundo 2"
-          },
-          "options__5": {
-            "label": "Inverso"
-          },
-          "label": "Esquema de cores"
-        },
         "full_width": {
           "label": "Definir seção com largura total"
         }
@@ -2212,22 +2026,6 @@
           "label": "Opacidade de sobreposição de imagem"
         },
         "color_scheme": {
-          "options__1": {
-            "label": "Destaque 1"
-          },
-          "options__2": {
-            "label": "Destaque 2"
-          },
-          "options__3": {
-            "label": "Plano de fundo 1"
-          },
-          "options__4": {
-            "label": "Plano de fundo 2"
-          },
-          "options__5": {
-            "label": "Inverso"
-          },
-          "label": "Esquema de cores",
           "info": "Visível quando o contêiner é exibido"
         },
         "show_text_below": {
@@ -2484,23 +2282,7 @@
               "label": "Opacidade de sobreposição de imagem"
             },
             "color_scheme": {
-              "info": "Visível quando o contêiner é exibido.",
-              "options__1": {
-                "label": "Destaque 1"
-              },
-              "options__2": {
-                "label": "Destaque 2"
-              },
-              "options__3": {
-                "label": "Plano de fundo 1"
-              },
-              "options__4": {
-                "label": "Plano de fundo 2"
-              },
-              "options__5": {
-                "label": "Inverso"
-              },
-              "label": "Esquema de cores"
+              "info": "Visível quando o contêiner é exibido."
             },
             "text_alignment_mobile": {
               "label": "Alinhamento de conteúdo em dispositivos móveis",
@@ -2554,41 +2336,8 @@
             "label": "Contêiner de seção"
           }
         },
-        "color_scheme": {
-          "label": "Esquema de cores",
-          "options__1": {
-            "label": "Plano de fundo 1"
-          },
-          "options__2": {
-            "label": "Plano de fundo 2"
-          },
-          "options__3": {
-            "label": "Inverso"
-          },
-          "options__4": {
-            "label": "Destaque 1"
-          },
-          "options__5": {
-            "label": "Destaque 2"
-          }
-        },
         "container_color_scheme": {
           "label": "Esquema de cores do contêiner",
-          "options__1": {
-            "label": "Plano de fundo 1"
-          },
-          "options__2": {
-            "label": "Plano de fundo 2"
-          },
-          "options__3": {
-            "label": "Inverso"
-          },
-          "options__4": {
-            "label": "Destaque 1"
-          },
-          "options__5": {
-            "label": "Destaque 2"
-          },
           "info": "Visível quando o layout está definido para contêiner de Linha ou de Seção."
         },
         "open_first_collapsible_row": {

--- a/locales/pt-PT.schema.json
+++ b/locales/pt-PT.schema.json
@@ -77,12 +77,6 @@
       "name": "Ícones",
       "settings": {
         "accent_icons": {
-          "options__1": {
-            "label": "Destaque 1"
-          },
-          "options__2": {
-            "label": "Destaque 2"
-          },
           "options__3": {
             "label": "Botão de contorno"
           },
@@ -238,24 +232,6 @@
             "label": "Direita"
           },
           "label": "Alinhamento do texto"
-        },
-        "color_scheme": {
-          "options__1": {
-            "label": "Destaque 1"
-          },
-          "options__2": {
-            "label": "Destaque 2"
-          },
-          "options__3": {
-            "label": "Fundo 1"
-          },
-          "options__4": {
-            "label": "Fundo 2"
-          },
-          "options__5": {
-            "label": "Invertido"
-          },
-          "label": "Esquema de cores"
         }
       }
     },
@@ -360,24 +336,6 @@
           "settings": {
             "text": {
               "label": "Texto"
-            },
-            "color_scheme": {
-              "label": "Esquema de cores",
-              "options__1": {
-                "label": "Fundo 1"
-              },
-              "options__2": {
-                "label": "Fundo 2"
-              },
-              "options__3": {
-                "label": "Inverter"
-              },
-              "options__4": {
-                "label": "Destaque 1"
-              },
-              "options__5": {
-                "label": "Destaque 2"
-              }
             },
             "link": {
               "label": "Ligação"
@@ -647,24 +605,6 @@
         }
       },
       "settings": {
-        "color_scheme": {
-          "options__1": {
-            "label": "Destaque 1"
-          },
-          "options__2": {
-            "label": "Destaque 2"
-          },
-          "options__3": {
-            "label": "Fundo 1"
-          },
-          "options__4": {
-            "label": "Fundo 2"
-          },
-          "options__5": {
-            "label": "Inverter"
-          },
-          "label": "Esquema de cores"
-        },
         "newsletter_enable": {
           "label": "Mostrar registo de e-mail"
         },
@@ -744,24 +684,6 @@
           "label": "Ativar cabeçalho fixo",
           "info": "O cabeçalho é apresentado no ecrã enquanto os clientes deslocam para cima."
         },
-        "color_scheme": {
-          "options__1": {
-            "label": "Destaque 1"
-          },
-          "options__2": {
-            "label": "Destaque 2"
-          },
-          "options__3": {
-            "label": "Fundo 1"
-          },
-          "options__4": {
-            "label": "Fundo 2"
-          },
-          "options__5": {
-            "label": "Inverter"
-          },
-          "label": "Esquema de cores"
-        },
         "margin_bottom": {
           "label": "Margem inferior"
         }
@@ -777,22 +699,6 @@
           "label": "Segunda imagem"
         },
         "color_scheme": {
-          "options__1": {
-            "label": "Destaque 1"
-          },
-          "options__2": {
-            "label": "Destaque 2"
-          },
-          "options__3": {
-            "label": "Fundo 1"
-          },
-          "options__4": {
-            "label": "Fundo 2"
-          },
-          "options__5": {
-            "label": "Inverter"
-          },
-          "label": "Esquema de cores",
           "info": "Visível quando o recetor é exibido."
         },
         "stack_images_on_mobile": {
@@ -967,24 +873,6 @@
             "label": "Grande"
           },
           "label": "Altura da imagem"
-        },
-        "color_scheme": {
-          "options__1": {
-            "label": "Fundo 1"
-          },
-          "options__2": {
-            "label": "Fundo 2"
-          },
-          "options__3": {
-            "label": "Inverter"
-          },
-          "options__4": {
-            "label": "Destaque 1"
-          },
-          "options__5": {
-            "label": "Destaque 2"
-          },
-          "label": "Esquema de cores"
         },
         "layout": {
           "options__1": {
@@ -1377,27 +1265,7 @@
       "name": "Página"
     },
     "main-password-footer": {
-      "name": "Rodapé de palavra-passe",
-      "settings": {
-        "color_scheme": {
-          "options__1": {
-            "label": "Destaque 1"
-          },
-          "options__2": {
-            "label": "Destaque 2"
-          },
-          "options__3": {
-            "label": "Fundo 1"
-          },
-          "options__4": {
-            "label": "Fundo 2"
-          },
-          "options__5": {
-            "label": "Inverter"
-          },
-          "label": "Esquema de cores"
-        }
-      }
+      "name": "Rodapé de palavra-passe"
     },
     "main-password-header": {
       "name": "Cabeçalho de palavra-passe",
@@ -1408,24 +1276,6 @@
         "logo_max_width": {
           "label": "Largura de logótipo personalizada",
           "unit": "px"
-        },
-        "color_scheme": {
-          "options__1": {
-            "label": "Destaque 1"
-          },
-          "options__2": {
-            "label": "Destaque 2"
-          },
-          "options__3": {
-            "label": "Fundo 1"
-          },
-          "options__4": {
-            "label": "Fundo 2"
-          },
-          "options__5": {
-            "label": "Inverter"
-          },
-          "label": "Esquema de cores"
         }
       }
     },
@@ -1868,24 +1718,6 @@
     "newsletter": {
       "name": "Registo de e-mail",
       "settings": {
-        "color_scheme": {
-          "label": "Esquema de cores",
-          "options__1": {
-            "label": "Destaque 1"
-          },
-          "options__2": {
-            "label": "Destaque 2"
-          },
-          "options__3": {
-            "label": "Fundo 1"
-          },
-          "options__4": {
-            "label": "Fundo 2"
-          },
-          "options__5": {
-            "label": "Inverter"
-          }
-        },
         "full_width": {
           "label": "Tornar a secção em largura total"
         },
@@ -1971,24 +1803,6 @@
     "rich-text": {
       "name": "Texto formatado",
       "settings": {
-        "color_scheme": {
-          "options__1": {
-            "label": "Destaque 1"
-          },
-          "options__2": {
-            "label": "Destaque 2"
-          },
-          "options__3": {
-            "label": "Fundo 1"
-          },
-          "options__4": {
-            "label": "Fundo 2"
-          },
-          "options__5": {
-            "label": "Inverter"
-          },
-          "label": "Esquema de cores"
-        },
         "full_width": {
           "label": "Tornar a secção em largura total"
         }
@@ -2212,22 +2026,6 @@
           "label": "Opacidade da sobreposição da imagem"
         },
         "color_scheme": {
-          "options__1": {
-            "label": "Destaque 1"
-          },
-          "options__2": {
-            "label": "Destaque 2"
-          },
-          "options__3": {
-            "label": "Fundo 1"
-          },
-          "options__4": {
-            "label": "Fundo 2"
-          },
-          "options__5": {
-            "label": "Inverter"
-          },
-          "label": "Esquema de cores",
           "info": "Visível quando o recetor é exibido"
         },
         "show_text_below": {
@@ -2484,23 +2282,7 @@
               "label": "Opacidade da sobreposição da imagem"
             },
             "color_scheme": {
-              "info": "Visível quando o recetor é exibido.",
-              "options__1": {
-                "label": "Destaque 1"
-              },
-              "options__2": {
-                "label": "Destaque 2"
-              },
-              "options__3": {
-                "label": "Fundo 1"
-              },
-              "options__4": {
-                "label": "Fundo 2"
-              },
-              "options__5": {
-                "label": "Inverter"
-              },
-              "label": "Esquema de cores"
+              "info": "Visível quando o recetor é exibido."
             },
             "text_alignment_mobile": {
               "label": "Alinhamento do conteúdo em dispositivos móveis",
@@ -2554,42 +2336,9 @@
             "label": "Contentor de secção"
           }
         },
-        "color_scheme": {
-          "label": "Esquema de cores",
-          "options__1": {
-            "label": "Fundo 1"
-          },
-          "options__2": {
-            "label": "Fundo 2"
-          },
-          "options__3": {
-            "label": "Inverter"
-          },
-          "options__4": {
-            "label": "Destaque 1"
-          },
-          "options__5": {
-            "label": "Destaque 2"
-          }
-        },
         "container_color_scheme": {
           "label": "Esquema de cores do contentor",
-          "info": "Visível quando o esquema está definido para contentor de linha ou de secção.",
-          "options__1": {
-            "label": "Fundo 1"
-          },
-          "options__2": {
-            "label": "Fundo 2"
-          },
-          "options__3": {
-            "label": "Invertido"
-          },
-          "options__4": {
-            "label": "Destaque 1"
-          },
-          "options__5": {
-            "label": "Destaque 2"
-          }
+          "info": "Visível quando o esquema está definido para contentor de linha ou de secção."
         },
         "open_first_collapsible_row": {
           "label": "Abrir primeira linha recolhível"

--- a/locales/sv.schema.json
+++ b/locales/sv.schema.json
@@ -77,12 +77,6 @@
       "name": "Ikoner",
       "settings": {
         "accent_icons": {
-          "options__1": {
-            "label": "Accent 1"
-          },
-          "options__2": {
-            "label": "Accent 2"
-          },
           "options__3": {
             "label": "Knappkontur"
           },
@@ -238,24 +232,6 @@
             "label": "Höger"
           },
           "label": "Textjustering"
-        },
-        "color_scheme": {
-          "options__1": {
-            "label": "Accent 1"
-          },
-          "options__2": {
-            "label": "Accent 2"
-          },
-          "options__3": {
-            "label": "Bakgrund 1"
-          },
-          "options__4": {
-            "label": "Bakgrund 2"
-          },
-          "options__5": {
-            "label": "Omvänd"
-          },
-          "label": "Färgschema"
         }
       }
     },
@@ -360,24 +336,6 @@
           "settings": {
             "text": {
               "label": "Text"
-            },
-            "color_scheme": {
-              "label": "Färgschema",
-              "options__1": {
-                "label": "Bakgrund 1"
-              },
-              "options__2": {
-                "label": "Bakgrund 2"
-              },
-              "options__3": {
-                "label": "Omvänd"
-              },
-              "options__4": {
-                "label": "Accent 1"
-              },
-              "options__5": {
-                "label": "Accent 2"
-              }
             },
             "link": {
               "label": "Länk"
@@ -647,24 +605,6 @@
         }
       },
       "settings": {
-        "color_scheme": {
-          "options__1": {
-            "label": "Accent 1"
-          },
-          "options__2": {
-            "label": "Accent 2"
-          },
-          "options__3": {
-            "label": "Bakgrund 1"
-          },
-          "options__4": {
-            "label": "Bakgrund 2"
-          },
-          "options__5": {
-            "label": "Omvänd"
-          },
-          "label": "Färgschema"
-        },
         "newsletter_enable": {
           "label": "Visa e-postregistrering"
         },
@@ -744,24 +684,6 @@
           "label": "Aktivera fast rubrik",
           "info": "Rubrik visas på skärmen när kunder skrollar upp."
         },
-        "color_scheme": {
-          "options__1": {
-            "label": "Accent 1"
-          },
-          "options__2": {
-            "label": "Accent 2"
-          },
-          "options__3": {
-            "label": "Bakgrund 1"
-          },
-          "options__4": {
-            "label": "Bakgrund 2"
-          },
-          "options__5": {
-            "label": "Omvänd"
-          },
-          "label": "Färgschema"
-        },
         "margin_bottom": {
           "label": "Nedre marginal"
         }
@@ -777,22 +699,6 @@
           "label": "Andra bild"
         },
         "color_scheme": {
-          "options__1": {
-            "label": "Accent 1"
-          },
-          "options__2": {
-            "label": "Accent 2"
-          },
-          "options__3": {
-            "label": "Bakgrund 1"
-          },
-          "options__4": {
-            "label": "Bakgrund 2"
-          },
-          "options__5": {
-            "label": "Omvänd"
-          },
-          "label": "Färgschema",
           "info": "Synlig när ruta visas."
         },
         "stack_images_on_mobile": {
@@ -967,24 +873,6 @@
             "label": "Stor"
           },
           "label": "Bildhöjd"
-        },
-        "color_scheme": {
-          "options__1": {
-            "label": "Bakgrund 1"
-          },
-          "options__2": {
-            "label": "Bakgrund 2"
-          },
-          "options__3": {
-            "label": "Omvänd"
-          },
-          "options__4": {
-            "label": "Accent 1"
-          },
-          "options__5": {
-            "label": "Accent 2"
-          },
-          "label": "Färgschema"
         },
         "layout": {
           "options__1": {
@@ -1377,27 +1265,7 @@
       "name": "Sida"
     },
     "main-password-footer": {
-      "name": "Lösenord sidfot",
-      "settings": {
-        "color_scheme": {
-          "options__1": {
-            "label": "Accent 1"
-          },
-          "options__2": {
-            "label": "Accent 2"
-          },
-          "options__3": {
-            "label": "Bakgrund 1"
-          },
-          "options__4": {
-            "label": "Bakgrund 2"
-          },
-          "options__5": {
-            "label": "Omvänd"
-          },
-          "label": "Färgschema"
-        }
-      }
+      "name": "Lösenord sidfot"
     },
     "main-password-header": {
       "name": "Lösenord sidhuvud",
@@ -1408,24 +1276,6 @@
         "logo_max_width": {
           "label": "Anpassad logotypsbredd",
           "unit": "px"
-        },
-        "color_scheme": {
-          "options__1": {
-            "label": "Accent 1"
-          },
-          "options__2": {
-            "label": "Accent 2"
-          },
-          "options__3": {
-            "label": "Bakgrund 1"
-          },
-          "options__4": {
-            "label": "Bakgrund 2"
-          },
-          "options__5": {
-            "label": "Omvänd"
-          },
-          "label": "Färgschema"
         }
       }
     },
@@ -1868,24 +1718,6 @@
     "newsletter": {
       "name": "E-postregistrering",
       "settings": {
-        "color_scheme": {
-          "label": "Färgschema",
-          "options__1": {
-            "label": "Accent 1"
-          },
-          "options__2": {
-            "label": "Accent 2"
-          },
-          "options__3": {
-            "label": "Bakgrund 1"
-          },
-          "options__4": {
-            "label": "Bakgrund 2"
-          },
-          "options__5": {
-            "label": "Omvänd"
-          }
-        },
         "full_width": {
           "label": "Ge avsnittet full bredd"
         },
@@ -1971,24 +1803,6 @@
     "rich-text": {
       "name": "Rich text",
       "settings": {
-        "color_scheme": {
-          "options__1": {
-            "label": "Accent 1"
-          },
-          "options__2": {
-            "label": "Accent 2"
-          },
-          "options__3": {
-            "label": "Bakgrund 1"
-          },
-          "options__4": {
-            "label": "Bakgrund 2"
-          },
-          "options__5": {
-            "label": "Omvänd"
-          },
-          "label": "Färgschema"
-        },
         "full_width": {
           "label": "Ge avsnittet full bredd"
         }
@@ -2212,22 +2026,6 @@
           "label": "Bildens opacitet för överlagring"
         },
         "color_scheme": {
-          "options__1": {
-            "label": "Accent 1"
-          },
-          "options__2": {
-            "label": "Accent 2"
-          },
-          "options__3": {
-            "label": "Bakgrund 1"
-          },
-          "options__4": {
-            "label": "Bakgrund 2"
-          },
-          "options__5": {
-            "label": "Omvänd"
-          },
-          "label": "Färgschema",
           "info": "Synlig när ruta visas"
         },
         "show_text_below": {
@@ -2484,23 +2282,7 @@
               "label": "Bildens opacitet för överlagring"
             },
             "color_scheme": {
-              "label": "Färgschema",
-              "info": "Synlig när ruta visas.",
-              "options__1": {
-                "label": "Accent 1"
-              },
-              "options__2": {
-                "label": "Accent 2"
-              },
-              "options__3": {
-                "label": "Bakgrund 1"
-              },
-              "options__4": {
-                "label": "Bakgrund 2"
-              },
-              "options__5": {
-                "label": "Omvänd"
-              }
+              "info": "Synlig när ruta visas."
             },
             "text_alignment_mobile": {
               "label": "Linjering av innehåll på mobil",
@@ -2554,24 +2336,6 @@
             "label": "Avsnittshållare"
           }
         },
-        "color_scheme": {
-          "label": "Färgschema",
-          "options__1": {
-            "label": "Bakgrund 1"
-          },
-          "options__2": {
-            "label": "Bakgrund 2"
-          },
-          "options__3": {
-            "label": "Omvänd"
-          },
-          "options__4": {
-            "label": "Accent 1"
-          },
-          "options__5": {
-            "label": "Accent 2"
-          }
-        },
         "open_first_collapsible_row": {
           "label": "Öppna den första raden som kan döljas"
         },
@@ -2605,21 +2369,6 @@
         },
         "container_color_scheme": {
           "label": "Färgschema för container",
-          "options__1": {
-            "label": "Bakgrund 1"
-          },
-          "options__2": {
-            "label": "Bakgrund 2"
-          },
-          "options__3": {
-            "label": "Omvänd"
-          },
-          "options__4": {
-            "label": "Accent 1"
-          },
-          "options__5": {
-            "label": "Accent 2"
-          },
           "info": "Synligt när layouten är inställd på rad- eller avsnittscontainer."
         }
       },

--- a/locales/th.schema.json
+++ b/locales/th.schema.json
@@ -77,12 +77,6 @@
       "name": "ไอคอน",
       "settings": {
         "accent_icons": {
-          "options__1": {
-            "label": "การเน้น 1"
-          },
-          "options__2": {
-            "label": "การเน้น 2"
-          },
           "options__3": {
             "label": "ปุ่มแบบเค้าโครง"
           },
@@ -238,24 +232,6 @@
             "label": "ขวา"
           },
           "label": "การจัดวางข้อความ"
-        },
-        "color_scheme": {
-          "options__1": {
-            "label": "ส่วนเน้น 1"
-          },
-          "options__2": {
-            "label": "ส่วนเน้น 2"
-          },
-          "options__3": {
-            "label": "พื้นหลัง 1"
-          },
-          "options__4": {
-            "label": "พื้นหลัง 2"
-          },
-          "options__5": {
-            "label": "ตรงกันข้าม"
-          },
-          "label": "รูปแบบสี"
         }
       }
     },
@@ -360,24 +336,6 @@
           "settings": {
             "text": {
               "label": "ข้อความ"
-            },
-            "color_scheme": {
-              "label": "รูปแบบสี",
-              "options__1": {
-                "label": "พื้นหลัง 1"
-              },
-              "options__2": {
-                "label": "พื้นหลัง 2"
-              },
-              "options__3": {
-                "label": "ตรงกันข้าม"
-              },
-              "options__4": {
-                "label": "การเน้น 1"
-              },
-              "options__5": {
-                "label": "การเน้น 2"
-              }
             },
             "link": {
               "label": "ลิงก์"
@@ -647,24 +605,6 @@
         }
       },
       "settings": {
-        "color_scheme": {
-          "options__1": {
-            "label": "การเน้น 1"
-          },
-          "options__2": {
-            "label": "การเน้น 2"
-          },
-          "options__3": {
-            "label": "พื้นหลัง 1"
-          },
-          "options__4": {
-            "label": "พื้นหลัง 2"
-          },
-          "options__5": {
-            "label": "ตรงกันข้าม"
-          },
-          "label": "รูปแบบสี"
-        },
         "newsletter_enable": {
           "label": "แสดงการลงทะเบียนอีเมล"
         },
@@ -744,24 +684,6 @@
           "label": "เปิดใช้งานส่วนหัวแบบยึดตำแหน่ง",
           "info": "แสดงส่วนหัวบนหน้าจอเมื่อลูกค้าเลื่อนหน้าจอขึ้น"
         },
-        "color_scheme": {
-          "options__1": {
-            "label": "การเน้น 1"
-          },
-          "options__2": {
-            "label": "การเน้น 2"
-          },
-          "options__3": {
-            "label": "พื้นหลัง 1"
-          },
-          "options__4": {
-            "label": "พื้นหลัง 2"
-          },
-          "options__5": {
-            "label": "ตรงกันข้าม"
-          },
-          "label": "รูปแบบสี"
-        },
         "margin_bottom": {
           "label": "ย่อหน้าล่าง"
         }
@@ -777,22 +699,6 @@
           "label": "รูปภาพที่สอง"
         },
         "color_scheme": {
-          "options__1": {
-            "label": "การเน้น 1"
-          },
-          "options__2": {
-            "label": "การเน้น 2"
-          },
-          "options__3": {
-            "label": "พื้นหลัง 1"
-          },
-          "options__4": {
-            "label": "พื้นหลัง 2"
-          },
-          "options__5": {
-            "label": "ตรงกันข้าม"
-          },
-          "label": "รูปแบบสี",
           "info": "ปรากฏให้เห็นเมื่อแสดงคอนเทนเนอร์"
         },
         "stack_images_on_mobile": {
@@ -967,24 +873,6 @@
             "label": "ใหญ่"
           },
           "label": "ความสูงของรูปภาพ"
-        },
-        "color_scheme": {
-          "options__1": {
-            "label": "พื้นหลัง 1"
-          },
-          "options__2": {
-            "label": "พื้นหลัง 2"
-          },
-          "options__3": {
-            "label": "ตรงกันข้าม"
-          },
-          "options__4": {
-            "label": "การเน้น 1"
-          },
-          "options__5": {
-            "label": "การเน้น 2"
-          },
-          "label": "รูปแบบสี"
         },
         "layout": {
           "options__1": {
@@ -1377,27 +1265,7 @@
       "name": "หน้า"
     },
     "main-password-footer": {
-      "name": "ส่วนท้ายของรหัสผ่าน",
-      "settings": {
-        "color_scheme": {
-          "options__1": {
-            "label": "การเน้น 1"
-          },
-          "options__2": {
-            "label": "การเน้น 2"
-          },
-          "options__3": {
-            "label": "พื้นหลัง 1"
-          },
-          "options__4": {
-            "label": "พื้นหลัง 2"
-          },
-          "options__5": {
-            "label": "ตรงกันข้าม"
-          },
-          "label": "รูปแบบสี"
-        }
-      }
+      "name": "ส่วนท้ายของรหัสผ่าน"
     },
     "main-password-header": {
       "name": "ส่วนหัวของรหัสผ่าน",
@@ -1408,24 +1276,6 @@
         "logo_max_width": {
           "label": "ความกว้างของโลโก้แบบกำหนดเอง",
           "unit": "px"
-        },
-        "color_scheme": {
-          "options__1": {
-            "label": "การเน้น 1"
-          },
-          "options__2": {
-            "label": "การเน้น 2"
-          },
-          "options__3": {
-            "label": "พื้นหลัง 1"
-          },
-          "options__4": {
-            "label": "พื้นหลัง 2"
-          },
-          "options__5": {
-            "label": "ตรงกันข้าม"
-          },
-          "label": "รูปแบบสี"
         }
       }
     },
@@ -1868,24 +1718,6 @@
     "newsletter": {
       "name": "การลงทะเบียนอีเมล",
       "settings": {
-        "color_scheme": {
-          "label": "รูปแบบสี",
-          "options__1": {
-            "label": "การเน้น 1"
-          },
-          "options__2": {
-            "label": "การเน้น 2"
-          },
-          "options__3": {
-            "label": "พื้นหลัง 1"
-          },
-          "options__4": {
-            "label": "พื้นหลัง 2"
-          },
-          "options__5": {
-            "label": "ตรงกันข้าม"
-          }
-        },
         "full_width": {
           "label": "ทำส่วนให้เต็มความกว้าง"
         },
@@ -1971,24 +1803,6 @@
     "rich-text": {
       "name": "Rich Text",
       "settings": {
-        "color_scheme": {
-          "options__1": {
-            "label": "การเน้น 1"
-          },
-          "options__2": {
-            "label": "การเน้น 2"
-          },
-          "options__3": {
-            "label": "พื้นหลัง 1"
-          },
-          "options__4": {
-            "label": "พื้นหลัง 2"
-          },
-          "options__5": {
-            "label": "ตรงกันข้าม"
-          },
-          "label": "รูปแบบสี"
-        },
         "full_width": {
           "label": "ทำส่วนให้เต็มความกว้าง"
         }
@@ -2212,22 +2026,6 @@
           "label": "ความทึบของการวางซ้อนรูปภาพ"
         },
         "color_scheme": {
-          "options__1": {
-            "label": "การเน้น 1"
-          },
-          "options__2": {
-            "label": "การเน้น 2"
-          },
-          "options__3": {
-            "label": "พื้นหลัง 1"
-          },
-          "options__4": {
-            "label": "พื้นหลัง 2"
-          },
-          "options__5": {
-            "label": "ตรงกันข้าม"
-          },
-          "label": "รูปแบบสี",
           "info": "ปรากฏให้เห็นเมื่อแสดงคอนเทนเนอร์"
         },
         "show_text_below": {
@@ -2484,23 +2282,7 @@
               "label": "ความทึบของการวางซ้อนรูปภาพ"
             },
             "color_scheme": {
-              "label": "รูปแบบสี",
-              "info": "ปรากฏให้เห็นเมื่อแสดงกรอบเนื้อหา",
-              "options__1": {
-                "label": "การเน้นตัวอักษร 1"
-              },
-              "options__2": {
-                "label": "การเน้นตัวอักษร 2"
-              },
-              "options__3": {
-                "label": "พื้นหลัง 1"
-              },
-              "options__4": {
-                "label": "พื้นหลัง 2"
-              },
-              "options__5": {
-                "label": "ตรงกันข้าม"
-              }
+              "info": "ปรากฏให้เห็นเมื่อแสดงกรอบเนื้อหา"
             },
             "text_alignment_mobile": {
               "label": "การจัดวางเนื้อหาบนมือถือ",
@@ -2554,24 +2336,6 @@
             "label": "คอนเทนเนอร์ส่วน"
           }
         },
-        "color_scheme": {
-          "label": "รูปแบบสี",
-          "options__1": {
-            "label": "พื้นหลัง 1"
-          },
-          "options__2": {
-            "label": "พื้นหลัง 2"
-          },
-          "options__3": {
-            "label": "ตรงกันข้าม"
-          },
-          "options__4": {
-            "label": "การเน้นตัวอักษร 1"
-          },
-          "options__5": {
-            "label": "การเน้นตัวอักษร 2"
-          }
-        },
         "open_first_collapsible_row": {
           "label": "เปิดแถวที่ย่อได้แถวแรก"
         },
@@ -2605,21 +2369,6 @@
         },
         "container_color_scheme": {
           "label": "รูปแบบสีของคอนเทนเนอร์",
-          "options__1": {
-            "label": "พื้นหลัง 1"
-          },
-          "options__2": {
-            "label": "พื้นหลัง 2"
-          },
-          "options__3": {
-            "label": "ตรงกันข้าม"
-          },
-          "options__4": {
-            "label": "ส่วนเน้น 1"
-          },
-          "options__5": {
-            "label": "ส่วนเน้น 2"
-          },
           "info": "ปรากฏให้เห็นเมื่อตั้งค่าเลย์เอาต์เป็นคอนเทนเนอร์แถวหรือส่วน"
         }
       },

--- a/locales/tr.schema.json
+++ b/locales/tr.schema.json
@@ -77,12 +77,6 @@
       "name": "Simgeler",
       "settings": {
         "accent_icons": {
-          "options__1": {
-            "label": "1. Vurgu"
-          },
-          "options__2": {
-            "label": "2. Vurgu"
-          },
           "options__3": {
             "label": "Dış çizgi düğmesi"
           },
@@ -238,24 +232,6 @@
             "label": "Sağ"
           },
           "label": "Metin hizalaması"
-        },
-        "color_scheme": {
-          "options__1": {
-            "label": "1. Vurgu"
-          },
-          "options__2": {
-            "label": "2. Vurgu"
-          },
-          "options__3": {
-            "label": "1. Arka plan"
-          },
-          "options__4": {
-            "label": "2. Arka plan"
-          },
-          "options__5": {
-            "label": "Ters"
-          },
-          "label": "Renk şeması"
         }
       }
     },
@@ -361,24 +337,6 @@
           "settings": {
             "text": {
               "label": "Metin"
-            },
-            "color_scheme": {
-              "label": "Renk şeması",
-              "options__1": {
-                "label": "1. Arka plan"
-              },
-              "options__2": {
-                "label": "2. Arka plan"
-              },
-              "options__3": {
-                "label": "Ters"
-              },
-              "options__4": {
-                "label": "1. Vurgu"
-              },
-              "options__5": {
-                "label": "2. Vurgu"
-              }
             },
             "link": {
               "label": "Bağlantı"
@@ -647,24 +605,6 @@
         }
       },
       "settings": {
-        "color_scheme": {
-          "options__1": {
-            "label": "1. Vurgu"
-          },
-          "options__2": {
-            "label": "2. Vurgu"
-          },
-          "options__3": {
-            "label": "1. Arka plan"
-          },
-          "options__4": {
-            "label": "2. Arka plan"
-          },
-          "options__5": {
-            "label": "Ters"
-          },
-          "label": "Renk şeması"
-        },
         "newsletter_enable": {
           "label": "E-posta kaydını göster"
         },
@@ -744,24 +684,6 @@
           "label": "Yapışkanlı üstbilgiyi etkinleştir",
           "info": "Müşteriler yukarı doğru kaydırırken üstbilgi ekranda görünür."
         },
-        "color_scheme": {
-          "options__1": {
-            "label": "1. Vurgu"
-          },
-          "options__2": {
-            "label": "2. Vurgu"
-          },
-          "options__3": {
-            "label": "1. Arka plan"
-          },
-          "options__4": {
-            "label": "2. Arka plan"
-          },
-          "options__5": {
-            "label": "Ters"
-          },
-          "label": "Renk şeması"
-        },
         "margin_bottom": {
           "label": "Alt kenar boşluğu"
         }
@@ -777,22 +699,6 @@
           "label": "İkinci görsel"
         },
         "color_scheme": {
-          "options__1": {
-            "label": "1. Vurgu"
-          },
-          "options__2": {
-            "label": "2. Vurgu"
-          },
-          "options__3": {
-            "label": "1. Arka plan"
-          },
-          "options__4": {
-            "label": "2. Arka plan"
-          },
-          "options__5": {
-            "label": "Ters"
-          },
-          "label": "Renk şeması",
           "info": "Kapsayıcı gösterildiğinde görünür."
         },
         "stack_images_on_mobile": {
@@ -967,24 +873,6 @@
             "label": "Büyük"
           },
           "label": "Görsel yüksekliği"
-        },
-        "color_scheme": {
-          "options__1": {
-            "label": "1. Arka plan"
-          },
-          "options__2": {
-            "label": "2. Arka plan"
-          },
-          "options__3": {
-            "label": "Ters"
-          },
-          "options__4": {
-            "label": "1. Vurgu"
-          },
-          "options__5": {
-            "label": "2. Vurgu"
-          },
-          "label": "Renk şeması"
         },
         "layout": {
           "options__1": {
@@ -1377,27 +1265,7 @@
       "name": "Sayfa"
     },
     "main-password-footer": {
-      "name": "Parola altbilgisi",
-      "settings": {
-        "color_scheme": {
-          "options__1": {
-            "label": "1. Vurgu"
-          },
-          "options__2": {
-            "label": "2. Vurgu"
-          },
-          "options__3": {
-            "label": "1. Arka plan"
-          },
-          "options__4": {
-            "label": "2. Arka plan"
-          },
-          "options__5": {
-            "label": "Ters"
-          },
-          "label": "Renk şeması"
-        }
-      }
+      "name": "Parola altbilgisi"
     },
     "main-password-header": {
       "name": "Parola üstbilgisi",
@@ -1408,24 +1276,6 @@
         "logo_max_width": {
           "label": "Özel logo genişliği",
           "unit": "piksel"
-        },
-        "color_scheme": {
-          "options__1": {
-            "label": "1. Vurgu"
-          },
-          "options__2": {
-            "label": "2. Vurgu"
-          },
-          "options__3": {
-            "label": "1. Arka plan"
-          },
-          "options__4": {
-            "label": "2. Arka plan"
-          },
-          "options__5": {
-            "label": "Ters"
-          },
-          "label": "Renk şeması"
         }
       }
     },
@@ -1868,24 +1718,6 @@
     "newsletter": {
       "name": "E-posta kaydı",
       "settings": {
-        "color_scheme": {
-          "label": "Renk şeması",
-          "options__1": {
-            "label": "1. Vurgu"
-          },
-          "options__2": {
-            "label": "2. Vurgu"
-          },
-          "options__3": {
-            "label": "1. Arka plan"
-          },
-          "options__4": {
-            "label": "2. Arka plan"
-          },
-          "options__5": {
-            "label": "Ters"
-          }
-        },
         "full_width": {
           "label": "Bölümü tam genişlikli yap"
         },
@@ -1971,24 +1803,6 @@
     "rich-text": {
       "name": "Zengin metin",
       "settings": {
-        "color_scheme": {
-          "options__1": {
-            "label": "1. Vurgu"
-          },
-          "options__2": {
-            "label": "2. Vurgu"
-          },
-          "options__3": {
-            "label": "1. Arka plan"
-          },
-          "options__4": {
-            "label": "2. Arka plan"
-          },
-          "options__5": {
-            "label": "Ters"
-          },
-          "label": "Renk şeması"
-        },
         "full_width": {
           "label": "Bölümü tam genişlikli yap"
         }
@@ -2212,22 +2026,6 @@
           "label": "Görsel yer paylaşımı opaklığı"
         },
         "color_scheme": {
-          "options__1": {
-            "label": "1. Vurgu"
-          },
-          "options__2": {
-            "label": "2. Vurgu"
-          },
-          "options__3": {
-            "label": "1. Arka plan"
-          },
-          "options__4": {
-            "label": "2. Arka plan"
-          },
-          "options__5": {
-            "label": "Ters"
-          },
-          "label": "Renk şeması",
           "info": "Kapsayıcı gösterildiğinde görünür"
         },
         "show_text_below": {
@@ -2484,23 +2282,7 @@
               "label": "Görsel yer paylaşımı opaklığı"
             },
             "color_scheme": {
-              "info": "Kapsayıcı gösterildiğinde görünür.",
-              "options__1": {
-                "label": "1. Vurgu"
-              },
-              "options__2": {
-                "label": "2. Vurgu"
-              },
-              "options__3": {
-                "label": "1. Arka plan"
-              },
-              "options__4": {
-                "label": "2. Arka plan"
-              },
-              "options__5": {
-                "label": "Ters"
-              },
-              "label": "Renk şeması"
+              "info": "Kapsayıcı gösterildiğinde görünür."
             },
             "text_alignment_mobile": {
               "label": "Mobil içerik hizalaması",
@@ -2554,41 +2336,8 @@
             "label": "Bölüm kapsayıcı"
           }
         },
-        "color_scheme": {
-          "label": "Renk şeması",
-          "options__1": {
-            "label": "1. Arka plan"
-          },
-          "options__2": {
-            "label": "2. Arka plan"
-          },
-          "options__3": {
-            "label": "Ters"
-          },
-          "options__4": {
-            "label": "1. Vurgu"
-          },
-          "options__5": {
-            "label": "2. Vurgu"
-          }
-        },
         "container_color_scheme": {
           "label": "Kapsayıcı renk şeması",
-          "options__1": {
-            "label": "1. Arka plan"
-          },
-          "options__2": {
-            "label": "2. Arka plan"
-          },
-          "options__3": {
-            "label": "Ters"
-          },
-          "options__4": {
-            "label": "1. Vurgu"
-          },
-          "options__5": {
-            "label": "2. Vurgu"
-          },
           "info": "Düzen; satır veya bölüm kapsayıcısına ayarlandığında görünür."
         },
         "open_first_collapsible_row": {

--- a/locales/vi.schema.json
+++ b/locales/vi.schema.json
@@ -77,12 +77,6 @@
       "name": "Biểu tượng",
       "settings": {
         "accent_icons": {
-          "options__1": {
-            "label": "Điểm nhấn 1"
-          },
-          "options__2": {
-            "label": "Điểm nhấn 2"
-          },
           "options__3": {
             "label": "Nút viền ngoài"
           },
@@ -238,24 +232,6 @@
             "label": "Phải"
           },
           "label": "Căn chỉnh văn bản"
-        },
-        "color_scheme": {
-          "options__1": {
-            "label": "Điểm nhấn 1"
-          },
-          "options__2": {
-            "label": "Điểm nhấn 2"
-          },
-          "options__3": {
-            "label": "Nền 1"
-          },
-          "options__4": {
-            "label": "Nền 2"
-          },
-          "options__5": {
-            "label": "Nghịch đảo"
-          },
-          "label": "Bảng màu"
         }
       }
     },
@@ -361,24 +337,6 @@
           "settings": {
             "text": {
               "label": "Văn bản"
-            },
-            "color_scheme": {
-              "label": "Bảng màu",
-              "options__1": {
-                "label": "Nền 1"
-              },
-              "options__2": {
-                "label": "Nền 2"
-              },
-              "options__3": {
-                "label": "Nghịch đảo"
-              },
-              "options__4": {
-                "label": "Nhấn 1"
-              },
-              "options__5": {
-                "label": "Nhấn 2"
-              }
             },
             "link": {
               "label": "Liên kết"
@@ -647,24 +605,6 @@
         }
       },
       "settings": {
-        "color_scheme": {
-          "options__1": {
-            "label": "Nhấn 1"
-          },
-          "options__2": {
-            "label": "Nhấn 2"
-          },
-          "options__3": {
-            "label": "Nền 1"
-          },
-          "options__4": {
-            "label": "Nền 2"
-          },
-          "options__5": {
-            "label": "Nghịch đảo"
-          },
-          "label": "Bảng màu"
-        },
         "newsletter_enable": {
           "label": "Hiển thị đăng ký nhận email"
         },
@@ -744,24 +684,6 @@
           "label": "Bật đầu trang dính",
           "info": "Đầu trang hiển thị trên màn hình khi khách hàng cuộn lên."
         },
-        "color_scheme": {
-          "options__1": {
-            "label": "Điểm nhấn 1"
-          },
-          "options__2": {
-            "label": "Điểm nhấn 2"
-          },
-          "options__3": {
-            "label": "Nền 1"
-          },
-          "options__4": {
-            "label": "Nền 2"
-          },
-          "options__5": {
-            "label": "Nghịch đảo"
-          },
-          "label": "Bảng màu"
-        },
         "margin_bottom": {
           "label": "Lề dưới"
         }
@@ -777,22 +699,6 @@
           "label": "Hình ảnh thứ hai"
         },
         "color_scheme": {
-          "options__1": {
-            "label": "Nhấn 1"
-          },
-          "options__2": {
-            "label": "Nhấn 2"
-          },
-          "options__3": {
-            "label": "Nền 1"
-          },
-          "options__4": {
-            "label": "Nền 2"
-          },
-          "options__5": {
-            "label": "Nghịch đảo"
-          },
-          "label": "Bảng màu",
           "info": "Có thể nhìn thấy khi vùng chứa hiển thị."
         },
         "stack_images_on_mobile": {
@@ -967,24 +873,6 @@
             "label": "Lớn"
           },
           "label": "Chiều cao hình ảnh"
-        },
-        "color_scheme": {
-          "options__1": {
-            "label": "Nền 1"
-          },
-          "options__2": {
-            "label": "Nền 2"
-          },
-          "options__3": {
-            "label": "Nghịch đảo"
-          },
-          "options__4": {
-            "label": "Nhấn 1"
-          },
-          "options__5": {
-            "label": "Nhấn 2"
-          },
-          "label": "Bảng màu"
         },
         "layout": {
           "options__1": {
@@ -1377,27 +1265,7 @@
       "name": "Trang"
     },
     "main-password-footer": {
-      "name": "Chân trang mật khẩu",
-      "settings": {
-        "color_scheme": {
-          "options__1": {
-            "label": "Nhấn 1"
-          },
-          "options__2": {
-            "label": "Nhấn 2"
-          },
-          "options__3": {
-            "label": "Nền 1"
-          },
-          "options__4": {
-            "label": "Nền 2"
-          },
-          "options__5": {
-            "label": "Nghịch đảo"
-          },
-          "label": "Bảng màu"
-        }
-      }
+      "name": "Chân trang mật khẩu"
     },
     "main-password-header": {
       "name": "Đầu trang mật khẩu",
@@ -1408,24 +1276,6 @@
         "logo_max_width": {
           "label": "Chiều rộng logo tùy chỉnh",
           "unit": "px"
-        },
-        "color_scheme": {
-          "options__1": {
-            "label": "Nhấn 1"
-          },
-          "options__2": {
-            "label": "Nhấn 2"
-          },
-          "options__3": {
-            "label": "Nền 1"
-          },
-          "options__4": {
-            "label": "Nền 2"
-          },
-          "options__5": {
-            "label": "Nghịch đảo"
-          },
-          "label": "Bảng màu"
         }
       }
     },
@@ -1868,24 +1718,6 @@
     "newsletter": {
       "name": "Đăng ký nhận email",
       "settings": {
-        "color_scheme": {
-          "label": "Bảng màu",
-          "options__1": {
-            "label": "Nhấn 1"
-          },
-          "options__2": {
-            "label": "Nhấn 2"
-          },
-          "options__3": {
-            "label": "Nền 1"
-          },
-          "options__4": {
-            "label": "Nền 2"
-          },
-          "options__5": {
-            "label": "Nghịch đảo"
-          }
-        },
         "full_width": {
           "label": "Làm cho mục có chiều rộng đầy đủ"
         },
@@ -1971,24 +1803,6 @@
     "rich-text": {
       "name": "Văn bản đa dạng thức",
       "settings": {
-        "color_scheme": {
-          "options__1": {
-            "label": "Nhấn 1"
-          },
-          "options__2": {
-            "label": "Nhấn 2"
-          },
-          "options__3": {
-            "label": "Nền 1"
-          },
-          "options__4": {
-            "label": "Nền 2"
-          },
-          "options__5": {
-            "label": "Nghịch đảo"
-          },
-          "label": "Bảng màu"
-        },
         "full_width": {
           "label": "Làm cho mục có chiều rộng đầy đủ"
         }
@@ -2212,22 +2026,6 @@
           "label": "Độ chắn sáng của lớp phủ hình ảnh"
         },
         "color_scheme": {
-          "options__1": {
-            "label": "Điểm nhấn 1"
-          },
-          "options__2": {
-            "label": "Điểm nhấn 2"
-          },
-          "options__3": {
-            "label": "Nền 1"
-          },
-          "options__4": {
-            "label": "Nền 2"
-          },
-          "options__5": {
-            "label": "Nghịch đảo"
-          },
-          "label": "Bảng màu",
           "info": "Có thể nhìn thấy khi vùng chứa hiển thị"
         },
         "show_text_below": {
@@ -2484,23 +2282,7 @@
               "label": "Độ chắn sáng của lớp phủ hình ảnh"
             },
             "color_scheme": {
-              "info": "Có thể nhìn thấy khi vùng chứa hiển thị.",
-              "options__1": {
-                "label": "Điểm nhấn 1"
-              },
-              "options__2": {
-                "label": "Điểm nhấn 2"
-              },
-              "options__3": {
-                "label": "Nền 1"
-              },
-              "options__4": {
-                "label": "Nền 2"
-              },
-              "options__5": {
-                "label": "Nghịch đảo"
-              },
-              "label": "Bảng màu"
+              "info": "Có thể nhìn thấy khi vùng chứa hiển thị."
             },
             "text_alignment_mobile": {
               "label": "Căn chỉnh nội dung trên thiết bị di động",
@@ -2554,24 +2336,6 @@
             "label": "Khoảng chứa mục"
           }
         },
-        "color_scheme": {
-          "label": "Bảng màu",
-          "options__1": {
-            "label": "Nền 1"
-          },
-          "options__2": {
-            "label": "Nền 2"
-          },
-          "options__3": {
-            "label": "Nghịch đảo"
-          },
-          "options__4": {
-            "label": "Điểm nhấn 1"
-          },
-          "options__5": {
-            "label": "Điểm nhấn 2"
-          }
-        },
         "open_first_collapsible_row": {
           "label": "Mở hàng có thể thu gọn đầu tiên"
         },
@@ -2605,22 +2369,7 @@
         },
         "container_color_scheme": {
           "label": "Bảng màu cho khoảng chửa",
-          "info": "Hiển thị khi đặt Bố cục thành khoảng chứa Hàng hoặc khoảng chứa Mục.",
-          "options__1": {
-            "label": "Nền 1"
-          },
-          "options__2": {
-            "label": "Nền 2"
-          },
-          "options__3": {
-            "label": "Nghịch đảo"
-          },
-          "options__4": {
-            "label": "Điểm nhấn 1"
-          },
-          "options__5": {
-            "label": "Điểm nhấn 2"
-          }
+          "info": "Hiển thị khi đặt Bố cục thành khoảng chứa Hàng hoặc khoảng chứa Mục."
         }
       },
       "blocks": {

--- a/locales/zh-CN.schema.json
+++ b/locales/zh-CN.schema.json
@@ -77,12 +77,6 @@
       "name": "图标",
       "settings": {
         "accent_icons": {
-          "options__1": {
-            "label": "强调色 1"
-          },
-          "options__2": {
-            "label": "强调色 2"
-          },
           "options__3": {
             "label": "轮廓按钮"
           },
@@ -238,24 +232,6 @@
             "label": "右"
           },
           "label": "文本对齐方式"
-        },
-        "color_scheme": {
-          "options__1": {
-            "label": "强调色 1"
-          },
-          "options__2": {
-            "label": "强调色 2"
-          },
-          "options__3": {
-            "label": "背景 1"
-          },
-          "options__4": {
-            "label": "背景 2"
-          },
-          "options__5": {
-            "label": "反转色"
-          },
-          "label": "配色方案"
         }
       }
     },
@@ -360,24 +336,6 @@
           "settings": {
             "text": {
               "label": "文本"
-            },
-            "color_scheme": {
-              "label": "配色方案",
-              "options__1": {
-                "label": "背景 1"
-              },
-              "options__2": {
-                "label": "背景 2"
-              },
-              "options__3": {
-                "label": "反转"
-              },
-              "options__4": {
-                "label": "强调色 1"
-              },
-              "options__5": {
-                "label": "强调色 2"
-              }
             },
             "link": {
               "label": "链接"
@@ -647,24 +605,6 @@
         }
       },
       "settings": {
-        "color_scheme": {
-          "options__1": {
-            "label": "强调色 1"
-          },
-          "options__2": {
-            "label": "强调色 2"
-          },
-          "options__3": {
-            "label": "背景 1"
-          },
-          "options__4": {
-            "label": "背景 2"
-          },
-          "options__5": {
-            "label": "反转"
-          },
-          "label": "配色方案"
-        },
         "newsletter_enable": {
           "label": "显示电子邮件注册信息"
         },
@@ -744,24 +684,6 @@
           "label": "启用粘性标头",
           "info": "在客户向上滑动时，屏幕上会显示标头。"
         },
-        "color_scheme": {
-          "options__1": {
-            "label": "强调色 1"
-          },
-          "options__2": {
-            "label": "强调色 2"
-          },
-          "options__3": {
-            "label": "背景 1"
-          },
-          "options__4": {
-            "label": "背景 2"
-          },
-          "options__5": {
-            "label": "反转"
-          },
-          "label": "配色方案"
-        },
         "margin_bottom": {
           "label": "下边距"
         }
@@ -777,22 +699,6 @@
           "label": "第二张图片"
         },
         "color_scheme": {
-          "options__1": {
-            "label": "强调色 1"
-          },
-          "options__2": {
-            "label": "强调色 2"
-          },
-          "options__3": {
-            "label": "背景 1"
-          },
-          "options__4": {
-            "label": "背景 2"
-          },
-          "options__5": {
-            "label": "反转"
-          },
-          "label": "配色方案",
           "info": "在显示容器时可见。"
         },
         "stack_images_on_mobile": {
@@ -967,24 +873,6 @@
             "label": "大"
           },
           "label": "图片高度"
-        },
-        "color_scheme": {
-          "options__1": {
-            "label": "背景 1"
-          },
-          "options__2": {
-            "label": "背景 2"
-          },
-          "options__3": {
-            "label": "反转"
-          },
-          "options__4": {
-            "label": "强调色 1"
-          },
-          "options__5": {
-            "label": "强调色 2"
-          },
-          "label": "配色方案"
         },
         "layout": {
           "options__1": {
@@ -1377,27 +1265,7 @@
       "name": "页面"
     },
     "main-password-footer": {
-      "name": "密码页脚",
-      "settings": {
-        "color_scheme": {
-          "options__1": {
-            "label": "强调色 1"
-          },
-          "options__2": {
-            "label": "强调色 2"
-          },
-          "options__3": {
-            "label": "背景 1"
-          },
-          "options__4": {
-            "label": "背景 2"
-          },
-          "options__5": {
-            "label": "反转"
-          },
-          "label": "配色方案"
-        }
-      }
+      "name": "密码页脚"
     },
     "main-password-header": {
       "name": "密码标头",
@@ -1408,24 +1276,6 @@
         "logo_max_width": {
           "label": "自定义 logo 宽度",
           "unit": "px"
-        },
-        "color_scheme": {
-          "options__1": {
-            "label": "强调色 1"
-          },
-          "options__2": {
-            "label": "强调色 2"
-          },
-          "options__3": {
-            "label": "背景 1"
-          },
-          "options__4": {
-            "label": "背景 2"
-          },
-          "options__5": {
-            "label": "反转"
-          },
-          "label": "配色方案"
         }
       }
     },
@@ -1868,24 +1718,6 @@
     "newsletter": {
       "name": "电子邮件注册信息",
       "settings": {
-        "color_scheme": {
-          "label": "配色方案",
-          "options__1": {
-            "label": "强调色 1"
-          },
-          "options__2": {
-            "label": "强调色 2"
-          },
-          "options__3": {
-            "label": "背景 1"
-          },
-          "options__4": {
-            "label": "背景 2"
-          },
-          "options__5": {
-            "label": "反转"
-          }
-        },
         "full_width": {
           "label": "使分区展示全宽"
         },
@@ -1971,24 +1803,6 @@
     "rich-text": {
       "name": "富文本",
       "settings": {
-        "color_scheme": {
-          "options__1": {
-            "label": "强调色 1"
-          },
-          "options__2": {
-            "label": "强调色 2"
-          },
-          "options__3": {
-            "label": "背景 1"
-          },
-          "options__4": {
-            "label": "背景 2"
-          },
-          "options__5": {
-            "label": "反转"
-          },
-          "label": "配色方案"
-        },
         "full_width": {
           "label": "使分区展示全宽"
         }
@@ -2212,22 +2026,6 @@
           "label": "图片叠加不透明度"
         },
         "color_scheme": {
-          "options__1": {
-            "label": "强调色 1"
-          },
-          "options__2": {
-            "label": "强调色 2"
-          },
-          "options__3": {
-            "label": "背景 1"
-          },
-          "options__4": {
-            "label": "背景 2"
-          },
-          "options__5": {
-            "label": "反转"
-          },
-          "label": "配色方案",
           "info": "在显示容器时可见"
         },
         "show_text_below": {
@@ -2484,23 +2282,7 @@
               "label": "图片叠加不透明度"
             },
             "color_scheme": {
-              "label": "配色方案",
-              "info": "在显示容器时可见。",
-              "options__1": {
-                "label": "强调色 1"
-              },
-              "options__2": {
-                "label": "强调色 2"
-              },
-              "options__3": {
-                "label": "背景 1"
-              },
-              "options__4": {
-                "label": "背景 2"
-              },
-              "options__5": {
-                "label": "反转"
-              }
+              "info": "在显示容器时可见。"
             },
             "text_alignment_mobile": {
               "label": "移动设备内容对齐方式",
@@ -2554,24 +2336,6 @@
             "label": "分区容器"
           }
         },
-        "color_scheme": {
-          "label": "配色方案",
-          "options__1": {
-            "label": "背景 1"
-          },
-          "options__2": {
-            "label": "背景 2"
-          },
-          "options__3": {
-            "label": "反转"
-          },
-          "options__4": {
-            "label": "强调色 1"
-          },
-          "options__5": {
-            "label": "强调色 2"
-          }
-        },
         "open_first_collapsible_row": {
           "label": "打开第一个可折叠行"
         },
@@ -2605,21 +2369,6 @@
         },
         "container_color_scheme": {
           "label": "容器配色方案",
-          "options__1": {
-            "label": "背景 1"
-          },
-          "options__2": {
-            "label": "背景 2"
-          },
-          "options__3": {
-            "label": "反转"
-          },
-          "options__4": {
-            "label": "强调色 1"
-          },
-          "options__5": {
-            "label": "强调色 2"
-          },
           "info": "在将“布局”设置为“行”或“分区”容器时可见。"
         }
       },

--- a/locales/zh-TW.schema.json
+++ b/locales/zh-TW.schema.json
@@ -77,12 +77,6 @@
       "name": "圖示",
       "settings": {
         "accent_icons": {
-          "options__1": {
-            "label": "色調 1"
-          },
-          "options__2": {
-            "label": "色調 2"
-          },
           "options__3": {
             "label": "外框按鈕"
           },
@@ -238,24 +232,6 @@
             "label": "靠右"
           },
           "label": "文字對齊方式"
-        },
-        "color_scheme": {
-          "options__1": {
-            "label": "色調 1"
-          },
-          "options__2": {
-            "label": "色調 2"
-          },
-          "options__3": {
-            "label": "背景 1"
-          },
-          "options__4": {
-            "label": "背景 2"
-          },
-          "options__5": {
-            "label": "反轉"
-          },
-          "label": "顏色配置"
         }
       }
     },
@@ -360,24 +336,6 @@
           "settings": {
             "text": {
               "label": "文字"
-            },
-            "color_scheme": {
-              "label": "顏色配置",
-              "options__1": {
-                "label": "背景 1"
-              },
-              "options__2": {
-                "label": "背景 2"
-              },
-              "options__3": {
-                "label": "倒轉"
-              },
-              "options__4": {
-                "label": "色調 1"
-              },
-              "options__5": {
-                "label": "色調 2"
-              }
             },
             "link": {
               "label": "連結"
@@ -647,24 +605,6 @@
         }
       },
       "settings": {
-        "color_scheme": {
-          "options__1": {
-            "label": "色調 1"
-          },
-          "options__2": {
-            "label": "色調 2"
-          },
-          "options__3": {
-            "label": "背景 1"
-          },
-          "options__4": {
-            "label": "背景 2"
-          },
-          "options__5": {
-            "label": "倒轉"
-          },
-          "label": "顏色配置"
-        },
         "newsletter_enable": {
           "label": "顯示電子郵件訂閱"
         },
@@ -744,24 +684,6 @@
           "label": "啟用固定式頁首",
           "info": "頁首會在顧客往上滑時顯示在螢幕上。"
         },
-        "color_scheme": {
-          "options__1": {
-            "label": "色調 1"
-          },
-          "options__2": {
-            "label": "色調 2"
-          },
-          "options__3": {
-            "label": "背景 1"
-          },
-          "options__4": {
-            "label": "背景 2"
-          },
-          "options__5": {
-            "label": "反轉"
-          },
-          "label": "顏色配置"
-        },
         "margin_bottom": {
           "label": "下方邊界"
         }
@@ -777,22 +699,6 @@
           "label": "第二張圖片"
         },
         "color_scheme": {
-          "options__1": {
-            "label": "色調 1"
-          },
-          "options__2": {
-            "label": "色調 2"
-          },
-          "options__3": {
-            "label": "背景 1"
-          },
-          "options__4": {
-            "label": "背景 2"
-          },
-          "options__5": {
-            "label": "倒轉"
-          },
-          "label": "顏色配置",
           "info": "顯示容器時可見。"
         },
         "stack_images_on_mobile": {
@@ -967,24 +873,6 @@
             "label": "大"
           },
           "label": "圖片高度"
-        },
-        "color_scheme": {
-          "options__1": {
-            "label": "背景 1"
-          },
-          "options__2": {
-            "label": "背景 2"
-          },
-          "options__3": {
-            "label": "倒轉"
-          },
-          "options__4": {
-            "label": "色調 1"
-          },
-          "options__5": {
-            "label": "色調 2"
-          },
-          "label": "顏色配置"
         },
         "layout": {
           "options__1": {
@@ -1377,27 +1265,7 @@
       "name": "頁面"
     },
     "main-password-footer": {
-      "name": "密碼頁尾",
-      "settings": {
-        "color_scheme": {
-          "options__1": {
-            "label": "色調 1"
-          },
-          "options__2": {
-            "label": "色調 2"
-          },
-          "options__3": {
-            "label": "背景 1"
-          },
-          "options__4": {
-            "label": "背景 2"
-          },
-          "options__5": {
-            "label": "倒轉"
-          },
-          "label": "顏色配置"
-        }
-      }
+      "name": "密碼頁尾"
     },
     "main-password-header": {
       "name": "密碼頁首",
@@ -1408,24 +1276,6 @@
         "logo_max_width": {
           "label": "自訂標誌寬度",
           "unit": "像素"
-        },
-        "color_scheme": {
-          "options__1": {
-            "label": "色調 1"
-          },
-          "options__2": {
-            "label": "色調 2"
-          },
-          "options__3": {
-            "label": "背景 1"
-          },
-          "options__4": {
-            "label": "背景 2"
-          },
-          "options__5": {
-            "label": "倒轉"
-          },
-          "label": "顏色配置"
         }
       }
     },
@@ -1868,24 +1718,6 @@
     "newsletter": {
       "name": "電子郵件訂閱",
       "settings": {
-        "color_scheme": {
-          "label": "顏色配置",
-          "options__1": {
-            "label": "色調 1"
-          },
-          "options__2": {
-            "label": "色調 2"
-          },
-          "options__3": {
-            "label": "背景 1"
-          },
-          "options__4": {
-            "label": "背景 2"
-          },
-          "options__5": {
-            "label": "倒轉"
-          }
-        },
         "full_width": {
           "label": "讓區段呈現全寬度"
         },
@@ -1971,24 +1803,6 @@
     "rich-text": {
       "name": "RTF 文字",
       "settings": {
-        "color_scheme": {
-          "options__1": {
-            "label": "色調 1"
-          },
-          "options__2": {
-            "label": "色調 2"
-          },
-          "options__3": {
-            "label": "背景 1"
-          },
-          "options__4": {
-            "label": "背景 2"
-          },
-          "options__5": {
-            "label": "倒轉"
-          },
-          "label": "顏色配置"
-        },
         "full_width": {
           "label": "讓區段呈現全寬度"
         }
@@ -2212,22 +2026,6 @@
           "label": "圖片疊加層透明度"
         },
         "color_scheme": {
-          "options__1": {
-            "label": "色調 1"
-          },
-          "options__2": {
-            "label": "色調 2"
-          },
-          "options__3": {
-            "label": "背景 1"
-          },
-          "options__4": {
-            "label": "背景 2"
-          },
-          "options__5": {
-            "label": "反轉"
-          },
-          "label": "顏色配置",
           "info": "顯示容器時可見"
         },
         "show_text_below": {
@@ -2484,23 +2282,7 @@
               "label": "圖片疊加層透明度"
             },
             "color_scheme": {
-              "label": "顏色配置",
-              "info": "顯示容器時可見。",
-              "options__1": {
-                "label": "色調 1"
-              },
-              "options__2": {
-                "label": "色調 2"
-              },
-              "options__3": {
-                "label": "背景 1"
-              },
-              "options__4": {
-                "label": "背景 2"
-              },
-              "options__5": {
-                "label": "反轉"
-              }
+              "info": "顯示容器時可見。"
             },
             "text_alignment_mobile": {
               "label": "行動版內容對齊方式",
@@ -2554,41 +2336,8 @@
             "label": "區段容器"
           }
         },
-        "color_scheme": {
-          "label": "顏色配置",
-          "options__1": {
-            "label": "背景 1"
-          },
-          "options__2": {
-            "label": "背景 2"
-          },
-          "options__3": {
-            "label": "反轉"
-          },
-          "options__4": {
-            "label": "色調 1"
-          },
-          "options__5": {
-            "label": "色調 2"
-          }
-        },
         "container_color_scheme": {
           "label": "容器顏色配置",
-          "options__1": {
-            "label": "背景 1"
-          },
-          "options__2": {
-            "label": "背景 2"
-          },
-          "options__3": {
-            "label": "反轉"
-          },
-          "options__4": {
-            "label": "色調 1"
-          },
-          "options__5": {
-            "label": "色調 2"
-          },
           "info": "版面配置設為橫列或區段容器時即可查看。"
         },
         "open_first_collapsible_row": {

--- a/sections/announcement-bar.liquid
+++ b/sections/announcement-bar.liquid
@@ -61,7 +61,7 @@
         }
       ],
        "default": "accent-1",
-       "label": "t:sections.all.colors.accent_1.label"
+       "label": "t:sections.all.colors.label"
         },
         {
           "type": "url",

--- a/sections/announcement-bar.liquid
+++ b/sections/announcement-bar.liquid
@@ -62,7 +62,7 @@
       ],
        "default": "accent-1",
        "label": "t:sections.all.colors.label"
-        },
+      },
         {
           "type": "url",
           "id": "link",

--- a/sections/announcement-bar.liquid
+++ b/sections/announcement-bar.liquid
@@ -39,30 +39,30 @@
           "type": "select",
           "id": "color_scheme",
           "options": [
-        {
-          "value": "accent-1",
-          "label": "t:sections.all.colors.accent_1.label"
+            {
+              "value": "accent-1",
+              "label": "t:sections.all.colors.accent_1.label"
+            },
+            {
+              "value": "accent-2",
+              "label": "t:sections.all.colors.accent_2.label"
+            },
+            {
+              "value": "background-1",
+              "label": "t:sections.all.colors.background_1.label"
+            },
+            {
+              "value": "background-2",
+              "label": "t:sections.all.colors.background_2.label"
+            },
+            {
+              "value": "inverse",
+              "label": "t:sections.all.colors.inverse.label"
+            }
+          ],
+          "default": "accent-1",
+          "label": "t:sections.all.colors.label"
         },
-        {
-          "value": "accent-2",
-          "label": "t:sections.all.colors.accent_2.label"
-        },
-        {
-          "value": "background-1",
-          "label": "t:sections.all.colors.background_1.label"
-        },
-        {
-          "value": "background-2",
-          "label": "t:sections.all.colors.background_2.label"
-        },
-        {
-          "value": "inverse",
-          "label": "t:sections.all.colors.inverse.label"
-        }
-      ],
-       "default": "accent-1",
-       "label": "t:sections.all.colors.label"
-      },
         {
           "type": "url",
           "id": "link",

--- a/sections/announcement-bar.liquid
+++ b/sections/announcement-bar.liquid
@@ -40,6 +40,14 @@
           "id": "color_scheme",
           "options": [
             {
+              "value": "accent-1",
+              "label": "t:sections.announcement-bar.blocks.announcement.settings.color_scheme.options__4.label"
+            },
+            {
+              "value": "accent-2",
+              "label": "t:sections.announcement-bar.blocks.announcement.settings.color_scheme.options__5.label"
+            },
+            {
               "value": "background-1",
               "label": "t:sections.announcement-bar.blocks.announcement.settings.color_scheme.options__1.label"
             },
@@ -50,14 +58,6 @@
             {
               "value": "inverse",
               "label": "t:sections.announcement-bar.blocks.announcement.settings.color_scheme.options__3.label"
-            },
-            {
-              "value": "accent-1",
-              "label": "t:sections.announcement-bar.blocks.announcement.settings.color_scheme.options__4.label"
-            },
-            {
-              "value": "accent-2",
-              "label": "t:sections.announcement-bar.blocks.announcement.settings.color_scheme.options__5.label"
             }
           ],
           "default": "accent-1",

--- a/sections/announcement-bar.liquid
+++ b/sections/announcement-bar.liquid
@@ -39,29 +39,29 @@
           "type": "select",
           "id": "color_scheme",
           "options": [
-            {
-              "value": "accent-1",
-              "label": "t:sections.announcement-bar.blocks.announcement.settings.color_scheme.options__4.label"
-            },
-            {
-              "value": "accent-2",
-              "label": "t:sections.announcement-bar.blocks.announcement.settings.color_scheme.options__5.label"
-            },
-            {
-              "value": "background-1",
-              "label": "t:sections.announcement-bar.blocks.announcement.settings.color_scheme.options__1.label"
-            },
-            {
-              "value": "background-2",
-              "label": "t:sections.announcement-bar.blocks.announcement.settings.color_scheme.options__2.label"
-            },
-            {
-              "value": "inverse",
-              "label": "t:sections.announcement-bar.blocks.announcement.settings.color_scheme.options__3.label"
-            }
-          ],
-          "default": "accent-1",
-          "label": "t:sections.announcement-bar.blocks.announcement.settings.color_scheme.label"
+        {
+          "value": "accent-1",
+          "label": "t:sections.all.colors.accent_1.label"
+        },
+        {
+          "value": "accent-2",
+          "label": "t:sections.all.colors.accent_2.label"
+        },
+        {
+          "value": "background-1",
+          "label": "t:sections.all.colors.background_1.label"
+        },
+        {
+          "value": "background-2",
+          "label": "t:sections.all.colors.background_2.label"
+        },
+        {
+          "value": "inverse",
+          "label": "t:sections.all.colors.inverse.label"
+        }
+      ],
+       "default": "accent-1",
+       "label": "t:sections.all.colors.accent_1.label"
         },
         {
           "type": "url",

--- a/sections/collapsible-content.liquid
+++ b/sections/collapsible-content.liquid
@@ -142,27 +142,27 @@
       "options": [
         {
           "value": "accent-1",
-          "label": "t:sections.collapsible_content.settings.color_scheme.options__4.label"
+          "label": "t:sections.all.colors.accent_1.label"
         },
         {
           "value": "accent-2",
-          "label": "t:sections.collapsible_content.settings.color_scheme.options__5.label"
+          "label": "t:sections.all.colors.accent_2.label"
         },
         {
           "value": "background-1",
-          "label": "t:sections.collapsible_content.settings.color_scheme.options__1.label"
+          "label": "t:sections.all.colors.background_1.label"
         },
         {
           "value": "background-2",
-          "label": "t:sections.collapsible_content.settings.color_scheme.options__2.label"
+          "label": "t:sections.all.colors.background_2.label"
         },
         {
           "value": "inverse",
-          "label": "t:sections.collapsible_content.settings.color_scheme.options__3.label"
+          "label": "t:sections.all.colors.inverse.label"
         }
       ],
       "default": "background-1",
-      "label": "t:sections.collapsible_content.settings.color_scheme.label"
+      "label": "t:sections.all.colors.label"
     },
     {
       "type": "select",
@@ -170,23 +170,23 @@
       "options": [
         {
           "value": "accent-1",
-          "label": "t:sections.collapsible_content.settings.container_color_scheme.options__4.label"
+          "label": "t:sections.all.colors.accent_1.label"
         },
         {
           "value": "accent-2",
-          "label": "t:sections.collapsible_content.settings.container_color_scheme.options__5.label"
+          "label": "t:sections.all.colors.accent_2.label"
         },
         {
           "value": "background-1",
-          "label": "t:sections.collapsible_content.settings.container_color_scheme.options__1.label"
+          "label": "t:sections.all.colors.background_1.label"
         },
         {
           "value": "background-2",
-          "label": "t:sections.collapsible_content.settings.container_color_scheme.options__2.label"
+          "label": "t:sections.all.colors.background_2.label"
         },
         {
           "value": "inverse",
-          "label": "t:sections.collapsible_content.settings.container_color_scheme.options__3.label"
+          "label": "t:sections.all.colors.inverse.label"
         }
       ],
       "default": "background-2",

--- a/sections/email-signup-banner.liquid
+++ b/sections/email-signup-banner.liquid
@@ -242,27 +242,27 @@
       "options": [
         {
           "value": "accent-1",
-          "label": "t:sections.email-signup-banner.settings.color_scheme.options__1.label"
+          "label": "t:sections.all.colors.accent_1.label"
         },
         {
           "value": "accent-2",
-          "label": "t:sections.email-signup-banner.settings.color_scheme.options__2.label"
+          "label": "t:sections.all.colors.accent_2.label"
         },
         {
           "value": "background-1",
-          "label": "t:sections.email-signup-banner.settings.color_scheme.options__3.label"
+          "label": "t:sections.all.colors.background_1.label"
         },
         {
           "value": "background-2",
-          "label": "t:sections.email-signup-banner.settings.color_scheme.options__4.label"
+          "label": "t:sections.all.colors.background_2.label"
         },
         {
           "value": "inverse",
-          "label": "t:sections.email-signup-banner.settings.color_scheme.options__5.label"
+          "label": "t:sections.all.colors.inverse.label"
         }
       ],
       "default": "background-1",
-      "label": "t:sections.email-signup-banner.settings.color_scheme.label",
+      "label": "t:sections.all.colors.label",
       "info": "t:sections.email-signup-banner.settings.color_scheme.info"
     },
     {

--- a/sections/footer.liquid
+++ b/sections/footer.liquid
@@ -481,27 +481,27 @@
       "options": [
         {
           "value": "accent-1",
-          "label": "t:sections.footer.settings.color_scheme.options__1.label"
+          "label": "t:sections.all.colors.accent_1.label"
         },
         {
           "value": "accent-2",
-          "label": "t:sections.footer.settings.color_scheme.options__2.label"
+          "label": "t:sections.all.colors.accent_2.label"
         },
         {
           "value": "background-1",
-          "label": "t:sections.footer.settings.color_scheme.options__3.label"
+          "label": "t:sections.all.colors.background_1.label"
         },
         {
           "value": "background-2",
-          "label": "t:sections.footer.settings.color_scheme.options__4.label"
+          "label": "t:sections.all.colors.background_2.label"
         },
         {
           "value": "inverse",
-          "label": "t:sections.footer.settings.color_scheme.options__5.label"
+          "label": "t:sections.all.colors.inverse.label"
         }
       ],
       "default": "background-1",
-      "label": "t:sections.footer.settings.color_scheme.label"
+      "label": "t:sections.all.colors.label"
     },
     {
       "type": "header",

--- a/sections/header.liquid
+++ b/sections/header.liquid
@@ -669,27 +669,27 @@
       "options": [
         {
           "value": "accent-1",
-          "label": "t:sections.header.settings.color_scheme.options__1.label"
+          "label": "t:sections.all.colors.accent_1.label"
         },
         {
           "value": "accent-2",
-          "label": "t:sections.header.settings.color_scheme.options__2.label"
+          "label": "t:sections.all.colors.accent_2.label"
         },
         {
           "value": "background-1",
-          "label": "t:sections.header.settings.color_scheme.options__3.label"
+          "label": "t:sections.all.colors.background_1.label"
         },
         {
           "value": "background-2",
-          "label": "t:sections.header.settings.color_scheme.options__4.label"
+          "label": "t:sections.all.colors.background_2.label"
         },
         {
           "value": "inverse",
-          "label": "t:sections.header.settings.color_scheme.options__5.label"
+          "label": "t:sections.all.colors.inverse.label"
         }
       ],
       "default": "background-1",
-      "label": "t:sections.header.settings.color_scheme.label"
+      "label": "t:sections.all.colors.label"
     },
     {
       "type": "image_picker",

--- a/sections/image-banner.liquid
+++ b/sections/image-banner.liquid
@@ -237,27 +237,27 @@
       "options": [
         {
           "value": "accent-1",
-          "label": "t:sections.image-banner.settings.color_scheme.options__1.label"
+          "label": "t:sections.all.colors.accent_1.label"
         },
         {
           "value": "accent-2",
-          "label": "t:sections.image-banner.settings.color_scheme.options__2.label"
+          "label": "t:sections.all.colors.accent_2.label"
         },
         {
           "value": "background-1",
-          "label": "t:sections.image-banner.settings.color_scheme.options__3.label"
+          "label": "t:sections.all.colors.background_1.label"
         },
         {
           "value": "background-2",
-          "label": "t:sections.image-banner.settings.color_scheme.options__4.label"
+          "label": "t:sections.all.colors.background_2.label"
         },
         {
           "value": "inverse",
-          "label": "t:sections.image-banner.settings.color_scheme.options__5.label"
+          "label": "t:sections.all.colors.inverse.label"
         }
       ],
       "default": "background-1",
-      "label": "t:sections.image-banner.settings.color_scheme.label",
+      "label": "t:sections.all.colors.label",
       "info": "t:sections.image-banner.settings.color_scheme.info"
     },
     {

--- a/sections/image-with-text.liquid
+++ b/sections/image-with-text.liquid
@@ -196,27 +196,27 @@
       "options": [
         {
           "value": "accent-1",
-          "label": "t:sections.image-with-text.settings.color_scheme.options__4.label"
+          "label": "t:sections.all.colors.accent_1.label"
         },
         {
           "value": "accent-2",
-          "label": "t:sections.image-with-text.settings.color_scheme.options__5.label"
+          "label": "t:sections.all.colors.accent_2.label"
         },
         {
           "value": "background-1",
-          "label": "t:sections.image-with-text.settings.color_scheme.options__1.label"
+          "label": "t:sections.all.colors.background_1.label"
         },
         {
           "value": "background-2",
-          "label": "t:sections.image-with-text.settings.color_scheme.options__2.label"
+          "label": "t:sections.all.colors.background_2.label"
         },
         {
           "value": "inverse",
-          "label": "t:sections.image-with-text.settings.color_scheme.options__3.label"
+          "label": "t:sections.all.colors.inverse.label"
         }
       ],
       "default": "background-1",
-      "label": "t:sections.image-with-text.settings.color_scheme.label"
+      "label": "t:sections.all.colors.label"
     },
     {
       "type": "header",

--- a/sections/main-password-footer.liquid
+++ b/sections/main-password-footer.liquid
@@ -98,27 +98,27 @@
       "options": [
         {
           "value": "accent-1",
-          "label": "t:sections.main-password-footer.settings.color_scheme.options__1.label"
+          "label": "t:sections.all.colors.accent_1.label"
         },
         {
           "value": "accent-2",
-          "label": "t:sections.main-password-footer.settings.color_scheme.options__2.label"
+          "label": "t:sections.all.colors.accent_2.label"
         },
         {
           "value": "background-1",
-          "label": "t:sections.main-password-footer.settings.color_scheme.options__3.label"
+          "label": "t:sections.all.colors.background_1.label"
         },
         {
           "value": "background-2",
-          "label": "t:sections.main-password-footer.settings.color_scheme.options__4.label"
+          "label": "t:sections.all.colors.background_2.label"
         },
         {
           "value": "inverse",
-          "label": "t:sections.main-password-footer.settings.color_scheme.options__5.label"
+          "label": "t:sections.all.colors.inverse.label"
         }
       ],
       "default": "background-1",
-      "label": "t:sections.main-password-footer.settings.color_scheme.label"
+      "label": "t:sections.all.colors.label"
     }
   ]
 }

--- a/sections/main-password-header.liquid
+++ b/sections/main-password-header.liquid
@@ -104,27 +104,27 @@
       "options": [
         {
           "value": "accent-1",
-          "label": "t:sections.main-password-header.settings.color_scheme.options__1.label"
+          "label": "t:sections.all.colors.accent_1.label"
         },
         {
           "value": "accent-2",
-          "label": "t:sections.main-password-header.settings.color_scheme.options__2.label"
+          "label": "t:sections.all.colors.accent_2.label"
         },
         {
           "value": "background-1",
-          "label": "t:sections.main-password-header.settings.color_scheme.options__3.label"
+          "label": "t:sections.all.colors.background_1.label"
         },
         {
           "value": "background-2",
-          "label": "t:sections.main-password-header.settings.color_scheme.options__4.label"
+          "label": "t:sections.all.colors.background_2.label"
         },
         {
           "value": "inverse",
-          "label": "t:sections.main-password-header.settings.color_scheme.options__5.label"
+          "label": "t:sections.all.colors.inverse.label"
         }
       ],
       "default": "background-1",
-      "label": "t:sections.main-password-header.settings.color_scheme.label"
+      "label": "t:sections.all.colors.label"
     }
   ]
 }

--- a/sections/newsletter.liquid
+++ b/sections/newsletter.liquid
@@ -84,27 +84,27 @@
       "options": [
         {
           "value": "accent-1",
-          "label": "t:sections.newsletter.settings.color_scheme.options__1.label"
+          "label": "t:sections.all.colors.accent_1.label"
         },
         {
           "value": "accent-2",
-          "label": "t:sections.newsletter.settings.color_scheme.options__2.label"
+          "label": "t:sections.all.colors.accent_2.label"
         },
         {
           "value": "background-1",
-          "label": "t:sections.newsletter.settings.color_scheme.options__3.label"
+          "label": "t:sections.all.colors.background_1.label"
         },
         {
           "value": "background-2",
-          "label": "t:sections.newsletter.settings.color_scheme.options__4.label"
+          "label": "t:sections.all.colors.background_2.label"
         },
         {
           "value": "inverse",
-          "label": "t:sections.newsletter.settings.color_scheme.options__5.label"
+          "label": "t:sections.all.colors.inverse.label"
         }
       ],
       "default": "background-1",
-      "label": "t:sections.newsletter.settings.color_scheme.label"
+      "label": "t:sections.all.colors.label"
     },
     {
       "type": "checkbox",

--- a/sections/rich-text.liquid
+++ b/sections/rich-text.liquid
@@ -49,27 +49,27 @@
       "options": [
         {
           "value": "accent-1",
-          "label": "t:sections.rich-text.settings.color_scheme.options__1.label"
+          "label": "t:sections.all.colors.accent_1.label"
         },
         {
           "value": "accent-2",
-          "label": "t:sections.rich-text.settings.color_scheme.options__2.label"
+          "label": "t:sections.all.colors.accent_2.label"
         },
         {
           "value": "background-1",
-          "label": "t:sections.rich-text.settings.color_scheme.options__3.label"
+          "label": "t:sections.all.colors.background_1.label"
         },
         {
           "value": "background-2",
-          "label": "t:sections.rich-text.settings.color_scheme.options__4.label"
+          "label": "t:sections.all.colors.background_2.label"
         },
         {
           "value": "inverse",
-          "label": "t:sections.rich-text.settings.color_scheme.options__5.label"
+          "label": "t:sections.all.colors.inverse.label"
         }
       ],
       "default": "background-1",
-      "label": "t:sections.rich-text.settings.color_scheme.label"
+      "label": "t:sections.all.colors.label"
     },
     {
       "type": "checkbox",

--- a/sections/slideshow.liquid
+++ b/sections/slideshow.liquid
@@ -393,27 +393,27 @@
           "options": [
             {
               "value": "accent-1",
-              "label": "t:sections.slideshow.blocks.slide.settings.color_scheme.options__1.label"
+              "label": "t:sections.all.colors.accent_1.label"
             },
             {
               "value": "accent-2",
-              "label": "t:sections.slideshow.blocks.slide.settings.color_scheme.options__2.label"
+              "label": "t:sections.all.colors.accent_2.label"
             },
             {
               "value": "background-1",
-              "label": "t:sections.slideshow.blocks.slide.settings.color_scheme.options__3.label"
+              "label": "t:sections.all.colors.background_1.label"
             },
             {
               "value": "background-2",
-              "label": "t:sections.slideshow.blocks.slide.settings.color_scheme.options__4.label"
+              "label": "t:sections.all.colors.background_2.label"
             },
             {
               "value": "inverse",
-              "label": "t:sections.slideshow.blocks.slide.settings.color_scheme.options__5.label"
+              "label": "t:sections.all.colors.inverse.label"
             }
           ],
           "default": "background-1",
-          "label": "t:sections.slideshow.blocks.slide.settings.color_scheme.label",
+          "label": "t:sections.all.colors.label",
           "info": "t:sections.slideshow.blocks.slide.settings.color_scheme.info"
         },
         {


### PR DESCRIPTION
**PR Summary:** 

_Harmonizing the color scheme list of options' order for consistent usage and removing redundant code to improve performance._


**Why are these changes introduced?**

1. Reorder the Announcement bar color scheme option list to match the rest.
2. Simplify section string and remove redundant translations.

**What approach did you take?**

- Convert section strings to use the `all.colors` string.

**Testing steps/scenarios**

- [ ] Check that there are no missing labels or bugs introduced by my attempt to make the change. Look at the color scheme setting and no missing content. Areas to look for are:
   - [ ] Announcement bar
   - [ ] Collapsible content; both for the content container and the section
   - [ ] Footer
   - [ ] Header
   - [ ] Image banner
   - [ ] Image with text
   - [ ] Password footer
   - [ ] Password header
   - [ ] Email signup banner (Password page)
   - [ ] Email signup section
   - [ ] Rich text
   - [ ] Slideshow
   - [ ] Header and footer
   - [ ] Global settings for Badges, Icons and Cards


**Demo links**

- [Editor](https://os2-demo.myshopify.com/admin/themes/127646531606/editor)

**Checklist**
- [x] Added PR summary for [release notes](https://themes.shopify.com/themes/dawn/styles/default#ReleaseNotes)
- [ ] Followed [theme code principles](https://github.com/Shopify/dawn/blob/main/.github/CONTRIBUTING.md#theme-code-principles)
- [ ] Linted with [Theme Check](https://github.com/Shopify/theme-check)
- [ ] Tested on [mobile](https://shopify.dev/themes/store/requirements#mobile-browser-requirements)
- [ ] Tested on [multiple browsers](https://shopify.dev/themes/store/requirements#desktop-browser-requirements)
- [ ] Tested for [accessibility](https://shopify.dev/themes/best-practices/accessibility)
