### PR TITLE
Rename grid desktop class for consistency

### DIFF
--- a/assets/base.css
+++ b/assets/base.css
@@ -1095,12 +1095,12 @@ summary::-webkit-details-marker {
   }
 }
 
-.grid--1-col-desktop {
-  flex: 0 0 100%;
-  max-width: 100%;
-}
-
 @media screen and (min-width: 990px) {
+  .grid--1-col-desktop {
+    flex: 0 0 100%;
+    max-width: 100%;
+  }
+
   .grid--1-col-desktop .grid__item {
     width: 100%;
     max-width: 100%;

--- a/assets/base.css
+++ b/assets/base.css
@@ -1095,13 +1095,13 @@ summary::-webkit-details-marker {
   }
 }
 
-.grid--full-width {
+.grid--1-col-desktop {
   flex: 0 0 100%;
   max-width: 100%;
 }
 
 @media screen and (min-width: 990px) {
-  .grid--full-width .grid__item {
+  .grid--1-col-desktop .grid__item {
     width: 100%;
     max-width: 100%;
   }

--- a/assets/section-featured-blog.css
+++ b/assets/section-featured-blog.css
@@ -30,7 +30,7 @@
 }
 
 @media screen and (min-width: 990px) {
-  .grid--full-width .article-card .card__content {
+  .grid--1-col-desktop .article-card .card__content {
     text-align: center;
   }
 }

--- a/sections/collection-list.liquid
+++ b/sections/collection-list.liquid
@@ -39,7 +39,7 @@
     {%- endunless -%}
   
     <slider-component class="slider-mobile-gutter">
-      <ul class="collection-list contains-card{% if settings.card_style == 'standard' %} contains-card--standard{% endif %} grid{% if section.settings.columns_desktop == 1 %} grid--full-width{% else %} grid--{{ section.settings.columns_desktop }}-col-desktop{% endif %} grid--{{ section.settings.columns_mobile }}-col-tablet-down{% if section.settings.swipe_on_mobile %} slider slider--tablet grid--peek{% endif %} collection-list--{{ section.blocks.size }}-items"
+      <ul class="collection-list contains-card{% if settings.card_style == 'standard' %} contains-card--standard{% endif %} grid grid--{{ section.settings.columns_desktop }}-col-desktop grid--{{ section.settings.columns_mobile }}-col-tablet-down{% if section.settings.swipe_on_mobile %} slider slider--tablet grid--peek{% endif %} collection-list--{{ section.blocks.size }}-items"
         id="Slider-{{ section.id }}"
         role="list"
       >

--- a/sections/featured-blog.liquid
+++ b/sections/featured-blog.liquid
@@ -48,7 +48,7 @@
     {%- if section.settings.blog != blank and section.settings.blog.articles_count > 0 -%}
       <slider-component class="slider-mobile-gutter">
         <ul id="Slider-{{ section.id }}"
-          class="blog__posts articles-wrapper contains-card{% if settings.card_style == 'standard' %} contains-card--standard{% endif %} grid grid--peek grid--2-col-tablet{% if section.settings.columns_desktop == 1 %} grid--full-width{% else %} grid--{{ section.settings.columns_desktop }}-col-desktop{% endif %} slider {% if posts_displayed > 2 %}slider--tablet{% else %}slider--mobile{% endif %}"
+          class="blog__posts articles-wrapper contains-card{% if settings.card_style == 'standard' %} contains-card--standard{% endif %} grid grid--peek grid--2-col-tablet grid--{{ section.settings.columns_desktop }}-col-desktop slider {% if posts_displayed > 2 %}slider--tablet{% else %}slider--mobile{% endif %}"
           role="list"
         >
           {%- for article in section.settings.blog.articles limit: section.settings.post_limit -%}

--- a/sections/featured-collection.liquid
+++ b/sections/featured-collection.liquid
@@ -49,7 +49,7 @@
     {%- endunless -%}
   
     <slider-component class="slider-mobile-gutter">
-      <ul id="Slider-{{ section.id }}" class="grid product-grid contains-card{% if settings.card_style == 'standard' %} contains-card--standard{% endif %}{% if section.settings.columns_desktop == 1 %} grid--full-width{% else %} grid--{{ section.settings.columns_desktop }}-col-desktop{% endif %}{% if section.settings.collection == blank %} grid--2-col-tablet-down{% else %} grid--{{ section.settings.columns_mobile }}-col-tablet-down{% endif %}{% if show_mobile_slider %} slider slider--tablet grid--peek{% endif %}" role="list">
+      <ul id="Slider-{{ section.id }}" class="grid product-grid contains-card{% if settings.card_style == 'standard' %} contains-card--standard{% endif %} grid--{{ section.settings.columns_desktop }}-col-desktop {% if section.settings.collection == blank %} grid--2-col-tablet-down{% else %} grid--{{ section.settings.columns_mobile }}-col-tablet-down{% endif %}{% if show_mobile_slider %} slider slider--tablet grid--peek{% endif %}" role="list">
         {%- for product in section.settings.collection.products limit: section.settings.products_to_show -%}
           <li id="Slide-{{ section.id }}-{{ forloop.index }}" class="grid__item{% if show_mobile_slider %} slider__slide{% endif %}">
             {% render 'card-product',

--- a/sections/main-collection-product-grid.liquid
+++ b/sections/main-collection-product-grid.liquid
@@ -49,9 +49,7 @@
   
           <ul id="product-grid" data-id="{{ section.id }}" class="
             grid product-grid grid--{{ section.settings.columns_mobile }}-col-tablet-down
-            {% if section.settings.columns_desktop == 1 %} grid--full-width{% else %}
-              grid--{{ section.settings.columns_desktop }}-col-desktop
-            {% endif %}">
+            grid--{{ section.settings.columns_desktop }}-col-desktop
             {%- for product in collection.products -%}
               {% assign lazy_load = false %}
               {%- if forloop.index > 2 -%}

--- a/sections/main-collection-product-grid.liquid
+++ b/sections/main-collection-product-grid.liquid
@@ -49,7 +49,7 @@
   
           <ul id="product-grid" data-id="{{ section.id }}" class="
             grid product-grid grid--{{ section.settings.columns_mobile }}-col-tablet-down
-            grid--{{ section.settings.columns_desktop }}-col-desktop
+            grid--{{ section.settings.columns_desktop }}-col-desktop">
             {%- for product in collection.products -%}
               {% assign lazy_load = false %}
               {%- if forloop.index > 2 -%}

--- a/sections/main-search.liquid
+++ b/sections/main-search.liquid
@@ -154,7 +154,7 @@
         {% paginate search.results by 24 %}
           <div class="template-search__results collection page-width" id="product-grid" data-id="{{ section.id }}">
             <div class="loading-overlay gradient"></div>
-            <ul class="grid product-grid  grid--{{ section.settings.columns_mobile }}-col-tablet-down{% if section.settings.columns_desktop == 1 %} grid--full-width{% else %} grid--{{ section.settings.columns_desktop }}-col-desktop{% endif %}" role="list">
+            <ul class="grid product-grid  grid--{{ section.settings.columns_mobile }}-col-tablet-down grid--{{ section.settings.columns_desktop }}-col-desktop" role="list">
               {%- for item in search.results -%}
                 {% assign lazy_load = false %}
                 {%- if forloop.index > 2 -%}

--- a/sections/multicolumn.liquid
+++ b/sections/multicolumn.liquid
@@ -37,7 +37,7 @@
       </div>
     {%- endunless -%}
     <slider-component class="slider-mobile-gutter">
-      <ul class="multicolumn-list contains-content-container grid grid--{{ section.settings.columns_mobile }}-col-tablet-down{% if section.settings.columns_desktop == 1 %} grid--full-width{% else %} grid--{{ section.settings.columns_desktop }}-col-desktop{% endif %}{% if show_mobile_slider %} slider slider--mobile grid--peek{% endif %}"
+      <ul class="multicolumn-list contains-content-container grid grid--{{ section.settings.columns_mobile }}-col-tablet-down grid--{{ section.settings.columns_desktop }}-col-desktop{% if show_mobile_slider %} slider slider--mobile grid--peek{% endif %}"
         id="Slider-{{ section.id }}"
         role="list"
       >

--- a/sections/product-recommendations.liquid
+++ b/sections/product-recommendations.liquid
@@ -24,7 +24,7 @@
   <product-recommendations class="product-recommendations page-width section-{{ section.id }}-padding isolate" data-url="{{ routes.product_recommendations_url }}?section_id={{ section.id }}&product_id={{ product.id }}&limit=4">
     {% if recommendations.performed and recommendations.products_count > 0 %}
       <h2 class="product-recommendations__heading {{ section.settings.heading_size }}">{{ section.settings.heading | escape }}</h2>
-      <ul class="grid product-grid{% if section.settings.columns_desktop == 1 %} grid--full-width{% else %} grid--{{ section.settings.columns_desktop }}-col-desktop{% endif %} grid--{{ section.settings.columns_mobile }}-col-tablet-down" role="list">
+      <ul class="grid product-grid grid--{{ section.settings.columns_desktop }}-col-desktop grid--{{ section.settings.columns_mobile }}-col-tablet-down" role="list">
         {% for recommendation in recommendations.products %}
           <li class="grid__item">
             {% render 'card-product',


### PR DESCRIPTION
**PR Summary:** 

Updated all `grid--full-width` classes to be named `grid--{{ section.settings.columns_desktop }}-col-desktop`. Desktop grid settings should still work when 1 column is selected

**Why are these changes introduced?**

For better consistency in class naming on desktop and mobile and less if statements and lines of code

**What approach did you take?**

Updated the naming when the column selection is of 1 for desktop

**Testing steps/scenarios**
Test all of these sections with 1 column on desktop (grid setting):
- [ ] Collection list
- [ ] Featured blog
- [ ] Feat collection
- [ ] Main collection 
- [ ] Search
- [ ] Multicolumn
- [ ] Prod rec

**Demo links**

- [Editor](https://os2-demo.myshopify.com/admin/themes/127645974550/editor)

**Checklist**
- [ ] Added PR summary for [release notes](https://themes.shopify.com/themes/dawn/styles/default#ReleaseNotes)
- [ ] Followed [theme code principles](https://github.com/Shopify/dawn/blob/main/.github/CONTRIBUTING.md#theme-code-principles)
- [ ] Linted with [Theme Check](https://github.com/Shopify/theme-check)
- [ ] Tested on [mobile](https://shopify.dev/themes/store/requirements#mobile-browser-requirements)
- [ ] Tested on [multiple browsers](https://shopify.dev/themes/store/requirements#desktop-browser-requirements)
- [ ] Tested for [accessibility](https://shopify.dev/themes/best-practices/accessibility)
