### PR TITLE
Implement zero grid spacing and border collapsing

### DIFF
--- a/assets/base.css
+++ b/assets/base.css
@@ -177,8 +177,8 @@
   --shadow-opacity: var(--text-boxes-shadow-opacity);
 }
 
-.product__media-gallery .slider,
-.product__media-item {
+.contains-media,
+.global-media-settings {
   --border-radius: var(--media-radius);
   --border-width: var(--media-border-width);
   --border-opacity: var(--media-border-opacity);

--- a/assets/base.css
+++ b/assets/base.css
@@ -177,8 +177,8 @@
   --shadow-opacity: var(--text-boxes-shadow-opacity);
 }
 
-.contains-media,
-.global-media-settings {
+.product__media-gallery .slider,
+.product__media-item {
   --border-radius: var(--media-radius);
   --border-width: var(--media-border-width);
   --border-opacity: var(--media-border-opacity);
@@ -975,13 +975,6 @@ summary::-webkit-details-marker {
   list-style: none;
   column-gap: var(--grid-mobile-horizontal-spacing);
   row-gap: var(--grid-mobile-vertical-spacing);
-}
-
-.grid--collapsed.contains-card,
-.grid--collapsed.contains-media,
-.grid--collapsed.contains-content-container {
-  padding-bottom: var(--collapsed-offset-y);
-  margin-right: var(--collapsed-offset-x);
 }
 
 @media screen and (min-width: 750px) {
@@ -2784,16 +2777,6 @@ details-disclosure > details {
   }
 }
 
-.grid--collapsed.contains-content-container .content-container {
-  margin-bottom: var(--collapsed-offset-y);
-  margin-right: var(--collapsed-offset-x);
-}
-
-.grid--collapsed.contains-content-container .content-container:after {
-  margin-top: var(--collapsed-shadow-offset-y);
-  margin-left: var(--collapsed-shadow-offset-x);
-}
-
 .global-media-settings {
   position: relative;
   border: var(--media-border-width) solid rgba(var(--color-foreground), var(--media-border-opacity));
@@ -2842,6 +2825,24 @@ details-disclosure > details {
   margin-right: var(--collapsed-offset-x);
 }
 
+.grid--collapsed.contains-media .global-media-settings:after {
+  margin-top: var(--collapsed-shadow-offset-y);
+  margin-left: var(--collapsed-shadow-offset-x);
+}
+
+.grid--collapsed.contains-content-container,
+.grid--collapsed.contains-media {
+  padding-bottom: var(--collapsed-offset-y);
+  margin-right: var(--collapsed-offset-x);
+}
+
+.grid--collapsed.contains-content-container .content-container,
+.grid--collapsed.contains-media .global-media-setting {
+  margin-bottom: var(--collapsed-offset-y);
+  margin-right: var(--collapsed-offset-x);
+}
+
+.grid--collapsed.contains-content-container .content-container:after,
 .grid--collapsed.contains-media .global-media-settings:after {
   margin-top: var(--collapsed-shadow-offset-y);
   margin-left: var(--collapsed-shadow-offset-x);

--- a/assets/base.css
+++ b/assets/base.css
@@ -977,6 +977,13 @@ summary::-webkit-details-marker {
   row-gap: var(--grid-mobile-vertical-spacing);
 }
 
+.grid--collapsed.contains-card,
+.grid--collapsed.contains-media,
+.grid--collapsed.contains-content-container {
+  padding-bottom: var(--collapsed-offset-y);
+  margin-right: var(--collapsed-offset-x);
+}
+
 @media screen and (min-width: 750px) {
   .grid {
     column-gap: var(--grid-desktop-horizontal-spacing);
@@ -2777,6 +2784,16 @@ details-disclosure > details {
   }
 }
 
+.grid--collapsed.contains-content-container .content-container {
+  margin-bottom: var(--collapsed-offset-y);
+  margin-right: var(--collapsed-offset-x);
+}
+
+.grid--collapsed.contains-content-container .content-container:after {
+  margin-top: var(--collapsed-shadow-offset-y);
+  margin-left: var(--collapsed-shadow-offset-x);
+}
+
 .global-media-settings {
   position: relative;
   border: var(--media-border-width) solid rgba(var(--color-foreground), var(--media-border-opacity));
@@ -2818,6 +2835,16 @@ details-disclosure > details {
   border-radius: 0;
   border-left: none;
   border-right: none;
+}
+
+.grid--collapsed.contains-media .global-media-settings {
+  margin-bottom: var(--collapsed-offset-y);
+  margin-right: var(--collapsed-offset-x);
+}
+
+.grid--collapsed.contains-media .global-media-settings:after {
+  margin-top: var(--collapsed-shadow-offset-y);
+  margin-left: var(--collapsed-shadow-offset-x);
 }
 
 /* check for flexbox gap in older Safari versions */

--- a/assets/collage.css
+++ b/assets/collage.css
@@ -120,9 +120,9 @@
   box-shadow: var(--card-shadow-horizontal-offset) var(--card-shadow-vertical-offset) var(--card-shadow-blur-radius) rgba(var(--color-shadow), var(--card-shadow-opacity));
   content: '';
   position: absolute;
-  width: calc(var(--card-border-width) * 2 + 100%);
-  height: calc(var(--card-border-width) * 2 + 100%);
   top: calc(var(--card-border-width) * -1);
+  right: calc(var(--card-border-width) * -1);
+  bottom: calc(var(--card-border-width) * -1);
   left: calc(var(--card-border-width) * -1);
   z-index: -1;
 }
@@ -182,4 +182,72 @@
 
 .collage .collage-card-spacing img {
   object-fit: contain;
+}
+
+.collage--collapsed-y .card-wrapper {
+  height: calc(100% + var(--card-border-width));
+}
+.collage--collapsed-x .collage-card {
+  width: calc(100% + var(--card-border-width));
+}
+.collage--collapsed-y .collage-card {
+  height: calc(100% + var(--card-border-width));
+}
+
+.collage--collapsed-x {
+  margin-right: var(--card-border-width);
+}
+.collage--collapsed-y {
+  padding-bottom: var(--card-border-width);
+}
+.collage--collapsed-x :where(.card, .collage-card) {
+  margin-right: calc(var(--card-border-width) * -1);
+}
+.collage--collapsed-y :where(.card, .collage-card) {
+  margin-bottom: calc(var(--card-border-width) * -1);
+}
+
+.collage--collapsed-x .collage__item--left:first-child :where(.card--card, .collage-card):after,
+.collage--collapsed-x .collage__item--left:first-child .card--standard .card__inner:after {
+  margin-right: var(--card-border-width);
+}
+.collage--collapsed-x .collage__item--right:last-child :where(.card--card, .collage-card):after,
+.collage--collapsed-x .collage__item--right:last-child .card--standard .card__inner:after {
+  margin-left: var(--card-border-width);
+}
+
+.collage--collapsed-y .collage__item--left:nth-child(3n) :where(.card--card, .collage-card):after,
+.collage--collapsed-y .collage__item--left:nth-child(3n) .card--standard .card__inner:after {
+  margin-top: var(--card-border-width);
+}
+
+@media screen and (min-width: 750px) {
+  .collage--collapsed-y .collage__item--right:nth-child(3n - 2) :where(.card--card, .collage-card):after,
+  .collage--collapsed-y .collage__item--right:nth-child(3n - 2) .card--standard .card__inner:after {
+    margin-bottom: var(--card-border-width);
+  }
+}
+
+@media screen and (max-width: 749px) {
+  .collage--collapsed-y:not(.collage--mobile) .collage__item :where(.card--card, .collage-card):after,
+  .collage--collapsed-y:not(.collage--mobile) .collage__item .card--standard .card__inner:after,
+  .collage--collapsed-y.collage--mobile .collage__item--right:nth-child(3n) :where(.card--card, .collage-card):after,
+  .collage--collapsed-y.collage--mobile .collage__item--right:nth-child(3n) .card--standard .card__inner:after {
+    margin-top: var(--card-border-width);
+  }
+
+  .collage--mobile.collage--collapsed-y .collage__item--left:nth-child(3n - 2) :where(.card--card, .collage-card):after,
+  .collage--mobile.collage--collapsed-y .collage__item--left:nth-child(3n - 2) .card--standard .card__inner:after {
+    margin-bottom: var(--card-border-width);
+  }
+
+  .collage--mobile.collage--collapsed-x .collage__item--left:nth-child(3n) :where(.card--card, .collage-card):after,
+  .collage--mobile.collage--collapsed-x .collage__item--left:nth-child(3n) .card--standard .card__inner:after {
+    margin-left: var(--card-border-width);
+  }
+
+  .collage--mobile.collage--collapsed-x .collage__item--right:nth-child(3n - 2) :where(.card--card, .collage-card):after,
+  .collage--mobile.collage--collapsed-x .collage__item--right:nth-child(3n - 2) .card--standard .card__inner:after {
+    margin-right: var(--card-border-width);
+  }
 }

--- a/assets/component-card.css
+++ b/assets/component-card.css
@@ -26,9 +26,9 @@
 .card--standard .card__inner:after {
   content: '';
   position: absolute;
-  width: calc(var(--card-border-width) * 2 + 100%);
-  height: calc(var(--card-border-width) * 2 + 100%);
   top: calc(var(--card-border-width) * -1);
+  right: calc(var(--card-border-width) * -1);
+  bottom: calc(var(--card-border-width) * -1);
   left: calc(var(--card-border-width) * -1);
   z-index: -1;
   border-radius: var(--card-corner-radius);
@@ -45,6 +45,21 @@
 .card--card .card__inner .card__media {
   border-bottom-right-radius: 0;
   border-bottom-left-radius: 0;
+}
+
+.grid--collapsed-y.contains-card .card-wrapper {
+  height: calc(100% - var(--collapsed-offset-y));
+}
+
+.grid--collapsed.contains-card .card {
+  margin-bottom: var(--collapsed-offset-y);
+  margin-right: var(--collapsed-offset-x);
+}
+
+.grid--collapsed.contains-card .card--card:after,
+.grid--collapsed.contains-card .card--standard .card__inner:after {
+  margin-top: var(--collapsed-shadow-offset-y);
+  margin-left: var(--collapsed-shadow-offset-x);
 }
 
 .card--standard.card--text {

--- a/assets/component-card.css
+++ b/assets/component-card.css
@@ -51,6 +51,11 @@
   height: calc(100% - var(--collapsed-offset-y));
 }
 
+.grid--collapsed.contains-card {
+  padding-bottom: var(--collapsed-offset-y);
+  margin-right: var(--collapsed-offset-x);
+}
+
 .grid--collapsed.contains-card .card {
   margin-bottom: var(--collapsed-offset-y);
   margin-right: var(--collapsed-offset-x);

--- a/assets/component-slider.css
+++ b/assets/component-slider.css
@@ -43,6 +43,16 @@ slider-component {
   .slider.slider--mobile.contains-content-container .slider__slide {
     --focus-outline-padding: 0rem;
   }
+
+  .grid--collapsed.slider--mobile .slider__slide {
+    --collapsed-offset-y: 0px;
+    --collapsed-shadow-offset-y: 0px;
+    --collapsed-shadow-offset-x: var(--border-width) !important;
+  }
+
+  .grid--collapsed.slider--mobile .slider__slide:first-child {
+    --collapsed-shadow-offset-x: 0px !important;
+  }
 }
 
 @media screen and (min-width: 750px) {
@@ -86,6 +96,17 @@ slider-component {
   .slider.slider--tablet.contains-content-container .slider__slide {
     --focus-outline-padding: 0rem;
   }
+
+  .grid--collapsed.slider--tablet .slider__slide {
+    --collapsed-offset-y: 0px;
+    --collapsed-shadow-offset-y: 0px;
+    --collapsed-shadow-offset-x: var(--border-width) !important;
+  }
+
+  .grid--collapsed.slider--tablet .slider__slide:first-child {
+    --collapsed-shadow-offset-x: 0px !important;
+  }
+
 }
 
 .slider--everywhere {

--- a/assets/component-slider.css
+++ b/assets/component-slider.css
@@ -44,14 +44,14 @@ slider-component {
     --focus-outline-padding: 0rem;
   }
 
-  .grid--collapsed.slider--mobile .slider__slide {
+  .slider.slider--mobile.grid--collapsed .slider__slide {
     --collapsed-offset-y: 0px;
     --collapsed-shadow-offset-y: 0px;
-    --collapsed-shadow-offset-x: var(--border-width) !important;
+    --collapsed-shadow-offset-x: var(--border-width);
   }
 
-  .grid--collapsed.slider--mobile .slider__slide:first-child {
-    --collapsed-shadow-offset-x: 0px !important;
+  .slider.slider--mobile.grid--collapsed .slider__slide:first-child {
+    --collapsed-shadow-offset-x: 0px;
   }
 }
 
@@ -97,14 +97,14 @@ slider-component {
     --focus-outline-padding: 0rem;
   }
 
-  .grid--collapsed.slider--tablet .slider__slide {
+  .slider.slider--tablet.grid--collapsed .slider__slide {
     --collapsed-offset-y: 0px;
     --collapsed-shadow-offset-y: 0px;
-    --collapsed-shadow-offset-x: var(--border-width) !important;
+    --collapsed-shadow-offset-x: var(--border-width);
   }
 
-  .grid--collapsed.slider--tablet .slider__slide:first-child {
-    --collapsed-shadow-offset-x: 0px !important;
+  .slider.slider--tablet.grid--collapsed .slider__slide:first-child {
+    --collapsed-shadow-offset-x: 0px;
   }
 
 }

--- a/assets/grid-collapsed.css
+++ b/assets/grid-collapsed.css
@@ -1,0 +1,77 @@
+.grid--collapsed-x {
+  --collapsed-offset-x: var(--border-width);
+}
+.grid--collapsed-y {
+  --collapsed-offset-y: var(--border-width);
+}
+.grid--collapsed-x .grid__item {
+  --collapsed-offset-x: calc(var(--border-width) * -1);
+  --collapsed-shadow-offset-x: var(--border-width);
+}
+.grid--collapsed-y .grid__item {
+  --collapsed-offset-y: calc(var(--border-width) * -1);
+  --collapsed-shadow-offset-y: var(--border-width);
+}
+
+/* 1 col */
+/* .grid--1-col-tablet-down.grid--collapsed-x,
+.grid--1-col-tablet-down.grid--collapsed-x .grid__item {
+  --collapsed-offset-x: 0px;
+  --collapsed-shadow-offset-x: 0px;
+} */
+.grid--1-col.grid--collapsed-y .grid__item:first-child,
+.grid--1-col-tablet-down.grid--collapsed-y .grid__item:first-child {
+  --collapsed-shadow-offset-y: 0px;
+}
+
+@media screen and (max-width: 989px) {
+  /* 2 col tablet down */
+  .grid--2-col-tablet-down.grid--collapsed-x .grid__item:nth-child(2n + 1) {
+    --collapsed-shadow-offset-x: 0px;
+  }
+  .grid--2-col-tablet-down.grid--collapsed-y .grid__item:nth-child(-n + 2) {
+    --collapsed-shadow-offset-y: 0px;
+  }
+}
+
+@media screen and (min-width: 990px) {
+  /* 2 col desktop */
+  .grid--2-col-desktop.grid--collapsed-x .grid__item:nth-child(2n + 1) {
+    --collapsed-shadow-offset-x: 0px;
+  }
+  .grid--2-col-desktop.grid--collapsed-y .grid__item:nth-child(-n + 2) {
+    --collapsed-shadow-offset-y: 0px;
+  }
+
+  /* 3 col desktop */
+  .grid--3-col-desktop.grid--collapsed-x .grid__item:nth-child(3n + 1) {
+    --collapsed-shadow-offset-x: 0px;
+  }
+  .grid--3-col-desktop.grid--collapsed-y .grid__item:nth-child(-n + 3) {
+    --collapsed-shadow-offset-y: 0px;
+  }
+
+  /* 4 col desktop */
+  .grid--4-col-desktop.grid--collapsed-x .grid__item:nth-child(4n + 1) {
+    --collapsed-shadow-offset-x: 0px;
+  }
+  .grid--4-col-desktop.grid--collapsed-y .grid__item:nth-child(-n + 4) {
+    --collapsed-shadow-offset-y: 0px;
+  }
+
+  /* 5 col desktop */
+  .grid--5-col-desktop.grid--collapsed-x .grid__item:nth-child(5n + 1) {
+    --collapsed-shadow-offset-x: 0px;
+  }
+  .grid--5-col-desktop.grid--collapsed-y .grid__item:nth-child(-n + 5) {
+    --collapsed-shadow-offset-y: 0px;
+  }
+
+  /* 6 col desktop */
+  .grid--6-col-desktop.grid--collapsed-x .grid__item:nth-child(6n + 1) {
+    --collapsed-shadow-offset-x: 0px;
+  }
+  .grid--6-col-desktop.grid--collapsed-y .grid__item:nth-child(-n + 6) {
+    --collapsed-shadow-offset-y: 0px;
+  }
+}

--- a/assets/grid-collapsed.css
+++ b/assets/grid-collapsed.css
@@ -1,9 +1,14 @@
+/* 
+  --collapsed-offset-x/y: the distance to offset an item's border onto the siblings below and to the right
+  --collapsed-shadow-offset-x/y: the distance to offset the overlapping shadows caused by offsetting grid items
+*/
 .grid--collapsed-x {
   --collapsed-offset-x: var(--border-width);
 }
 .grid--collapsed-y {
   --collapsed-offset-y: var(--border-width);
 }
+
 .grid--collapsed-x .grid__item {
   --collapsed-offset-x: calc(var(--border-width) * -1);
   --collapsed-shadow-offset-x: var(--border-width);
@@ -13,64 +18,33 @@
   --collapsed-shadow-offset-y: var(--border-width);
 }
 
-/* 1 col */
-/* .grid--1-col-tablet-down.grid--collapsed-x,
-.grid--1-col-tablet-down.grid--collapsed-x .grid__item {
-  --collapsed-offset-x: 0px;
-  --collapsed-shadow-offset-x: 0px;
-} */
-.grid--1-col.grid--collapsed-y .grid__item:first-child,
-.grid--1-col-tablet-down.grid--collapsed-y .grid__item:first-child {
-  --collapsed-shadow-offset-y: 0px;
-}
-
 @media screen and (max-width: 989px) {
-  /* 2 col tablet down */
+  /* reset shadow origin along first row/col so its flush with grid edge */
+  .grid--1-col-tablet-down.grid--collapsed-x .grid__item,
   .grid--2-col-tablet-down.grid--collapsed-x .grid__item:nth-child(2n + 1) {
     --collapsed-shadow-offset-x: 0px;
   }
+  .grid--1-col-tablet-down.grid--collapsed-y .grid__item:first-child,
   .grid--2-col-tablet-down.grid--collapsed-y .grid__item:nth-child(-n + 2) {
     --collapsed-shadow-offset-y: 0px;
   }
 }
 
 @media screen and (min-width: 990px) {
-  /* 2 col desktop */
-  .grid--2-col-desktop.grid--collapsed-x .grid__item:nth-child(2n + 1) {
-    --collapsed-shadow-offset-x: 0px;
-  }
-  .grid--2-col-desktop.grid--collapsed-y .grid__item:nth-child(-n + 2) {
-    --collapsed-shadow-offset-y: 0px;
-  }
-
-  /* 3 col desktop */
-  .grid--3-col-desktop.grid--collapsed-x .grid__item:nth-child(3n + 1) {
-    --collapsed-shadow-offset-x: 0px;
-  }
-  .grid--3-col-desktop.grid--collapsed-y .grid__item:nth-child(-n + 3) {
-    --collapsed-shadow-offset-y: 0px;
-  }
-
-  /* 4 col desktop */
-  .grid--4-col-desktop.grid--collapsed-x .grid__item:nth-child(4n + 1) {
-    --collapsed-shadow-offset-x: 0px;
-  }
-  .grid--4-col-desktop.grid--collapsed-y .grid__item:nth-child(-n + 4) {
-    --collapsed-shadow-offset-y: 0px;
-  }
-
-  /* 5 col desktop */
-  .grid--5-col-desktop.grid--collapsed-x .grid__item:nth-child(5n + 1) {
-    --collapsed-shadow-offset-x: 0px;
-  }
-  .grid--5-col-desktop.grid--collapsed-y .grid__item:nth-child(-n + 5) {
-    --collapsed-shadow-offset-y: 0px;
-  }
-
-  /* 6 col desktop */
+  /* reset shadow origin along first row/col so its flush with grid edge */
+  .grid--1-col-desktop.grid--collapsed-x .grid__item,
+  .grid--2-col-desktop.grid--collapsed-x .grid__item:nth-child(2n + 1),
+  .grid--3-col-desktop.grid--collapsed-x .grid__item:nth-child(3n + 1),
+  .grid--4-col-desktop.grid--collapsed-x .grid__item:nth-child(4n + 1),
+  .grid--5-col-desktop.grid--collapsed-x .grid__item:nth-child(5n + 1),
   .grid--6-col-desktop.grid--collapsed-x .grid__item:nth-child(6n + 1) {
     --collapsed-shadow-offset-x: 0px;
   }
+  .grid--1-col-desktop.grid--collapsed-y .grid__item:nth-child(1),
+  .grid--2-col-desktop.grid--collapsed-y .grid__item:nth-child(-n + 2),
+  .grid--3-col-desktop.grid--collapsed-y .grid__item:nth-child(-n + 3),
+  .grid--4-col-desktop.grid--collapsed-y .grid__item:nth-child(-n + 4),
+  .grid--5-col-desktop.grid--collapsed-y .grid__item:nth-child(-n + 5),
   .grid--6-col-desktop.grid--collapsed-y .grid__item:nth-child(-n + 6) {
     --collapsed-shadow-offset-y: 0px;
   }

--- a/assets/section-main-blog.css
+++ b/assets/section-main-blog.css
@@ -59,3 +59,35 @@
     padding-bottom: 82.5rem;
   }
 }
+
+.blog--collapsed-y:not(.contains-card--standard) .card-wrapper {
+  height: calc(100% + var(--card-border-width));
+}
+
+.blog--collapsed-x {
+  margin-right: var(--card-border-width);
+}
+
+.blog--collapsed-y:not(.contains-card--standard) {
+  margin-bottom: var(--card-border-width);
+}
+
+.blog--collapsed-x .card {
+  margin-right: calc(var(--card-border-width) * -1);
+}
+
+.blog--collapsed-y:not(.contains-card--standard) .card {
+  margin-bottom: calc(var(--card-border-width) * -1);
+}
+
+.blog--collapsed-x:not(.blog-articles--collage) .article:nth-child(even) .card--card:after,
+.blog--collapsed-x:not(.blog-articles--collage) .article:nth-child(even) .card--standard .card__inner:after,
+.blog--collapsed-x.blog-articles--collage .article:nth-child(3n) .card--card:after,
+.blog--collapsed-x.blog-articles--collage .article:nth-child(3n) .card--standard .card__inner:after {
+  margin-left: var(--card-border-width);
+}
+
+.blog--collapsed-y:not(.contains-card--standard).blog-articles--collage .article:not(:first-child) .card:after,
+.blog--collapsed-y:not(.contains-card--standard, .blog-articles--collage) .article:not(:nth-child(-n + 2)) .card:after {
+  margin-top: var(--card-border-width);
+}

--- a/assets/section-main-product.css
+++ b/assets/section-main-product.css
@@ -545,6 +545,10 @@ a.product__text {
     padding: 0 0 0.5rem;
     width: 100%;
   }
+
+  .product__media-list.grid--collapsed .product__media-item {
+    --collapsed-shadow-offset-x: 0px;
+  }
 }
 
 .product__media-icon .icon {
@@ -587,6 +591,10 @@ a.product__text {
   .grid__item.product__media-item--full {
     width: 100%;
   }
+
+  .product__media-list.grid--collapsed-y .product__media-item:first-child {
+    --collapsed-shadow-offset-y: 0px;
+  }
 }
 
 @media screen and (min-width: 990px) {
@@ -597,6 +605,12 @@ a.product__text {
   .product__modal-opener:hover .product__media-icon,
   .product__modal-opener:focus .product__media-icon {
     opacity: 1;
+  }
+
+  .product__media-list.grid--collapsed-x .product__media-item:first-child,
+  .product__media-list.grid--collapsed-x .product__media-item--full,
+  .product__media-list.grid--collapsed-x .product__media-item:nth-child(even) {
+    --collapsed-shadow-offset-x: 0px;
   }
 }
 

--- a/assets/section-multicolumn.css
+++ b/assets/section-multicolumn.css
@@ -58,7 +58,6 @@
 
 .multicolumn:not(.background-none) .multicolumn-card {
   background: rgb(var(--color-background));
-  height: 100%;
 }
 
 .multicolumn.background-primary .multicolumn-card {
@@ -199,6 +198,11 @@
 .multicolumn-card {
   position: relative;
   box-sizing: border-box;
+  height: 100%;
+}
+
+.grid--collapsed.contains-content-container .multicolumn-card {
+  height: calc(100% - var(--collapsed-offset-y));
 }
 
 .multicolumn-card > .multicolumn-card__image-wrapper--full-width:not(.multicolumn-card-spacing) {

--- a/config/settings_schema.json
+++ b/config/settings_schema.json
@@ -167,7 +167,7 @@
       {
         "type": "range",
         "id": "spacing_grid_horizontal",
-        "min": 4,
+        "min": 0,
         "max": 40,
         "step": 4,
         "default": 8,
@@ -177,7 +177,7 @@
       {
         "type": "range",
         "id": "spacing_grid_vertical",
-        "min": 4,
+        "min": 0,
         "max": 40,
         "step": 4,
         "default": 8,

--- a/layout/theme.liquid
+++ b/layout/theme.liquid
@@ -191,6 +191,10 @@
 
     {{ 'base.css' | asset_url | stylesheet_tag }}
 
+    {%- if settings.spacing_grid_horizontal == 0 or settings.spacing_grid_vertical -%}
+      {{ 'grid-collapsed.css' | asset_url | stylesheet_tag }}
+    {%- endif -%}
+
     {%- unless settings.type_body_font.system? -%}
       <link rel="preload" as="font" href="{{ settings.type_body_font | font_url }}" type="font/woff2" crossorigin>
     {%- endunless -%}

--- a/sections/collage.liquid
+++ b/sections/collage.liquid
@@ -19,10 +19,20 @@
 
 <link rel="stylesheet" href="{{ 'component-deferred-media.css' | asset_url }}" media="print" onload="this.media='all'">
 
+{%- liquid
+  if settings.spacing_grid_horizontal == 0 and settings.spacing_grid_vertical == 0 and settings.card_style == 'card'
+    assign collapsed_class = 'collage--collapsed collage--collapsed-x collage--collapsed-y'
+  elsif settings.spacing_grid_horizontal == 0
+    assign collapsed_class = 'collage--collapsed collage--collapsed-x'
+  elsif settings.spacing_grid_vertical == 0 and settings.card_style == 'card'
+    assign collapsed_class = 'collage--collapsed collage--collapsed-y'
+  endif
+-%}
+
 <div class="color-{{ section.settings.color_scheme }} gradient isolate">
   <div class="page-width{% if section.settings.heading == blank %} no-heading{% endif %} section-{{ section.id }}-padding">
     <h2 class="collage-wrapper-title {{ section.settings.heading_size }}">{{ section.settings.heading | escape }}</h2>
-    <div class="collage{% if section.settings.mobile_layout == 'collage' %} collage--mobile{% endif %}">
+    <div class="{{ collapsed_class }} collage{% if section.settings.mobile_layout == 'collage' %} collage--mobile{% endif %}">
       {%- for block in section.blocks -%}
         <div class="collage__item collage__item--{{ block.type }} collage__item--{{ section.settings.desktop_layout }}" {{ block.shopify_attributes }}>
           {%- case block.type -%}

--- a/sections/collection-list.liquid
+++ b/sections/collection-list.liquid
@@ -24,6 +24,14 @@
   if section.settings.swipe_on_mobile and section.blocks.size > columns_mobile_int
     assign show_mobile_slider = true
   endif
+
+  if settings.spacing_grid_horizontal == 0 and settings.spacing_grid_vertical == 0 and settings.card_style == 'card'
+    assign collapsed_class = 'grid--collapsed grid--collapsed-x grid--collapsed-y'
+  elsif settings.spacing_grid_horizontal == 0
+    assign collapsed_class = 'grid--collapsed grid--collapsed-x'
+  elsif settings.spacing_grid_vertical == 0 and settings.card_style == 'card'
+    assign collapsed_class = 'grid--collapsed grid--collapsed-y'
+  endif
 -%}
 
 <div class="color-{{ section.settings.color_scheme }} gradient">
@@ -39,7 +47,7 @@
     {%- endunless -%}
   
     <slider-component class="slider-mobile-gutter">
-      <ul class="collection-list contains-card{% if settings.card_style == 'standard' %} contains-card--standard{% endif %} grid grid--{{ section.settings.columns_desktop }}-col-desktop grid--{{ section.settings.columns_mobile }}-col-tablet-down{% if section.settings.swipe_on_mobile %} slider slider--tablet grid--peek{% endif %} collection-list--{{ section.blocks.size }}-items"
+      <ul class="collection-list contains-card{% if settings.card_style == 'standard' %} contains-card--standard{% endif %} grid grid--{{ section.settings.columns_desktop }}-col-desktop grid--{{ section.settings.columns_mobile }}-col-tablet-down {{ collapsed_class }}{% if section.settings.swipe_on_mobile %} slider slider--tablet grid--peek{% endif %} collection-list--{{ section.blocks.size }}-items"
         id="Slider-{{ section.id }}"
         role="list"
       >

--- a/sections/featured-blog.liquid
+++ b/sections/featured-blog.liquid
@@ -29,6 +29,14 @@
     assign posts_exceed_limit = true
     assign posts_displayed = section.settings.post_limit
   endif
+
+  if settings.spacing_grid_horizontal == 0 and settings.spacing_grid_vertical == 0 and settings.card_style == 'card'
+    assign collapsed_class = 'grid--collapsed grid--collapsed-x grid--collapsed-y'
+  elsif settings.spacing_grid_horizontal == 0
+    assign collapsed_class = 'grid--collapsed grid--collapsed-x'
+  elsif settings.spacing_grid_vertical == 0 and settings.card_style == 'card'
+    assign collapsed_class = 'grid--collapsed grid--collapsed-y'
+  endif
 -%}
 <div class="blog color-{{ section.settings.color_scheme }} gradient{% if section.settings.heading == blank %} no-heading{% endif %}">
   <div class="page-width-desktop isolate{% if posts_displayed < 3 %} page-width-tablet{% endif %} section-{{ section.id }}-padding">
@@ -48,7 +56,7 @@
     {%- if section.settings.blog != blank and section.settings.blog.articles_count > 0 -%}
       <slider-component class="slider-mobile-gutter">
         <ul id="Slider-{{ section.id }}"
-          class="blog__posts articles-wrapper contains-card{% if settings.card_style == 'standard' %} contains-card--standard{% endif %} grid grid--peek grid--2-col-tablet grid--{{ section.settings.columns_desktop }}-col-desktop slider {% if posts_displayed > 2 %}slider--tablet{% else %}slider--mobile{% endif %}"
+          class="blog__posts articles-wrapper contains-card{% if settings.card_style == 'standard' %} contains-card--standard{% endif %} grid grid--peek grid--2-col-tablet grid--{{ section.settings.columns_desktop }}-col-desktop slider {{ collapsed_class }}{% if posts_displayed > 2 %} slider--tablet{% else %} slider--mobile{% endif %}"
           role="list"
         >
           {%- for article in section.settings.blog.articles limit: section.settings.post_limit -%}

--- a/sections/featured-collection.liquid
+++ b/sections/featured-collection.liquid
@@ -34,6 +34,14 @@
   if section.settings.swipe_on_mobile and products_to_display > columns_mobile_int
     assign show_mobile_slider = true
   endif
+
+  if settings.spacing_grid_horizontal == 0 and settings.spacing_grid_vertical == 0 and settings.card_style == 'card'
+    assign collapsed_class = 'grid--collapsed grid--collapsed-x grid--collapsed-y'
+  elsif settings.spacing_grid_horizontal == 0
+    assign collapsed_class = 'grid--collapsed grid--collapsed-x'
+  elsif settings.spacing_grid_vertical == 0 and settings.card_style == 'card'
+    assign collapsed_class = 'grid--collapsed grid--collapsed-y'
+  endif
 -%}
 
 <div class="color-{{ section.settings.color_scheme }} isolate gradient">
@@ -49,7 +57,7 @@
     {%- endunless -%}
   
     <slider-component class="slider-mobile-gutter">
-      <ul id="Slider-{{ section.id }}" class="grid product-grid contains-card{% if settings.card_style == 'standard' %} contains-card--standard{% endif %} grid--{{ section.settings.columns_desktop }}-col-desktop {% if section.settings.collection == blank %} grid--2-col-tablet-down{% else %} grid--{{ section.settings.columns_mobile }}-col-tablet-down{% endif %}{% if show_mobile_slider %} slider slider--tablet grid--peek{% endif %}" role="list">
+      <ul id="Slider-{{ section.id }}" class="grid product-grid contains-card{% if settings.card_style == 'standard' %} contains-card--standard{% endif %} {{ collapsed_class }} grid--{{ section.settings.columns_desktop }}-col-desktop {% if section.settings.collection == blank %} grid--2-col-tablet-down{% else %} grid--{{ section.settings.columns_mobile }}-col-tablet-down{% endif %}{% if show_mobile_slider %} slider slider--tablet grid--peek{% endif %}" role="list">
         {%- for product in section.settings.collection.products limit: section.settings.products_to_show -%}
           <li id="Slide-{{ section.id }}-{{ forloop.index }}" class="grid__item{% if show_mobile_slider %} slider__slide{% endif %}">
             {% render 'card-product',

--- a/sections/main-blog.liquid
+++ b/sections/main-blog.liquid
@@ -16,11 +16,21 @@
   }
 {%- endstyle -%}
 
+{%- liquid
+  if settings.spacing_grid_horizontal == 0 and settings.spacing_grid_vertical == 0 and settings.card_style == 'card'
+    assign collapsed_class = 'grid--collapsed grid--collapsed-x grid--collapsed-y'
+  elsif settings.spacing_grid_horizontal == 0
+    assign collapsed_class = 'grid--collapsed grid--collapsed-x'
+  elsif settings.spacing_grid_vertical == 0 and settings.card_style == 'card'
+    assign collapsed_class = 'grid--collapsed grid--collapsed-y'
+  endif
+-%}
+
 {%- paginate blog.articles by 6 -%}
   <div class="main-blog page-width section-{{ section.id }}-padding">
     <h1 class="title--primary">{{ blog.title | escape }}</h1>
 
-    <div class="blog-articles {% if section.settings.layout == 'collage' %}blog-articles--collage{% endif %}">
+    <div class="{{ collapsed_class }} contains-card blog-articles {% if section.settings.layout == 'collage' %}blog-articles--collage{% endif %}">
       {%- for article in blog.articles -%}
         <div class="blog-articles__article article">
           {%- render 'article-card',

--- a/sections/main-blog.liquid
+++ b/sections/main-blog.liquid
@@ -18,11 +18,11 @@
 
 {%- liquid
   if settings.spacing_grid_horizontal == 0 and settings.spacing_grid_vertical == 0 and settings.card_style == 'card'
-    assign collapsed_class = 'grid--collapsed grid--collapsed-x grid--collapsed-y'
+    assign collapsed_class = 'blog--collapsed blog--collapsed-x blog--collapsed-y'
   elsif settings.spacing_grid_horizontal == 0
-    assign collapsed_class = 'grid--collapsed grid--collapsed-x'
+    assign collapsed_class = 'blog--collapsed blog--collapsed-x'
   elsif settings.spacing_grid_vertical == 0 and settings.card_style == 'card'
-    assign collapsed_class = 'grid--collapsed grid--collapsed-y'
+    assign collapsed_class = 'blog--collapsed blog--collapsed-y'
   endif
 -%}
 

--- a/sections/main-collection-product-grid.liquid
+++ b/sections/main-collection-product-grid.liquid
@@ -21,6 +21,16 @@
   }
 {%- endstyle -%}
 
+{%- liquid
+  if settings.spacing_grid_horizontal == 0 and settings.spacing_grid_vertical == 0 and settings.card_style == 'card'
+    assign collapsed_class = 'grid--collapsed grid--collapsed-x grid--collapsed-y'
+  elsif settings.spacing_grid_horizontal == 0
+    assign collapsed_class = 'grid--collapsed grid--collapsed-x'
+  elsif settings.spacing_grid_vertical == 0 and settings.card_style == 'card'
+    assign collapsed_class = 'grid--collapsed grid--collapsed-y'
+  endif
+-%}
+
 <div class="section-{{ section.id }}-padding">
   {%- if section.settings.enable_filtering or section.settings.enable_sorting -%}
     {{ 'component-facets.css' | asset_url | stylesheet_tag }}
@@ -48,6 +58,7 @@
           <div class="loading-overlay gradient"></div>
   
           <ul id="product-grid" data-id="{{ section.id }}" class="
+            {{ collapsed_class }} contains-card
             grid product-grid grid--{{ section.settings.columns_mobile }}-col-tablet-down
             grid--{{ section.settings.columns_desktop }}-col-desktop">
             {%- for product in collection.products -%}

--- a/sections/main-list-collections.liquid
+++ b/sections/main-list-collections.liquid
@@ -14,8 +14,16 @@
     if section.settings.sort == 'products_high' or section.settings.sort == 'date_reversed' or section.settings.sort == 'alphabetical_reversed'
       assign collections = collections | reverse
     endif
+
+    if settings.spacing_grid_horizontal == 0 and settings.spacing_grid_vertical == 0 and settings.card_style == 'card'
+      assign collapsed_class = 'grid--collapsed grid--collapsed-x grid--collapsed-y'
+    elsif settings.spacing_grid_horizontal == 0
+      assign collapsed_class = 'grid--collapsed grid--collapsed-x'
+    elsif settings.spacing_grid_vertical == 0 and settings.card_style == 'card'
+      assign collapsed_class = 'grid--collapsed grid--collapsed-y'
+    endif
   -%}
-  <ul class="collection-list grid grid--1-col grid--3-col-tablet" role="list">
+  <ul class="{{ collapsed_class }} contains-card collection-list grid grid--1-col grid--3-col-tablet" role="list">
     {%- for collection in collections -%}
       <li class="collection-list__item grid__item">
         {% render 'card-collection', card_collection: collection, media_aspect_ratio: section.settings.image_ratio, columns: 3 %}

--- a/sections/main-list-collections.liquid
+++ b/sections/main-list-collections.liquid
@@ -23,7 +23,7 @@
       assign collapsed_class = 'grid--collapsed grid--collapsed-y'
     endif
   -%}
-  <ul class="{{ collapsed_class }} contains-card collection-list grid grid--1-col grid--3-col-tablet" role="list">
+  <ul class="{{ collapsed_class }} contains-card collection-list grid grid--1-col-tablet-down grid--3-col-desktop" role="list">
     {%- for collection in collections -%}
       <li class="collection-list__item grid__item">
         {% render 'card-collection', card_collection: collection, media_aspect_ratio: section.settings.image_ratio, columns: 3 %}

--- a/sections/main-product.liquid
+++ b/sections/main-product.liquid
@@ -31,6 +31,16 @@
   <link id="ModelViewerOverride" rel="stylesheet" href="{{ 'component-model-viewer-ui.css' | asset_url }}" media="print" onload="this.media='all'">
 {%- endif -%}
 
+{%- liquid
+  if settings.spacing_grid_horizontal == 0 and settings.spacing_grid_vertical == 0
+    assign collapsed_class = 'grid--collapsed grid--collapsed-x grid--collapsed-y'
+  elsif settings.spacing_grid_horizontal == 0
+    assign collapsed_class = 'grid--collapsed grid--collapsed-x'
+  elsif settings.spacing_grid_vertical == 0
+    assign collapsed_class = 'grid--collapsed grid--collapsed-y'
+  endif
+-%}
+
 <section class="page-width section-{{ section.id }}-padding">
   <div class="product product--{{ section.settings.media_size }} product--{{ section.settings.gallery_layout }} grid grid--1-col {% if product.media.size > 0 %}grid--2-col-tablet{% else %}product--no-media{% endif %}">
     <div class="grid__item product__media-wrapper">
@@ -40,7 +50,7 @@
           <a class="skip-to-content-link button visually-hidden" href="#ProductInfo-{{ section.id }}">
             {{ "accessibility.skip_to_product_info" | t }}
           </a>
-          <ul id="Slider-Gallery-{{ section.id }}" class="product__media-list grid grid--peek list-unstyled slider slider--mobile" role="list">
+          <ul id="Slider-Gallery-{{ section.id }}" class="{{ collapsed_class }} contains-media product__media-list grid grid--peek list-unstyled slider slider--mobile" role="list">
             {%- liquid
               assign variant_images = product.images | where: 'attached_to_variant?', true | map: 'src'
               assign media_count = product.media.size

--- a/sections/main-search.liquid
+++ b/sections/main-search.liquid
@@ -44,6 +44,14 @@
   assign sort_by = search.sort_by | default: search.default_sort_by
   assign terms = search.terms | escape
   assign search_url = '?q=' | append: terms | append: '&options%5Bprefix%5D=last&sort_by=' | append: sort_by
+  
+  if settings.spacing_grid_horizontal == 0 and settings.spacing_grid_vertical == 0 and settings.card_style == 'card'
+    assign collapsed_class = 'grid--collapsed grid--collapsed-x grid--collapsed-y'
+  elsif settings.spacing_grid_horizontal == 0
+    assign collapsed_class = 'grid--collapsed grid--collapsed-x'
+  elsif settings.spacing_grid_vertical == 0 and settings.card_style == 'card'
+    assign collapsed_class = 'grid--collapsed grid--collapsed-y'
+  endif
 -%}
 
 {%- style -%}
@@ -154,7 +162,7 @@
         {% paginate search.results by 24 %}
           <div class="template-search__results collection page-width" id="product-grid" data-id="{{ section.id }}">
             <div class="loading-overlay gradient"></div>
-            <ul class="grid product-grid  grid--{{ section.settings.columns_mobile }}-col-tablet-down grid--{{ section.settings.columns_desktop }}-col-desktop" role="list">
+            <ul class="grid product-grid contains-card grid--{{ section.settings.columns_mobile }}-col-tablet-down grid--{{ section.settings.columns_desktop }}-col-desktop {{ collapsed_class }}" role="list">
               {%- for item in search.results -%}
                 {% assign lazy_load = false %}
                 {%- if forloop.index > 2 -%}

--- a/sections/multicolumn.liquid
+++ b/sections/multicolumn.liquid
@@ -22,6 +22,14 @@
   if section.settings.swipe_on_mobile and section.blocks.size > columns_mobile_int
     assign show_mobile_slider = true
   endif
+
+  if settings.spacing_grid_horizontal == 0 and settings.spacing_grid_vertical == 0
+    assign collapsed_class = 'grid--collapsed grid--collapsed-x grid--collapsed-y'
+  elsif settings.spacing_grid_horizontal == 0
+    assign collapsed_class = 'grid--collapsed grid--collapsed-x'
+  elsif settings.spacing_grid_vertical == 0
+    assign collapsed_class = 'grid--collapsed grid--collapsed-y'
+  endif
 -%}
 
 <div class="multicolumn color-{{ section.settings.color_scheme }} gradient{% unless section.settings.background_style == 'none' and settings.text_boxes_border_thickness > 0 or settings.text_boxes_shadow_opacity > 0 %} background-{{ section.settings.background_style }}{% endunless %}{% if section.settings.title == blank %} no-heading{% endif %}">
@@ -37,7 +45,7 @@
       </div>
     {%- endunless -%}
     <slider-component class="slider-mobile-gutter">
-      <ul class="multicolumn-list contains-content-container grid grid--{{ section.settings.columns_mobile }}-col-tablet-down grid--{{ section.settings.columns_desktop }}-col-desktop{% if show_mobile_slider %} slider slider--mobile grid--peek{% endif %}"
+      <ul class="multicolumn-list contains-content-container grid grid--{{ section.settings.columns_mobile }}-col-tablet-down grid--{{ section.settings.columns_desktop }}-col-desktop {{ collapsed_class }}{% if show_mobile_slider %} slider slider--mobile grid--peek{% endif %}"
         id="Slider-{{ section.id }}"
         role="list"
       >

--- a/sections/product-recommendations.liquid
+++ b/sections/product-recommendations.liquid
@@ -20,11 +20,21 @@
   }
 {%- endstyle -%}
 
+{%- liquid
+  if settings.spacing_grid_horizontal == 0 and settings.spacing_grid_vertical == 0 and settings.card_style == 'card'
+    assign collapsed_class = 'grid--collapsed grid--collapsed-x grid--collapsed-y'
+  elsif settings.spacing_grid_horizontal == 0
+    assign collapsed_class = 'grid--collapsed grid--collapsed-x'
+  elsif settings.spacing_grid_vertical == 0 and settings.card_style == 'card'
+    assign collapsed_class = 'grid--collapsed grid--collapsed-y'
+  endif
+-%}
+
 <div class="color-{{ section.settings.color_scheme }} gradient">
   <product-recommendations class="product-recommendations page-width section-{{ section.id }}-padding isolate" data-url="{{ routes.product_recommendations_url }}?section_id={{ section.id }}&product_id={{ product.id }}&limit={{ section.settings.products_to_show }}">
     {% if recommendations.performed and recommendations.products_count > 0 %}
       <h2 class="product-recommendations__heading {{ section.settings.heading_size }}">{{ section.settings.heading | escape }}</h2>
-      <ul class="grid product-grid grid--{{ section.settings.columns_desktop }}-col-desktop grid--{{ section.settings.columns_mobile }}-col-tablet-down" role="list">
+      <ul class="grid product-grid contains-card grid--{{ section.settings.columns_desktop }}-col-desktop grid--{{ section.settings.columns_mobile }}-col-tablet-down {{ collapsed_class }}" role="list">
         {% for recommendation in recommendations.products %}
           <li class="grid__item">
             {% render 'card-product',


### PR DESCRIPTION
**PR Summary:** 

Adds the ability to use 0px grid spacing.

**Why are these changes introduced?**

Fixes #922 

These changes lower the minimum value of the [grid spacing setting](https://screenshot.click/07-19-osiax-m6ak0.png) from `4px` to `0px` and allows for borders on grid items to "collapse" (not [double up](https://screenshot.click/07-56-804ul-hxfwi.png) against adjacent items). The double border and corner radius effect is why we didn't initially enable` 0px` spacing.

Right now, this PR only addresses _border_ collapsing. The _corner radius_ collapsing aspect also needs to be accounted for, but will be handled in a separate branch which I will link to here.

**What approach did you take?**

 **Achieving the collapsed borders**
tl;dr I've chosen to "collapse" the borders by applying negative margins equal to the border width to grid items. 
<details>
<summary>Achieving the collapsed borders continued...</summary>
A small caveat with this, right now it's actually the `card` or `content-container` element within a grid__item that I'm offsetting, rather than the grid item itself. This is because our grid doesn't currently store the number of columns in a css var and we'd need that info to calculate the proper counter-offset for the grid list. I see this as a change we can make after further grid refactoring if we want to.
<br/><br/>
In addition to `--collapsed-offset-x` there's also a `collapsed-shadow-offset-x` variable being used. This is used to modify the bounds of the shadow [pseudo element] so they don't overlap with adjacent shadows. 
<img src="https://screenshot.click/07-07-iu37u-s4ik1.png" width="300"/>
<br/><br/>
I've looked at many other possibilities such as removing certain borders, halving borders along vertices, using a grid gap and a underlaid background color to create a border, hacking box-shadow and/or drop-shadow filters, etc but I found these all to be either dead ends or more complicated and fragile. If there's an approach I dismissed that might be worth another look, please let me know.
</details>

**Added new css file `grid-collapsed.css`**
Most of the selectors related to collapsed grids have been added to a new css file that only gets loaded if the global spacing setting is set to `0`. The css needed right now may not warrant its own css file, but the amount of code needed will dramatically increase when the corner collapsing is factored in.

**Added new `grid--collapsed-x/y` classes**
Vertical and horizontal spacing settings can be independently set to `0` so we need to be able to handle all 3 scenarios (x-only, y-only, both). The appropriate x or y classes will be applied to inform the necessary selectors. One caveat is that when card style `standard` is selected, we never render the `grid--collapsed-y` on grids that contain cards because it's [not applicable](https://screenshot.click/07-45-20wna-wjf3m.png).

**Collage, Main blog, Product media are special cases**
Product media uses the `grid` class but no `grid--#-col` classes, while collage and main blog don't use `grid` at all. These all have "irregular" 2 column layouts with their own concerns and variations (collage in particular). I'm including the border collapse styles for each of these in their respective css files, since they don't directly relate to the general grid classes referenced in `grid-collapsed.css`.
 
 **Heavy use of css vars**
By relying on css vars like `--collapsed-offset-x` we can set rules within a specific grid item context without needing to be concerned about the specific element or property the value needs to be applied to. It also allows us to extend and override complicated rules with less duplication. This is useful for border collapsing but will be absolutely critical for corner radius styles. It's also allows us to reference a "border width" without having to know which settings that border width is from and which elements its relevant to.

**Other considerations**

⚠️ Visual change
The main collections list page still needs to be equipped with the number of columns settings that other grids have. We should be adding those settings in this PR, but I need to utilize the new grid col class structure that update will impose which is basically a single `grid--#col-tablet-down` and a `grid--#-col-desktop`. This will cause the tablet grid on this page to change from 3 cols (like desktop) to 1 col like mobile.

**Testing steps/scenarios**
- [ ] _List all the testing tasks that applies to your fix and help peers to review your work._

**Demo links**
_Please include a link to a demo store that includes preconfigured sections and settings to allow reviewers to easily test the features you are working on._

- [Store](url)
- [Editor](url)

**Checklist**
- [ ] Added PR summary for [release notes](https://themes.shopify.com/themes/dawn/styles/default#ReleaseNotes)
- [ ] Followed [theme code principles](https://github.com/Shopify/dawn/blob/main/.github/CONTRIBUTING.md#theme-code-principles)
- [ ] Linted with [Theme Check](https://github.com/Shopify/theme-check)
- [ ] Tested on [mobile](https://shopify.dev/themes/store/requirements#mobile-browser-requirements)
- [ ] Tested on [multiple browsers](https://shopify.dev/themes/store/requirements#desktop-browser-requirements)
- [ ] Tested for [accessibility](https://shopify.dev/themes/best-practices/accessibility)
