### PR TITLE
Remove some unused multicolumn styles

### DIFF
--- a/assets/section-multicolumn.css
+++ b/assets/section-multicolumn.css
@@ -111,23 +111,6 @@
   }
 }
 
-
-@media screen and (min-width: 750px) {
-  .multicolumn-list.slider,
-  .multicolumn-list.grid--4-col-desktop {
-    padding: 0;
-  }
-
-  .multicolumn-list__item,
-  .grid--4-col-desktop .multicolumn-list__item {
-    padding-bottom: 0;
-  }
-
-  .background-none .grid--2-col-tablet .multicolumn-list__item {
-    margin-top: 4rem;
-  }
-}
-
 .background-none .multicolumn-card-spacing {
   padding: 0;
   margin: 0;


### PR DESCRIPTION
**PR Summary:** 

Cleans up some unused CSS from multicolumn.

**Why are these changes introduced?**

Multicolumn has gone through a lot of changes and has a lot of unused CSS. This PR specifically removes a couple selectors that will cause issues in another PR. This PR does not intend to take on a wholesale cleanup of the multicolumn stylesheet.

**What approach did you take?**

Removed unused stuff.

**Other considerations**

The issue described in https://github.com/Shopify/dawn/issues/1387 will likely be the most obvious while testing. 

**Testing steps/scenarios**
- Verify no visual regressions
- Ensure toggling various multicolumn settings, particularly the "enable slider" setting doesn't result in different list padding/margin.
- The removed code was in a tablet-up selector so testing mobile viewport is not necessary for this PR.

**Demo links**

- [Editor](https://os2-demo.myshopify.com/admin/themes/127691096086/editor)

**Checklist**
- [ ] Added PR summary for [release notes](https://themes.shopify.com/themes/dawn/styles/default#ReleaseNotes)
- [ ] Followed [theme code principles](https://github.com/Shopify/dawn/blob/main/.github/CONTRIBUTING.md#theme-code-principles)
- [ ] Linted with [Theme Check](https://github.com/Shopify/theme-check)
- [ ] Tested on [mobile](https://shopify.dev/themes/store/requirements#mobile-browser-requirements)
- [ ] Tested on [multiple browsers](https://shopify.dev/themes/store/requirements#desktop-browser-requirements)
- [ ] Tested for [accessibility](https://shopify.dev/themes/best-practices/accessibility)
