### PR TITLE
Implement corner collapsing

### DIFF
--- a/assets/base.css
+++ b/assets/base.css
@@ -2854,11 +2854,11 @@ details-disclosure > details {
 }
 
 .grid--collapsed-x.contains-content-container .content-container:after,
-.grid--collapsed-y.contains-media .global-media-settings:after {
+.grid--collapsed-x.contains-media .global-media-settings:after {
   margin-left: var(--collapsed-shadow-offset-x);
 }
 
-.grid--collapsed-x.contains-content-container .content-container:after,
+.grid--collapsed-y.contains-content-container .content-container:after,
 .grid--collapsed-y.contains-media .global-media-settings:after {
   margin-top: var(--collapsed-shadow-offset-y);
 }

--- a/assets/base.css
+++ b/assets/base.css
@@ -1002,6 +1002,13 @@ summary::-webkit-details-marker {
   }
 }
 
+.grid--collapsed .grid__item {
+  --top-left-radius: var(--border-radius);
+  --top-right-radius: var(--border-radius);
+  --bottom-right-radius: var(--border-radius);
+  --bottom-left-radius: var(--border-radius);
+}
+
 .grid--gapless.grid {
   column-gap: 0;
   row-gap: 0;
@@ -2847,13 +2854,30 @@ details-disclosure > details {
 }
 
 .grid--collapsed-x.contains-content-container .content-container:after,
-.grid--collapsed-x.contains-media .global-media-settings:after {
+.grid--collapsed-y.contains-media .global-media-settings:after {
   margin-left: var(--collapsed-shadow-offset-x);
 }
 
-.grid--collapsed-y.contains-content-container .content-container:after,
+.grid--collapsed-x.contains-content-container .content-container:after,
 .grid--collapsed-y.contains-media .global-media-settings:after {
   margin-top: var(--collapsed-shadow-offset-y);
+}
+
+.grid--collapsed.contains-content-container .content-container,
+.grid--collapsed.contains-media .global-media-settings,
+.grid--collapsed.contains-content-container .content-container:after,
+.grid--collapsed.contains-media .global-media-settings:after {
+  border-radius: var(--top-left-radius) var(--top-right-radius) var(--bottom-right-radius) var(--bottom-left-radius);
+}
+
+.grid--collapsed.contains-media .global-media-settings img,
+.grid--collapsed.contains-media .global-media-settings iframe,
+.grid--collapsed.contains-media .global-media-settings model-viewer,
+.grid--collapsed.contains-media .global-media-settings video {
+  border-top-left-radius: calc(var(--top-left-radius) - var(--media-border-width));
+  border-top-right-radius: calc(var(--top-right-radius) - var(--media-border-width));
+  border-bottom-right-radius: calc(var(--bottom-right-radius) - var(--media-border-width));
+  border-bottom-left-radius: calc(var(--bottom-left-radius) - var(--media-border-width));
 }
 
 /* check for flexbox gap in older Safari versions */

--- a/assets/collage.css
+++ b/assets/collage.css
@@ -270,50 +270,76 @@
 
 @media screen and (min-width: 750px) {
   .collage--collapsed .collage__item:only-child,
-  .collage--collapsed-x .collage__item--left:first-child {
+  .collage--collapsed .collage__item--left:first-child,
+  .collage--collapsed-y:not(.collage--collapsed-x) .collage__item--right:last-child {
     --top-left-radius: var(--card-corner-radius);
     --bottom-left-radius: var(--card-corner-radius);
   }
 
   .collage--collapsed .collage__item:only-child,
-  .collage--collapsed-x .collage__item--right:last-child {
+  .collage--collapsed .collage__item--right:last-child,
+  .collage--collapsed-y:not(.collage--collapsed-x) .collage__item--left:first-child {
     --top-right-radius: var(--card-corner-radius);
     --bottom-right-radius: var(--card-corner-radius);
   }
 
-  .collage--collapsed-x .collage__item--right:first-child {
+  .collage--collapsed-x .collage__item--right:first-child,
+  .collage--collapsed-x:not(.collage--collapsed-y) .collage__item--right:nth-last-child(2),
+  .collage--collapsed-y:not(.collage--collapsed-x) .collage__item--left:nth-child(2),
+  .collage--collapsed-y:not(.collage--collapsed-x) .collage__item--right:first-child,
+  .collage--collapsed-y.contains-card--standard .collage__item--right:first-child:where(.collage__item--product, .collage__item--collection) + .collage__item:nth-last-child(2),
+   .collage--collapsed-y.contains-card--standard:not(.collage--collapsed-x) .collage__item--left:nth-child(2):where(.collage__item--product, .collage__item--collection) + .collage__item {
     --top-left-radius: var(--card-corner-radius);
   }
 
-  .collage--collapsed-x .collage__item--left:nth-child(2) {
+  .collage--collapsed-x .collage__item--left:nth-child(2),
+  .collage--collapsed-x:not(.collage--collapsed-y) .collage__item--left:last-child,
+  .collage--collapsed-y:not(.collage--collapsed-x) .collage__item--left:nth-child(2),
+  .collage--collapsed-y:not(.collage--collapsed-x) .collage__item--right:first-child,
+  .collage--collapsed-y.contains-card--standard .collage__item--left:nth-child(2):where(.collage__item--product, .collage__item--collection) + .collage__item,
+  .collage--collapsed-y.contains-card--standard:not(.collage--collapsed-x) .collage__item--right:first-child:where(.collage__item--product, .collage__item--collection) + .collage__item {
     --top-right-radius: var(--card-corner-radius);
   }
 
-  .collage--collapsed-x .collage__item--left:last-child {
+  .collage--collapsed-x .collage__item--left:last-child,
+  .collage--collapsed-x:not(.collage--collapsed-y) .collage__item--left:nth-child(2),
+  .collage--collapsed-y:not(.collage--collapsed-x) .collage__item--left:last-child,
+  .collage--collapsed-y:not(.collage--collapsed-x) .collage__item--right:nth-last-child(2),
+  .collage--collapsed-y.contains-card--standard .collage__item--left:nth-child(2):where(.collage__item--product, .collage__item--collection),
+  .collage--collapsed-y.contains-card--standard:not(.collage--collapsed-x) .collage__item--right:first-child:where(.collage__item--product, .collage__item--collection) {
     --bottom-right-radius: var(--card-corner-radius);
   }
 
   .collage--collapsed-x .collage__item--right:nth-last-child(2):first-child,
-  .collage--collapsed-x .collage__item--right:nth-child(3n - 1):not(:last-child),
-  .collage--collapsed-x .collage__item--right:nth-child(3n - 2):not(:first-child)  {
+  .collage--collapsed-x .collage__item--right:nth-child(2):not(:last-child),
+  .collage--collapsed-x:not(.collage--collapsed-y) .collage__item--right:first-child,
+  .collage--collapsed-y:not(.collage--collapsed-x) .collage__item--left:last-child,
+  .collage--collapsed-y:not(.collage--collapsed-x) .collage__item--right:nth-last-child(2),
+  .collage--collapsed-y.contains-card--standard .collage__item--right:first-child:where(.collage__item--product, .collage__item--collection),
+  .collage--collapsed-y.contains-card--standard:not(.collage--collapsed-x) .collage__item--left:nth-child(2):where(.collage__item--product, .collage__item--collection) {
     --bottom-left-radius: var(--card-corner-radius);
   }
+
 }
 
 @media screen and (max-width: 749px) {
-  .collage--collapsed-y .collage__item--left:nth-last-child(3n),
+  .collage--collapsed-y .collage__item--left:nth-last-child(3),
   .collage--collapsed-y:not(.collage--mobile) .collage__item:first-child,
+  .collage--collapsed-x:not(.collage--collapsed-y):not(.collage--mobile) .collage__item,
   .collage--collapsed-x:not(.collage--collapsed-y).collage--mobile .collage__item--left:nth-last-child(3),
   .collage--collapsed-x:not(.collage--collapsed-y).collage--mobile .collage__item--right:nth-child(3),
-  .collage--collapsed-y:not(.collage--collapsed-x).collage--mobile .collage__item--right:nth-child(-n + 2) {
+  .collage--collapsed-y:not(.collage--collapsed-x).collage--mobile .collage__item--right:nth-child(-n + 2),
+  .collage--collapsed-y.contains-card--standard:not(.collage--mobile) .collage__item:where(.collage__item--product, .collage__item--collection) + .collage__item {
     --top-left-radius: var(--card-corner-radius);
     --top-right-radius: var(--card-corner-radius);
   }
 
   .collage--collapsed-y:not(.collage--mobile) .collage__item:last-child,
+  .collage--collapsed-x:not(.collage--collapsed-y):not(.collage--mobile) .collage__item,
   .collage--collapsed-x:not(.collage--collapsed-y).collage--mobile .collage__item--left:nth-last-child(3),
   .collage--collapsed-x:not(.collage--collapsed-y).collage--mobile .collage__item--right:nth-child(3),
-  .collage--collapsed-y:not(.collage--collapsed-x).collage--mobile .collage__item--left:nth-last-child(-n + 2) {
+  .collage--collapsed-y:not(.collage--collapsed-x).collage--mobile .collage__item--left:nth-last-child(-n + 2),
+  .collage--collapsed-y.contains-card--standard:not(.collage--mobile) .collage__item:where(.collage__item--product, .collage__item--collection) {
     --bottom-left-radius: var(--card-corner-radius);
     --bottom-right-radius: var(--card-corner-radius);
   }
@@ -330,16 +356,22 @@
     --bottom-right-radius: var(--card-corner-radius);
   }
 
-  .collage--collapsed-y .collage__item:first-child {
+  .collage--collapsed-y .collage__item:first-child,
+  .collage--collapsed-y.collage--mobile.contains-card--standard .collage__item--right:first-child:where(.collage__item--product, .collage__item--collection) ~ .collage__item:nth-child(3),
+  .collage--collapsed-y.collage--mobile.contains-card--standard .collage__item--left:nth-last-child(3):where(.collage__item--product, .collage__item--collection) + .collage__item:nth-child(2) {
     --top-left-radius: var(--card-corner-radius);
   }
 
   .collage--collapsed-x.collage--mobile .collage__item--right:nth-child(2),
-  .collage--collapsed-x.collage--mobile .collage__item:nth-last-child(3n - 2):not(:nth-child(3)) {
+  .collage--collapsed-x.collage--mobile .collage__item:last-child:not(:nth-child(3)),
+  .collage--collapsed-y.collage--mobile.contains-card--standard .collage__item--right:nth-child(2):where(.collage__item--product, .collage__item--collection) + .collage__item,
+  .collage--collapsed-y.collage--mobile.contains-card--standard .collage__item--left:first-child:where(.collage__item--product, .collage__item--collection) ~ .collage__item:nth-child(3) {
     --top-right-radius: var(--card-corner-radius);
   }
 
-  .collage--collapsed.collage--mobile .collage__item:last-child {
+  .collage--collapsed.collage--mobile .collage__item:last-child,
+  .collage--collapsed-y.collage--mobile.contains-card--standard .collage__item--right:nth-child(2):where(.collage__item--product, .collage__item--collection),
+  .collage--collapsed-y.collage--mobile.contains-card--standard .collage__item--left:nth-last-child(3):where(.collage__item--product, .collage__item--collection) {
     --bottom-right-radius: var(--card-corner-radius);
   }
 
@@ -347,7 +379,8 @@
   .collage--collapsed-x.collage--mobile .collage__item--right:nth-last-child(2):first-child,
   .collage--collapsed-y:not(.collage--collapsed-x).collage--mobile .collage__item--left:nth-child(2),
   .collage--collapsed-y.collage--mobile .collage__item--right:nth-child(3),
-  .collage--collapsed-x.collage--mobile .collage__item--left:nth-last-child(3n - 1) {
+  .collage--collapsed-x.collage--mobile .collage__item--left:nth-last-child(2),
+  .collage--collapsed-y.collage--mobile.contains-card--standard .collage__item:first-child:where(.collage__item--product, .collage__item--collection) {
     --bottom-left-radius: var(--card-corner-radius);
   }
 }

--- a/assets/collage.css
+++ b/assets/collage.css
@@ -329,7 +329,9 @@
   .collage--collapsed-x:not(.collage--collapsed-y).collage--mobile .collage__item--left:nth-last-child(3),
   .collage--collapsed-x:not(.collage--collapsed-y).collage--mobile .collage__item--right:nth-child(3),
   .collage--collapsed-y:not(.collage--collapsed-x).collage--mobile .collage__item--right:nth-child(-n + 2),
-  .collage--collapsed-y.contains-card--standard:not(.collage--mobile) .collage__item:where(.collage__item--product, .collage__item--collection) + .collage__item {
+  .collage--collapsed-y.contains-card--standard:not(.collage--mobile) .collage__item:where(.collage__item--product, .collage__item--collection) + .collage__item,
+  .collage--collapsed-y:not(.collage--collapsed-x).collage--mobile .collage__item--left:nth-child(2):last-child,
+  .collage--collapsed-y:not(.collage--collapsed-x).collage--mobile .collage__item--left:nth-last-child(2):first-child {
     --top-left-radius: var(--card-corner-radius);
     --top-right-radius: var(--card-corner-radius);
   }
@@ -339,7 +341,9 @@
   .collage--collapsed-x:not(.collage--collapsed-y).collage--mobile .collage__item--left:nth-last-child(3),
   .collage--collapsed-x:not(.collage--collapsed-y).collage--mobile .collage__item--right:nth-child(3),
   .collage--collapsed-y:not(.collage--collapsed-x).collage--mobile .collage__item--left:nth-last-child(-n + 2),
-  .collage--collapsed-y.contains-card--standard:not(.collage--mobile) .collage__item:where(.collage__item--product, .collage__item--collection) {
+  .collage--collapsed-y.contains-card--standard:not(.collage--mobile) .collage__item:where(.collage__item--product, .collage__item--collection),
+  .collage--collapsed-y:not(.collage--collapsed-x).collage--mobile .collage__item--right:nth-child(2):last-child,
+  .collage--collapsed-y:not(.collage--collapsed-x).collage--mobile .collage__item--right:nth-last-child(2):first-child {
     --bottom-left-radius: var(--card-corner-radius);
     --bottom-right-radius: var(--card-corner-radius);
   }
@@ -358,14 +362,16 @@
 
   .collage--collapsed-y .collage__item:first-child,
   .collage--collapsed-y.collage--mobile.contains-card--standard .collage__item--right:first-child:where(.collage__item--product, .collage__item--collection) ~ .collage__item:nth-child(3),
-  .collage--collapsed-y.collage--mobile.contains-card--standard .collage__item--left:nth-last-child(3):where(.collage__item--product, .collage__item--collection) + .collage__item:nth-child(2) {
+  .collage--collapsed-y.collage--mobile.contains-card--standard .collage__item--left:nth-last-child(3):where(.collage__item--product, .collage__item--collection) + .collage__item:nth-child(2),
+  .collage--collapsed-y:not(.collage--collapsed-x).collage--mobile.contains-card--standard .collage__item--left:nth-last-child(3):where(.collage__item--product, .collage__item--collection) ~ .collage__item {
     --top-left-radius: var(--card-corner-radius);
   }
 
   .collage--collapsed-x.collage--mobile .collage__item--right:nth-child(2),
   .collage--collapsed-x.collage--mobile .collage__item:last-child:not(:nth-child(3)),
   .collage--collapsed-y.collage--mobile.contains-card--standard .collage__item--right:nth-child(2):where(.collage__item--product, .collage__item--collection) + .collage__item,
-  .collage--collapsed-y.collage--mobile.contains-card--standard .collage__item--left:first-child:where(.collage__item--product, .collage__item--collection) ~ .collage__item:nth-child(3) {
+  .collage--collapsed-y.collage--mobile.contains-card--standard .collage__item--left:first-child:where(.collage__item--product, .collage__item--collection) ~ .collage__item:nth-child(3),
+  .collage--collapsed-y:not(.collage--collapsed-x).collage--mobile.contains-card--standard .collage__item--left:nth-last-child(3):where(.collage__item--product, .collage__item--collection) ~ .collage__item {
     --top-right-radius: var(--card-corner-radius);
   }
 

--- a/assets/collage.css
+++ b/assets/collage.css
@@ -133,6 +133,19 @@
   overflow: hidden;
 }
 
+.collage--collapsed .collage-card,
+.collage--collapsed .collage-card:after {
+  border-radius: var(--top-left-radius) var(--top-right-radius) var(--bottom-right-radius) var(--bottom-left-radius);
+}
+
+.collage--collapsed .collage-card .media {
+  border-top-left-radius: calc(var(--top-left-radius) - var(--card-border-width) - var(--card-image-padding));
+  border-top-right-radius: calc(var(--top-right-radius) - var(--card-border-width) - var(--card-image-padding));
+  border-bottom-right-radius: calc(var(--bottom-right-radius) - var(--card-border-width) - var(--card-image-padding));
+  border-bottom-left-radius: calc(var(--bottom-left-radius) - var(--card-border-width) - var(--card-image-padding));
+}
+
+
 .collage-card .deferred-media {
   height: 100%;
   overflow: visible;
@@ -245,5 +258,96 @@
   .collage--mobile.collage--collapsed-x .collage__item--right:first-child :where(.card--card, .collage-card):after,
   .collage--mobile.collage--collapsed-x .collage__item--right:first-child .card--standard .card__inner:after {
     margin-right: var(--card-border-width);
+  }
+}
+
+.collage--collapsed .collage__item {
+  --top-left-radius: 0;
+  --top-right-radius: 0;
+  --bottom-right-radius: 0;
+  --bottom-left-radius: 0;
+}
+
+@media screen and (min-width: 750px) {
+  .collage--collapsed .collage__item:only-child,
+  .collage--collapsed-x .collage__item--left:first-child {
+    --top-left-radius: var(--card-corner-radius);
+    --bottom-left-radius: var(--card-corner-radius);
+  }
+
+  .collage--collapsed .collage__item:only-child,
+  .collage--collapsed-x .collage__item--right:last-child {
+    --top-right-radius: var(--card-corner-radius);
+    --bottom-right-radius: var(--card-corner-radius);
+  }
+
+  .collage--collapsed-x .collage__item--right:first-child {
+    --top-left-radius: var(--card-corner-radius);
+  }
+
+  .collage--collapsed-x .collage__item--left:nth-child(2) {
+    --top-right-radius: var(--card-corner-radius);
+  }
+
+  .collage--collapsed-x .collage__item--left:last-child {
+    --bottom-right-radius: var(--card-corner-radius);
+  }
+
+  .collage--collapsed-x .collage__item--right:nth-last-child(2):first-child,
+  .collage--collapsed-x .collage__item--right:nth-child(3n - 1):not(:last-child),
+  .collage--collapsed-x .collage__item--right:nth-child(3n - 2):not(:first-child)  {
+    --bottom-left-radius: var(--card-corner-radius);
+  }
+}
+
+@media screen and (max-width: 749px) {
+  .collage--collapsed-y .collage__item--left:nth-last-child(3n),
+  .collage--collapsed-y:not(.collage--mobile) .collage__item:first-child,
+  .collage--collapsed-x:not(.collage--collapsed-y).collage--mobile .collage__item--left:nth-last-child(3),
+  .collage--collapsed-x:not(.collage--collapsed-y).collage--mobile .collage__item--right:nth-child(3),
+  .collage--collapsed-y:not(.collage--collapsed-x).collage--mobile .collage__item--right:nth-child(-n + 2) {
+    --top-left-radius: var(--card-corner-radius);
+    --top-right-radius: var(--card-corner-radius);
+  }
+
+  .collage--collapsed-y:not(.collage--mobile) .collage__item:last-child,
+  .collage--collapsed-x:not(.collage--collapsed-y).collage--mobile .collage__item--left:nth-last-child(3),
+  .collage--collapsed-x:not(.collage--collapsed-y).collage--mobile .collage__item--right:nth-child(3),
+  .collage--collapsed-y:not(.collage--collapsed-x).collage--mobile .collage__item--left:nth-last-child(-n + 2) {
+    --bottom-left-radius: var(--card-corner-radius);
+    --bottom-right-radius: var(--card-corner-radius);
+  }
+
+  .collage--collapsed-x:not(.collage--collapsed-y).collage--mobile .collage__item--left:nth-last-child(2),
+  .collage--collapsed-x:not(.collage--collapsed-y).collage--mobile .collage__item--right:first-child {
+    --top-left-radius: var(--card-corner-radius);
+    --bottom-left-radius: var(--card-corner-radius);
+  }
+
+  .collage--collapsed-x:not(.collage--collapsed-y).collage--mobile .collage__item--left:last-child,
+  .collage--collapsed-x:not(.collage--collapsed-y).collage--mobile .collage__item--right:nth-child(2) {
+    --top-right-radius: var(--card-corner-radius);
+    --bottom-right-radius: var(--card-corner-radius);
+  }
+
+  .collage--collapsed-y .collage__item:first-child {
+    --top-left-radius: var(--card-corner-radius);
+  }
+
+  .collage--collapsed-x.collage--mobile .collage__item--right:nth-child(2),
+  .collage--collapsed-x.collage--mobile .collage__item:nth-last-child(3n - 2):not(:nth-child(3)) {
+    --top-right-radius: var(--card-corner-radius);
+  }
+
+  .collage--collapsed.collage--mobile .collage__item:last-child {
+    --bottom-right-radius: var(--card-corner-radius);
+  }
+
+  .collage--collapsed.collage--mobile .collage__item:only-child,
+  .collage--collapsed-x.collage--mobile .collage__item--right:nth-last-child(2):first-child,
+  .collage--collapsed-y:not(.collage--collapsed-x).collage--mobile .collage__item--left:nth-child(2),
+  .collage--collapsed-y.collage--mobile .collage__item--right:nth-child(3),
+  .collage--collapsed-x.collage--mobile .collage__item--left:nth-last-child(3n - 1) {
+    --bottom-left-radius: var(--card-corner-radius);
   }
 }

--- a/assets/component-card.css
+++ b/assets/component-card.css
@@ -43,19 +43,9 @@
 
 .card .card__inner .card__media {
   overflow: hidden;
-  /* Fix for Safari border bug on hover */
-  z-index: 0;
+  z-index: 0; /* Fix for Safari border bug on hover */
   border-radius: calc(var(--card-corner-radius) - var(--card-border-width) - var(--card-image-padding));
 }
-
-.grid[class*='--collapsed'].contains-card .card--card,
-.grid[class*='--collapsed'].contains-card .card--standard .card__inner,
-.grid[class*='--collapsed'].contains-card .card--card:after,
-.grid[class*='--collapsed'].contains-card .card--standard .card__inner:after {
-  border-radius: var(--top-left-radius) var(--top-right-radius) var(--bottom-right-radius) var(--bottom-left-radius);
-}
-
-/* is ^ this better? */
 
 .grid--collapsed.contains-card .card--card,
 .grid--collapsed.contains-card .card--standard .card__inner,

--- a/assets/component-card.css
+++ b/assets/component-card.css
@@ -48,14 +48,33 @@
   border-radius: calc(var(--card-corner-radius) - var(--card-border-width) - var(--card-image-padding));
 }
 
-.grid--collapsed.contains-card .grid__item .card--card,
-.grid--collapsed.contains-card .grid__item .card--standard .card__inner,
-.grid--collapsed.contains-card .grid__item .card--card:after,
-.grid--collapsed.contains-card .grid__item .card--standard .card__inner:after {
+.grid[class*='--collapsed'].contains-card .card--card,
+.grid[class*='--collapsed'].contains-card .card--standard .card__inner,
+.grid[class*='--collapsed'].contains-card .card--card:after,
+.grid[class*='--collapsed'].contains-card .card--standard .card__inner:after {
   border-radius: var(--top-left-radius) var(--top-right-radius) var(--bottom-right-radius) var(--bottom-left-radius);
 }
 
-.grid--collapsed.contains-card .grid__item .card__inner .card__media {
+/* is ^ this better? */
+
+.grid--collapsed.contains-card .card--card,
+.grid--collapsed.contains-card .card--standard .card__inner,
+.grid--collapsed.contains-card .card--card:after,
+.grid--collapsed.contains-card .card--standard .card__inner:after,
+.blog--collapsed .card--card,
+.blog--collapsed .card--standard .card__inner,
+.blog--collapsed .card--card:after,
+.blog--collapsed .card--standard .card__inner:after,
+.collage--collapsed .card--card,
+.collage--collapsed .card--standard .card__inner,
+.collage--collapsed .card--card:after,
+.collage--collapsed .card--standard .card__inner:after {
+  border-radius: var(--top-left-radius) var(--top-right-radius) var(--bottom-right-radius) var(--bottom-left-radius);
+}
+
+.grid--collapsed.contains-card .card__inner .card__media,
+.blog--collapsed .card__inner .card__media,
+.collage--collapsed .card__inner .card__media {
   border-top-left-radius: calc(var(--top-left-radius) - var(--card-border-width) - var(--card-image-padding));
   border-top-right-radius: calc(var(--top-right-radius) - var(--card-border-width) - var(--card-image-padding));
   border-bottom-right-radius: calc(var(--bottom-right-radius) - var(--card-border-width) - var(--card-image-padding));

--- a/assets/component-card.css
+++ b/assets/component-card.css
@@ -48,9 +48,18 @@
   border-radius: calc(var(--card-corner-radius) - var(--card-border-width) - var(--card-image-padding));
 }
 
-.card--card .card__inner .card__media {
-  border-bottom-right-radius: 0;
-  border-bottom-left-radius: 0;
+.grid--collapsed.contains-card .grid__item .card--card,
+.grid--collapsed.contains-card .grid__item .card--standard .card__inner,
+.grid--collapsed.contains-card .grid__item .card--card:after,
+.grid--collapsed.contains-card .grid__item .card--standard .card__inner:after {
+  border-radius: var(--top-left-radius) var(--top-right-radius) var(--bottom-right-radius) var(--bottom-left-radius);
+}
+
+.grid--collapsed.contains-card .grid__item .card__inner .card__media {
+  border-top-left-radius: calc(var(--top-left-radius) - var(--card-border-width) - var(--card-image-padding));
+  border-top-right-radius: calc(var(--top-right-radius) - var(--card-border-width) - var(--card-image-padding));
+  border-bottom-right-radius: calc(var(--bottom-right-radius) - var(--card-border-width) - var(--card-image-padding));
+  border-bottom-left-radius: calc(var(--bottom-left-radius) - var(--card-border-width) - var(--card-image-padding));
 }
 
 .grid--collapsed-y.contains-card .card:where(.card--card, .card--text) {
@@ -87,6 +96,11 @@
 /* vertically offset shadows for card style cards only */
 .grid--collapsed-y.contains-card .card--card:after {
   margin-top: var(--collapsed-shadow-offset-y);
+}
+
+.card.card--card .card__inner .card__media {
+  border-bottom-right-radius: 0;
+  border-bottom-left-radius: 0;
 }
 
 .card--standard.card--text {

--- a/assets/component-slider.css
+++ b/assets/component-slider.css
@@ -61,7 +61,8 @@ slider-component.slider-component-full-width {
     --focus-outline-padding: 0rem;
   }
 
-  .slider.slider--mobile.grid--collapsed .slider__slide {
+  /* certain specificity needed for all rules below, modify with care */
+  .slider.slider--mobile.grid.grid--collapsed .slider__slide {
     --collapsed-offset-y: 0px;
     --collapsed-shadow-offset-y: 0px;
     --collapsed-shadow-offset-x: var(--border-width);
@@ -69,6 +70,23 @@ slider-component.slider-component-full-width {
 
   .slider.slider--mobile.grid--collapsed .slider__slide:first-child {
     --collapsed-shadow-offset-x: 0px;
+  }
+
+  .slider.slider--mobile.grid.grid--collapsed-x .slider__slide.grid__item {
+    --top-left-radius: 0px;
+    --top-right-radius: 0px;
+    --bottom-right-radius: 0px;
+    --bottom-left-radius: 0px;
+  }
+
+  .slider.slider--mobile.grid.grid--collapsed-x .slider__slide.grid__item:first-child {
+    --top-left-radius: var(--border-radius);
+    --bottom-left-radius: var(--border-radius);
+  }
+
+  .slider.slider--mobile.grid.grid--collapsed-x .slider__slide.grid__item:last-child {
+    --top-right-radius: var(--border-radius);
+    --bottom-right-radius: var(--border-radius);
   }
 }
 
@@ -114,14 +132,32 @@ slider-component.slider-component-full-width {
     --focus-outline-padding: 0rem;
   }
 
-  .slider.slider--tablet.grid--collapsed .slider__slide {
+  /* certain specificity needed for all rules below, modify with care */
+  .slider.slider--tablet.grid.grid--collapsed .slider__slide {
     --collapsed-offset-y: 0px;
     --collapsed-shadow-offset-y: 0px;
     --collapsed-shadow-offset-x: var(--border-width);
   }
 
-  .slider.slider--tablet.grid--collapsed .slider__slide:first-child {
+  .slider.slider--tablet.grid.grid--collapsed .slider__slide:first-child {
     --collapsed-shadow-offset-x: 0px;
+  }
+
+  .slider.slider--tablet.grid.grid--collapsed-x .slider__slide.grid__item {
+    --top-left-radius: 0px;
+    --top-right-radius: 0px;
+    --bottom-right-radius: 0px;
+    --bottom-left-radius: 0px;
+  }
+
+  .slider.slider--tablet.grid.grid--collapsed-x .slider__slide:first-child {
+    --top-left-radius: var(--border-radius);
+    --bottom-left-radius: var(--border-radius);
+  }
+
+  .slider.slider--tablet.grid.grid.grid--collapsed-x .slider__slide:last-child {
+    --top-right-radius: var(--border-radius);
+    --bottom-right-radius: var(--border-radius);
   }
 
 }

--- a/assets/component-slider.css
+++ b/assets/component-slider.css
@@ -262,6 +262,23 @@ slider-component.slider-component-full-width {
   .slider.slider--desktop.grid--collapsed .slider__slide:first-child {
     --collapsed-shadow-offset-x: 0px;
   }
+
+  .slider.slider--desktop.grid.grid--collapsed-x .slider__slide.grid__item {
+    --top-left-radius: 0px;
+    --top-right-radius: 0px;
+    --bottom-right-radius: 0px;
+    --bottom-left-radius: 0px;
+  }
+
+  .slider.slider--desktop.grid.grid--collapsed-x .slider__slide.grid__item:first-child {
+    --top-left-radius: var(--border-radius);
+    --bottom-left-radius: var(--border-radius);
+  }
+
+  .slider.slider--desktop.grid.grid.grid--collapsed-x .slider__slide.grid__item:last-child {
+    --top-right-radius: var(--border-radius);
+    --bottom-right-radius: var(--border-radius);
+  }
 }
 
 @media (prefers-reduced-motion) {

--- a/assets/component-slider.css
+++ b/assets/component-slider.css
@@ -79,12 +79,14 @@ slider-component.slider-component-full-width {
     --bottom-left-radius: 0px;
   }
 
-  .slider.slider--mobile.grid.grid--collapsed-x .slider__slide.grid__item:first-child {
+  .slider.slider--mobile.grid.grid--collapsed-x .slider__slide.grid__item:first-child,
+  .slider.slider--mobile.grid--collapsed-y:not(.grid--collapsed-x) .slider__slide.grid__item {
     --top-left-radius: var(--border-radius);
     --bottom-left-radius: var(--border-radius);
   }
 
-  .slider.slider--mobile.grid.grid--collapsed-x .slider__slide.grid__item:last-child {
+  .slider.slider--mobile.grid.grid--collapsed-x .slider__slide.grid__item:last-child,
+  .slider.slider--mobile.grid--collapsed-y:not(.grid--collapsed-x) .slider__slide.grid__item {
     --top-right-radius: var(--border-radius);
     --bottom-right-radius: var(--border-radius);
   }
@@ -150,12 +152,14 @@ slider-component.slider-component-full-width {
     --bottom-left-radius: 0px;
   }
 
-  .slider.slider--tablet.grid.grid--collapsed-x .slider__slide:first-child {
+  .slider.slider--tablet.grid.grid--collapsed-x .slider__slide:first-child,
+  .slider.slider--tablet.grid--collapsed-y:not(.grid--collapsed-x) .slider__slide.grid__item {
     --top-left-radius: var(--border-radius);
     --bottom-left-radius: var(--border-radius);
   }
 
-  .slider.slider--tablet.grid.grid.grid--collapsed-x .slider__slide:last-child {
+  .slider.slider--tablet.grid.grid.grid--collapsed-x .slider__slide:last-child,
+  .slider.slider--tablet.grid--collapsed-y:not(.grid--collapsed-x) .slider__slide.grid__item {
     --top-right-radius: var(--border-radius);
     --bottom-right-radius: var(--border-radius);
   }
@@ -270,12 +274,14 @@ slider-component.slider-component-full-width {
     --bottom-left-radius: 0px;
   }
 
-  .slider.slider--desktop.grid.grid--collapsed-x .slider__slide.grid__item:first-child {
+  .slider.slider--desktop.grid.grid--collapsed-x .slider__slide.grid__item:first-child,
+  .slider.slider--desktop.grid--collapsed-y:not(.grid--collapsed-x) .slider__slide.grid__item {
     --top-left-radius: var(--border-radius);
     --bottom-left-radius: var(--border-radius);
   }
 
-  .slider.slider--desktop.grid.grid.grid--collapsed-x .slider__slide.grid__item:last-child {
+  .slider.slider--desktop.grid.grid.grid--collapsed-x .slider__slide.grid__item:last-child,
+  .slider.slider--desktop.grid--collapsed-y:not(.grid--collapsed-x) .slider__slide.grid__item {
     --top-right-radius: var(--border-radius);
     --bottom-right-radius: var(--border-radius);
   }

--- a/assets/grid-collapsed.css
+++ b/assets/grid-collapsed.css
@@ -1,7 +1,14 @@
 /* 
+  Each block of radius selectors for a particular number of columns is identical and repeatable.
+  Any modification for one block should be made to all.
+  
+  Specificity matters. Modify with caution.
+
   --collapsed-offset-x/y: the distance to offset an item's border onto the siblings below and to the right
   --collapsed-shadow-offset-x/y: the distance to offset the overlapping shadows caused by offsetting grid items
+  --top/bottom-left/right: the radius value of one particular corner of the item
 */
+
 .grid--collapsed-x {
   --collapsed-offset-x: var(--border-width);
 }
@@ -18,6 +25,13 @@
   --collapsed-shadow-offset-y: var(--border-width);
 }
 
+.grid--collapsed .grid__item {
+  --top-left-radius: 0px;
+  --top-right-radius: 0px;
+  --bottom-right-radius: 0px;
+  --bottom-left-radius: 0px;
+}
+
 @media screen and (max-width: 989px) {
   /* reset shadow origin along first row/col so its flush with grid edge */
   .grid--1-col-tablet-down.grid--collapsed-x .grid__item,
@@ -27,6 +41,63 @@
   .grid--1-col-tablet-down.grid--collapsed-y .grid__item:first-child,
   .grid--2-col-tablet-down.grid--collapsed-y .grid__item:nth-child(-n + 2) {
     --collapsed-shadow-offset-y: 0px;
+  }
+
+  .grid--1-col-tablet-down.grid--collapsed:not(.grid--collapsed-y) .grid__item,
+  .grid--1-col-tablet-down.grid--collapsed-y .grid__item:first-child {
+    --top-left-radius: var(--border-radius);
+    --top-right-radius: var(--border-radius);
+  }
+  .grid--1-col-tablet-down.grid--collapsed:not(.grid--collapsed-y) .grid__item,
+  .grid--1-col-tablet-down.grid--collapsed-y .grid__item:last-child {
+    --bottom-left-radius: var(--border-radius);
+    --bottom-right-radius: var(--border-radius);
+  }
+
+  .grid--2-col-tablet-down.grid--collapsed-y:not(.grid--collapsed-x) .grid__item:nth-child(-n + 2) {
+    --top-left-radius: var(--border-radius);
+    --top-right-radius: var(--border-radius);
+  }
+  .grid--2-col-tablet-down.grid--collapsed-y:not(.grid--collapsed-x) .grid__item:nth-last-child(-n + 2) {
+    --bottom-left-radius: var(--border-radius);
+    --bottom-right-radius: var(--border-radius);
+  }
+  .grid--2-col-tablet-down.grid--collapsed-x:not(.grid--collapsed-y) .grid__item:nth-child(2n) {
+    --top-right-radius: var(--border-radius);
+  }
+  .grid--2-col-tablet-down.grid--collapsed-x:not(.grid--collapsed-y) .grid__item:nth-child(2n),
+  .grid--2-col-tablet-down.grid--collapsed-x .grid__item:nth-child(2n):nth-last-child(-n + 2) {
+    --bottom-right-radius: var(--border-radius);
+  }
+  .grid--2-col-tablet-down.grid--collapsed-x .grid__item:nth-child(2n + 1) {
+    --top-left-radius: var(--border-radius);
+    --bottom-left-radius: var(--border-radius);
+  }
+  .grid--2-col-tablet-down.grid--collapsed-y .grid__item:nth-child(2n):nth-last-child(2n + 1) {
+    --bottom-right-radius: 0px;
+  }
+  .grid--2-col-tablet-down.grid--collapsed-y .grid__item:nth-last-child(2n + 1) {
+    --top-right-radius: 0px;
+  }
+  .grid--2-col-tablet-down.grid--collapsed.grid--collapsed-y .grid__item:nth-child(2n + 1) {
+    --bottom-left-radius: 0px;
+  }
+  .grid--2-col-tablet-down.grid--collapsed.grid--collapsed-y .grid__item:nth-child(2n + 1) {
+    --top-left-radius: 0px;
+  }
+  .grid--2-col-tablet-down.grid.grid--collapsed-x:not(.grid--collapsed-y) .grid__item:nth-last-child(1),
+  .grid--2-col-tablet-down.grid.grid--collapsed .grid__item:nth-child(2),
+  .grid--2-col-tablet-down.grid.grid--collapsed .grid__item:nth-child(-n + 2):last-child {
+    --top-right-radius: var(--border-radius);
+  }
+  .grid--2-col-tablet-down.grid.grid--collapsed .grid__item:nth-child(1) {
+    --top-left-radius: var(--border-radius);
+  }
+  .grid--2-col-tablet-down.grid.grid--collapsed .grid__item:nth-last-child(1) {
+    --bottom-right-radius: var(--border-radius);
+  }
+  .grid--2-col-tablet-down.grid.grid--collapsed .grid__item:nth-child(2n + 1):nth-last-child(-n + 2) {
+    --bottom-left-radius: var(--border-radius);
   }
 }
 
@@ -47,5 +118,246 @@
   .grid--5-col-desktop.grid--collapsed-y .grid__item:nth-child(-n + 5),
   .grid--6-col-desktop.grid--collapsed-y .grid__item:nth-child(-n + 6) {
     --collapsed-shadow-offset-y: 0px;
+  }
+
+  .grid--1-col-desktop.grid--collapsed:not(.grid--collapsed-y) .grid__item,
+  .grid--1-col-desktop.grid--collapsed-y .grid__item:first-child {
+    --top-left-radius: var(--border-radius);
+    --top-right-radius: var(--border-radius);
+  }
+  .grid--1-col-desktop.grid--collapsed:not(.grid--collapsed-y) .grid__item,
+  .grid--1-col-desktop.grid--collapsed-y .grid__item:last-child {
+    --bottom-left-radius: var(--border-radius);
+    --bottom-right-radius: var(--border-radius);
+  }
+
+  .grid--2-col-desktop.grid--collapsed-y:not(.grid--collapsed-x) .grid__item:nth-child(-n + 2) {
+    --top-left-radius: var(--border-radius);
+    --top-right-radius: var(--border-radius);
+  }
+  .grid--2-col-desktop.grid--collapsed-y:not(.grid--collapsed-x) .grid__item:nth-last-child(-n + 2) {
+    --bottom-left-radius: var(--border-radius);
+    --bottom-right-radius: var(--border-radius);
+  }
+  .grid--2-col-desktop.grid--collapsed-x:not(.grid--collapsed-y) .grid__item:nth-child(2n) {
+    --top-right-radius: var(--border-radius);
+  }
+  .grid--2-col-desktop.grid--collapsed-x:not(.grid--collapsed-y) .grid__item:nth-child(2n),
+  .grid--2-col-desktop.grid--collapsed-x .grid__item:nth-child(2n):nth-last-child(-n + 2) {
+    --bottom-right-radius: var(--border-radius);
+  }
+  .grid--2-col-desktop.grid--collapsed-x .grid__item:nth-child(2n + 1) {
+    --top-left-radius: var(--border-radius);
+    --bottom-left-radius: var(--border-radius);
+  }
+  .grid--2-col-desktop.grid--collapsed-y .grid__item:nth-child(2n):nth-last-child(2n + 1) {
+    --bottom-right-radius: 0px;
+  }
+  .grid--2-col-desktop.grid--collapsed-y .grid__item:nth-last-child(2n + 1) {
+    --top-right-radius: 0px;
+  }
+  .grid--2-col-desktop.grid--collapsed.grid--collapsed-y .grid__item:nth-child(2n + 1) {
+    --bottom-left-radius: 0px;
+  }
+  .grid--2-col-desktop.grid--collapsed.grid--collapsed-y .grid__item:nth-child(2n + 1) {
+    --top-left-radius: 0px;
+  }
+  .grid--2-col-desktop.grid.grid--collapsed-x:not(.grid--collapsed-y) .grid__item:nth-last-child(1),
+  .grid--2-col-desktop.grid.grid--collapsed .grid__item:nth-child(2),
+  .grid--2-col-desktop.grid.grid--collapsed .grid__item:nth-child(-n + 2):last-child {
+    --top-right-radius: var(--border-radius);
+  }
+  .grid--2-col-desktop.grid.grid--collapsed .grid__item:nth-child(1) {
+    --top-left-radius: var(--border-radius);
+  }
+  .grid--2-col-desktop.grid.grid--collapsed .grid__item:nth-last-child(1) {
+    --bottom-right-radius: var(--border-radius);
+  }
+  .grid--2-col-desktop.grid.grid--collapsed .grid__item:nth-child(2n + 1):nth-last-child(-n + 2) {
+    --bottom-left-radius: var(--border-radius);
+  }
+
+  .grid--3-col-desktop.grid--collapsed-y:not(.grid--collapsed-x) .grid__item:nth-child(-n + 3) {
+    --top-left-radius: var(--border-radius);
+    --top-right-radius: var(--border-radius);
+  }
+  .grid--3-col-desktop.grid--collapsed-y:not(.grid--collapsed-x) .grid__item:nth-last-child(-n + 3) {
+    --bottom-left-radius: var(--border-radius);
+    --bottom-right-radius: var(--border-radius);
+  }
+  .grid--3-col-desktop.grid--collapsed-x:not(.grid--collapsed-y) .grid__item:nth-child(3n) {
+    --top-right-radius: var(--border-radius);
+  }
+  .grid--3-col-desktop.grid--collapsed-x:not(.grid--collapsed-y) .grid__item:nth-child(3n),
+  .grid--3-col-desktop.grid--collapsed-x .grid__item:nth-child(3n):nth-last-child(-n + 3) {
+    --bottom-right-radius: var(--border-radius);
+  }
+  .grid--3-col-desktop.grid--collapsed-x .grid__item:nth-child(3n + 1) {
+    --top-left-radius: var(--border-radius);
+    --bottom-left-radius: var(--border-radius);
+  }
+  .grid--3-col-desktop.grid--collapsed-y .grid__item:nth-child(3n):nth-last-child(3n + 1) {
+    --bottom-right-radius: 0px;
+  }
+  .grid--3-col-desktop.grid--collapsed-y .grid__item:nth-last-child(3n + 1) {
+    --top-right-radius: 0px;
+  }
+  .grid--3-col-desktop.grid--collapsed.grid--collapsed-y .grid__item:nth-child(3n + 1) {
+    --bottom-left-radius: 0px;
+  }
+  .grid--3-col-desktop.grid--collapsed.grid--collapsed-y .grid__item:nth-child(3n + 1) {
+    --top-left-radius: 0px;
+  }
+  .grid--3-col-desktop.grid.grid--collapsed-x:not(.grid--collapsed-y) .grid__item:nth-last-child(1),
+  .grid--3-col-desktop.grid.grid--collapsed .grid__item:nth-child(3),
+  .grid--3-col-desktop.grid.grid--collapsed .grid__item:nth-child(-n + 3):last-child {
+    --top-right-radius: var(--border-radius);
+  }
+  .grid--3-col-desktop.grid.grid--collapsed .grid__item:nth-child(1) {
+    --top-left-radius: var(--border-radius);
+  }
+  .grid--3-col-desktop.grid.grid--collapsed .grid__item:nth-last-child(1) {
+    --bottom-right-radius: var(--border-radius);
+  }
+  .grid--3-col-desktop.grid.grid--collapsed .grid__item:nth-child(3n + 1):nth-last-child(-n + 3) {
+    --bottom-left-radius: var(--border-radius);
+  }
+
+  .grid--4-col-desktop.grid--collapsed-y:not(.grid--collapsed-x) .grid__item:nth-child(-n + 4) {
+    --top-left-radius: var(--border-radius);
+    --top-right-radius: var(--border-radius);
+  }
+  .grid--4-col-desktop.grid--collapsed-y:not(.grid--collapsed-x) .grid__item:nth-last-child(-n + 4) {
+    --bottom-left-radius: var(--border-radius);
+    --bottom-right-radius: var(--border-radius);
+  }
+  .grid--4-col-desktop.grid--collapsed-x:not(.grid--collapsed-y) .grid__item:nth-child(4n) {
+    --top-right-radius: var(--border-radius);
+  }
+  .grid--4-col-desktop.grid--collapsed-x:not(.grid--collapsed-y) .grid__item:nth-child(4n),
+  .grid--4-col-desktop.grid--collapsed-x .grid__item:nth-child(4n):nth-last-child(-n + 4) {
+    --bottom-right-radius: var(--border-radius);
+  }
+  .grid--4-col-desktop.grid--collapsed-x .grid__item:nth-child(4n + 1) {
+    --top-left-radius: var(--border-radius);
+    --bottom-left-radius: var(--border-radius);
+  }
+  .grid--4-col-desktop.grid--collapsed-y .grid__item:nth-child(4n):nth-last-child(4n + 1) {
+    --bottom-right-radius: 0px;
+  }
+  .grid--4-col-desktop.grid--collapsed-y .grid__item:nth-last-child(4n + 1) {
+    --top-right-radius: 0px;
+  }
+  .grid--4-col-desktop.grid--collapsed.grid--collapsed-y .grid__item:nth-child(4n + 1) {
+    --bottom-left-radius: 0px;
+  }
+  .grid--4-col-desktop.grid--collapsed.grid--collapsed-y .grid__item:nth-child(4n + 1) {
+    --top-left-radius: 0px;
+  }
+  .grid--4-col-desktop.grid.grid--collapsed-x:not(.grid--collapsed-y) .grid__item:nth-last-child(1),
+  .grid--4-col-desktop.grid.grid--collapsed .grid__item:nth-child(4),
+  .grid--4-col-desktop.grid.grid--collapsed .grid__item:nth-child(-n + 4):last-child {
+    --top-right-radius: var(--border-radius);
+  }
+  .grid--4-col-desktop.grid.grid--collapsed .grid__item:nth-child(1) {
+    --top-left-radius: var(--border-radius);
+  }
+  .grid--4-col-desktop.grid.grid--collapsed .grid__item:nth-last-child(1) {
+    --bottom-right-radius: var(--border-radius);
+  }
+  .grid--4-col-desktop.grid.grid--collapsed .grid__item:nth-child(4n + 1):nth-last-child(-n + 4) {
+    --bottom-left-radius: var(--border-radius);
+  }
+
+  .grid--5-col-desktop.grid--collapsed-y:not(.grid--collapsed-x) .grid__item:nth-child(-n + 5) {
+    --top-left-radius: var(--border-radius);
+    --top-right-radius: var(--border-radius);
+  }
+  .grid--5-col-desktop.grid--collapsed-y:not(.grid--collapsed-x) .grid__item:nth-last-child(-n + 5) {
+    --bottom-left-radius: var(--border-radius);
+    --bottom-right-radius: var(--border-radius);
+  }
+  .grid--5-col-desktop.grid--collapsed-x:not(.grid--collapsed-y) .grid__item:nth-child(5n) {
+    --top-right-radius: var(--border-radius);
+  }
+  .grid--5-col-desktop.grid--collapsed-x:not(.grid--collapsed-y) .grid__item:nth-child(5n),
+  .grid--5-col-desktop.grid--collapsed-x .grid__item:nth-child(5n):nth-last-child(-n + 5) {
+    --bottom-right-radius: var(--border-radius);
+  }
+  .grid--5-col-desktop.grid--collapsed-x .grid__item:nth-child(5n + 1) {
+    --top-left-radius: var(--border-radius);
+    --bottom-left-radius: var(--border-radius);
+  }
+  .grid--5-col-desktop.grid--collapsed-y .grid__item:nth-child(5n):nth-last-child(5n + 1) {
+    --bottom-right-radius: 0px;
+  }
+  .grid--5-col-desktop.grid--collapsed-y .grid__item:nth-last-child(5n + 1) {
+    --top-right-radius: 0px;
+  }
+  .grid--5-col-desktop.grid--collapsed.grid--collapsed-y .grid__item:nth-child(5n + 1) {
+    --bottom-left-radius: 0px;
+  }
+  .grid--5-col-desktop.grid--collapsed.grid--collapsed-y .grid__item:nth-child(5n + 1) {
+    --top-left-radius: 0px;
+  }
+  .grid--5-col-desktop.grid.grid--collapsed-x:not(.grid--collapsed-y) .grid__item:nth-last-child(1),
+  .grid--5-col-desktop.grid.grid--collapsed .grid__item:nth-child(5),
+  .grid--5-col-desktop.grid.grid--collapsed .grid__item:nth-child(-n + 5):last-child {
+    --top-right-radius: var(--border-radius);
+  }
+  .grid--5-col-desktop.grid.grid--collapsed .grid__item:nth-child(1) {
+    --top-left-radius: var(--border-radius);
+  }
+  .grid--5-col-desktop.grid.grid--collapsed .grid__item:nth-last-child(1) {
+    --bottom-right-radius: var(--border-radius);
+  }
+  .grid--5-col-desktop.grid.grid--collapsed .grid__item:nth-child(5n + 1):nth-last-child(-n + 5) {
+    --bottom-left-radius: var(--border-radius);
+  }
+
+  .grid--6-col-desktop.grid--collapsed-y:not(.grid--collapsed-x) .grid__item:nth-child(-n + 6) {
+    --top-left-radius: var(--border-radius);
+    --top-right-radius: var(--border-radius);
+  }
+  .grid--6-col-desktop.grid--collapsed-y:not(.grid--collapsed-x) .grid__item:nth-last-child(-n + 6) {
+    --bottom-left-radius: var(--border-radius);
+    --bottom-right-radius: var(--border-radius);
+  }
+  .grid--6-col-desktop.grid--collapsed-x:not(.grid--collapsed-y) .grid__item:nth-child(6n) {
+    --top-right-radius: var(--border-radius);
+  }
+  .grid--6-col-desktop.grid--collapsed-x:not(.grid--collapsed-y) .grid__item:nth-child(6n),
+  .grid--6-col-desktop.grid--collapsed-x .grid__item:nth-child(6n):nth-last-child(-n + 6) {
+    --bottom-right-radius: var(--border-radius);
+  }
+  .grid--6-col-desktop.grid--collapsed-x .grid__item:nth-child(6n + 1) {
+    --top-left-radius: var(--border-radius);
+    --bottom-left-radius: var(--border-radius);
+  }
+  .grid--6-col-desktop.grid--collapsed-y .grid__item:nth-child(6n):nth-last-child(6n + 1) {
+    --bottom-right-radius: 0px;
+  }
+  .grid--6-col-desktop.grid--collapsed-y .grid__item:nth-last-child(6n + 1) {
+    --top-right-radius: 0px;
+  }
+  .grid--6-col-desktop.grid--collapsed.grid--collapsed-y .grid__item:nth-child(6n + 1) {
+    --bottom-left-radius: 0px;
+  }
+  .grid--6-col-desktop.grid--collapsed.grid--collapsed-y .grid__item:nth-child(6n + 1) {
+    --top-left-radius: 0px;
+  }
+  .grid--6-col-desktop.grid.grid--collapsed-x:not(.grid--collapsed-y) .grid__item:nth-last-child(1),
+  .grid--6-col-desktop.grid.grid--collapsed .grid__item:nth-child(6),
+  .grid--6-col-desktop.grid.grid--collapsed .grid__item:nth-child(-n + 6):last-child {
+    --top-right-radius: var(--border-radius);
+  }
+  .grid--6-col-desktop.grid.grid--collapsed .grid__item:nth-child(1) {
+    --top-left-radius: var(--border-radius);
+  }
+  .grid--6-col-desktop.grid.grid--collapsed .grid__item:nth-last-child(1) {
+    --bottom-right-radius: var(--border-radius);
+  }
+  .grid--6-col-desktop.grid.grid--collapsed .grid__item:nth-child(6n + 1):nth-last-child(-n + 6) {
+    --bottom-left-radius: var(--border-radius);
   }
 }

--- a/assets/grid-collapsed.css
+++ b/assets/grid-collapsed.css
@@ -1,6 +1,6 @@
 /* 
-  Each block of radius selectors for a particular number of columns is identical and repeatable.
-  Any modification for one block should be made to all.
+  Each group of radius selectors for a particular number of columns is identical and repeatable.
+  Any modification for one group should be made to all.
   
   Specificity matters. Modify with caution.
 

--- a/assets/grid-collapsed.css
+++ b/assets/grid-collapsed.css
@@ -44,12 +44,14 @@
   }
 
   .grid--1-col-tablet-down.grid--collapsed:not(.grid--collapsed-y) .grid__item,
-  .grid--1-col-tablet-down.grid--collapsed-y .grid__item:first-child {
+  .grid--1-col-tablet-down.grid--collapsed-y .grid__item:first-child,
+  .contains-card--standard.grid--1-col-tablet-down.grid--collapsed-x .grid__item {
     --top-left-radius: var(--border-radius);
     --top-right-radius: var(--border-radius);
   }
   .grid--1-col-tablet-down.grid--collapsed:not(.grid--collapsed-y) .grid__item,
-  .grid--1-col-tablet-down.grid--collapsed-y .grid__item:last-child {
+  .grid--1-col-tablet-down.grid--collapsed-y .grid__item:last-child,
+  .contains-card--standard.grid--1-col-tablet-down.grid--collapsed-x .grid__item {
     --bottom-left-radius: var(--border-radius);
     --bottom-right-radius: var(--border-radius);
   }
@@ -99,6 +101,15 @@
   .grid--2-col-tablet-down.grid.grid--collapsed .grid__item:nth-child(2n + 1):nth-last-child(-n + 2) {
     --bottom-left-radius: var(--border-radius);
   }
+  .contains-card--standard.grid--2-col-tablet-down.grid--collapsed-x .grid__item:nth-child(2n + 1) {
+    --top-left-radius: var(--border-radius);
+    --bottom-left-radius: var(--border-radius);
+  }
+  .contains-card--standard.grid--2-col-tablet-down.grid--collapsed-x .grid__item:last-child,
+  .contains-card--standard.grid--2-col-tablet-down.grid--collapsed-x .grid__item:nth-child(2n + 2) {
+    --top-right-radius: var(--border-radius);
+    --bottom-right-radius: var(--border-radius);
+  }
 }
 
 @media screen and (min-width: 990px) {
@@ -121,12 +132,14 @@
   }
 
   .grid--1-col-desktop.grid--collapsed:not(.grid--collapsed-y) .grid__item,
-  .grid--1-col-desktop.grid--collapsed-y .grid__item:first-child {
+  .grid--1-col-desktop.grid--collapsed-y .grid__item:first-child,
+  .contains-card--standard.grid--1-col-desktop.grid--collapsed-x .grid__item {
     --top-left-radius: var(--border-radius);
     --top-right-radius: var(--border-radius);
   }
   .grid--1-col-desktop.grid--collapsed:not(.grid--collapsed-y) .grid__item,
-  .grid--1-col-desktop.grid--collapsed-y .grid__item:last-child {
+  .grid--1-col-desktop.grid--collapsed-y .grid__item:last-child,
+  .contains-card--standard.grid--1-col-desktop.grid--collapsed-x .grid__item {
     --bottom-left-radius: var(--border-radius);
     --bottom-right-radius: var(--border-radius);
   }
@@ -176,6 +189,15 @@
   .grid--2-col-desktop.grid.grid--collapsed .grid__item:nth-child(2n + 1):nth-last-child(-n + 2) {
     --bottom-left-radius: var(--border-radius);
   }
+  .contains-card--standard.grid--2-col-desktop.grid--collapsed-x .grid__item:nth-child(2n + 1) {
+    --top-left-radius: var(--border-radius);
+    --bottom-left-radius: var(--border-radius);
+  }
+  .contains-card--standard.grid--2-col-desktop.grid--collapsed-x .grid__item:last-child,
+  .contains-card--standard.grid--2-col-desktop.grid--collapsed-x .grid__item:nth-child(2n + 2) {
+    --top-right-radius: var(--border-radius);
+    --bottom-right-radius: var(--border-radius);
+  }
 
   .grid--3-col-desktop.grid--collapsed-y:not(.grid--collapsed-x) .grid__item:nth-child(-n + 3) {
     --top-left-radius: var(--border-radius);
@@ -221,6 +243,15 @@
   }
   .grid--3-col-desktop.grid.grid--collapsed .grid__item:nth-child(3n + 1):nth-last-child(-n + 3) {
     --bottom-left-radius: var(--border-radius);
+  }
+  .contains-card--standard.grid--3-col-desktop.grid--collapsed-x .grid__item:nth-child(3n + 1) {
+    --top-left-radius: var(--border-radius);
+    --bottom-left-radius: var(--border-radius);
+  }
+  .contains-card--standard.grid--3-col-desktop.grid--collapsed-x .grid__item:last-child,
+  .contains-card--standard.grid--3-col-desktop.grid--collapsed-x .grid__item:nth-child(3n + 3) {
+    --top-right-radius: var(--border-radius);
+    --bottom-right-radius: var(--border-radius);
   }
 
   .grid--4-col-desktop.grid--collapsed-y:not(.grid--collapsed-x) .grid__item:nth-child(-n + 4) {
@@ -268,6 +299,15 @@
   .grid--4-col-desktop.grid.grid--collapsed .grid__item:nth-child(4n + 1):nth-last-child(-n + 4) {
     --bottom-left-radius: var(--border-radius);
   }
+  .contains-card--standard.grid--4-col-desktop.grid--collapsed-x .grid__item:nth-child(4n + 1) {
+    --top-left-radius: var(--border-radius);
+    --bottom-left-radius: var(--border-radius);
+  }
+  .contains-card--standard.grid--4-col-desktop.grid--collapsed-x .grid__item:last-child,
+  .contains-card--standard.grid--4-col-desktop.grid--collapsed-x .grid__item:nth-child(4n + 4) {
+    --top-right-radius: var(--border-radius);
+    --bottom-right-radius: var(--border-radius);
+  }
 
   .grid--5-col-desktop.grid--collapsed-y:not(.grid--collapsed-x) .grid__item:nth-child(-n + 5) {
     --top-left-radius: var(--border-radius);
@@ -314,6 +354,15 @@
   .grid--5-col-desktop.grid.grid--collapsed .grid__item:nth-child(5n + 1):nth-last-child(-n + 5) {
     --bottom-left-radius: var(--border-radius);
   }
+  .contains-card--standard.grid--5-col-desktop.grid--collapsed-x .grid__item:nth-child(5n + 1) {
+    --top-left-radius: var(--border-radius);
+    --bottom-left-radius: var(--border-radius);
+  }
+  .contains-card--standard.grid--5-col-desktop.grid--collapsed-x .grid__item:last-child,
+  .contains-card--standard.grid--5-col-desktop.grid--collapsed-x .grid__item:nth-child(5n + 5) {
+    --top-right-radius: var(--border-radius);
+    --bottom-right-radius: var(--border-radius);
+  }
 
   .grid--6-col-desktop.grid--collapsed-y:not(.grid--collapsed-x) .grid__item:nth-child(-n + 6) {
     --top-left-radius: var(--border-radius);
@@ -359,5 +408,14 @@
   }
   .grid--6-col-desktop.grid.grid--collapsed .grid__item:nth-child(6n + 1):nth-last-child(-n + 6) {
     --bottom-left-radius: var(--border-radius);
+  }
+  .contains-card--standard.grid--6-col-desktop.grid--collapsed-x .grid__item:nth-child(6n + 1) {
+    --top-left-radius: var(--border-radius);
+    --bottom-left-radius: var(--border-radius);
+  }
+  .contains-card--standard.grid--6-col-desktop.grid--collapsed-x .grid__item:last-child,
+  .contains-card--standard.grid--6-col-desktop.grid--collapsed-x .grid__item:nth-child(6n + 6) {
+    --top-right-radius: var(--border-radius);
+    --bottom-right-radius: var(--border-radius);
   }
 }

--- a/assets/grid-collapsed.css
+++ b/assets/grid-collapsed.css
@@ -32,6 +32,14 @@
   --bottom-left-radius: 0px;
 }
 
+/* universal standard card exception */
+.contains-card--standard.grid.grid.grid--collapsed:not(.grid--collapsed-x) .grid__item {
+  --top-left-radius: var(--border-radius);
+  --top-right-radius: var(--border-radius);
+  --bottom-right-radius: var(--border-radius);
+  --bottom-left-radius: var(--border-radius);
+}
+
 @media screen and (max-width: 989px) {
   /* reset shadow origin along first row/col so its flush with grid edge */
   .grid--1-col-tablet-down.grid--collapsed-x .grid__item,

--- a/assets/section-main-blog.css
+++ b/assets/section-main-blog.css
@@ -106,11 +106,13 @@
 }
 
 @media screen and (max-width: 749px) {
-  .blog--collapsed .article:first-child {
+  .blog--collapsed .article:first-child,
+  .blog--collapsed.blog-articles--collage.contains-card--standard .article {
     --top-right-radius: var(--border-radius);
     --top-left-radius: var(--border-radius);
   }
-  .blog--collapsed .article:last-child {
+  .blog--collapsed .article:last-child,
+  .blog--collapsed.blog-articles--collage.contains-card--standard .article {
     --bottom-right-radius: var(--border-radius);
     --bottom-left-radius: var(--border-radius);
   }
@@ -118,19 +120,30 @@
 
 @media screen and (min-width: 750px) {
   /* collage layout */
-  .blog--collapsed.blog-articles--collage .article:first-child {
+  .blog--collapsed.blog-articles--collage .article:first-child,
+  .blog--collapsed.blog-articles--collage.contains-card--standard .article:nth-child(3n + 1) {
     --top-right-radius: var(--border-radius);
     --top-left-radius: var(--border-radius);
   }
   .blog--collapsed.blog-articles--collage .article:nth-child(3n + 1):last-child,
-  .blog--collapsed.blog-articles--collage .article:nth-child(3n + 2):nth-last-child(-n + 2) {
+  .blog--collapsed.blog-articles--collage .article:nth-child(3n + 2):nth-last-child(-n + 2),
+  .blog--collapsed.blog-articles--collage.contains-card--standard .article:nth-child(3n + 1) {
     --bottom-left-radius: var(--border-radius);
   }
   .blog--collapsed.blog-articles--collage .article:last-child,
-  .blog--collapsed.blog-articles--collage .article:nth-child(3n + 2):last-child {
+  .blog--collapsed.blog-articles--collage .article:nth-child(3n + 2):last-child,
+  .blog--collapsed.blog-articles--collage.contains-card--standard .article:nth-child(3n + 1) {
     --bottom-right-radius: var(--border-radius);
   }
-  /* TODO: account for not-y */
+  .blog--collapsed.blog-articles--collage.contains-card--standard .article:nth-child(3n + 2) {
+    --top-left-radius: var(--border-radius);
+    --bottom-left-radius: var(--border-radius);
+  }
+  .blog--collapsed.blog-articles--collage.contains-card--standard .article:nth-child(3n),
+  .blog--collapsed.blog-articles--collage.contains-card--standard .article:nth-child(3n + 2):last-child {
+    --top-right-radius: var(--border-radius);
+    --bottom-right-radius: var(--border-radius);
+  }
 
   /* grid layout */
   .blog--collapsed-y:not(.blog-articles--collage) .article:first-child,
@@ -153,11 +166,14 @@
     --bottom-left-radius: var(--border-radius);
   }
   .blog--collapsed-x:not(.blog-articles--collage):not(.blog--collapsed-y) .article:nth-child(even),
-  .blog--collapsed-x:not(.blog-articles--collage):not(.blog--collapsed-y) .article:nth-child(odd):last-child {
+  .blog--collapsed-x:not(.blog-articles--collage):not(.blog--collapsed-y) .article:nth-child(odd):last-child,
+  .blog--collapsed-x.contains-card--standard:not(.blog-articles--collage) .article:last-child,
+  .blog--collapsed-x.contains-card--standard:not(.blog-articles--collage) .article:nth-child(2n + 2) {
     --top-right-radius: var(--border-radius);
     --bottom-right-radius: var(--border-radius);
   }
-  .blog--collapsed-x:not(.blog-articles--collage):not(.blog--collapsed-y) .article:nth-child(odd) {
+  .blog--collapsed-x:not(.blog-articles--collage):not(.blog--collapsed-y) .article:nth-child(odd),
+  .blog--collapsed-x.contains-card--standard:not(.blog-articles--collage) .article:nth-child(2n + 1) {
     --top-left-radius: var(--border-radius);
     --bottom-left-radius: var(--border-radius);
   }

--- a/assets/section-main-blog.css
+++ b/assets/section-main-blog.css
@@ -60,7 +60,7 @@
   }
 }
 
-.blog--collapsed-y:not(.contains-card--standard) .card-wrapper {
+.blog--collapsed-y .card-wrapper {
   height: calc(100% + var(--card-border-width));
 }
 
@@ -95,4 +95,70 @@
 .blog--collapsed-y.blog-articles--collage.blog-articles--text-only .article:not(:first-child) .card--standard .card__inner:after,
 .blog--collapsed-y.blog-articles--text-only:not(.blog-articles--collage) .article:not(:nth-child(-n + 2)) .card--standard .card__inner:after {
   margin-top: var(--card-border-width);
+}
+
+
+.blog--collapsed .article  {
+  --top-left-radius: 0;
+  --top-right-radius: 0;
+  --bottom-right-radius: 0;
+  --bottom-left-radius: 0;
+}
+
+@media screen and (max-width: 749px) {
+  .blog--collapsed .article:first-child {
+    --top-right-radius: var(--border-radius);
+    --top-left-radius: var(--border-radius);
+  }
+  .blog--collapsed .article:last-child {
+    --bottom-right-radius: var(--border-radius);
+    --bottom-left-radius: var(--border-radius);
+  }
+}
+
+@media screen and (min-width: 750px) {
+  /* collage layout */
+  .blog--collapsed.blog-articles--collage .article:first-child {
+    --top-right-radius: var(--border-radius);
+    --top-left-radius: var(--border-radius);
+  }
+  .blog--collapsed.blog-articles--collage .article:nth-child(3n + 1):last-child,
+  .blog--collapsed.blog-articles--collage .article:nth-child(3n + 2):nth-last-child(-n + 2) {
+    --bottom-left-radius: var(--border-radius);
+  }
+  .blog--collapsed.blog-articles--collage .article:last-child,
+  .blog--collapsed.blog-articles--collage .article:nth-child(3n + 2):last-child {
+    --bottom-right-radius: var(--border-radius);
+  }
+  /* TODO: account for not-y */
+
+  /* grid layout */
+  .blog--collapsed-y:not(.blog-articles--collage) .article:first-child,
+  .blog--collapsed-y:not(.blog-articles--collage):not(.blog--collapsed-x) .article:nth-child(2):nth-child(even) {
+    --top-left-radius: var(--border-radius);
+  }
+  .blog--collapsed-y:not(.blog-articles--collage) .article:nth-child(2),
+  .blog--collapsed-y:not(.blog-articles--collage) .article:only-child,
+  .blog--collapsed-y:not(.blog-articles--collage):not(.blog--collapsed-x) .article:first-child {
+    --top-right-radius: var(--border-radius);
+  }
+  .blog--collapsed-y:not(.blog-articles--collage) .article:last-child:nth-child(odd),
+  .blog--collapsed-y:not(.blog-articles--collage) .article:last-child:nth-child(even),
+  .blog--collapsed-y:not(.blog-articles--collage) .article:nth-last-child(2):nth-child(even),
+  .blog--collapsed-y:not(.blog-articles--collage):not(.blog--collapsed-x) .article:nth-last-child(2):nth-child(odd) {
+    --bottom-right-radius: var(--border-radius);
+  }
+  .blog--collapsed-y:not(.blog-articles--collage) .article:nth-last-child(-n + 2):nth-child(odd),
+  .blog--collapsed-y:not(.blog-articles--collage):not(.blog--collapsed-x) .article:nth-last-child(-n + 2):nth-child(even) {
+    --bottom-left-radius: var(--border-radius);
+  }
+  .blog--collapsed-x:not(.blog-articles--collage):not(.blog--collapsed-y) .article:nth-child(even),
+  .blog--collapsed-x:not(.blog-articles--collage):not(.blog--collapsed-y) .article:nth-child(odd):last-child {
+    --top-right-radius: var(--border-radius);
+    --bottom-right-radius: var(--border-radius);
+  }
+  .blog--collapsed-x:not(.blog-articles--collage):not(.blog--collapsed-y) .article:nth-child(odd) {
+    --top-left-radius: var(--border-radius);
+    --bottom-left-radius: var(--border-radius);
+  }
 }

--- a/assets/section-main-product.css
+++ b/assets/section-main-product.css
@@ -689,6 +689,23 @@ a.product__text {
   bottom: calc(var(--media-border-width) * -1);
 }
 
+.grid--collapsed.contains-media .product__media-toggle:focus-visible:after {
+  box-shadow: 0 0 0 0.3rem rgb(var(--color-background)),0 0 0rem 0.5rem rgba(var(--color-foreground), 0.5);
+  border-top-left-radius: calc(var(--top-left-radius) - var(--media-border-width));
+  border-top-right-radius: calc(var(--top-right-radius) - var(--media-border-width));
+  border-bottom-right-radius: calc(var(--bottom-right-radius) - var(--media-border-width));
+  border-bottom-left-radius: calc(var(--bottom-left-radius) - var(--media-border-width));
+}
+
+.grid--collapsed.contains-media .product__media-toggle.focused:after {
+  box-shadow: 0 0 0 0.3rem rgb(var(--color-background)),0 0 0rem 0.5rem rgba(var(--color-foreground), 0.5);
+  border-radius: var(--top-left-radius) var(--top-right-radius) var(--bottom-right-radius) var(--bottom-left-radius);
+}
+
+.grid--collapsed.contains-media .product__media-toggle:focus-visible:after {
+  border-radius: var(--top-left-radius) var(--top-right-radius) var(--bottom-right-radius) var(--bottom-left-radius);
+}
+
 .product-media-modal {
   background-color: rgb(var(--color-background));
   height: 100%;

--- a/assets/section-main-product.css
+++ b/assets/section-main-product.css
@@ -690,7 +690,7 @@ a.product__text {
 }
 
 .grid--collapsed.contains-media .product__media-toggle:focus-visible:after {
-  box-shadow: 0 0 0 0.3rem rgb(var(--color-background)),0 0 0rem 0.5rem rgba(var(--color-foreground), 0.5);
+  box-shadow: 0 0 0 0.3rem rgb(var(--color-background)), 0 0 0 0.5rem rgba(var(--color-foreground), 0.5);
   border-top-left-radius: calc(var(--top-left-radius) - var(--media-border-width));
   border-top-right-radius: calc(var(--top-right-radius) - var(--media-border-width));
   border-bottom-right-radius: calc(var(--bottom-right-radius) - var(--media-border-width));
@@ -698,7 +698,7 @@ a.product__text {
 }
 
 .grid--collapsed.contains-media .product__media-toggle.focused:after {
-  box-shadow: 0 0 0 0.3rem rgb(var(--color-background)),0 0 0rem 0.5rem rgba(var(--color-foreground), 0.5);
+  box-shadow: 0 0 0 0.3rem rgb(var(--color-background)),0 0 0 0.5rem rgba(var(--color-foreground), 0.5);
   border-radius: var(--top-left-radius) var(--top-right-radius) var(--bottom-right-radius) var(--bottom-left-radius);
 }
 

--- a/assets/section-main-product.css
+++ b/assets/section-main-product.css
@@ -537,9 +537,17 @@ a.product__text {
 }
 
 @media screen and (max-width: 749px) {
-  .product__media-item--variant:first-child {
+  /* center only visible slider item */
+  .product__media-item--variant.product__media-item--only-visible {
     padding-right: 1.5rem;
   }
+}
+/* override slider radius collapse selectors (gallery with 1 visible item still renders as slider) */
+.grid--collapsed.grid.grid.grid .grid__item.product__media-item--variant.product__media-item--only-visible {
+  --top-left-radius: var(--media-radius);
+  --top-right-radius: var(--media-radius);
+  --bottom-right-radius: var(--media-radius);
+  --bottom-left-radius: var(--media-radius);
 }
 
 @media screen and (min-width: 750px) and (max-width: 989px) {

--- a/assets/section-main-product.css
+++ b/assets/section-main-product.css
@@ -1228,3 +1228,59 @@ a.product__text {
   margin-left: 1.2rem;
   flex-shrink: 0;
 }
+
+/* collapsed grid overrides */
+@media screen and (min-width: 750px) {
+  .product--stacked .grid--collapsed-y .grid__item:first-child {
+    --top-left-radius: var(--border-radius);
+    --top-right-radius: var(--border-radius);
+  }
+
+  .product--thumbnail .grid--collapsed .is-active,
+  .product--thumbnail_slider .grid--collapsed .is-active {
+    --top-left-radius: var(--border-radius);
+    --top-right-radius: var(--border-radius);
+    --bottom-right-radius: var(--border-radius);
+    --bottom-left-radius: var(--border-radius);
+  }
+}
+
+@media screen and (min-width: 750px) and (max-width: 989px) {
+  .product--stacked .grid--collapsed-y .grid__item:last-child {
+    --bottom-right-radius: var(--border-radius);
+    --bottom-left-radius: var(--border-radius);
+  }
+}
+
+@media screen and (min-width: 990px) {
+  .product--stacked .grid--collapsed-y .grid__item:first-child {
+    --top-left-radius: var(--border-radius);
+    --top-right-radius: var(--border-radius);
+  }
+
+  .product--stacked .grid--collapsed-y .grid__item:only-child,
+  .product--stacked .grid--collapsed-y .grid__item:last-child:nth-child(even) {
+    --bottom-left-radius: var(--border-radius);
+    --bottom-right-radius: var(--border-radius);
+  }
+
+  .product--stacked .grid--collapsed-y .grid__item:last-child:nth-child(odd) {
+    --bottom-right-radius: var(--border-radius);
+  }
+
+  .product--stacked .grid--collapsed-y .grid__item:nth-last-child(2):nth-child(even):not(.product__media-item--full) {
+    --bottom-left-radius: var(--border-radius);
+  }
+
+  .product--stacked .grid--collapsed-x:not(.grid--collapsed-y) .grid__item:first-child,
+  .product--stacked .grid--collapsed-x:not(.grid--collapsed-y) .grid__item:nth-child(even) {
+    --top-left-radius: var(--border-radius);
+    --bottom-left-radius: var(--border-radius);
+  }
+
+  .product--stacked .grid--collapsed-x:not(.grid--collapsed-y) .grid__item:nth-child(odd),
+  .product--stacked .grid--collapsed-x:not(.grid--collapsed-y) .grid__item:last-child:nth-child(even) {
+    --top-right-radius: var(--border-radius);
+    --bottom-right-radius: var(--border-radius);
+  }
+}

--- a/assets/section-main-product.css
+++ b/assets/section-main-product.css
@@ -1246,9 +1246,15 @@ a.product__text {
 }
 
 @media screen and (min-width: 750px) and (max-width: 989px) {
-  .product--stacked .grid--collapsed-y .grid__item:last-child {
+  .product--stacked .grid--collapsed-y .grid__item:last-child,
+  .product--stacked .grid--collapsed-x:not(.grid--collapsed-y) .grid__item {
     --bottom-right-radius: var(--border-radius);
     --bottom-left-radius: var(--border-radius);
+  }
+
+  .product--stacked .grid--collapsed-x:not(.grid--collapsed-y) .grid__item {
+    --top-left-radius: var(--border-radius);
+    --top-right-radius: var(--border-radius);
   }
 }
 

--- a/assets/section-multicolumn.css
+++ b/assets/section-multicolumn.css
@@ -100,7 +100,6 @@
 @media screen and (max-width: 749px) {
   .multicolumn-list {
     margin: 0;
-    width: 100%;
   }
 }
 

--- a/sections/collage.liquid
+++ b/sections/collage.liquid
@@ -32,7 +32,7 @@
 <div class="color-{{ section.settings.color_scheme }} gradient isolate">
   <div class="page-width{% if section.settings.heading == blank %} no-heading{% endif %} section-{{ section.id }}-padding">
     <h2 class="collage-wrapper-title {{ section.settings.heading_size }}">{{ section.settings.heading | escape }}</h2>
-    <div class="collage {{ collapsed_class }}{% if section.settings.mobile_layout == 'collage' %} collage--mobile{% endif %}">
+    <div class="collage contains-card {{ collapsed_class }}{% if section.settings.mobile_layout == 'collage' %} collage--mobile{% endif %}">
       {%- for block in section.blocks -%}
         <div class="collage__item collage__item--{{ block.type }} collage__item--{{ section.settings.desktop_layout }}" {{ block.shopify_attributes }}>
           {%- case block.type -%}

--- a/sections/collage.liquid
+++ b/sections/collage.liquid
@@ -32,7 +32,7 @@
 <div class="color-{{ section.settings.color_scheme }} gradient isolate">
   <div class="page-width{% if section.settings.heading == blank %} no-heading{% endif %} section-{{ section.id }}-padding">
     <h2 class="collage-wrapper-title {{ section.settings.heading_size }}">{{ section.settings.heading | escape }}</h2>
-    <div class="collage contains-card {{ collapsed_class }}{% if section.settings.mobile_layout == 'collage' %} collage--mobile{% endif %}">
+    <div class="collage contains-card{% if settings.card_style == 'standard' %} contains-card--standard{% endif %} {{ collapsed_class }}{% if section.settings.mobile_layout == 'collage' %} collage--mobile{% endif %}">
       {%- for block in section.blocks -%}
         <div class="collage__item collage__item--{{ block.type }} collage__item--{{ section.settings.desktop_layout }}" {{ block.shopify_attributes }}>
           {%- case block.type -%}

--- a/sections/main-collection-product-grid.liquid
+++ b/sections/main-collection-product-grid.liquid
@@ -101,7 +101,7 @@
             <ul id="product-grid" data-id="{{ section.id }}" class="
               grid product-grid grid--{{ section.settings.columns_mobile }}-col-tablet-down
               grid--{{ section.settings.columns_desktop }}-col-desktop
-              {% render 'collapsed-classes' %} contains-card">
+              {% render 'collapsed-classes' %} contains-card{% if settings.card_style == 'standard' %} contains-card--standard{% endif %}">
               {%- for product in collection.products -%}
                 {% assign lazy_load = false %}
                 {%- if forloop.index > 2 -%}

--- a/sections/main-list-collections.liquid
+++ b/sections/main-list-collections.liquid
@@ -15,7 +15,7 @@
       assign collections = collections | reverse
     endif
   -%}
-  <ul class="collection-list contains-card grid grid--{{ section.settings.columns_desktop }}-col-desktop grid--{{ section.settings.columns_mobile }}-col-tablet-down{% render 'collapsed-classes' %}" role="list">
+  <ul class="collection-list contains-card{% if settings.card_style == 'standard' %} contains-card--standard{% endif %} grid grid--{{ section.settings.columns_desktop }}-col-desktop grid--{{ section.settings.columns_mobile }}-col-tablet-down{% render 'collapsed-classes' %}" role="list">
     {%- for collection in collections -%}
       <li class="collection-list__item grid__item">
         {% render 'card-collection', card_collection: collection, media_aspect_ratio: section.settings.image_ratio, columns: 3 %}

--- a/sections/main-product.liquid
+++ b/sections/main-product.liquid
@@ -31,6 +31,13 @@
     <link id="ModelViewerOverride" rel="stylesheet" href="{{ 'component-model-viewer-ui.css' | asset_url }}" media="print" onload="this.media='all'">
   {%- endif -%}
 
+  {%- liquid
+    assign variant_images = product.images | where: 'attached_to_variant?', true | map: 'src'
+    if section.settings.hide_variants and variant_images.size == product.media.size
+      assign single_visible_media = true
+    endif
+  -%}
+
   <div class="product product--{{ section.settings.media_size }} product--{{ section.settings.gallery_layout }} grid grid--1-col {% if product.media.size > 0 %}grid--2-col-tablet{% else %}product--no-media{% endif %}">
     <div class="grid__item product__media-wrapper">
       <media-gallery id="MediaGallery-{{ section.id }}" role="region" {% if section.settings.enable_sticky_info %}class="product__media-gallery"{% endif %} aria-label="{{ 'products.product.media.gallery_viewer' | t }}" data-desktop-layout="{{ section.settings.gallery_layout }}">
@@ -41,7 +48,6 @@
           </a>
           <ul id="Slider-Gallery-{{ section.id }}" class="product__media-list contains-media grid grid--peek{% render 'collapsed-classes' %} list-unstyled slider slider--mobile" role="list">
             {%- liquid
-              assign variant_images = product.images | where: 'attached_to_variant?', true | map: 'src'
               assign media_count = product.media.size
               if section.settings.hide_variants
                 assign media_count = media_count | minus: variant_images.size | plus: 1
@@ -57,14 +63,14 @@
             -%}
             {%- if product.selected_or_first_available_variant.featured_media != null -%}
               {%- assign featured_media = product.selected_or_first_available_variant.featured_media -%}
-              <li id="Slide-{{ section.id }}-{{ featured_media.id }}" class="product__media-item grid__item slider__slide is-active{% if featured_media.media_type != 'image' %} product__media-item--full{% endif %}{% if section.settings.hide_variants and variant_images contains featured_media.src %} product__media-item--variant{% endif %}" data-media-id="{{ section.id }}-{{ featured_media.id }}">
+              <li id="Slide-{{ section.id }}-{{ featured_media.id }}" class="product__media-item grid__item slider__slide is-active{% if featured_media.media_type != 'image' %} product__media-item--full{% endif %}{% if section.settings.hide_variants and variant_images contains featured_media.src %} product__media-item--variant{% endif %}{% if single_visible_media %} product__media-item--only-visible{% endif %}" data-media-id="{{ section.id }}-{{ featured_media.id }}">
                 {%- assign media_position = 1 -%}
                 {% render 'product-thumbnail', media: featured_media, position: media_position, loop: section.settings.enable_video_looping, modal_id: section.id, xr_button: true, media_width: media_width, lazy_load: false %}
               </li>
             {%- endif -%}
             {%- for media in product.media -%}
               {%- unless media.id == product.selected_or_first_available_variant.featured_media.id -%}
-                <li id="Slide-{{ section.id }}-{{ media.id }}" class="product__media-item grid__item slider__slide{% if product.selected_or_first_available_variant.featured_media == null and forloop.index == 1 %} is-active{% endif %}{% if media.media_type != 'image' %} product__media-item--full{% endif %}{% if section.settings.hide_variants and variant_images contains media.src %} product__media-item--variant{% endif %}" data-media-id="{{ section.id }}-{{ media.id }}">
+                <li id="Slide-{{ section.id }}-{{ media.id }}" class="product__media-item grid__item slider__slide{% if product.selected_or_first_available_variant.featured_media == null and forloop.index == 1 %} is-active{% endif %}{% if media.media_type != 'image' %} product__media-item--full{% endif %}{% if section.settings.hide_variants and variant_images contains media.src %} product__media-item--variant{% endif %}{% if single_visible_media %} product__media-item--only-visible{% endif %}" data-media-id="{{ section.id }}-{{ media.id }}">
                   {%- assign media_position = media_position | default: 0 | plus: 1 -%}
                   {% render 'product-thumbnail', media: media, position: media_position, loop: section.settings.enable_video_looping, modal_id: section.id, xr_button: true, media_width: media_width, lazy_load: true %}
                 </li>

--- a/sections/main-search.liquid
+++ b/sections/main-search.liquid
@@ -199,7 +199,7 @@
           {% paginate search.results by 24 %}
             <div class="template-search__results collection{% if section.settings.filter_type != 'vertical' %} page-width{% endif %}" id="product-grid" data-id="{{ section.id }}">
               <div class="loading-overlay gradient"></div>
-              <ul class="grid product-grid contains-card grid--{{ section.settings.columns_mobile }}-col-tablet-down grid--{{ section.settings.columns_desktop }}-col-desktop{% render 'collapsed-classes' %}" role="list">
+              <ul class="grid product-grid contains-card{% if settings.card_style == 'standard' %} contains-card--standard{% endif %} grid--{{ section.settings.columns_mobile }}-col-tablet-down grid--{{ section.settings.columns_desktop }}-col-desktop{% render 'collapsed-classes' %}" role="list">
                 {%- for item in search.results -%}
                   {% assign lazy_load = false %}
                   {%- if forloop.index > 2 -%}


### PR DESCRIPTION
**Why are these changes introduced?**

This is a follow up to #1464 and should either be merged after the `grid-collapse` branch or merged into it upon approval.
Refs #922 

These changes build on the 0px grid spacing and border collapsing added in the other PR to also [collapse adjacent rounded corners](https://screenshot.click/10-26-zsqor-osyew.png) in grids. Without this change we end up with [this effect](https://screenshot.click/10-25-pjnpt-br3mc.png).

**What approach did you take?**

**Enabling independent radius values**
All applicable elements (cards, media, content containers) received additional selectors scoped to the `grid-collapsed` class that define each corner radius independently using css vars to represent each corner (e.g. `--top-left-radius`).

**:nth-child mayhem**
The selectors in `grid-collapsed.css` do not set any properties, only variables which serve as the single source of truth for independent corner radii within the `.grid .grid__item` context. A group of selectors exists for each possible column number configuration (2 cols, 3 cols, etc). These groups of selectors are unfortunately verbose and cryptic. However, all groups are completely identical to each other. The only difference being the integer used which correlates to the number of columns. This makes it easy to copy and paste to support additional column numbers in the future. If CSS allowed vars to be used in selectors, we could reduce this logic to perhaps a single ~50 line group of selectors per breakpoint.

**Exceptions to the single source of truth**
The only place were radius vars are overridden outside of `grid-collapsed.css` is `component-slider.css`. Slider grids disregard all `grid--#-col` rules to form a horizontal list so we also must override all radius values associated with a particular number of columns.

As with the border collapsing PR, the other notable exceptions are product media gallery, main blog, and collage. Each of these use their own irregular "grid" and are excluded from the global grid collapse rules for integrity purposes. Corner collapsing logic has been included in their respective stylesheets, but I could be convinced to move it all into `grid-collapsed.css` if that sounds better.

**Why all the variables?**
We _could_ explicitly set the properties (e.g. `border-top-left-radius: 0px`) directly from the selectors in `grid-collapsed.css`. However, we'd need to expand the selectors to target the specific elements within grid items that have the border radius, like cards, media, content containers, and any future types. Additionally, each of these elements already re-purpose radius values in children and pseudo elements for shadows, focus outlines, calculations etc so we'd need to further expand every single one of the ~100 selectors that are already needed to account for every single one of those cases (read: not feasible). **I feel that maintaining an agnostic context for grids that children can choose to access and utilize how they need is a more sane approach.**

It's also worth pointing out that if we hope to consolidate focus outline styles that also respect collapsed corners, we will most likely need to use this type of approach.

**Possible alternative approach**
<details>
<summary>Alternative approach details..</summary>
Rather than declaring all the necessary styles for each possible grid column configuration, it may be possible to dynamically generate only those needed and render them via inline style tags in the liquid. <a href="https://gist.github.com/kmeleta/c230ffef6a5c54176ba8306bf891010b">It might look like this</a>
<br/><br/>
This would be nice because if we increase the max number of columns above 6, no additional work would be required and no additional css would need to be added to account for the new configuration. Additionally, on a page with only a single grid, this would have the benefit of surely requiring less css than the current approach.
<br/><br/>
However on a more complicated page, you could end up with duplicated styles resulting in even more css that what the grid-overrides.css would. The biggest issue here though may be that these inline rendered style tags wouldn't be cached by the browser. This _might_ still benefit first load for a user (which is important) but overall I don't foresee it being a net gain. I think for now, with our max columns limit what it is and our grid classes what they are are currently (tablet-down and desktop-up) we're fine without this alternative approach. However with future changes to either of those 2 points, this approach could definitely be worth exploring and performance testing.
</details>

**Other considerations**

**Known issue: Product media orphans**
Because there'd be no way of knowing if the last item would be full width or not, we can't safely apply corner radius to the second to last item. I think it's a fairly minor issue and only applicable when there is a non-full-width orphan in the gallery.
<img src="https://screenshot.click/10-54-4zw31-5az8t.png" width="175" />

**Known issue: Focus outlines**
This PR doesn't introduce any new logic to enable rounded focus outlines. A possible approach to this that can be easily expanded to account for collapsed corners can be seen in #1337 
<img src="https://screenshot.click/10-25-nbk0c-ql9ky.png" width="175" />

**Known issue: Mixed card types in main blog, search, collection list section**
In situations where card style cards (text--only) can be rendered along with standard cards, we can't realistically predict which grid items will be touching other items enough to collapse corners. These cases will collapse borders, but we can't take action on the corners without risking the proper display of that grid in the "best case scenario" (all standard cards have images). We can open an investigation to look into this more, see how close to ideal we can get it, and consider the trade off in complexity in isolation.
<img src="https://screenshot.click/21-32-3nh7m-4tbhz.png" width="175" />

**Testing steps/scenarios**

Affected areas..
- [ ] Main collection
- [ ] Search results
- [ ] Main collections list
- [ ] Collection list section
- [ ] Featured collection
- [ ] Multicolumn
- [ ] Featured blogs
- [ ] Main blog
- [ ] Collage
- [ ] Product media gallery

Permutations..
- [ ] zero horizontal spacing
- [ ] zero vertical spacing
- [ ] zero horizontal and vertical spacing
- [ ] with and without sliders enabled
- [ ] card/standard style cards
- [ ] various corner radius values
- [ ] various number of columns
- [ ] with drop shadows 

**Demo links**

- [Editor](https://os2-demo.myshopify.com/admin/themes/127704596502/editor)

**Checklist**
- [ ] Added PR summary for [release notes](https://themes.shopify.com/themes/dawn/styles/default#ReleaseNotes)
- [ ] Followed [theme code principles](https://github.com/Shopify/dawn/blob/main/.github/CONTRIBUTING.md#theme-code-principles)
- [ ] Linted with [Theme Check](https://github.com/Shopify/theme-check)
- [ ] Tested on [mobile](https://shopify.dev/themes/store/requirements#mobile-browser-requirements)
- [ ] Tested on [multiple browsers](https://shopify.dev/themes/store/requirements#desktop-browser-requirements)
- [ ] Tested for [accessibility](https://shopify.dev/themes/best-practices/accessibility)
