### PR TITLE
Center mega menu

### DIFF
--- a/assets/component-mega-menu.css
+++ b/assets/component-mega-menu.css
@@ -63,7 +63,6 @@
 }
 
 .header--top-center .mega-menu__list > li {
-  text-align: center;
   width: 16%;
 }
 

--- a/assets/component-mega-menu.css
+++ b/assets/component-mega-menu.css
@@ -65,7 +65,7 @@
 
 .header--top-center .mega-menu__list > li {
   width: 16%;
-  margin-right: 2.4rem;
+  padding-right: 2.4rem;
 }
 
 .mega-menu__link:hover,

--- a/assets/component-mega-menu.css
+++ b/assets/component-mega-menu.css
@@ -62,7 +62,8 @@
   flex-wrap: wrap;
 }
 
-.header--top-center .mega-menu__list li {
+.header--top-center .mega-menu__list > li {
+  text-align: center;
   width: 16%;
 }
 

--- a/assets/component-mega-menu.css
+++ b/assets/component-mega-menu.css
@@ -62,10 +62,6 @@
   flex-wrap: wrap;
 }
 
-.header--top-center .mega-menu__list > li {
-  width: 16%;
-}
-
 .mega-menu__link:hover,
 .mega-menu__link--active {
   color: rgb(var(--color-foreground));

--- a/assets/component-mega-menu.css
+++ b/assets/component-mega-menu.css
@@ -60,6 +60,12 @@
   display: flex;
   justify-content: center;
   flex-wrap: wrap;
+  column-gap: 0;
+}
+
+.header--top-center .mega-menu__list > li {
+  width: 16%;
+  margin-right: 2.4rem;
 }
 
 .mega-menu__link:hover,

--- a/assets/component-mega-menu.css
+++ b/assets/component-mega-menu.css
@@ -56,6 +56,16 @@
   transition: text-decoration var(--duration-short) ease;
 }
 
+.header--top-center .mega-menu__list {
+  display: flex;
+  justify-content: center;
+  flex-wrap: wrap;
+}
+
+.header--top-center .mega-menu__list li {
+  width: 16%;
+}
+
 .mega-menu__link:hover,
 .mega-menu__link--active {
   color: rgb(var(--color-foreground));

--- a/sections/header.liquid
+++ b/sections/header.liquid
@@ -426,7 +426,7 @@
                       <summary class="header__menu-item list-menu__item link focus-inset">
                         <span {%- if link.child_active %} class="header__active-menu-item"{% endif %}>{{ link.title | escape }}</span>
                         {% render 'icon-caret' %}
-                      </summary>               
+                      </summary>
                       <div id="MegaMenu-Content-{{ forloop.index }}" class="mega-menu__content gradient motion-reduce global-settings-popup" tabindex="-1">
                         <ul class="mega-menu__list page-width" role="list">
                           {%- for childlink in link.links -%}


### PR DESCRIPTION
**PR Summary:** 

Center mega menu when `Desktop logo position: center top` is selected

**Why are these changes introduced?**

Fixes #1480 .

**What approach did you take?**

I am using `flex` and only applying it when we have the mega menu centered

**Other considerations**
I tried to use the `Grid ` approach Tyler mentioned in the issue (For instance, 3 columns would be  be 3 / 6 which would be 0.5 so 50%. https://screenshot.click/11-11-xf1z1-qymjl.png . The problem is when we have multiple rows: https://screenshot.click/11-11-0p7vv-410al.png . We'd want to ensure these rows are also centered and it'd require more logic.  I also attempted to use `grid-column-start` but had the same issues when we have more rows. 

After some research as well, grid isn't the right tool for the job since it's also trying to ensure the items stay within their grid position. Flex makes more sense at the end, especially since we have dynamic content.

**Testing steps/scenarios**
- [ ] Test all of the mega menu alignments
- [ ] Different screen sizes
- [ ] Different menu sizes

**Demo links**
- [Editor](https://os2-demo.myshopify.com/admin/themes/127708921878/editor)

**Checklist**
- [ ] Added PR summary for [release notes](https://themes.shopify.com/themes/dawn/styles/default#ReleaseNotes)
- [ ] Followed [theme code principles](https://github.com/Shopify/dawn/blob/main/.github/CONTRIBUTING.md#theme-code-principles)
- [ ] Linted with [Theme Check](https://github.com/Shopify/theme-check)
- [ ] Tested on [mobile](https://shopify.dev/themes/store/requirements#mobile-browser-requirements)
- [ ] Tested on [multiple browsers](https://shopify.dev/themes/store/requirements#desktop-browser-requirements)
- [ ] Tested for [accessibility](https://shopify.dev/themes/best-practices/accessibility)
