### PR TITLE
Hide inactive mobile menu items from screen readers

### DIFF
--- a/assets/component-facets.css
+++ b/assets/component-facets.css
@@ -766,6 +766,10 @@ details.menu-opening .mobile-facets__close svg {
   overflow-y: auto;
 }
 
+.js .mobile-facets .submenu-open {
+  visibility: hidden; /* hide menus from screen readers when hidden by submenu */
+}
+
 .mobile-facets__item {
   position: relative;
 }

--- a/assets/component-menu-drawer.css
+++ b/assets/component-menu-drawer.css
@@ -70,6 +70,10 @@ details[open].menu-opening > .menu-drawer__submenu {
   visibility: visible;
 }
 
+.js .menu-drawer__menu.submenu-open {
+  visibility: hidden;
+}
+
 @media screen and (min-width: 750px) {
   .menu-drawer {
     width: 40rem;

--- a/assets/component-menu-drawer.css
+++ b/assets/component-menu-drawer.css
@@ -70,7 +70,8 @@ details[open].menu-opening > .menu-drawer__submenu {
   visibility: visible;
 }
 
-.js .menu-drawer__menu.submenu-open {
+.js .menu-drawer__menu.submenu-open,
+.js .menu-drawer__menu .menu-drawer__submenu.submenu-open {
   visibility: hidden;
 }
 

--- a/assets/component-menu-drawer.css
+++ b/assets/component-menu-drawer.css
@@ -70,9 +70,8 @@ details[open].menu-opening > .menu-drawer__submenu {
   visibility: visible;
 }
 
-.js .menu-drawer__menu.submenu-open,
-.js .menu-drawer__menu .menu-drawer__submenu.submenu-open {
-  visibility: hidden;
+.js .menu-drawer__navigation .submenu-open {
+  visibility: hidden; /* hide menus from screen readers when hidden by submenu */
 }
 
 @media screen and (min-width: 750px) {

--- a/assets/global.js
+++ b/assets/global.js
@@ -313,6 +313,7 @@ class MenuDrawer extends HTMLElement {
   onSummaryClick(event) {
     const summaryElement = event.currentTarget;
     const detailsElement = summaryElement.parentNode;
+    const parentMenuElement = detailsElement.closest('.menu-drawer__menu');
     const isOpen = detailsElement.hasAttribute('open');
     const reducedMotion = window.matchMedia("(prefers-reduced-motion: reduce)");
 
@@ -328,6 +329,7 @@ class MenuDrawer extends HTMLElement {
       setTimeout(() => {
         detailsElement.classList.add('menu-opening');
         summaryElement.setAttribute('aria-expanded', true);
+        parentMenuElement.classList.add('submenu-open');
         !reducedMotion || reducedMotion.matches ? addTrapFocus() : summaryElement.nextElementSibling.addEventListener('transitionend', addTrapFocus);
       }, 100);
     }
@@ -367,6 +369,7 @@ class MenuDrawer extends HTMLElement {
   }
 
   closeSubmenu(detailsElement) {
+    detailsElement.closest('.menu-drawer__menu').classList.remove('submenu-open');
     detailsElement.classList.remove('menu-opening');
     detailsElement.querySelector('summary').setAttribute('aria-expanded', false);
     removeTrapFocus(detailsElement.querySelector('summary'));

--- a/assets/global.js
+++ b/assets/global.js
@@ -352,6 +352,9 @@ class MenuDrawer extends HTMLElement {
       details.removeAttribute('open');
       details.classList.remove('menu-opening');
     });
+    this.mainDetailsToggle.querySelectorAll('.submenu-open').forEach(submenu =>  {
+      submenu.classList.remove('submenu-open');
+    });
     document.body.classList.remove(`overflow-hidden-${this.dataset.breakpoint}`);
     removeTrapFocus(elementToFocus);
     this.closeAnimation(this.mainDetailsToggle);

--- a/assets/global.js
+++ b/assets/global.js
@@ -313,7 +313,7 @@ class MenuDrawer extends HTMLElement {
   onSummaryClick(event) {
     const summaryElement = event.currentTarget;
     const detailsElement = summaryElement.parentNode;
-    const parentMenuElement = detailsElement.closest('.menu-drawer__menu');
+    const parentMenuElement = detailsElement.closest('.menu-drawer__submenu') || detailsElement.closest('.menu-drawer__menu');
     const isOpen = detailsElement.hasAttribute('open');
     const reducedMotion = window.matchMedia("(prefers-reduced-motion: reduce)");
 
@@ -369,7 +369,8 @@ class MenuDrawer extends HTMLElement {
   }
 
   closeSubmenu(detailsElement) {
-    detailsElement.closest('.menu-drawer__menu').classList.remove('submenu-open');
+    const parentMenuElement = detailsElement.closest('.menu-drawer__submenu') || detailsElement.closest('.menu-drawer__menu');
+    parentMenuElement.classList.remove('submenu-open');
     detailsElement.classList.remove('menu-opening');
     detailsElement.querySelector('summary').setAttribute('aria-expanded', false);
     removeTrapFocus(detailsElement.querySelector('summary'));

--- a/assets/global.js
+++ b/assets/global.js
@@ -313,7 +313,7 @@ class MenuDrawer extends HTMLElement {
   onSummaryClick(event) {
     const summaryElement = event.currentTarget;
     const detailsElement = summaryElement.parentNode;
-    const parentMenuElement = detailsElement.closest('.menu-drawer__submenu') || detailsElement.closest('.menu-drawer__menu');
+    const parentMenuElement = detailsElement.closest('.has-submenu');
     const isOpen = detailsElement.hasAttribute('open');
     const reducedMotion = window.matchMedia("(prefers-reduced-motion: reduce)");
 
@@ -329,7 +329,7 @@ class MenuDrawer extends HTMLElement {
       setTimeout(() => {
         detailsElement.classList.add('menu-opening');
         summaryElement.setAttribute('aria-expanded', true);
-        parentMenuElement.classList.add('submenu-open');
+        parentMenuElement && parentMenuElement.classList.add('submenu-open');
         !reducedMotion || reducedMotion.matches ? addTrapFocus() : summaryElement.nextElementSibling.addEventListener('transitionend', addTrapFocus);
       }, 100);
     }
@@ -348,11 +348,11 @@ class MenuDrawer extends HTMLElement {
     if (event === undefined) return;
 
     this.mainDetailsToggle.classList.remove('menu-opening');
-    this.mainDetailsToggle.querySelectorAll('details').forEach(details =>  {
+    this.mainDetailsToggle.querySelectorAll('details').forEach(details => {
       details.removeAttribute('open');
       details.classList.remove('menu-opening');
     });
-    this.mainDetailsToggle.querySelectorAll('.submenu-open').forEach(submenu =>  {
+    this.mainDetailsToggle.querySelectorAll('.submenu-open').forEach(submenu => {
       submenu.classList.remove('submenu-open');
     });
     document.body.classList.remove(`overflow-hidden-${this.dataset.breakpoint}`);
@@ -372,8 +372,8 @@ class MenuDrawer extends HTMLElement {
   }
 
   closeSubmenu(detailsElement) {
-    const parentMenuElement = detailsElement.closest('.menu-drawer__submenu') || detailsElement.closest('.menu-drawer__menu');
-    parentMenuElement.classList.remove('submenu-open');
+    const parentMenuElement = detailsElement.closest('.submenu-open');
+    parentMenuElement && parentMenuElement.classList.remove('submenu-open');
     detailsElement.classList.remove('menu-opening');
     detailsElement.querySelector('summary').setAttribute('aria-expanded', false);
     removeTrapFocus(detailsElement.querySelector('summary'));

--- a/sections/header.liquid
+++ b/sections/header.liquid
@@ -110,7 +110,7 @@
             <div class="menu-drawer__inner-container">
               <div class="menu-drawer__navigation-container">
                 <nav class="menu-drawer__navigation">
-                  <ul class="menu-drawer__menu list-menu" role="list">
+                  <ul class="menu-drawer__menu has-submenu list-menu" role="list">
                     {%- for link in section.settings.menu.links -%}
                       <li>
                         {%- if link.links != blank -%}
@@ -120,7 +120,7 @@
                               {% render 'icon-arrow' %}
                               {% render 'icon-caret' %}
                             </summary>
-                            <div id="link-{{ link.title | escape }}" class="menu-drawer__submenu gradient motion-reduce" tabindex="-1">
+                            <div id="link-{{ link.title | escape }}" class="menu-drawer__submenu has-submenu gradient motion-reduce" tabindex="-1">
                               <div class="menu-drawer__inner-submenu">
                                 <button class="menu-drawer__close-button link link--text focus-inset" aria-expanded="true">
                                   {% render 'icon-arrow' %}
@@ -140,7 +140,7 @@
                                             {% render 'icon-arrow' %}
                                             {% render 'icon-caret' %}
                                           </summary>
-                                          <div id="childlink-{{ childlink.title | escape }}" class="menu-drawer__submenu gradient motion-reduce">
+                                          <div id="childlink-{{ childlink.title | escape }}" class="menu-drawer__submenu has-submenu gradient motion-reduce">
                                             <button class="menu-drawer__close-button link link--text focus-inset" aria-expanded="true">
                                               {% render 'icon-arrow' %}
                                               {{ childlink.title | escape }}

--- a/snippets/facets.liquid
+++ b/snippets/facets.liquid
@@ -292,7 +292,7 @@
                 </p>
               </div>
             </div>
-            <div class="mobile-facets__main gradient">
+            <div class="mobile-facets__main has-submenu gradient">
               {%- for filter in results.filters -%}
                 {% case filter.type %}
                 {% when 'list' %}


### PR DESCRIPTION
**PR Summary:** 

Prevents unintended mobile menu items from being discoverable by screen readers.

**Why are these changes introduced?**

Fixes #769 

**What approach did you take?**

As recommended in the ticket I've achieved this using `visibility: hidden` on the parent menu of the currently active submenu. I'm toggling a class called `submenu-open` on the parent list element whenever a child submenu is opened or closed. Probably doesn't matter that much, but I'm flexible on the class naming if anyone has strong opinions. I also considered `menu-hidden` and `has-open-submenu`.

**Testing steps/scenarios**
Navigate through various levels of the mobile nav with a screen reader active. Ensure menu items from the previously viewed menus aren't discoverable.

**Demo links**

- [Store](https://6ifg8relf3ta8gfg-45840990230.shopifypreview.com)
- [Editor](https://os2-demo.myshopify.com/admin/themes/127719669782/editor)

**Checklist**
- [ ] Added PR summary for [release notes](https://themes.shopify.com/themes/dawn/styles/default#ReleaseNotes)
- [ ] Followed [theme code principles](https://github.com/Shopify/dawn/blob/main/.github/CONTRIBUTING.md#theme-code-principles)
- [ ] Linted with [Theme Check](https://github.com/Shopify/theme-check)
- [ ] Tested on [mobile](https://shopify.dev/themes/store/requirements#mobile-browser-requirements)
- [ ] Tested on [multiple browsers](https://shopify.dev/themes/store/requirements#desktop-browser-requirements)
- [ ] Tested for [accessibility](https://shopify.dev/themes/best-practices/accessibility)
