### PR TITLE
Update featured blog view all position

### DIFF
--- a/assets/section-featured-blog.css
+++ b/assets/section-featured-blog.css
@@ -67,16 +67,6 @@
   width: 100%;
 }
 
-.blog__button {
-  margin-top: 3rem;
-}
-
-@media screen and (min-width: 750px) {
-  .blog__button {
-    margin-top: 5rem;
-  }
-}
-
 /* check for flexbox gap in older Safari versions */
 @supports not (inset: 10px) {
   @media screen and (min-width: 750px) {

--- a/locales/en.default.json
+++ b/locales/en.default.json
@@ -255,6 +255,7 @@
     },
     "featured_blog": {
       "view_all": "View all",
+      "view_all_label": "View all articles in the {{ blog_name }} blog",
       "onboarding_title": "Blog post",
       "onboarding_content": "Give your customers a summary of your blog post"
     },

--- a/locales/en.default.schema.json
+++ b/locales/en.default.schema.json
@@ -40,18 +40,6 @@
             "label": "Right"
           },
           "label": "Text alignment"
-        },
-        "view_all_style": {
-          "label": "\"View all\" style",
-          "options__1": {
-            "label": "Link"
-          },
-          "options__2": {
-            "label": "Outline button"
-          },
-          "options__3": {
-            "label": "Solid button"
-          }
         }
       }
     },

--- a/locales/en.default.schema.json
+++ b/locales/en.default.schema.json
@@ -351,6 +351,18 @@
         "options__3": {
           "label": "Large"
         }
+      },
+      "view_all_style": {
+        "label": "\"View all\" style",
+        "options__1": {
+          "label": "Link"
+        },
+        "options__2": {
+          "label": "Outline button"
+        },
+        "options__3": {
+          "label": "Solid button"
+        }
       }
     },
     "announcement-bar": {

--- a/sections/featured-blog.liquid
+++ b/sections/featured-blog.liquid
@@ -33,16 +33,8 @@
 <div class="blog color-{{ section.settings.color_scheme }} gradient{% if section.settings.heading == blank %} no-heading{% endif %}">
   <div class="page-width-desktop isolate{% if posts_displayed < 3 %} page-width-tablet{% endif %} section-{{ section.id }}-padding">
     {%- unless section.settings.heading == blank -%}
-      <div class="title-wrapper-with-link{% if posts_displayed > 2 %} title-wrapper--self-padded-tablet-down{% else %} title-wrapper--self-padded-mobile{% endif %} title-wrapper--no-top-margin">
+      <div class="title-wrapper{% if posts_displayed > 2 %} title-wrapper--self-padded-tablet-down{% else %} title-wrapper--self-padded-mobile{% endif %} title-wrapper--no-top-margin">
         <h2 class="blog__title {{ section.settings.heading_size }}">{{ section.settings.heading | escape }}</h2>
-
-        {%- if section.settings.blog != blank and section.settings.show_view_all and section.settings.post_limit < section.settings.blog.articles_count -%}
-          <a href="{{ section.settings.blog.url }}"
-            class="link underlined-link large-up-hide"
-          >
-            {{ 'sections.featured_blog.view_all' | t }}
-          </a>
-        {%- endif -%}
       </div>
     {%- endunless -%}
     {%- if section.settings.blog != blank and section.settings.blog.articles_count > 0 -%}
@@ -72,8 +64,11 @@
       </slider-component>
 
       {%- if section.settings.show_view_all and section.settings.post_limit < section.settings.blog.articles_count -%}
-        <div class="blog__view-all center small-hide medium-hide">
-          <a href="{{ section.settings.blog.url }}" class="blog__button button">
+        <div class="center">
+          <a href="{{ section.settings.blog.url }}"
+            class="view-all-button {% if section.settings.view_all_style == 'link' %}link underlined-link{% elsif section.settings.view_all_style == 'solid' %}button{% else %}button button--secondary{% endif %}"
+            aria-label="{{ 'sections.featured_blog.view_all_label' | t: blog_name: section.settings.blog.title }}"
+          >
             {{ 'sections.featured_blog.view_all' | t }}
           </a>
         </div>
@@ -204,6 +199,26 @@
       "id": "show_view_all",
       "default": true,
       "label": "t:sections.featured-blog.settings.show_view_all.label"
+    },
+    {
+      "type": "select",
+      "id": "view_all_style",
+      "label": "t:sections.all.view_all_style.label",
+      "options": [
+        {
+          "value": "link",
+          "label": "t:sections.all.view_all_style.options__1.label"
+        },
+        {
+          "value": "outline",
+          "label": "t:sections.all.view_all_style.options__2.label"
+        },
+        {
+          "value": "solid",
+          "label": "t:sections.all.view_all_style.options__3.label"
+        }
+      ],
+      "default": "solid"
     },
     {
       "type": "header",

--- a/sections/featured-collection.liquid
+++ b/sections/featured-collection.liquid
@@ -89,7 +89,7 @@
     {%- if section.settings.show_view_all and more_in_collection -%}
       <div class="center">
         <a href="{{ section.settings.collection.url }}"
-          class="view-all-button{% if section.settings.view_all_style == 'link' %} link underlined-link{% elsif section.settings.view_all_style == 'solid' %} button{% else %} button button--secondary{% endif %}"
+          class="view-all-button {% if section.settings.view_all_style == 'link' %}link underlined-link{% elsif section.settings.view_all_style == 'solid' %}button{% else %}button button--secondary{% endif %}"
           aria-label="{{ 'sections.featured_collection.view_all_label' | t: collection_name: section.settings.collection.title }}"
         >
           {{ 'sections.featured_collection.view_all' | t }}
@@ -200,19 +200,19 @@
     {
       "type": "select",
       "id": "view_all_style",
-      "label": "t:settings_schema.global.settings.view_all_style.label",
+      "label": "t:sections.all.view_all_style.label",
       "options": [
         {
           "value": "link",
-          "label": "t:settings_schema.global.settings.view_all_style.options__1.label"
+          "label": "t:sections.all.view_all_style.options__1.label"
         },
         {
           "value": "outline",
-          "label": "t:settings_schema.global.settings.view_all_style.options__2.label"
+          "label": "t:sections.all.view_all_style.options__2.label"
         },
         {
           "value": "solid",
-          "label": "t:settings_schema.global.settings.view_all_style.options__3.label"
+          "label": "t:sections.all.view_all_style.options__3.label"
         }
       ],
       "default": "solid"


### PR DESCRIPTION
**PR Summary:** 

_Change "view all" behaviour on featured blog. The "view all" position is now always below the blog content._

**Why are these changes introduced?**
The "view all" position was inline with the heading when the slider was enabled, and below the content when it was not enabled. This introduced some magic in the positioning. With our plan to add Heading alignment, we want the position of the view all button to be constant - now it will always be placed below the content, and not inline with the heading.

**What approach did you take?**
I paired with Ludo to understand the approach that he and Yoann took for featured collections. 

* Removed the `<a>` that was inline with the heading
* Added the `title-wrapper` class to preserve margin bottom. (heading classes will be revisited in the heading alignment PR).
* Add a new setting for "view all" style. `Default to solid`
* Added `aria-label` to the "view all" link so that the context is properly communicated to assistive technology
* Moved view all styles translations to sections all since multiple sections use the same strings.
* Added `view-all-button` utility class that can be shared between different sections,

**Other considerations**
N/A

**Testing steps/scenarios**
- [ ] View all position should _always_ be below blog content - on mobile, desktop and tablet
- [ ] View all position should be below content when slider is present (previously, inline with heading).
- [ ] Ensure featured collection translations for "View all style" is working correctly as they have been moved.

**Demo links**
_Please include a link to a demo store that includes preconfigured sections and settings to allow reviewers to easily test the features you are working on._

- [Editor](https://os2-demo.myshopify.com/admin/themes/127723208726/editor)

**Checklist**
- [x] Added PR summary for [release notes](https://themes.shopify.com/themes/dawn/styles/default#ReleaseNotes)
- [x] Followed [theme code principles](https://github.com/Shopify/dawn/blob/main/.github/CONTRIBUTING.md#theme-code-principles)
- [x] Linted with [Theme Check](https://github.com/Shopify/theme-check)
- [x] Tested on [mobile](https://shopify.dev/themes/store/requirements#mobile-browser-requirements)
- [x] Tested on [multiple browsers](https://shopify.dev/themes/store/requirements#desktop-browser-requirements)
- [x] Tested for [accessibility](https://shopify.dev/themes/best-practices/accessibility)
