### PR TITLE
Fixed product page thumbnail slider arrows appearing when they shouldn't

### DIFF
--- a/assets/section-main-product.css
+++ b/assets/section-main-product.css
@@ -1035,7 +1035,7 @@ a.product__text {
     scroll-padding-left: 0.5rem;
   }
 
-  .product__media-gallery .slider-mobile-gutter .slider-button {
+  .product__media-wrapper .slider-mobile-gutter .slider-button {
     display: none;
   }
 


### PR DESCRIPTION
**Fixed this:**

<img width="395" alt="Screen Shot 2022-03-18 at 10 42 58 AM" src="https://user-images.githubusercontent.com/60230011/159024426-fcb1f826-851d-4d6c-8a86-de91af7d1727.png">

**Steps to reproduce original bug:**

1. Settings for the product page - Desktop layout: Stacked, Mobile layout: Show thumbnails, Enable sticky content: false
2. Go to your product page on desktop.  Notice that there are arrows below the gallery.

**Why did it happen?**

The class it was relying on was rendered only when sticky content was enabled.  To maintain the same specificity, I changed the selector to reference a non-conditional class.

**Demo stores**

[Editor](https://os2-demo.myshopify.com/admin/themes/127738937366/editor)