### PR TITLE
Fixed max price display on filter drawer

### DIFF
--- a/snippets/facets.liquid
+++ b/snippets/facets.liquid
@@ -358,6 +358,7 @@
                         {{ filter.label | escape }}
                       </button>
 
+                      {%- assign max_price_amount = filter.range_max | money | strip_html | escape -%}
                       <p class="mobile-facets__info">{{ "products.facets.max_price" | t: price: max_price_amount }}</p>
 
                       <price-range class="facets__price">


### PR DESCRIPTION
**PR Summary:** 

Fixed a bug where the max price was not displaying on the faceted drawer.

**What approach did you take?**

The variable was not being set when collapse on desktop was being used.

**Other considerations**

We could remove duplicate code by doing it higher up, but the variable would become very disconnected from where it's being used so I believe it's clearer to duplicate it.

**Screenshot of previous state**

<img width="473" alt="18-36-lt25u-v3me3" src="https://user-images.githubusercontent.com/60230011/159051933-2fa5366c-9e51-47fa-858e-37045a2679dc.png">

**Testing steps/scenarios**
- [ ] In the editor, enable "collapse on desktop"
- [ ] Note that when opening the price filter, the max price is now displayed

Note: you also need price enabled as a filter.

<img width="347" alt="Screen Shot 2022-03-18 at 1 20 05 PM" src="https://user-images.githubusercontent.com/60230011/159052053-405f73ba-8ea3-4a1f-b676-5c072fdb9774.png">

**Demo links**

- [Editor](https://os2-demo.myshopify.com/admin/themes/127739822102/editor)

**Checklist**
- [ ] Added PR summary for [release notes](https://themes.shopify.com/themes/dawn/styles/default#ReleaseNotes)
- [ ] Followed [theme code principles](https://github.com/Shopify/dawn/blob/main/.github/CONTRIBUTING.md#theme-code-principles)
- [ ] Linted with [Theme Check](https://github.com/Shopify/theme-check)
- [ ] Tested on [mobile](https://shopify.dev/themes/store/requirements#mobile-browser-requirements)
- [ ] Tested on [multiple browsers](https://shopify.dev/themes/store/requirements#desktop-browser-requirements)
- [ ] Tested for [accessibility](https://shopify.dev/themes/best-practices/accessibility)
