### PR TITLE
Add PR checkbox for theme documentation

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -22,7 +22,7 @@ _Please include a link to a demo store that includes preconfigured sections and 
 
 **Checklist**
 - [ ] Added PR summary for [release notes](https://themes.shopify.com/themes/dawn/styles/default#ReleaseNotes)
-- [ ] Reached out to the [help.shopify.com](https://help.shopify.com) team to update theme documentation (current contact: Kimli)
+- [ ] Notified the [help.shopify.com](https://help.shopify.com) team about updates to theme settings (current contact: Kimli)
 - [ ] Followed [theme code principles](https://github.com/Shopify/dawn/blob/main/.github/CONTRIBUTING.md#theme-code-principles)
 - [ ] Linted with [Theme Check](https://github.com/Shopify/theme-check)
 - [ ] Tested on [mobile](https://shopify.dev/themes/store/requirements#mobile-browser-requirements)

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -22,6 +22,7 @@ _Please include a link to a demo store that includes preconfigured sections and 
 
 **Checklist**
 - [ ] Added PR summary for [release notes](https://themes.shopify.com/themes/dawn/styles/default#ReleaseNotes)
+- [ ] Reached out to the [help.shopify.com](https://help.shopify.com) team to update theme documentation (current contact: Kimli)
 - [ ] Followed [theme code principles](https://github.com/Shopify/dawn/blob/main/.github/CONTRIBUTING.md#theme-code-principles)
 - [ ] Linted with [Theme Check](https://github.com/Shopify/theme-check)
 - [ ] Tested on [mobile](https://shopify.dev/themes/store/requirements#mobile-browser-requirements)


### PR DESCRIPTION
**PR description:** 

This PR adds a checkbox to notify the help.shopify.com team about any changes to settings/sections of a theme. 
cc. @nicklepine @melissaperreault 