### PR TITLE
Using font size and spacing for mega menu hierarchy

### DIFF
--- a/assets/component-mega-menu.css
+++ b/assets/component-mega-menu.css
@@ -49,11 +49,17 @@
 .mega-menu__link {
   color: rgba(var(--color-foreground), 0.75);
   display: block;
+  font-size: 1.2rem;
   line-height: calc(1 + 0.3 / var(--font-body-scale));
   padding-bottom: 0.8rem;
   padding-top: 0.8rem;
   text-decoration: none;
   transition: text-decoration var(--duration-short) ease;
+}
+
+.mega-menu__link--level-2:not(:only-child) {
+  font-size: 1.4rem;
+  margin-bottom: 1rem;
 }
 
 .header--top-center .mega-menu__list {

--- a/sections/header.liquid
+++ b/sections/header.liquid
@@ -431,7 +431,7 @@
                         <ul class="mega-menu__list page-width{% if link.levels == 1 %} mega-menu__list--condensed{% endif %}" role="list">
                           {%- for childlink in link.links -%}
                             <li>
-                              <a href="{{ childlink.url }}" class="mega-menu__link link font-body-bold{% if childlink.current %} mega-menu__link--active{% endif %}"{% if childlink.current %} aria-current="page"{% endif %}>
+                              <a href="{{ childlink.url }}" class="mega-menu__link mega-menu__link--level-2 link{% if childlink.current %} mega-menu__link--active{% endif %}"{% if childlink.current %} aria-current="page"{% endif %}>
                                 {{ childlink.title | escape }}
                               </a>
                               {%- if childlink.links != blank -%}


### PR DESCRIPTION
**Why are these changes introduced?**

Further explorations on how to improve the hierarchy of the different navigation levels for the mega menu.  In this PR we are trying removing the `bold` and instead using **font size** and **spacing** to help to emphasize the hierarchy.

**What approach did you take?**

Added a modifier.  I tried to use some fancy selectors, but this was cleaner.

**Other considerations**

I used `:not(:only-child)` to ensure that L2 links on their own won't have additional margins.

We may want to fine tune the numbers for the margin below the L2 link as well as potentially the vertical gap between the rows.  The total space below the L2 links including their padding is `1.8rem` and the total space between rows is `2.4rem` which is quite similar.

**Testing steps/scenarios**

- [ ] Add a navigation that has 3 levels
- [ ] In header -> apply "Mega Menu" setting to menu type setting

**Note:** This PR shouldn't affect any other menu types or make any changes to menus that only have 1 or 2 levels.

**Demo links**

- [Editor](https://os2-demo.myshopify.com/admin/themes/127752568854/editor)

**Checklist**
- [ ] Added PR summary for [release notes](https://themes.shopify.com/themes/dawn/styles/default#ReleaseNotes)
- [ ] Notified the [help.shopify.com](https://help.shopify.com) team about updates to theme settings (current contact: Kimli)
- [ ] Followed [theme code principles](https://github.com/Shopify/dawn/blob/main/.github/CONTRIBUTING.md#theme-code-principles)
- [ ] Linted with [Theme Check](https://github.com/Shopify/theme-check)
- [ ] Tested on [mobile](https://shopify.dev/themes/store/requirements#mobile-browser-requirements)
- [ ] Tested on [multiple browsers](https://shopify.dev/themes/store/requirements#desktop-browser-requirements)
- [ ] Tested for [accessibility](https://shopify.dev/themes/best-practices/accessibility)
