### PR TITLE
Featured Collection : Fix max width setting

### DIFF
--- a/assets/template-collection.css
+++ b/assets/template-collection.css
@@ -71,6 +71,7 @@
 
   .collection--full-width slider-component:not(.slider-component-desktop) {
     padding: 0 1.5rem;
+    max-width: none;
   }
 }
 


### PR DESCRIPTION
**Why are these changes introduced?**
Fixes `Make products full width` setting on Featured Collections.

**What approach did you take?**
Add `max-width: none` to the container.

**Demo links**
- [Store](https://os2-demo.myshopify.com/?preview_theme_id=127766593558)
- [Editor](https://os2-demo.myshopify.com/admin/themes/127766593558/editor)

**Checklist**
- [x] Added PR summary for [release notes](https://themes.shopify.com/themes/dawn/styles/default#ReleaseNotes)
- [x] Notified the [help.shopify.com](https://help.shopify.com) team about updates to theme settings (current contact: Kimli)
- [x] Followed [theme code principles](https://github.com/Shopify/dawn/blob/main/.github/CONTRIBUTING.md#theme-code-principles)
- [x] Linted with [Theme Check](https://github.com/Shopify/theme-check)
- [x] Tested on [mobile](https://shopify.dev/themes/store/requirements#mobile-browser-requirements)
- [x] Tested on [multiple browsers](https://shopify.dev/themes/store/requirements#desktop-browser-requirements)
- [x] Tested for [accessibility](https://shopify.dev/themes/best-practices/accessibility)