### PR TITLE
Fix shop link on giftcard page

### DIFF
--- a/templates/gift_card.liquid
+++ b/templates/gift_card.liquid
@@ -149,7 +149,7 @@
         {%- endif -%}
         <div class="gift-card__buttons no-print">
           <a
-            href="{{ request.origin }}"
+            href="{{ shop.url }}"
             class="button"
             target="_blank"
             rel="noopener"


### PR DESCRIPTION
**PR Summary:** 
Quick fix for the 'Continue Shopping' link on the gift card page by reverting a previous change

**Why are these changes introduced?**
Fixes https://github.com/Shopify/dawn/issues/1556

**What approach did you take?**
Reverts https://github.com/Shopify/dawn/commit/1098fd8137aa7659bd73c015a7237ce5fe258b1b on the Gift Card page