### PR TITLE
Fix gradient background in image with text

### DIFF
--- a/assets/component-image-with-text.css
+++ b/assets/component-image-with-text.css
@@ -163,9 +163,8 @@
 }
 
 .image-with-text--overlap .image-with-text__content {
-  transform: translate(0 , -3rem);
   width: 90%;
-  margin: 0 auto;
+  margin: -3rem auto 0;
 }
 
 @media screen and (min-width: 750px) {
@@ -207,11 +206,13 @@
     height: auto;
     width: calc(100% + 4rem);
     min-width: calc(100% + 4rem);
-    transform: translate(-4rem, 0);
+    margin-top: 0;
+    margin-left: -4rem;
   }
 
   .image-with-text--overlap .image-with-text__grid--reverse .image-with-text__content {
-    transform: translate(4rem, 0);
+    margin-left: 0;
+    margin-right: -4rem;
   }
 
   .image-with-text--overlap .image-with-text__grid--reverse .image-with-text__text-item {


### PR DESCRIPTION
**PR Summary:** 

Fixes background gradient positioning in image with text content.

**Why are these changes introduced?**

Fixes #1559 

**What approach did you take?**

Replaced css transforms used to position the content overlap with negative margins. The transform props ruin the effect of the `background-attachment: fixed` that we currently use in our `.gradient` class.

**Other considerations**

**Testing steps/scenarios**
1. Add gradient background to image with text
2. Enable overlap setting in image with text
3. Ensure gradient background behaves the same as backgrounds in other sections
4. Ensure overlap positioning is the same as before (desktop and mobile)

**Demo links**

- [Editor](https://os2-demo.myshopify.com/admin/themes/127782453270/editor)

**Checklist**
- [ ] Added PR summary for [release notes](https://themes.shopify.com/themes/dawn/styles/default#ReleaseNotes)
- [ ] Notified the [help.shopify.com](https://help.shopify.com) team about updates to theme settings (current contact: Kimli)
- [ ] Followed [theme code principles](https://github.com/Shopify/dawn/blob/main/.github/CONTRIBUTING.md#theme-code-principles)
- [ ] Linted with [Theme Check](https://github.com/Shopify/theme-check)
- [ ] Tested on [mobile](https://shopify.dev/themes/store/requirements#mobile-browser-requirements)
- [ ] Tested on [multiple browsers](https://shopify.dev/themes/store/requirements#desktop-browser-requirements)
- [ ] Tested for [accessibility](https://shopify.dev/themes/best-practices/accessibility)
