### PR TITLE
Quick Add: Fix button overflow on mobile carousel 

### DIFF
--- a/assets/quick-add.css
+++ b/assets/quick-add.css
@@ -197,4 +197,5 @@ quick-add-modal .product-form__buttons {
 .quick-add__submit {
   padding: 0 1rem;
   min-width: 100%;
+  box-sizing: border-box;
 }


### PR DESCRIPTION
**Why are these changes introduced?**
Fix button overflow on mobile product cards.

Fixes #1566.

**What approach did you take?**
Added `box-sizing: border-box`.

**Testing steps/scenarios**
- [ ] Add a `Featured Collection` section to the page:
  - [ ] Enable quick add button
  - [ ] Enable swipe on mobile
  - [ ] Set `Number of columns on mobile` to `2 columns`
- [ ] Test on mobile viewport

**Before & After**
<img width="320" alt="image" src="https://user-images.githubusercontent.com/37168033/161139623-1c5ff70f-46ee-461d-8dc9-bacb6fbfbc7e.png"> <img width="320" alt="image" src="https://user-images.githubusercontent.com/37168033/161139696-f613c7c7-d96a-4edb-9374-1fb2afc005d5.png">

**Demo links**
- [Store](https://os2-demo.myshopify.com/?preview_theme_id=127787532310)
- [Editor](https://os2-demo.myshopify.com/admin/themes/127787532310/editor)