### PR TITLE
Fix no-js layout for drawer and product count position

### DIFF
--- a/assets/component-facets.css
+++ b/assets/component-facets.css
@@ -992,11 +992,11 @@ input.mobile-facets__checkbox {
     padding-right: 3rem;
   }
 
-  .js .facets-vertical .facets-wrapper.no-filter {
+  .facets-vertical .facets-wrapper--no-filters {
     display: none;
   }
 
-  .no-js .facets-vertical .facets-wrapper.no-filter {
+  .no-js .facets-vertical .facets-wrapper--no-filter {
     display: block;
   }
 

--- a/assets/component-facets.css
+++ b/assets/component-facets.css
@@ -1069,6 +1069,7 @@ input.mobile-facets__checkbox {
   .facets-container-drawer {
     display: flex;;
     flex-flow: row wrap;
+    align-items: center;
     column-gap: 0;
   }
 

--- a/assets/component-facets.css
+++ b/assets/component-facets.css
@@ -1074,22 +1074,11 @@ input.mobile-facets__checkbox {
 
   .facets-container-drawer .mobile-facets__wrapper  {
     margin-right: 2rem;
+    flex-grow: 1;
   }
 
   .facets-container-drawer .product-count {
-    align-self: flex-start;
-  }
-
-  .facets-container-drawer .mobile-facets__wrapper {
-    width: calc(40% - 2rem);
-  }
-
-  .facets-container-drawer .facets {
-    width: 40%;
-  }
-
-  .facets-container-drawer .product-count {
-    width: 20%;
+    margin-left: 3.5rem;
   }
 
   .facets-container-drawer .facets-pill {
@@ -1099,18 +1088,6 @@ input.mobile-facets__checkbox {
 
   .facets-container-drawer .facets__form {
     display: block;
-  }
-
-  .no-js .facets-container-drawer .mobile-facets__wrapper  {
-    width: calc(20% - 2rem);
-  }
-
-  .no-js  .facets-container-drawer .facets {
-    width: 60%;
-  }
-
-  .no-js .facets-container-drawer .product-count {
-    width: 20%;
   }
 }
 

--- a/assets/component-facets.css
+++ b/assets/component-facets.css
@@ -996,7 +996,7 @@ input.mobile-facets__checkbox {
     display: none;
   }
 
-  .no-js .facets-vertical .facets-wrapper--no-filter {
+  .no-js .facets-vertical .facets-wrapper--no-filters {
     display: block;
   }
 
@@ -1040,8 +1040,9 @@ input.mobile-facets__checkbox {
     margin-bottom: 1.5rem;
   }
 
-  .facets-vertical .facet-filters.sorting.no-js {
+  .no-js .facets-vertical .facet-filters.sorting {
     padding-left: 0;
+    flex-direction: column;
   }
 
   .facets-vertical .facet-checkbox input[type='checkbox'] {
@@ -1079,7 +1080,7 @@ input.mobile-facets__checkbox {
   }
 
   .facets-container-drawer .product-count {
-    margin-left: 3.5rem;
+    margin:0 0 0.5rem 3.5rem;
   }
 
   .facets-container-drawer .facets-pill {

--- a/sections/main-collection-product-grid.liquid
+++ b/sections/main-collection-product-grid.liquid
@@ -77,7 +77,7 @@
     {{ 'component-facets.css' | asset_url | stylesheet_tag }}
     <script src="{{ 'facets.js' | asset_url }}" defer="defer"></script>
     {%- if section.settings.enable_filtering or section.settings.enable_sorting -%}
-      <aside aria-labelledby="verticalTitle" class="facets-wrapper{% if section.settings.enable_filtering == false %} no-filter{% endif %}{% if section.settings.filter_type != 'vertical' %} page-width{% endif %}" id="main-collection-filters" data-id="{{ section.id }}">
+      <aside aria-labelledby="verticalTitle" class="facets-wrapper{% unless section.settings.enable_filtering %} facets-wrapper--no-filters{% endunless %}{% if section.settings.filter_type != 'vertical' %} page-width{% endif %}" id="main-collection-filters" data-id="{{ section.id }}">
         {% render 'facets', results: collection, enable_filtering: section.settings.enable_filtering, enable_sorting: section.settings.enable_sorting, filter_type: section.settings.filter_type %}
       </aside>
     {%- endif -%}

--- a/sections/main-search.liquid
+++ b/sections/main-search.liquid
@@ -179,7 +179,7 @@
     <div{% if section.settings.filter_type == 'vertical' %} class="facets-vertical page-width"{% endif %}>
       {%- if search.filters != empty -%}
         {%- if section.settings.enable_filtering or section.settings.enable_sorting -%}
-          <aside aria-labelledby="verticalTitle" class="facets-wrapper{% if section.settings.enable_filtering == false %} no-filter{% endif %}{% if section.settings.filter_type != 'vertical' %} page-width{% endif %}" id="main-search-filters" data-id="{{ section.id }}">
+          <aside aria-labelledby="verticalTitle" class="facets-wrapper{% unless section.settings.enable_filtering %} facets-wrapper--no-filters{% endunless %}{% if section.settings.filter_type != 'vertical' %} page-width{% endif %}" id="main-search-filters" data-id="{{ section.id }}">
             {% render 'facets', results: search, enable_filtering: section.settings.enable_filtering, enable_sorting: section.settings.enable_sorting, filter_type: section.settings.filter_type %}
           </aside>
         {%- endif -%}

--- a/snippets/facets.liquid
+++ b/snippets/facets.liquid
@@ -355,7 +355,7 @@
     {%- if enable_sorting and filter_type == 'vertical' -%}
       <facet-filters-form class="small-hide">
         <form>
-          <div class="facet-filters sorting caption no-js small-hide">
+          <div class="facet-filters sorting caption no-js">
             <div class="facet-filters__field">
               <h2 class="facet-filters__label caption-large text-body">
                 <label for="SortBy">{{ 'products.facets.sort_by_label' | t }}</label>

--- a/snippets/facets.liquid
+++ b/snippets/facets.liquid
@@ -354,8 +354,8 @@
     {% comment %} Sorting for vertical filter are grouped with filter when no JS{% endcomment %}
     {%- if enable_sorting and filter_type == 'vertical' -%}
       <facet-filters-form class="small-hide">
-        <form>
-          <div class="facet-filters sorting caption no-js">
+        <form class="no-js">
+          <div class="facet-filters sorting caption">
             <div class="facet-filters__field">
               <h2 class="facet-filters__label caption-large text-body">
                 <label for="SortBy">{{ 'products.facets.sort_by_label' | t }}</label>

--- a/snippets/facets.liquid
+++ b/snippets/facets.liquid
@@ -353,7 +353,7 @@
     </facet-filters-form>
     {% comment %} Sorting for vertical filter are grouped with filter when no JS{% endcomment %}
     {%- if enable_sorting and filter_type == 'vertical' -%}
-      <facet-filters-form class="facets small-hide">
+      <facet-filters-form class="small-hide">
         <form>
           <div class="facet-filters sorting caption no-js small-hide">
             <div class="facet-filters__field">

--- a/snippets/facets.liquid
+++ b/snippets/facets.liquid
@@ -353,7 +353,7 @@
     </facet-filters-form>
     {% comment %} Sorting for vertical filter are grouped with filter when no JS{% endcomment %}
     {%- if enable_sorting and filter_type == 'vertical' -%}
-      <facet-filters-form>
+      <facet-filters-form class="facets small-hide">
         <form>
           <div class="facet-filters sorting caption no-js small-hide">
             <div class="facet-filters__field">
@@ -376,7 +376,7 @@
             </noscript>
           </div>
         </form>
-      <facet-filters-form>
+      </facet-filters-form>
     {%- endif -%}    
   {%- endif -%}
   {% comment %}  Drawer and mobile filter {% endcomment %}


### PR DESCRIPTION
**PR Summary:** 
See https://github.com/Shopify/dawn/pull/1443

**Why are these changes introduced?**
This PR fixes the layout/UI bugs for vertical filters in these specific usecases on Collection and Search.

Specifically these ones: 

**No JS**
Drawer option Desktop:

| **Filter and sort state** | **Filter visible** | **Sort visible** | **Product count visible** | Expected layout |
|---|---|---|---|---|
| Sort enabled only | ✅ No | ✅ Yes | ✅ | ✅  |
| Filters enabled only | ✅ Yes | ✅ No | ✅  | ⚠️ [Product count position is misaligned horizontally](https://screenshot.click/22-04-3lwfq-3pp1z.png) and [here](https://screenshot.click/22-04-ryt1f-xkwa3.png) <br> ⚠️ [filter pills not place properly](https://screenshot.click/22-04-f419h-ix8hl.png) |
| Filters and sort enabled | ✅ Yes | ✅ Yes | ✅  | ✅ |
| Filters and sort disabled | ✅ No | ✅ No | ✅ (search count) | ✅ |

**JS**
Drawer option Desktop: 

| **Filter and sort state** | **Filter visible** | **Sort visible** | **Product count visible** | Expected layout |
|---|---|---|---|---|
| Sort enabled only | ✅ No | ✅ Yes | ✅ | ✅  |
| Filters enabled only | ✅ Yes | ✅ No | ✅  | ⚠️ [Product count position is misaligned horizontally](https://screenshot.click/22-04-3lwfq-3pp1z.png) and [here](https://screenshot.click/22-04-ryt1f-xkwa3.png) |
| Filters and sort enabled | ✅ Yes | ✅ Yes | ✅  | ✅ |
| Filters and sort disabled | ✅ No | ✅ No | ✅ (search count) | ✅ |

**Sort by position**
https://github.com/Shopify/dawn/pull/1568#issuecomment-1085115319 Currently, the sort by/product count width is changing between Drawer and Horizontal.

**Fix HMTL**
I noticed an HTML element which wasn't closed, so the browser was closing the element incorrectly. 

**What approach did you take?**

1. Sort misalignment Horizontal vs. Drawer. See https://github.com/Shopify/dawn/pull/1568#issuecomment-1085115319
    Horizontal is using a grid layout, while Drawer is using flex. 
    * I decided to remove the fixed width being applied when drawer is enabled. This will allow Sort and product count to rely on their content's width. 
    * At the same time, I applied `margin-left: 3.5rem` to product count which is equivalent to the grid gap being applied on Horizontal. 

2. Product count misalignment (horizontal alignment) 
  * By applying `flex-grow: 1` to `facets-container-drawer .mobile-facets__wrapper` it means that the sort by and product count will be forced to the end of the row, allowing them to remain in the right position.

3. No JS product count position + Pills position
  * Similar to # 1, I removed the fixed width positioning. 
  * With pills being set to 100% in the previous PR, it means that they will be forced to take up their own row.

**Other considerations**
N/A

**Testing steps/scenarios**
- [ ] I will share tables below in a separate comment with all the testing scenarios to make sure regressions were not introduced.

**Demo links**
_Please include a link to a demo store that includes preconfigured sections and settings to allow reviewers to easily test the features you are working on._

- [Editor](https://os2-demo.myshopify.com/admin/themes/127790284822/editor?previewPath=%2Fcollections%2Fsets)

**Checklist**
- [x] Added PR summary for [release notes](https://themes.shopify.com/themes/dawn/styles/default#ReleaseNotes)
- [ ] ~Notified the [help.shopify.com](https://help.shopify.com) team about updates to theme settings (current contact: Kimli)~
- [x] Followed [theme code principles](https://github.com/Shopify/dawn/blob/main/.github/CONTRIBUTING.md#theme-code-principles)
- [x] Linted with [Theme Check](https://github.com/Shopify/theme-check)
- [x] Tested on [mobile](https://shopify.dev/themes/store/requirements#mobile-browser-requirements)
- [x] Tested on [multiple browsers](https://shopify.dev/themes/store/requirements#desktop-browser-requirements)
- [x] Tested for [accessibility](https://shopify.dev/themes/best-practices/accessibility)
