### PR TITLE
Update padding on Quick Add button

### DIFF
--- a/assets/quick-add.css
+++ b/assets/quick-add.css
@@ -195,7 +195,7 @@ quick-add-modal .product-form__buttons {
 }
 
 .quick-add__submit {
-  padding: 0 1rem;
+  padding: 0.8rem;
   min-width: 100%;
   box-sizing: border-box;
 }


### PR DESCRIPTION
**Why are these changes introduced?**
Add vertical padding to Quick Add button. ([Original comment](https://github.com/Shopify/dawn/pull/1567#issuecomment-1087774454))

**What approach did you take?**
Updated `padding: 0 1rem` to `padding: 0.8rem`. A multiple of 4 was chosen to start systematizing spacing in the theme.

**Testing steps/scenarios**
- [ ] Using the inspector, update the button label to a longer string like `Aan winkelwagen toevoegen`
- [ ] Resize the window so the button is small enough to add line breaks to the label.

**Demo links**
_Please include a link to a demo store that includes preconfigured sections and settings to allow reviewers to easily test the features you are working on._
- [Store](https://os2-demo.myshopify.com/?preview_theme_id=127808929814)
- [Editor](https://os2-demo.myshopify.com/admin/themes/127808929814/editor)