### PR TITLE
Update icon-small-close svg color settings association success

### DIFF
--- a/snippets/icon-close-small.liquid
+++ b/snippets/icon-close-small.liquid
@@ -1,4 +1,4 @@
 <svg  aria-hidden="true" focusable="false" role="presentation" width="12" height="13" class="icon icon-close-small" viewBox="0 0 12 13" fill="none" xmlns="http://www.w3.org/2000/svg">
-  <path d="M8.48627 9.32917L2.82849 3.67098" stroke="#333030" stroke-linecap="round" stroke-linejoin="round"/>
-  <path d="M2.88539 9.38504L8.42932 3.61524" stroke="#333030" stroke-linecap="round" stroke-linejoin="round"/>
+  <path d="M8.48627 9.32917L2.82849 3.67098" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"/>
+  <path d="M2.88539 9.38504L8.42932 3.61524" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"/>
   </svg>


### PR DESCRIPTION
**PR Summary:** 

Update the filter pills small clear icon color to use the text color.


**Why are these changes introduced?**

Fixes #1590 
Fixes https://github.com/Shopify/dawn/issues/441

**What approach did you take?**

I replaced the `stroke="#333030"` with `stroke="currentColor"` to make sure the icon-close-small svg was picking the right color scheme color. 

- [Before](https://screenshot.click/22-04-m20jr-nkxdm.png)
- [After](https://screenshot.click/22-04-tp2av-p8cex.png) 

**Testing steps/scenarios**
- [ ] Change theme setting text and outline color pickers to color of your preference to notice which color impact what
- [ ] Visit the Collection template
- [ ] Apply filters to reveal filter pills
- [ ] Ensure the text and the clear svg have the same color
- [ ] Visit the Search template
- [ ] Do step 3 and 4 again

**Demo links**
_Please include a link to a demo store that includes preconfigured sections and settings to allow reviewers to easily test the features you are working on._

- [Editor](https://os2-demo.myshopify.com/admin/themes/127810928662/editor?previewPath=%2Fcollections%2Fall&context=theme&category=gid%3A%2F%2Fshopify%2FOnlineStoreThemeSettingsCategory%2FColors%3Ftheme_id%3D127810928662%26first_setting_id%3Dcolors_solid_button_labels)

**Checklist**
- [x] Added PR summary for [release notes](https://themes.shopify.com/themes/dawn/styles/default#ReleaseNotes)
- [ ] ~Notified the [help.shopify.com](https://help.shopify.com) team about updates to theme settings (current contact: Kimli)~
- [x] Followed [theme code principles](https://github.com/Shopify/dawn/blob/main/.github/CONTRIBUTING.md#theme-code-principles)
- [x] Linted with [Theme Check](https://github.com/Shopify/theme-check)
- [x] Tested on [mobile](https://shopify.dev/themes/store/requirements#mobile-browser-requirements)
- [x] Tested on [multiple browsers](https://shopify.dev/themes/store/requirements#desktop-browser-requirements)
- [x] Tested for [accessibility](https://shopify.dev/themes/best-practices/accessibility)
