### PR TITLE
fix(predictive-search): remove font from image

### DIFF
--- a/assets/component-predictive-search.css
+++ b/assets/component-predictive-search.css
@@ -172,5 +172,4 @@ predictive-search[loading] .predictive-search__results-list:first-child {
 .predictive-search__image {
   grid-area: product-image;
   object-fit: contain;
-  font-family: 'object-fit: contain';
 }


### PR DESCRIPTION
**PR Summary:** 
There was an unnecessary `font-family` property on the search image with the content of `'object-fit: container'`, which is invalid at first and second we don’t really need font-family on the search image explicit.


**Why are these changes introduced?**

clean code

**Testing steps/scenarios**
- [x] No difference at production, just syntax sugar.

**Checklist**
- [x] Added PR summary for [release notes](https://themes.shopify.com/themes/dawn/styles/default#ReleaseNotes)
- [x] Notified the [help.shopify.com](https://help.shopify.com) team about updates to theme settings (current contact: Kimli)
- [x] Followed [theme code principles](https://github.com/Shopify/dawn/blob/main/.github/CONTRIBUTING.md#theme-code-principles)
- [] Linted with [Theme Check](https://github.com/Shopify/theme-check)
- [ ] Tested on [mobile](https://shopify.dev/themes/store/requirements#mobile-browser-requirements)
- [ ] Tested on [multiple browsers](https://shopify.dev/themes/store/requirements#desktop-browser-requirements)
- [ ] Tested for [accessibility](https://shopify.dev/themes/best-practices/accessibility)
