### PR TITLE
Fix Product strucure-data markup for Brand property

### DIFF
--- a/sections/featured-product.liquid
+++ b/sections/featured-product.liquid
@@ -407,7 +407,7 @@
       "sku": {{ product.selected_or_first_available_variant.sku | json }},
     {%- endif %}
     "brand": {
-      "@type": "Thing",
+      "@type": "Brand",
       "name": {{ product.vendor | json }}
     },
     "offers": [

--- a/sections/main-product.liquid
+++ b/sections/main-product.liquid
@@ -601,7 +601,7 @@
         "sku": {{ product.selected_or_first_available_variant.sku | json }},
       {%- endif %}
       "brand": {
-        "@type": "Thing",
+        "@type": "Brand",
         "name": {{ product.vendor | json }}
       },
       "offers": [


### PR DESCRIPTION
**PR Summary:** 

_Fix Product structure-data markup for a Brand property

Example product structure data => Ref: https://developers.google.com/search/docs/advanced/structured-data/product


**Why are these changes introduced?**

Google Search Console detected incorrectly used "Brand" product structured data

**What approach did you take?**

Referenced [Google Search Central Documentation - Product Structured Data](https://developers.google.com/search/docs/advanced/structured-data/product)