### PR TITLE
Added missing semi colon in global.js

### DIFF
--- a/assets/global.js
+++ b/assets/global.js
@@ -837,7 +837,7 @@ class VariantSelects extends HTMLElement {
     fetch(`${this.dataset.url}?variant=${this.currentVariant.id}&section_id=${this.dataset.originalSection ? this.dataset.originalSection : this.dataset.section}`)
       .then((response) => response.text())
       .then((responseText) => {
-        const html = new DOMParser().parseFromString(responseText, 'text/html')
+        const html = new DOMParser().parseFromString(responseText, 'text/html');
         const destination = document.getElementById(`price-${this.dataset.section}`);
         const source = html.getElementById(`price-${this.dataset.originalSection ? this.dataset.originalSection : this.dataset.section}`);
         if (source && destination) destination.innerHTML = source.innerHTML;


### PR DESCRIPTION
Was reading the code and noticed a missing semi colon for terminating the end of a line of JavaScript. I know you guys have a whole template for a PR but it's so minor it feels a little silly to write it all out. 

I really appreciate the work that you guys do with Dawn, it is actually very easy to read the source code and I love the HTML first approach. Excellent engineering effort by Shopify! The least I can do is add a missing semi colon.