### PR TITLE
1-click Quick Add for products with 1 non-default variant

### DIFF
--- a/snippets/card-product.liquid
+++ b/snippets/card-product.liquid
@@ -143,7 +143,7 @@
         {%- if show_quick_add -%}
           <div class="quick-add">
             {%- assign product_form_id = 'quick-add-' | append: section_id | append: card_product.id -%}
-            {%- if card_product.has_only_default_variant -%}
+            {%- if card_product.has_only_default_variant or card_product.card_product.options.size == 1 -%}
               <product-form>
                 {%- form 'product', card_product, id: product_form_id, class: 'form', novalidate: 'novalidate', data-type: 'add-to-cart-form' -%}
                   <input type="hidden" name="id" value="{{ card_product.selected_or_first_available_variant.id }}" disabled>

--- a/snippets/card-product.liquid
+++ b/snippets/card-product.liquid
@@ -143,7 +143,7 @@
         {%- if show_quick_add -%}
           <div class="quick-add">
             {%- assign product_form_id = 'quick-add-' | append: section_id | append: card_product.id -%}
-            {%- if card_product.has_only_default_variant or card_product.card_product.options.size == 1 -%}
+            {%- if card_product.has_only_default_variant -%}
               <product-form>
                 {%- form 'product', card_product, id: product_form_id, class: 'form', novalidate: 'novalidate', data-type: 'add-to-cart-form' -%}
                   <input type="hidden" name="id" value="{{ card_product.selected_or_first_available_variant.id }}" disabled>

--- a/snippets/card-product.liquid
+++ b/snippets/card-product.liquid
@@ -143,7 +143,7 @@
         {%- if show_quick_add -%}
           <div class="quick-add">
             {%- assign product_form_id = 'quick-add-' | append: section_id | append: card_product.id -%}
-            {%- if card_product.has_only_default_variant -%}
+            {%- if card_product.has_only_default_variant or card_product.options.size == 1 -%}
               <product-form>
                 {%- form 'product', card_product, id: product_form_id, class: 'form', novalidate: 'novalidate', data-type: 'add-to-cart-form' -%}
                   <input type="hidden" name="id" value="{{ card_product.selected_or_first_available_variant.id }}" disabled>


### PR DESCRIPTION
**PR Summary:** 
Decreases clicks necessary to add products to the cart in cases where a product would have exactly one non-default variant or product option

**Why are these changes introduced?**
Fixes #1604.

**Other considerations**
An alternative could be to provide an option for the merchant to toggle this on or off.

**Checklist**
- [ ] Added PR summary for [release notes](https://themes.shopify.com/themes/dawn/styles/default#ReleaseNotes)
- [ ] Notified the [help.shopify.com](https://help.shopify.com) team about updates to theme settings (current contact: Kimli)
- [ ] Followed [theme code principles](https://github.com/Shopify/dawn/blob/main/.github/CONTRIBUTING.md#theme-code-principles)
- [ ] Linted with [Theme Check](https://github.com/Shopify/theme-check)
- [ ] Tested on [mobile](https://shopify.dev/themes/store/requirements#mobile-browser-requirements)
- [ ] Tested on [multiple browsers](https://shopify.dev/themes/store/requirements#desktop-browser-requirements)
- [ ] Tested for [accessibility](https://shopify.dev/themes/best-practices/accessibility)
