### PR TITLE
Remove unused setting from product grid

### DIFF
--- a/locales/cs.schema.json
+++ b/locales/cs.schema.json
@@ -1272,9 +1272,6 @@
         "header__3": {
           "content": "Karta produktu"
         },
-        "collapse_on_larger_devices": {
-          "label": "Sbalit v počítači"
-        },
         "show_rating": {
           "label": "Zobrazit hodnocení produktů",
           "info": "Pokud chcete zobrazovat hodnocení, přidejte si aplikaci pro hodnocení produktů. [Zjistit více](https://help.shopify.com/manual/online-store/themes/theme-structure/page-types#product-grid-section-settings)"

--- a/locales/da.schema.json
+++ b/locales/da.schema.json
@@ -1272,9 +1272,6 @@
         "header__3": {
           "content": "Produktkort"
         },
-        "collapse_on_larger_devices": {
-          "label": "Skjul på computer"
-        },
         "show_rating": {
           "label": "Vis produktbedømmelser",
           "info": "Hvis du vil vise bedømmelser, skal du tilføje en app til produktbedømmelse. [Få mere at vide](https://help.shopify.com/manual/online-store/themes/theme-structure/page-types#product-grid-section-settings)"

--- a/locales/de.schema.json
+++ b/locales/de.schema.json
@@ -1272,9 +1272,6 @@
           "label": "Filtern aktivieren",
           "info": "[Filter anpassen](/admin/menus)"
         },
-        "collapse_on_larger_devices": {
-          "label": "Auf Desktop minimieren"
-        },
         "show_rating": {
           "label": "Produktbewertung anzeigen",
           "info": "Um eine Bewertung anzuzeigen, musst du eine Produktbewertungs-App hinzufügen. [Mehr Informationen](https://help.shopify.com/manual/online-store/themes/theme-structure/page-types#product-grid-section-settings)"

--- a/locales/en.default.schema.json
+++ b/locales/en.default.schema.json
@@ -1418,9 +1418,6 @@
           "label": "Enable quick add button",
           "info": "Optimal with popup or drawer cart type."
         },
-        "collapse_on_larger_devices": {
-          "label": "Collapse on desktop"
-        },
         "header_mobile": {
           "content": "Mobile Layout"
         },

--- a/locales/es.schema.json
+++ b/locales/es.schema.json
@@ -1272,9 +1272,6 @@
         "header__3": {
           "content": "Tarjeta de producto"
         },
-        "collapse_on_larger_devices": {
-          "label": "Contraer en computadora"
-        },
         "show_rating": {
           "label": "Mostrar calificación de productos",
           "info": "Para mostrar una calificación, agrega una aplicación de calificación de productos [Más información](https://help.shopify.com/manual/online-store/themes/theme-structure/page-types#product-grid-section-settings)"

--- a/locales/fi.schema.json
+++ b/locales/fi.schema.json
@@ -1272,9 +1272,6 @@
         "header__3": {
           "content": "Tuotekortti"
         },
-        "collapse_on_larger_devices": {
-          "label": "Pienennä tietokoneella"
-        },
         "show_rating": {
           "label": "Näytä tuotteen luokitus",
           "info": "Näytä luokitus lisäämällä tuotearviointisovellus. [Lisätietoja](https://help.shopify.com/manual/online-store/themes/theme-structure/page-types#product-grid-section-settings)"

--- a/locales/fr.schema.json
+++ b/locales/fr.schema.json
@@ -1272,9 +1272,6 @@
           "label": "Activer le filtrage",
           "info": "[Personnaliser les filtres](/admin/menus)"
         },
-        "collapse_on_larger_devices": {
-          "label": "Résuire sur le bureau"
-        },
         "show_rating": {
           "label": "Afficher la note du produit",
           "info": "Pour afficher une note, ajoutez une application d'évaluation de produits. [En savoir plus](https://help.shopify.com/manual/online-store/themes/theme-structure/page-types#product-grid-section-settings)"

--- a/locales/it.schema.json
+++ b/locales/it.schema.json
@@ -1272,9 +1272,6 @@
         "header__3": {
           "content": "Scheda prodotto"
         },
-        "collapse_on_larger_devices": {
-          "label": "Comprimi su desktop"
-        },
         "show_rating": {
           "label": "Mostra valutazione del prodotto",
           "info": "Per mostrare una valutazione, aggiungi un'app di valutazione del prodotto. [Maggiori informazioni](https://help.shopify.com/manual/online-store/themes/theme-structure/page-types#product-grid-section-settings)"

--- a/locales/ja.schema.json
+++ b/locales/ja.schema.json
@@ -1272,9 +1272,6 @@
         "header__3": {
           "content": "商品カード"
         },
-        "collapse_on_larger_devices": {
-          "label": "デスクトップで折りたたむ"
-        },
         "show_rating": {
           "label": "商品の評価を表示",
           "info": "評価を表示するには、商品評価アプリを追加します。[詳しくはこちら](https://help.shopify.com/manual/online-store/themes/theme-structure/page-types#product-grid-section-settings)"

--- a/locales/ko.schema.json
+++ b/locales/ko.schema.json
@@ -1272,9 +1272,6 @@
         "header__3": {
           "content": "제품 카드"
         },
-        "collapse_on_larger_devices": {
-          "label": "데스크톱에서 축소"
-        },
         "show_rating": {
           "label": "제품 평점 표시",
           "info": "평점을 표시하려면 제품 평점 앱을 추가하십시오. [자세히 알아보기](https://help.shopify.com/manual/online-store/themes/theme-structure/page-types#product-grid-section-settings)"

--- a/locales/nb.schema.json
+++ b/locales/nb.schema.json
@@ -1272,9 +1272,6 @@
           "label": "Aktiver filtrering",
           "info": "[Tilpass filtre](/admin/menus)"
         },
-        "collapse_on_larger_devices": {
-          "label": "Lukk på datamaskiner"
-        },
         "show_rating": {
           "label": "Vis produktvurdering",
           "info": "Legg til en produktvurderingsapp for å vise en vurdering. [Finn ut mer](https://help.shopify.com/manual/online-store/themes/theme-structure/page-types#product-grid-section-settings)"

--- a/locales/nl.schema.json
+++ b/locales/nl.schema.json
@@ -1272,9 +1272,6 @@
         "header__3": {
           "content": "Productkaart"
         },
-        "collapse_on_larger_devices": {
-          "label": "Inklappen op desktop"
-        },
         "show_rating": {
           "label": "Geef productbeoordeling weer",
           "info": "Voeg een app toe voor productbeoordelingen om deze weer te geven. [Meer informatie](https://help.shopify.com/manual/online-store/themes/theme-structure/page-types#product-grid-section-settings)"

--- a/locales/pl.schema.json
+++ b/locales/pl.schema.json
@@ -1272,9 +1272,6 @@
         "header__3": {
           "content": "Karta produktów"
         },
-        "collapse_on_larger_devices": {
-          "label": "Zwiń na komputerze"
-        },
         "show_rating": {
           "label": "Pokaż ocenę produktu",
           "info": "Aby wyświetlić ocenę, dodaj aplikację do oceny produktów. [Dowiedz się więcej](https://help.shopify.com/manual/online-store/themes/theme-structure/page-types#product-grid-section-settings)"

--- a/locales/pt-BR.schema.json
+++ b/locales/pt-BR.schema.json
@@ -1272,9 +1272,6 @@
           "label": "Habilitar a filtragem",
           "info": "[Personalizar filtros](/admin/menus)"
         },
-        "collapse_on_larger_devices": {
-          "label": "Recolher no desktop"
-        },
         "show_rating": {
           "label": "Exibir avaliações do produto",
           "info": "Para exibir uma avaliação, adicione um app com essa funcionalidade específica. [Saiba mais](https://help.shopify.com/manual/online-store/themes/theme-structure/page-types#product-grid-section-settings)"

--- a/locales/pt-PT.schema.json
+++ b/locales/pt-PT.schema.json
@@ -1272,9 +1272,6 @@
         "header__3": {
           "content": "Cartão de produtos"
         },
-        "collapse_on_larger_devices": {
-          "label": "Fechar em desktop"
-        },
         "show_rating": {
           "label": "Mostrar classificação do produto",
           "info": "Para mostrar uma classificação, adicione uma aplicação de classificação de produto. [Saber mais](https://help.shopify.com/manual/online-store/themes/theme-structure/page-types#product-grid-section-settings)"

--- a/locales/sv.schema.json
+++ b/locales/sv.schema.json
@@ -1272,9 +1272,6 @@
         "header__3": {
           "content": "Produktkort"
         },
-        "collapse_on_larger_devices": {
-          "label": "Dölj på desktop"
-        },
         "show_rating": {
           "label": "Visa produktbetyg",
           "info": "Lägg till en produktbedömningsapp för att visa ett betyg. [Mer information](https://help.shopify.com/manual/online-store/themes/theme-structure/page-types#product-grid-section-settings)"

--- a/locales/th.schema.json
+++ b/locales/th.schema.json
@@ -1272,9 +1272,6 @@
         "header__3": {
           "content": "บัตรสินค้า"
         },
-        "collapse_on_larger_devices": {
-          "label": "ย่อบนเดสก์ท็อป"
-        },
         "show_rating": {
           "label": "แสดงคะแนนของสินค้า",
           "info": "หากต้องการแสดงคะแนน ให้เพิ่มแอปการให้คะแนนสินค้า [ดูข้อมูลเพิ่มเติม](https://help.shopify.com/manual/online-store/themes/theme-structure/page-types#product-grid-section-settings)"

--- a/locales/tr.schema.json
+++ b/locales/tr.schema.json
@@ -1272,9 +1272,6 @@
           "label": "Filtrelemeyi etkinleştir",
           "info": "[Filtreleri özelleştirin](/admin/menus)"
         },
-        "collapse_on_larger_devices": {
-          "label": "Masaüstünde daralt"
-        },
         "show_rating": {
           "label": "Ürün puanlarını göster",
           "info": "Puan göstermek için bir ürün puanlandırma uygulaması ekleyin. [Daha fazla bilgi edinin](https://help.shopify.com/manual/online-store/themes/theme-structure/page-types#product-grid-section-settings)"

--- a/locales/vi.schema.json
+++ b/locales/vi.schema.json
@@ -1272,9 +1272,6 @@
         "header__3": {
           "content": "Thẻ sản phẩm"
         },
-        "collapse_on_larger_devices": {
-          "label": "Thu nhỏ trên màn hình máy tính"
-        },
         "show_rating": {
           "label": "Hiển thị thứ hạng sản phẩm",
           "info": "Nếu muốn hiển thị thứ hạng, hãy thêm ứng dụng xếp hạng sản phẩm. [Tìm hiểu thêm](https://help.shopify.com/manual/online-store/themes/theme-structure/page-types#product-grid-section-settings)"

--- a/locales/zh-CN.schema.json
+++ b/locales/zh-CN.schema.json
@@ -1272,9 +1272,6 @@
         "header__3": {
           "content": "产品卡"
         },
-        "collapse_on_larger_devices": {
-          "label": "在台式设备上折叠"
-        },
         "show_rating": {
           "label": "显示产品评分",
           "info": "若要显示评分，请添加产品评分应用。[了解详细信息](https://help.shopify.com/manual/online-store/themes/theme-structure/page-types#product-grid-section-settings)"

--- a/locales/zh-TW.schema.json
+++ b/locales/zh-TW.schema.json
@@ -1272,9 +1272,6 @@
         "header__3": {
           "content": "產品卡"
         },
-        "collapse_on_larger_devices": {
-          "label": "在桌面版收合"
-        },
         "show_rating": {
           "label": "顯示產品評等",
           "info": "新增產品評等應用程式，即可顯示評等。[瞭解詳情](https://help.shopify.com/manual/online-store/themes/theme-structure/page-types#product-grid-section-settings)"

--- a/sections/main-collection-product-grid.liquid
+++ b/sections/main-collection-product-grid.liquid
@@ -82,7 +82,7 @@
       </aside>
     {%- endif -%}
 
-    <div class="product-grid-container{% if section.settings.filter_type == 'vertical' and section.settings.collapse_on_larger_devices %} product-grid-container-vertical{% endif %}" id="ProductGridContainer">
+    <div class="product-grid-container" id="ProductGridContainer">
       {%- paginate collection.products by section.settings.products_per_page -%}
         {%- if collection.products.size == 0 -%}
           <div class="collection collection--empty page-width" id="product-grid" data-id="{{ section.id }}">

--- a/templates/collection.json
+++ b/templates/collection.json
@@ -19,7 +19,6 @@
         "show_rating": false,
         "enable_filtering": true,
         "enable_sorting": true,
-        "collapse_on_larger_devices": false,
         "columns_mobile": "2",
         "padding_top": 36,
         "padding_bottom": 36

--- a/templates/search.json
+++ b/templates/search.json
@@ -10,7 +10,6 @@
         "show_rating": false,
         "enable_filtering": true,
         "enable_sorting": true,
-        "collapse_on_larger_devices": false,
         "article_show_date": true,
         "article_show_author": false,
         "columns_mobile": "2",


### PR DESCRIPTION
**Why are these changes introduced?**
Remove unused setting from collection product grid.
Fixes #1616 

**What approach did you take?**
Removed references to `collapse_on_larger_devices` in all files. This setting was removed on #1443 so it's no longer needed.

**Demo links**
- [Store](https://os2-demo.myshopify.com/?preview_theme_id=127838715926)
- [Editor](https://os2-demo.myshopify.com/admin/themes/127838715926/editor)

**Checklist**
- [x] Added PR summary for [release notes](https://themes.shopify.com/themes/dawn/styles/default#ReleaseNotes)
- [x] Notified the [help.shopify.com](https://help.shopify.com) team about updates to theme settings (current contact: Kimli)
- [x] Followed [theme code principles](https://github.com/Shopify/dawn/blob/main/.github/CONTRIBUTING.md#theme-code-principles)
- [x] Linted with [Theme Check](https://github.com/Shopify/theme-check)
- [x] Tested on [mobile](https://shopify.dev/themes/store/requirements#mobile-browser-requirements)
- [x] Tested on [multiple browsers](https://shopify.dev/themes/store/requirements#desktop-browser-requirements)
- [x] Tested for [accessibility](https://shopify.dev/themes/best-practices/accessibility)
