### PR TITLE
Rich text updates

### DIFF
--- a/assets/base.css
+++ b/assets/base.css
@@ -387,6 +387,16 @@ h5,
   word-break: break-word;
 }
 
+.hxl {
+  font-size: calc(var(--font-heading-scale) * 5rem);
+}
+
+@media only screen and (min-width: 750px) {
+  .hxl {
+    font-size: calc(var(--font-heading-scale) * 6.2rem);
+  }
+}
+
 .h0 {
   font-size: calc(var(--font-heading-scale) * 4rem);
 }
@@ -551,6 +561,10 @@ table:not([class]) th {
   .large-up-hide {
     display: none !important;
   }
+}
+
+.left {
+  text-align: left;
 }
 
 .center {

--- a/assets/section-rich-text.css
+++ b/assets/section-rich-text.css
@@ -1,38 +1,33 @@
 .rich-text {
-  margin-left: auto;
-  margin-right: auto;
-  text-align: center;
   z-index: 1;
 }
 
-.rich-text.rich-text--full-width {
-  max-width: initial;
-  width: 100%;
-}
-
-.rich-text__blocks {
-  margin: auto;
-  /* 2.5rem margin on left & right */
+.rich-text__wrapper {
+  display: flex;
+  justify-content: center;
   width: calc(100% - 5rem / var(--font-body-scale));
 }
 
-.rich-text__blocks * {
-  overflow-wrap: break-word;
-}
-
-.rich-text--full-width .rich-text__blocks {
-  /* 4rem (1.5rem + 2.5rem) margin on left & right */
+.rich-text:not(.rich-text--full-width) .rich-text__wrapper {
+  margin: auto;
   width: calc(100% - 8rem / var(--font-body-scale));
 }
 
 @media screen and (min-width: 750px) {
-  .rich-text__blocks {
-    max-width: 50rem;
+  .rich-text__wrapper {
+    width: 100%;
   }
 
-  .rich-text--full-width .rich-text__blocks {
-    /* 7.5rem (5rem + 2.5rem) margin on left & right */
-    width: calc(100% - 15rem);
+  .rich-text__wrapper--left {
+    justify-content: flex-start;
+  }
+
+  .rich-text__wrapper--right {
+    justify-content: flex-end;
+  }
+
+  .rich-text__blocks {
+    max-width: 60rem;
   }
 }
 
@@ -42,7 +37,9 @@
   }
 }
 
-/* Blocks */
+.rich-text__blocks * {
+  overflow-wrap: break-word;
+}
 
 .rich-text__blocks > * {
   margin-top: 0;

--- a/locales/en.default.schema.json
+++ b/locales/en.default.schema.json
@@ -338,6 +338,9 @@
         },
         "options__3": {
           "label": "Large"
+        },
+        "options__4": {
+          "label": "Extra large"
         }
       }
     },
@@ -2206,6 +2209,30 @@
     "rich-text": {
       "name": "Rich text",
       "settings": {
+        "desktop_content_position": {
+          "options__1": {
+            "label": "Left"
+          },
+          "options__2": {
+            "label": "Center"
+          },
+          "options__3": {
+            "label": "Right"
+          },
+          "label": "Desktop content position"
+        },
+        "content_alignment": {
+          "options__1": {
+            "label": "Left"
+          },
+          "options__2": {
+            "label": "Center"
+          },
+          "options__3": {
+            "label": "Right"
+          },
+          "label": "Content alignment"
+        },
         "full_width": {
           "label": "Make section full width"
         }
@@ -2216,6 +2243,35 @@
           "settings": {
             "heading": {
               "label": "Heading"
+            }
+          }
+        },
+        "caption": {
+          "name": "Caption",
+          "settings": {
+            "text": {
+              "label": "Text"
+            },
+            "text_style": {
+              "label": "Text style",
+              "options__1": {
+                "label": "Subtitle"
+              },
+              "options__2": {
+                "label": "Uppercase"
+              }
+            },
+            "caption_size": {
+              "label": "Text size",
+              "options__1": {
+                "label": "Small"
+              },
+              "options__2": {
+                "label": "Medium"
+              },
+              "options__3": {
+                "label": "Large"
+              }
             }
           }
         },

--- a/sections/rich-text.liquid
+++ b/sections/rich-text.liquid
@@ -20,19 +20,27 @@
 
 <div class="isolate{% unless section.settings.full_width %} page-width{% endunless %}">
   <div class="rich-text content-container color-{{ section.settings.color_scheme }} gradient{% if section.settings.full_width %} rich-text--full-width content-container--full-width{% endif %} section-{{ section.id }}-padding">
-    <div class="rich-text__blocks">
-      {%- for block in section.blocks -%}
-        {%- case block.type -%}
-          {%- when 'heading' -%}
-            <h2 class="{{ block.settings.heading_size }}" {{ block.shopify_attributes }}>{{ block.settings.heading | escape }}</h2>
-          {%- when 'text' -%}
-            <div class="rich-text__text rte" {{ block.shopify_attributes }}>{{ block.settings.text }}</div>
-          {%- when 'button' -%}
-            <a{% if block.settings.button_link == blank %} role="link" aria-disabled="true"{% else %} href="{{ block.settings.button_link }}"{% endif %} class="button{% if block.settings.button_style_secondary %} button--secondary{% else %} button--primary{% endif %}" {{ block.shopify_attributes }}>
-              {{ block.settings.button_label | escape }}
-            </a>
-        {%- endcase -%}
-      {%- endfor -%}
+    <div class="rich-text__wrapper rich-text__wrapper--{{ section.settings.desktop_content_position }}{% if section.settings.full_width %} page-width{% endif %}">
+      <div class="rich-text__blocks {{ section.settings.content_alignment }}">
+        {%- for block in section.blocks -%}
+          {%- case block.type -%}
+            {%- when 'heading' -%}
+              <h2 class="rich-text__heading rte {{ block.settings.heading_size }}" {{ block.shopify_attributes }}>{{ block.settings.heading }}</h2>
+            {%- when 'caption' -%}
+              <p class="rich-text__caption {{ block.settings.text_style }} {{ block.settings.text_style }}--{{ block.settings.text_size }} {{ block.settings.text_style }}" {{ block.shopify_attributes }}>{{ block.settings.caption }}</p>
+            {%- when 'text' -%}
+              <div class="rich-text__text rte" {{ block.shopify_attributes }}>{{ block.settings.text }}</div>
+            {%- when 'button' -%}
+              {%- if block.settings.button_label != blank -%}
+                <div class="rich-text__button">
+                  <a{% if block.settings.button_link == blank %} role="link" aria-disabled="true"{% else %} href="{{ block.settings.button_link }}"{% endif %} class="button{% if block.settings.button_style_secondary %} button--secondary{% else %} button--primary{% endif %}" {{ block.shopify_attributes }}>
+                    {{ block.settings.button_label | escape }}
+                  </a>
+                </div>
+              {%- endif -%}
+          {%- endcase -%}
+        {%- endfor -%}
+      </div>
     </div>
   </div>
 </div>
@@ -43,6 +51,46 @@
   "tag": "section",
   "class": "section",
   "settings": [
+    {
+      "type": "select",
+      "id": "desktop_content_position",
+      "options": [
+        {
+          "value": "left",
+          "label": "t:sections.rich-text.settings.desktop_content_position.options__1.label"
+        },
+        {
+          "value": "center",
+          "label": "t:sections.rich-text.settings.desktop_content_position.options__2.label"
+        },
+        {
+          "value": "right",
+          "label": "t:sections.rich-text.settings.desktop_content_position.options__3.label"
+        }
+      ],
+      "default": "center",
+      "label": "t:sections.rich-text.settings.desktop_content_position.label"
+    },
+    {
+      "type": "select",
+      "id": "content_alignment",
+      "options": [
+        {
+          "value": "left",
+          "label": "t:sections.rich-text.settings.content_alignment.options__1.label"
+        },
+        {
+          "value": "center",
+          "label": "t:sections.rich-text.settings.content_alignment.options__2.label"
+        },
+        {
+          "value": "right",
+          "label": "t:sections.rich-text.settings.content_alignment.options__3.label"
+        }
+      ],
+      "default": "center",
+      "label": "t:sections.rich-text.settings.content_alignment.label"
+    },
     {
       "type": "select",
       "id": "color_scheme",
@@ -106,12 +154,11 @@
     {
       "type": "heading",
       "name": "t:sections.rich-text.blocks.heading.name",
-      "limit": 1,
       "settings": [
         {
-          "type": "text",
+          "type": "richtext",
           "id": "heading",
-          "default": "Talk about your brand",
+          "default": "<p>Talk about your brand</p>",
           "label": "t:sections.rich-text.blocks.heading.settings.heading.label"
         },
         {
@@ -129,6 +176,10 @@
             {
               "value": "h0",
               "label": "t:sections.all.heading_size.options__3.label"
+            },
+            {
+              "value": "hxl",
+              "label": "t:sections.all.heading_size.options__4.label"
             }
           ],
           "default": "h1",
@@ -137,9 +188,56 @@
       ]
     },
     {
+      "type": "caption",
+      "name": "t:sections.rich-text.blocks.caption.name",
+      "settings": [
+        {
+          "type": "text",
+          "id": "caption",
+          "default": "Add a tagline",
+          "label": "t:sections.rich-text.blocks.caption.settings.text.label"
+        },
+        {
+          "type": "select",
+          "id": "text_style",
+          "options": [
+            {
+              "value": "subtitle",
+              "label": "t:sections.rich-text.blocks.caption.settings.text_style.options__1.label"
+            },
+            {
+              "value": "caption-with-letter-spacing",
+              "label": "t:sections.rich-text.blocks.caption.settings.text_style.options__2.label"
+            }
+          ],
+          "default": "caption-with-letter-spacing",
+          "label": "t:sections.rich-text.blocks.caption.settings.text_style.label"
+        },
+        {
+          "type": "select",
+          "id": "text_size",
+          "options": [
+            {
+              "value": "small",
+              "label": "t:sections.rich-text.blocks.caption.settings.caption_size.options__1.label"
+            },
+            {
+              "value": "medium",
+              "label": "t:sections.rich-text.blocks.caption.settings.caption_size.options__2.label"
+            },
+            {
+              "value": "large",
+              "label": "t:sections.rich-text.blocks.caption.settings.caption_size.options__3.label"
+            }
+          ],
+          "default": "medium",
+          "label": "t:sections.rich-text.blocks.caption.settings.caption_size.label"
+        }
+      ]
+    },
+    {
       "type": "text",
       "name": "t:sections.rich-text.blocks.text.name",
-      "limit": 1,
       "settings": [
         {
           "type": "richtext",
@@ -152,7 +250,6 @@
     {
       "type": "button",
       "name": "t:sections.rich-text.blocks.button.name",
-      "limit": 1,
       "settings": [
         {
           "type": "text",

--- a/templates/index.json
+++ b/templates/index.json
@@ -53,7 +53,7 @@
         "heading": {
           "type": "heading",
           "settings": {
-            "heading": "Talk about your brand",
+            "heading": "<p>Talk about your brand</p>",
             "heading_size": "h1"
           }
         },


### PR DESCRIPTION
### Draft PR

Rich text updates - UX feedback

cc: @wiktoriaswiecicka 

### Why are these changes introduced?

Related: https://github.com/Shopify/dawn/issues/1460

### What approach did you take?

**Section level settings**
- Desktop context position
- Text/content alignment

**Block level settings and additions**
- Add a new "Extra large" heading option
- Change the heading type from `text` to `richtext` to allow merchants to use bold, italic, links, dynamic source, and underline
- Add a caption block
- Remove limit for each block

### Other considerations

Range slider widths will need to be explored further / section parity etc.

### Demo links

- [Editor](https://os2-demo.myshopify.com/admin/themes/127844286486/editor)

---

### Questions

**Section settings**
- Text position on desktop:
  - This setting currently doesn't exist in our theme. The only similar setting that does is "Desktop content position" which I think conveys the same meaning. Let me know your thoughts on this.
- Text or content alignment:
  - Most other sections have "Desktop content alignment" and "Mobile content alignment".
  - We also have a global "Text alignment" setting for Cards.
  - Since this setting will set the alignment of all block elements, I think it makes sense to go with something that includes "content" instead of "text". If this ends up being the case:
    - Should we keep "Content alignment"?
    - For section parity, the **Image with text** section has "Desktop content alignment" and "Mobile content alignment" - if there are plans to include a mobile adjustment for text/content alignment, would it make more sense to offer "Desktop content alignment" and "Mobile content alignment" for rich text instead of just one text/content alignment adjustment for desktop and mobile. _Thoughts?_

**Extra large heading size**
- Let me know if this needs to be made smaller or larger.

**Caption block**
- I used the same caption block from the **Image with text** section which includes _text style_ and _text size_. Let me know if this is okay or if I should remove either _text style_ or _text size_.
- The default language for the caption block is "Add a tagline".
  - Should we change this to something else like, "Add a caption" or "Caption"?

**Block limit removal**
- I've removed the block limit for each block: Heading, Text, Caption, and Button. Looking for feedback on whether we should keep the limit for certain blocks and if so, which ones? I'm perfectly okay with the way it is now but I just think having multiple button blocks _might_ cause confusion or increased cognitive load for buyers. My mental model is one button being associated per rich text section.

**Presets**
- The current presets when adding a new Rich text section includes one of each: Heading, Text, Button
  - Should we include the new caption block?