### PR TITLE
Remove recaptcha visibility hidden on contact form

### DIFF
--- a/assets/section-contact-form.css
+++ b/assets/section-contact-form.css
@@ -37,7 +37,3 @@
     grid-column-gap: 2rem;
   }
 }
-
-.grecaptcha-badge {
-  visibility: hidden;
-}


### PR DESCRIPTION
**PR Summary:** 

Recaptcha badge is now visible on the contact form.

**Why are these changes introduced?**
We received a report that the recaptcha badge was not showing on the contact form. It turns out that any page where the contact form was visible, resulted in the badge not being displayed for _all_ form types.

**What approach did you take?**
We had removed the badge visually. This PR removes the css that was causing it to hide.

**Testing steps/scenarios**
- [ ] Go to Contact-us. Click on a form input. Make sure you see the recaptcha badge in the bottom righthand corner.
- [ ] Go to Contact-us. Click on the form input of the newsletter. Make sure you see the recaptcha badge in the bottom righthand corner.
- [ ] Go to Homepage. Click on the form input of the newletter. Make sure you see the recaptcha badge in the bottom righthand corner.

**Demo links**
- [Editor](https://os2-demo.myshopify.com/admin/themes/127904251926/editor?previewPath=%2Fpages%2Fabout-us)

**Checklist**
- [x] Added PR summary for [release notes](https://themes.shopify.com/themes/dawn/styles/default#ReleaseNotes)
- [ ] ~Notified the [help.shopify.com](https://help.shopify.com) team about updates to theme settings (current contact: Kimli)~
- [x] Followed [theme code principles](https://github.com/Shopify/dawn/blob/main/.github/CONTRIBUTING.md#theme-code-principles)
- [x] Linted with [Theme Check](https://github.com/Shopify/theme-check)
- [x] Tested on [mobile](https://shopify.dev/themes/store/requirements#mobile-browser-requirements)
- [x] Tested on [multiple browsers](https://shopify.dev/themes/store/requirements#desktop-browser-requirements)
- [x] Tested for [accessibility](https://shopify.dev/themes/best-practices/accessibility)
