### PR TITLE
Remove gradient when slide container is set to be hidden on desktop

### DIFF
--- a/assets/section-image-banner.css
+++ b/assets/section-image-banner.css
@@ -190,7 +190,7 @@
   }
 
   .banner:not(.banner--mobile-bottom):not(.email-signup-banner) .banner__box {
-    background-color: transparent;
+    background: transparent;
     --color-foreground: 255, 255, 255;
     --color-button: 255, 255, 255;
     --color-button-text: 0, 0, 0;
@@ -318,7 +318,6 @@
 @media screen and (min-width: 750px) {
   .banner--desktop-transparent .banner__box {
     background: transparent;
-    background-color: transparent;
     --color-foreground: 255, 255, 255;
     --color-button: 255, 255, 255;
     --color-button-text: 0, 0, 0;

--- a/assets/section-image-banner.css
+++ b/assets/section-image-banner.css
@@ -317,6 +317,7 @@
 
 @media screen and (min-width: 750px) {
   .banner--desktop-transparent .banner__box {
+    background: transparent;
     background-color: transparent;
     --color-foreground: 255, 255, 255;
     --color-button: 255, 255, 255;


### PR DESCRIPTION
**PR Summary:** 

This is a bug fix where if you were using a gradient and setting your slide to have a transparent background on desktop, it would instead show the gradient as the background wasn't set to `transparent`.

**Why are these changes introduced?**

Fixes https://github.com/Shopify/dawn/issues/1642

**What approach did you take?**

Added `background: transparent;` to the container in CSS as we were resetting the `background-color` but not the `background` which is the property used for the gradients.

**Testing steps/scenarios**
- [ ] Check out the slideshow's slides and make sure the background is transparent when set to while a gradient is also added in the theme settings.

**Demo links**

- [Store](https://os2-demo.myshopify.com/?preview_theme_id=127919685654)
- [Editor](https://os2-demo.myshopify.com/admin/themes/127919685654/editor)

**Checklist**
- [ ] Added PR summary for [release notes](https://themes.shopify.com/themes/dawn/styles/default#ReleaseNotes)
- [ ] Notified the [help.shopify.com](https://help.shopify.com) team about updates to theme settings (current contact: Kimli)
- [ ] Followed [theme code principles](https://github.com/Shopify/dawn/blob/main/.github/CONTRIBUTING.md#theme-code-principles)
- [ ] Linted with [Theme Check](https://github.com/Shopify/theme-check)
- [ ] Tested on [mobile](https://shopify.dev/themes/store/requirements#mobile-browser-requirements)
- [ ] Tested on [multiple browsers](https://shopify.dev/themes/store/requirements#desktop-browser-requirements)
- [ ] Tested for [accessibility](https://shopify.dev/themes/best-practices/accessibility)
