### PR TITLE
Fix button spinner in Safari

### DIFF
--- a/assets/base.css
+++ b/assets/base.css
@@ -1429,7 +1429,7 @@ button.shopify-payment-button__button--unbranded {
   align-items: center;
 }
 
-.button.loading > .loading-overlay__spinner > .spinner {
+.button.loading > .loading-overlay__spinner .spinner {
   width: fit-content;
 }
 

--- a/assets/base.css
+++ b/assets/base.css
@@ -1426,6 +1426,11 @@ button.shopify-payment-button__button--unbranded {
   position: absolute;
   height: 100%;
   display: flex;
+  align-items: center;
+}
+
+.button.loading > .loading-overlay__spinner > .spinner {
+  width: fit-content;
 }
 
 .button.loading > .loading-overlay__spinner .path {


### PR DESCRIPTION
**PR Summary:** 

Fixed a button loader spinner appearance in Safari. It was not showing up at all in Safari (for example, on product ATC click).

Before:
![Screen Recording 2022-04-28 at 12 46 49](https://user-images.githubusercontent.com/9170009/165736319-48c89beb-cb00-493e-8352-e5de894f98de.gif)

After:
![Screen Recording 2022-04-28 at 12 49 20](https://user-images.githubusercontent.com/9170009/165736597-94434f7f-595f-4f86-b823-27ff3065c97b.gif)

**Why are these changes introduced?**

Fixes #1645.

**What approach did you take?**

SVG inside a FlexBox requires a size in Safari, so I added width for a child SVG element. Also, positioned it in the center using align-items.

**Other considerations**

**Testing steps/scenarios**
- [x] Open a product page in Safari.
- [x] Click the "Add to Cart" button.
- [x] Check if the button appears well and the spinner shows up.

**Demo links**

- [Store](https://mashk5.myshopify.com/products/aged-dew?preview_theme_id=132430528769)
- [Editor](https://mashk5.myshopify.com/admin/themes/132430528769/editor)

**Checklist**
- [x] Added PR summary for [release notes](https://themes.shopify.com/themes/dawn/styles/default#ReleaseNotes)
- [ ] Notified the [help.shopify.com](https://help.shopify.com) team about updates to theme settings (current contact: Kimli)
- [x] Followed [theme code principles](https://github.com/Shopify/dawn/blob/main/.github/CONTRIBUTING.md#theme-code-principles)
- [x] Linted with [Theme Check](https://github.com/Shopify/theme-check)
- [ ] Tested on [mobile](https://shopify.dev/themes/store/requirements#mobile-browser-requirements)
- [ ] Tested on [multiple browsers](https://shopify.dev/themes/store/requirements#desktop-browser-requirements)
- [ ] Tested for [accessibility](https://shopify.dev/themes/best-practices/accessibility)
- [x] Tested on Mobile Safari (Latest)
- [x] Tested on Mobile Chrome (Latest, iOS)
- [x] Tested on Mac Chrome (Latest)
- [x] Tested on Mac Safari (Latest)
