### PR TITLE
[Header] add setting to tweak top and bottom padding

### DIFF
--- a/assets/base.css
+++ b/assets/base.css
@@ -2207,16 +2207,9 @@ input[type='checkbox'] {
   grid-template-areas: 'left-icon heading icons';
   grid-template-columns: 1fr 2fr 1fr;
   align-items: center;
-  padding-top: 1rem;
-  padding-bottom: 1rem;
 }
 
 @media screen and (min-width: 990px) {
-  .header {
-    padding-top: 2rem;
-    padding-bottom: 2rem;
-  }
-
   .header--has-menu:not(.header--middle-left) {
     padding-bottom: 0;
   }

--- a/assets/base.css
+++ b/assets/base.css
@@ -2210,10 +2210,6 @@ input[type='checkbox'] {
 }
 
 @media screen and (min-width: 990px) {
-  .header--has-menu:not(.header--middle-left) {
-    padding-bottom: 0;
-  }
-
   .header--top-left,
   .header--middle-left:not(.header--has-menu) {
     grid-template-areas:

--- a/sections/header.liquid
+++ b/sections/header.liquid
@@ -91,10 +91,6 @@
       padding-top: {{ section.settings.padding_top }}px;
       padding-bottom: {{ section.settings.padding_bottom }}px;
     }
-
-    .header--has-menu:not(.header--middle-left) {
-      padding-bottom: {{ section.settings.padding_bottom }}px;
-    }
   }
 {%- endstyle -%}
 

--- a/sections/header.liquid
+++ b/sections/header.liquid
@@ -71,6 +71,11 @@
 </style>
 
 {%- style -%}
+  .header {
+    padding-top: {{ section.settings.padding_top | times: 0.5 | round: 0 }}px;
+    padding-bottom: {{ section.settings.padding_bottom | times: 0.5 | round: 0 }}px;
+  }
+
   .section-header {
     margin-bottom: {{ section.settings.margin_bottom | times: 0.75 | round: 0 }}px;
   }
@@ -78,6 +83,13 @@
   @media screen and (min-width: 750px) {
     .section-header {
       margin-bottom: {{ section.settings.margin_bottom }}px;
+    }
+  }
+
+  @media screen and (min-width: 990px) {
+    .header {
+      padding-top: {{ section.settings.padding_top }}px;
+      padding-bottom: {{ section.settings.padding_bottom }}px;
     }
   }
 {%- endstyle -%}
@@ -826,6 +838,30 @@
       "unit": "px",
       "label": "t:sections.header.settings.margin_bottom.label",
       "default": 0
+    },
+    {
+      "type": "header",
+      "content": "t:sections.all.padding.section_padding_heading"
+    },
+    {
+      "type": "range",
+      "id": "padding_top",
+      "min": 0,
+      "max": 35,
+      "step": 5,
+      "unit": "px",
+      "label": "t:sections.all.padding.padding_top",
+      "default": 20
+    },
+    {
+      "type": "range",
+      "id": "padding_bottom",
+      "min": 0,
+      "max": 35,
+      "step": 5,
+      "unit": "px",
+      "label": "t:sections.all.padding.padding_bottom",
+      "default": 20
     }
   ]
 }

--- a/sections/header.liquid
+++ b/sections/header.liquid
@@ -91,6 +91,10 @@
       padding-top: {{ section.settings.padding_top }}px;
       padding-bottom: {{ section.settings.padding_bottom }}px;
     }
+
+    .header--has-menu:not(.header--middle-left) {
+      padding-bottom: {{ section.settings.padding_bottom }}px;
+    }
   }
 {%- endstyle -%}
 

--- a/sections/header.liquid
+++ b/sections/header.liquid
@@ -846,7 +846,7 @@
     {
       "type": "range",
       "id": "padding_top",
-      "min": 0,
+      "min": 5,
       "max": 35,
       "step": 5,
       "unit": "px",
@@ -856,7 +856,7 @@
     {
       "type": "range",
       "id": "padding_bottom",
-      "min": 0,
+      "min": 5,
       "max": 35,
       "step": 5,
       "unit": "px",

--- a/sections/header.liquid
+++ b/sections/header.liquid
@@ -846,9 +846,9 @@
     {
       "type": "range",
       "id": "padding_top",
-      "min": 5,
-      "max": 35,
-      "step": 5,
+      "min": 4,
+      "max": 36,
+      "step": 4,
       "unit": "px",
       "label": "t:sections.all.padding.padding_top",
       "default": 20
@@ -856,9 +856,9 @@
     {
       "type": "range",
       "id": "padding_bottom",
-      "min": 5,
-      "max": 35,
-      "step": 5,
+      "min": 4,
+      "max": 36,
+      "step": 4,
       "unit": "px",
       "label": "t:sections.all.padding.padding_bottom",
       "default": 20


### PR DESCRIPTION
**PR Summary:** 
Introduces a new setting to tweak top and bottom padding on the Header section.

**Why are these changes introduced?**
Fixes #1418.

**What approach did you take?**
- Reused language strings from other sections
- To match the current behaviour:
  - Each step equals to `4px`, with min `4px` and max = `36px`. 
   - Before this setting, the default padding is `2rem`=`20px` on desktop. On mobile and tablet, defaults to `1rem`=`10px`.
  - To match that behavior, we're setting the settings default to `20px` and applying a `0.5` multiplier on mobile.

**Demo links**
_Please include a link to a demo store that includes preconfigured sections and settings to allow reviewers to easily test the features you are working on._

- [Store](https://os2-demo.myshopify.com/admin/?preview_theme_id=127947014166)
- [Editor](https://os2-demo.myshopify.com/admin/themes/127947014166/editor)

**Checklist**
- [x] Added PR summary for [release notes](https://themes.shopify.com/themes/dawn/styles/default#ReleaseNotes)
- [] Notified the [help.shopify.com](https://help.shopify.com) team about updates to theme settings (current contact: Kimli)
- [x] Followed [theme code principles](https://github.com/Shopify/dawn/blob/main/.github/CONTRIBUTING.md#theme-code-principles)
- [x] Linted with [Theme Check](https://github.com/Shopify/theme-check)
- [x] Tested on [mobile](https://shopify.dev/themes/store/requirements#mobile-browser-requirements)
- [x] Tested on [multiple browsers](https://shopify.dev/themes/store/requirements#desktop-browser-requirements)
- [x] Tested for [accessibility](https://shopify.dev/themes/best-practices/accessibility)