### PR TITLE
[Collapsible content] Add vertical padding to blocks

### DIFF
--- a/assets/collapsible-content.css
+++ b/assets/collapsible-content.css
@@ -85,8 +85,7 @@
 }
 
 .collapsible-row-layout .accordion summary, .collapsible-row-layout .accordion .accordion__content {
-  padding-left: 1.5rem;
-  padding-right: 1.5rem;
+  padding: 1.5rem;
 }
 
 .collapsible-content summary:hover {

--- a/assets/collapsible-content.css
+++ b/assets/collapsible-content.css
@@ -84,8 +84,13 @@
   margin-bottom: 1.5rem;
 }
 
-.collapsible-row-layout .accordion summary, .collapsible-row-layout .accordion .accordion__content {
+.collapsible-row-layout .accordion summary,
+.collapsible-row-layout .accordion .accordion__content {
   padding: 1.5rem;
+}
+
+.collapsible-row-layout .accordion .accordion__content {
+  padding-top: 0;
 }
 
 .collapsible-content summary:hover {


### PR DESCRIPTION
**Why are these changes introduced?**
Adds padding to collapsible blocks.

Fixes #1597

**What approach did you take?**
Added `padding-bottom` and `padding-top` to collapsible blocks.

**Demo links**
- [Store](https://os2-demo.myshopify.com/?preview_theme_id=127947735062)
- [Editor](https://os2-demo.myshopify.com/admin/themes/127947735062/editor)

**Checklist**
- [x] Added PR summary for [release notes](https://themes.shopify.com/themes/dawn/styles/default#ReleaseNotes)
- [x] Followed [theme code principles](https://github.com/Shopify/dawn/blob/main/.github/CONTRIBUTING.md#theme-code-principles)
- [x] Linted with [Theme Check](https://github.com/Shopify/theme-check)
- [x] Tested on [mobile](https://shopify.dev/themes/store/requirements#mobile-browser-requirements)
- [x] Tested on [multiple browsers](https://shopify.dev/themes/store/requirements#desktop-browser-requirements)
- [x] Tested for [accessibility](https://shopify.dev/themes/best-practices/accessibility)
