### PR TITLE
Revert flex grow on collage card__content

### DIFF
--- a/assets/collage.css
+++ b/assets/collage.css
@@ -11,6 +11,10 @@
   width: 100%;
 }
 
+.collage__item .card__content {
+  flex-grow: unset;
+}
+
 @media screen and (max-width: 749px) {
   .collage {
     grid-column-gap: var(--grid-mobile-horizontal-spacing);


### PR DESCRIPTION
**PR Summary:** 

This is to fix a layout issue for the collage section where the spacing was off.

**Why are these changes introduced?**

Fixes https://github.com/Shopify/dawn/issues/1658

**What approach did you take?**

Used the approached suggested on the issue. Removed the `flex-grow: 1;` applied to `.card__content` specifically for the collage cards. 

**Testing steps/scenarios**
- [ ] Easiest way to see is to set the cards (in general settings) to style -> card with color scheme background 2 or inverse. 

**Demo links**

- [Store](url)
- [Editor](url)

**Checklist**
- [ ] Added PR summary for [release notes](https://themes.shopify.com/themes/dawn/styles/default#ReleaseNotes)
- [ ] Followed [theme code principles](https://github.com/Shopify/dawn/blob/main/.github/CONTRIBUTING.md#theme-code-principles)
- [ ] Linted with [Theme Check](https://github.com/Shopify/theme-check)
- [ ] Tested on [mobile](https://shopify.dev/themes/store/requirements#mobile-browser-requirements)
- [ ] Tested on [multiple browsers](https://shopify.dev/themes/store/requirements#desktop-browser-requirements)
- [ ] Tested for [accessibility](https://shopify.dev/themes/best-practices/accessibility)
