### PR TITLE
Update product-media.liquid

### DIFF
--- a/snippets/product-media.liquid
+++ b/snippets/product-media.liquid
@@ -89,7 +89,7 @@
         aria-label="{{ 'products.product.xr_button_label' | t }}"
         data-shopify-xr
         data-shopify-model3d-id="{{ media.id }}"
-        data-shopify-title="title"
+        data-shopify-title="{{ product.title | escape }}"
         data-shopify-xr-hidden
         >
         {% render 'icon-3d-model' %}


### PR DESCRIPTION
**PR Summary:** 
XR button for product media now uses "title" as the value of title attribute. This PR changes title value to product title as seen on Shopify's documentation:
https://shopify.dev/themes/product-merchandising/media/support-media#launch-the-display-with-a-button


**Why are these changes introduced?**
Because it makes sense

**What approach did you take?**
Common sense

**Other considerations**

**Testing steps/scenarios**
- [ ] Go to any product page that has 3D model as product media and use browser's inspect element to see if XR button's data-shopify-title attribute equals to product's title instead of "title".

**Checklist**
- [ ] Added PR summary for [release notes](https://themes.shopify.com/themes/dawn/styles/default#ReleaseNotes)
- [ ] Notified the [help.shopify.com](https://help.shopify.com) team about updates to theme settings (current contact: Kimli)
- [ ] Followed [theme code principles](https://github.com/Shopify/dawn/blob/main/.github/CONTRIBUTING.md#theme-code-principles)
- [ ] Linted with [Theme Check](https://github.com/Shopify/theme-check)
- [ ] Tested on [mobile](https://shopify.dev/themes/store/requirements#mobile-browser-requirements)
- [ ] Tested on [multiple browsers](https://shopify.dev/themes/store/requirements#desktop-browser-requirements)
- [ ] Tested for [accessibility](https://shopify.dev/themes/best-practices/accessibility)
