### PR TITLE
Add email signup redirect setting

### DIFF
--- a/config/settings_data.json
+++ b/config/settings_data.json
@@ -161,6 +161,7 @@
             "color_scheme": "background-1",
             "newsletter_enable": true,
             "newsletter_heading": "Subscribe to our emails",
+            "newsletter_return_to": "",
             "show_social": true,
             "enable_country_selector": false,
             "enable_language_selector": false,

--- a/locales/en.default.schema.json
+++ b/locales/en.default.schema.json
@@ -843,7 +843,8 @@
           "label": "Heading"
         },
         "newsletter_return_to": {
-          "label": "Signup Redirect URL"
+          "label": "Signup Redirect URL",
+          "info": "Direct visitors to a custom URL after signing up for your newsletter."
         },
         "header__1": {
           "content": "Email Signup",

--- a/locales/en.default.schema.json
+++ b/locales/en.default.schema.json
@@ -842,6 +842,9 @@
         "newsletter_heading": {
           "label": "Heading"
         },
+        "newsletter_return_to": {
+          "label": "Signup Redirect URL"
+        },
         "header__1": {
           "content": "Email Signup",
           "info": "Subscribers added automatically to your “accepted marketing” customer list. [Learn more](https://help.shopify.com/manual/customers/manage-customers)"

--- a/sections/footer.liquid
+++ b/sections/footer.liquid
@@ -104,6 +104,9 @@
             {%- endif -%}
             {%- form 'customer', id: 'ContactFooter', class: 'footer__newsletter newsletter-form' -%}
               <input type="hidden" name="contact[tags]" value="newsletter">
+              {%- if section.settings.newsletter_return_to != blank -%}
+                <input type="hidden" name="return_to" value="{{ section.settings.newsletter_return_to | escape }}">
+              {%- endif -%}
               <div class="newsletter-form__field-wrapper">
                 <div class="field">
                   <input


### PR DESCRIPTION
**PR Summary:** 

This (hopefully) adds a setting to control `return_to` for the footer newsletter signup.

**Why are these changes introduced?**

This fixes an issue my onboarding group ran into, where users of the Dawn theme currently have to edit Liquid templates to add a custom newsletter signup redirect.

**Testing steps/scenarios**
- [ ] Load the theme editor
- [ ] Open theme settings
- [ ] Verify that there is a new "Newsletter Signup Redirect" string setting
- [ ] Verify that saving a redirect path changes the redirect when signing up for an email newsletter

**Demo links**

(to do)

<!--
Please include a link to a demo store that includes preconfigured sections and settings to allow reviewers to easily test the features you are working on.

- [Store](url)
- [Editor](url)
-->

**Checklist**
- [ ] Added PR summary for [release notes](https://themes.shopify.com/themes/dawn/styles/default#ReleaseNotes)
- [ ] Notified the [help.shopify.com](https://help.shopify.com) team about updates to theme settings (current contact: Kimli)
- [ ] Followed [theme code principles](https://github.com/Shopify/dawn/blob/main/.github/CONTRIBUTING.md#theme-code-principles)
- [x] Linted with [Theme Check](https://github.com/Shopify/theme-check)
- [ ] Tested on [mobile](https://shopify.dev/themes/store/requirements#mobile-browser-requirements)
- [ ] Tested on [multiple browsers](https://shopify.dev/themes/store/requirements#desktop-browser-requirements)
- [ ] Tested for [accessibility](https://shopify.dev/themes/best-practices/accessibility)
