### PR TITLE
[Header] Update minimum padding to zero

### DIFF
--- a/sections/header.liquid
+++ b/sections/header.liquid
@@ -859,7 +859,7 @@
     {
       "type": "range",
       "id": "padding_top",
-      "min": 4,
+      "min": 0,
       "max": 36,
       "step": 4,
       "unit": "px",
@@ -869,7 +869,7 @@
     {
       "type": "range",
       "id": "padding_bottom",
-      "min": 4,
+      "min": 0,
       "max": 36,
       "step": 4,
       "unit": "px",


### PR DESCRIPTION
**PR Summary:** 
Follow up to #1654. Updates minimum header padding to `0`.

**Why are these changes introduced?**
When we introduced the new padding settings for Header, we made it impossible to reproduce the old look on `Top left` and `Top center` sections by having a new `min` value of `4px`. This PR changes it to `0`.

We also offer `0px` padding as an option for other sections padding, so this also keeps the same flexibility across similar elements for predictability.

**Demo links**
- [Store](https://os2-demo.myshopify.com/?preview_theme_id=128013631510)
- [Editor](https://os2-demo.myshopify.com/admin/themes/128013631510/editor)