### PR TITLE
Fix syntax error caused by missing calc in product CSS

### DIFF
--- a/assets/section-main-product.css
+++ b/assets/section-main-product.css
@@ -366,7 +366,7 @@ a.product__text {
   .product__info-container {
     max-width: 60rem;
   }
-
+  
   .product__info-container .price--on-sale .price-item--regular {
     font-size: 1.6rem;
   }

--- a/assets/section-main-product.css
+++ b/assets/section-main-product.css
@@ -651,8 +651,12 @@ a.product__text {
   box-shadow: none;
 }
 
-.product__media-toggle.focused:after,
 .product__media-toggle:focus-visible:after {
+  box-shadow: 0 0 0 0.3rem rgb(var(--color-background)), 0 0 0rem 0.5rem rgba(var(--color-foreground), 0.5);
+  border-radius: var(--media-radius);
+}
+
+.product__media-toggle.focused:after {
   box-shadow: 0 0 0 0.3rem rgb(var(--color-background)), 0 0 0rem 0.5rem rgba(var(--color-foreground), 0.5);
   border-radius: var(--media-radius);
 }

--- a/assets/section-main-product.css
+++ b/assets/section-main-product.css
@@ -366,7 +366,7 @@ a.product__text {
   .product__info-container {
     max-width: 60rem;
   }
-  
+
   .product__info-container .price--on-sale .price-item--regular {
     font-size: 1.6rem;
   }
@@ -651,17 +651,9 @@ a.product__text {
   box-shadow: none;
 }
 
+.product__media-toggle.focused:after,
 .product__media-toggle:focus-visible:after {
-  box-shadow: 0 0 0 0.3rem rgb(var(--color-background)),0 0 0rem 0.5rem rgba(var(--color-foreground), 0.5);
-  border-radius: calc(var(--media-radius) - var(--media-border-width));
-}
-
-.product__media-toggle.focused:after {
-  box-shadow: 0 0 0 0.3rem rgb(var(--color-background)),0 0 0rem 0.5rem rgba(var(--color-foreground), 0.5);
-  border-radius: var(--media-radius);
-}
-
-.product__media-toggle:focus-visible:after {
+  box-shadow: 0 0 0 0.3rem rgb(var(--color-background)), 0 0 0rem 0.5rem rgba(var(--color-foreground), 0.5);
   border-radius: var(--media-radius);
 }
 

--- a/assets/section-main-product.css
+++ b/assets/section-main-product.css
@@ -366,7 +366,7 @@ a.product__text {
   .product__info-container {
     max-width: 60rem;
   }
-  
+
   .product__info-container .price--on-sale .price-item--regular {
     font-size: 1.6rem;
   }
@@ -653,7 +653,7 @@ a.product__text {
 
 .product__media-toggle:focus-visible:after {
   box-shadow: 0 0 0 0.3rem rgb(var(--color-background)),0 0 0rem 0.5rem rgba(var(--color-foreground), 0.5);
-  border-radius: var(--media-radius) - var(--media-border-width);
+  border-radius: calc(var(--media-radius) - var(--media-border-width));
 }
 
 .product__media-toggle.focused:after {


### PR DESCRIPTION
**PR Summary:** 

Fix CSS syntax error.

**Why are these changes introduced?**

There was a syntax error in `assets/section-main-product.css` where a border-radius calculation was done outside of a calc() function. This was accidentally introduced in #1124 and is done correctly in other places in the file.

**What approach did you take?**

When running a CSS linter this was the only error it found in our fork of Dawn. As it was a simple fix i thought it was worth fixing in upstream too.

**Other considerations**

Visually this changes very little, only a small non-inherited change to the border-radius on focus. I've looked at the other PRs and as far as i can tell none of them make a change to this file, so i think this PR is not a duplicate.

**Checklist**
- [X] Added PR summary for [release notes](https://themes.shopify.com/themes/dawn/styles/default#ReleaseNotes)
- [ ] Notified the [help.shopify.com](https://help.shopify.com) team about updates to theme settings (current contact: Kimli)
- [ ] Followed [theme code principles](https://github.com/Shopify/dawn/blob/main/.github/CONTRIBUTING.md#theme-code-principles)
- [ ] Linted with [Theme Check](https://github.com/Shopify/theme-check)
- [ ] Tested on [mobile](https://shopify.dev/themes/store/requirements#mobile-browser-requirements)
- [ ] Tested on [multiple browsers](https://shopify.dev/themes/store/requirements#desktop-browser-requirements)
- [ ] Tested for [accessibility](https://shopify.dev/themes/best-practices/accessibility)
