### PR TITLE
Rich text - Revert button type and button 1 ids

### DIFF
--- a/sections/rich-text.liquid
+++ b/sections/rich-text.liquid
@@ -36,10 +36,10 @@
               <div class="rich-text__text rte" {{ block.shopify_attributes }}>
                 {{ block.settings.text }}
               </div>
-            {%- when 'buttons' -%}
-              <div class="rich-text__buttons{% if block.settings.button_label_1 != blank and block.settings.button_label_2 != blank %} rich-text__buttons--multiple{% endif %}" {{ block.shopify_attributes }}>
-                {%- if block.settings.button_label_1 != blank -%}
-                  <a{% if block.settings.button_link_1 == blank %} role="link" aria-disabled="true"{% else %} href="{{ block.settings.button_link_1 }}"{% endif %} class="button{% if block.settings.button_style_secondary_1 %} button--secondary{% else %} button--primary{% endif %}">{{ block.settings.button_label_1 | escape }}</a>
+            {%- when 'button' -%}
+              <div class="rich-text__buttons{% if block.settings.button_label != blank and block.settings.button_label_2 != blank %} rich-text__buttons--multiple{% endif %}" {{ block.shopify_attributes }}>
+                {%- if block.settings.button_label != blank -%}
+                  <a{% if block.settings.button_link == blank %} role="link" aria-disabled="true"{% else %} href="{{ block.settings.button_link }}"{% endif %} class="button{% if block.settings.button_style_secondary %} button--secondary{% else %} button--primary{% endif %}">{{ block.settings.button_label | escape }}</a>
                 {%- endif -%}
                 {%- if block.settings.button_label_2 != blank -%}
                   <a{% if block.settings.button_link_2 == blank %} role="link" aria-disabled="true"{% else %} href="{{ block.settings.button_link_2 }}"{% endif %} class="button{% if block.settings.button_style_secondary_2 %} button--secondary{% else %} button--primary{% endif %}">{{ block.settings.button_label_2 | escape }}</a>
@@ -259,32 +259,31 @@
       ]
     },
     {
-      "type": "buttons",
+      "type": "button",
       "name": "t:sections.rich-text.blocks.buttons.name",
       "limit": 2,
       "settings": [
         {
           "type": "text",
-          "id": "button_label_1",
+          "id": "button_label",
           "default": "Button label",
           "label": "t:sections.rich-text.blocks.buttons.settings.button_label_1.label",
           "info": "t:sections.rich-text.blocks.buttons.settings.button_label_1.info"
         },
         {
           "type": "url",
-          "id": "button_link_1",
+          "id": "button_link",
           "label": "t:sections.rich-text.blocks.buttons.settings.button_link_1.label"
         },
         {
           "type": "checkbox",
-          "id": "button_style_secondary_1",
+          "id": "button_style_secondary",
           "default": false,
           "label": "t:sections.rich-text.blocks.buttons.settings.button_style_secondary_1.label"
         },
         {
           "type": "text",
           "id": "button_label_2",
-          "default": "Button label",
           "label": "t:sections.rich-text.blocks.buttons.settings.button_label_2.label",
           "info": "t:sections.rich-text.blocks.buttons.settings.button_label_2.info"
         },
@@ -313,7 +312,7 @@
           "type": "text"
         },
         {
-          "type": "buttons"
+          "type": "button"
         }
       ]
     }


### PR DESCRIPTION
**PR Summary:** 
NA - No release notes needed for this PR


### Why are these changes introduced?
This PR reverts the `"type"` and `"id"` changes made to the rich text button block (see [here](https://github.com/Shopify/dawn/pull/1635/files?file-filters%5B%5D=.css&file-filters%5B%5D=.liquid&show-viewed-files=true#diff-cda2ba427dce267de2bfc93470928bfb37c023c850dea2e10c8a4f300f06a943R262-R284)).

By changing the `type` and the button `id`s, it means that merchants who have a button in their rich text section(s), and [update](https://shopify.dev/themes/store/success/updates) their theme to a newer version of Dawn through **Online store > Themes page**, will no longer have a button after the update. This would result in a poor experience for merchants. We want to make sure that their content is ported over to the new theme.

 <details>
  <summary>Before and after upgrade screenshots</summary>
  
  If a merchant were to upgrade to the current state of dawn, it would result in the buttons being removed: 
  
**Before:** 
<img width="1510" alt="Screen Shot 2022-05-17 at 10 06 09 AM" src="https://user-images.githubusercontent.com/26778637/168830307-9a06a6d4-b9ed-4981-85bc-280e542f8566.png">

   
**After update:** 
<img width="1502" alt="Screen Shot 2022-05-17 at 10 05 25 AM" src="https://user-images.githubusercontent.com/26778637/168830128-0b3c917d-a418-4eba-92d3-57098c636d25.png">
 </details>

### What approach did you take?
**Step 1**
I changed the button block type from `buttons` to `button`. 

This change means that the button block will still be present on the section after the update - because the block types will match in the templates.json file and the schema. 

By making this change only, it would result in this state after an update:
* Button block preserved
* Button content is not ported over

<details>
<summary>Revert button change only</summary>
<img width="1512" alt="Screen Shot 2022-05-17 at 10 13 30 AM" src="https://user-images.githubusercontent.com/26778637/168832043-53b907fa-7cef-4a00-83d2-3b1c8d0ee115.png">
</details>


 **Step 2**
I changed the button block's button 1 `id`s back.

_why?_ If we only reverted the block type, the block would be visible, but the merchant's content for the buttons would not be included and the setting's default copy would be outputted instead. This is because the button 1 ids no longer match. 

By reverting the button 1 `id`s, it means the merchant will preserve the state of the button block _and_ its content. 

<details>
<summary>Upgrade state with reverted type and id</summary>

<img width="1075" alt="Screen Shot 2022-05-17 at 10 17 33 AM" src="https://user-images.githubusercontent.com/26778637/168832944-a6348187-abfa-4cad-a434-832ca8d84676.png">

</details>

**Step 3**
In the above screenshot, you can see that the button 2 is visible. This is because it has default text in the schema, and the button relies only on the presence of the label to be displayed. To prevent this from happening on upgrade, we can remove the default text. The default property is [not required](https://shopify.dev/themes/architecture/settings/input-settings#standard-attributes) for "text" setting types. 

By removing the default value, it means that the merchant's button block and button 1 content will be preserved, but the second button will not be displayed. 

<img width="1512" alt="Screen Shot 2022-05-17 at 10 23 04 AM" src="https://user-images.githubusercontent.com/26778637/168834320-bde60f9a-6819-48d8-a398-f0c5d1fa33dc.png">

### Other considerations
There is one issue with step 3, from a merchant experience standpoint. 
Now, when merchants add the button block, it will only display one button, instead of 2. 
I'm open to discussing this, but I think it's the right choice from an upgrade standpoint, and there is an opportunity to re-add  the default text in future versions. 

This means that the onboarding experience for the button block will be different than image banner. The image banner block will add two buttons, but the rich text section will only add 1.

<img width="1502" alt="Screen Shot 2022-05-17 at 10 39 42 AM" src="https://user-images.githubusercontent.com/26778637/168838329-02d8dd18-d18c-4a3f-925a-a25a3a3ba6fb.png">

### Testing steps/scenarios
- [ ] Button translations are still correct 
- [ ] Button layout remains unchanged
- [ ] Button 1 label, link and style work as intended

### Demo links
_Please include a link to a demo store that includes preconfigured sections and settings to allow reviewers to easily test the features you are working on._

- [Editor](https://os2-demo.myshopify.com/admin/themes/128041353238/editor)

**Checklist**
- [ ] ~Added PR summary for [release notes](https://themes.shopify.com/themes/dawn/styles/default#ReleaseNotes)~
- [ ] ~Notified the [help.shopify.com](https://help.shopify.com) team about updates to theme settings (current contact: Kimli)~
- [x] Followed [theme code principles](https://github.com/Shopify/dawn/blob/main/.github/CONTRIBUTING.md#theme-code-principles)
- [x] Linted with [Theme Check](https://github.com/Shopify/theme-check)
- [x] Tested on [mobile](https://shopify.dev/themes/store/requirements#mobile-browser-requirements)
- [x] Tested on [multiple browsers](https://shopify.dev/themes/store/requirements#desktop-browser-requirements)
- [x] Tested for [accessibility](https://shopify.dev/themes/best-practices/accessibility)
