### PR TITLE
Removed Screen Reader Span for UX

### DIFF
--- a/sections/main-collection-banner.liquid
+++ b/sections/main-collection-banner.liquid
@@ -13,7 +13,6 @@
   <div class="collection-hero__inner page-width">
     <div class="collection-hero__text-wrapper">
       <h1 class="collection-hero__title">
-        <span class="visually-hidden">{{ 'sections.collection_template.title' | t }}: </span>
         {{- collection.title | escape -}}
       </h1>
 


### PR DESCRIPTION
**PR Summary:** 

Removed the hidden screen reader span for the h2 in order to reduce verbose user experience. This will ensure that the reader doesn't repeat the header unnecessarily.

**Why are these changes introduced?**

In order to reduce verbose user experience and eliminate the repetition of the h2.

**What approach did you take?**
Deleted the span.
**Other considerations**

**Testing steps/scenarios**
- [ ] Needs continuous testing using screen reader

**Checklist**
- [ ] Added PR summary for [release notes](https://themes.shopify.com/themes/dawn/styles/default#ReleaseNotes)
- [ ] Tested for [accessibility](https://shopify.dev/themes/best-practices/accessibility)
