### PR TITLE
Add pagination to main collection list

### DIFF
--- a/sections/main-list-collections.liquid
+++ b/sections/main-list-collections.liquid
@@ -14,8 +14,14 @@
     if section.settings.sort == 'products_high' or section.settings.sort == 'date_reversed' or section.settings.sort == 'alphabetical_reversed'
       assign collections = collections | reverse
     endif
+
+    assign moduloResult = 20 | modulo: section.settings.columns_desktop
+    assign paginate_by = 30
+    if moduloResult == 0
+      assign paginate_by = 20
+    endif
   -%}
-  {%- paginate collections by 9 -%}
+  {%- paginate collections by paginate_by -%}
     <ul class="collection-list grid grid--{{ section.settings.columns_desktop }}-col-desktop grid--{{ section.settings.columns_mobile }}-col-tablet-down" role="list">
       {%- for collection in collections -%}
         <li class="collection-list__item grid__item">

--- a/sections/main-list-collections.liquid
+++ b/sections/main-list-collections.liquid
@@ -15,12 +15,13 @@
       assign collections = collections | reverse
     endif
 
-    assign moduloResult = 20 | modulo: section.settings.columns_desktop
+    assign moduloResult = 28 | modulo: section.settings.columns_desktop
     assign paginate_by = 30
     if moduloResult == 0
-      assign paginate_by = 20
+      assign paginate_by = 28
     endif
   -%}
+  TEST {{ paginate_by }}
   {%- paginate collections by paginate_by -%}
     <ul class="collection-list grid grid--{{ section.settings.columns_desktop }}-col-desktop grid--{{ section.settings.columns_mobile }}-col-tablet-down" role="list">
       {%- for collection in collections -%}

--- a/sections/main-list-collections.liquid
+++ b/sections/main-list-collections.liquid
@@ -15,13 +15,16 @@
       assign collections = collections | reverse
     endif
   -%}
-  <ul class="collection-list grid grid--{{ section.settings.columns_desktop }}-col-desktop grid--{{ section.settings.columns_mobile }}-col-tablet-down" role="list">
-    {%- for collection in collections -%}
-      <li class="collection-list__item grid__item">
-        {% render 'card-collection', card_collection: collection, media_aspect_ratio: section.settings.image_ratio, columns: 3 %}
-      </li>
-    {%- endfor -%}
-  </ul>
+  {%- paginate collections by 9 -%}
+    <ul class="collection-list grid grid--{{ section.settings.columns_desktop }}-col-desktop grid--{{ section.settings.columns_mobile }}-col-tablet-down" role="list">
+      {%- for collection in collections -%}
+        <li class="collection-list__item grid__item">
+          {% render 'card-collection', card_collection: collection, media_aspect_ratio: section.settings.image_ratio, columns: 3 %}
+        </li>
+      {%- endfor -%}
+    </ul>
+    {% render 'pagination', paginate: paginate %}
+  {%- endpaginate -%}
 </div>
 {% schema %}
 {

--- a/sections/main-list-collections.liquid
+++ b/sections/main-list-collections.liquid
@@ -21,7 +21,6 @@
       assign paginate_by = 28
     endif
   -%}
-  TEST {{ paginate_by }}
   {%- paginate collections by paginate_by -%}
     <ul class="collection-list grid grid--{{ section.settings.columns_desktop }}-col-desktop grid--{{ section.settings.columns_mobile }}-col-tablet-down" role="list">
       {%- for collection in collections -%}


### PR DESCRIPTION
**PR Summary:** 

Add pagination to the collection list template which didn't have one. 

**Why are these changes introduced?**

Fixes #1744 

**What approach did you take?**

Added a pagination. Set it to be either 30 when the number of column on desktop is set to 3 or 5 and then 28 if it's set to 1, 2 or 4. 

**Testing steps/scenarios**
- [ ] Test the pagination. You might want to edit the number by which it paginates or create more collections as we currently have 24 😅 

**Demo links**

- [Store](https://os2-demo.myshopify.com/?preview_theme_id=128093093910)
- [Editor](https://os2-demo.myshopify.com/admin/themes/128093093910/editor)

**Checklist**
- [ ] Added PR summary for [release notes](https://themes.shopify.com/themes/dawn/styles/default#ReleaseNotes)
- [ ] Notified the [help.shopify.com](https://help.shopify.com) team about updates to theme settings (current contact: Kimli)
- [ ] Followed [theme code principles](https://github.com/Shopify/dawn/blob/main/.github/CONTRIBUTING.md#theme-code-principles)
- [ ] Linted with [Theme Check](https://github.com/Shopify/theme-check)
- [ ] Tested on [mobile](https://shopify.dev/themes/store/requirements#mobile-browser-requirements)
- [ ] Tested on [multiple browsers](https://shopify.dev/themes/store/requirements#desktop-browser-requirements)
- [ ] Tested for [accessibility](https://shopify.dev/themes/best-practices/accessibility)
