### PR TITLE
Try adding a CSS-only announcement bar marquee option

### DIFF
--- a/assets/base.css
+++ b/assets/base.css
@@ -2192,6 +2192,41 @@ input[type='checkbox'] {
   letter-spacing: 0.1rem;
 }
 
+.announcement-bar.marquee {
+  overflow: hidden;
+}
+
+.announcement-bar.marquee .announcement-bar__message {
+  display: inline-block;
+  white-space: nowrap;
+  color: #00112C;
+  width: 25vw;
+  text-align: initial;
+  animation: announcement-bar-marquee 2s linear infinite;
+
+  /* Use shadows to repeat the text */
+  text-shadow: 25vw 0 currentColor, calc(25vw * 2) 0 currentColor, calc(25vw * 3) 0 currentColor, calc(25vw * 4) 0 currentColor;
+}
+
+@keyframes announcement-bar-marquee {
+  0% { transform: translateX(0); }
+  100% { transform: translateX(-100%); }
+}
+
+@media (prefers-reduced-motion) {
+  .announcement-bar.marquee {
+    overflow: inherit;
+  }
+  
+  .announcement-bar.marquee .announcement-bar__message {
+    display: block;
+    white-space: inherit;
+    width: auto;
+    animation: none;
+    text-shadow: none;
+  }
+}
+
 /* section-header */
 #shopify-section-header {
   z-index: 3;

--- a/assets/base.css
+++ b/assets/base.css
@@ -2199,7 +2199,6 @@ input[type='checkbox'] {
 .announcement-bar.marquee .announcement-bar__message {
   display: inline-block;
   white-space: nowrap;
-  color: #00112C;
   width: 25vw;
   text-align: initial;
   animation: announcement-bar-marquee 2s linear infinite;

--- a/assets/base.css
+++ b/assets/base.css
@@ -2221,6 +2221,7 @@ input[type='checkbox'] {
     display: block;
     white-space: inherit;
     width: auto;
+    text-align: inherit;
     animation: none;
     text-shadow: none;
   }

--- a/assets/base.css
+++ b/assets/base.css
@@ -2201,7 +2201,7 @@ input[type='checkbox'] {
   white-space: nowrap;
   width: 25vw;
   text-align: initial;
-  animation: announcement-bar-marquee 2s linear infinite;
+  animation: announcement-bar-marquee 8s linear infinite;
 
   /* Use shadows to repeat the text */
   text-shadow: 25vw 0 currentColor, calc(25vw * 2) 0 currentColor, calc(25vw * 3) 0 currentColor, calc(25vw * 4) 0 currentColor;

--- a/config/settings_data.json
+++ b/config/settings_data.json
@@ -177,7 +177,7 @@
               "text": "Welcome to our store",
               "color_scheme": "accent-1",
               "link": "",
-              "marquee": true
+              "marquee": false
             }
           }
         },

--- a/config/settings_data.json
+++ b/config/settings_data.json
@@ -107,7 +107,8 @@
               "settings": {
                 "text": "Welcome to our store",
                 "color_scheme": "background-1",
-                "link": ""
+                "link": "",
+                "marquee": false
               }
             }
           },

--- a/locales/en.default.schema.json
+++ b/locales/en.default.schema.json
@@ -385,6 +385,9 @@
             },
             "link": {
               "label": "Link"
+            },
+            "marquee": {
+              "label": "Scrolling marquee"
             }
           }
         }

--- a/sections/announcement-bar.liquid
+++ b/sections/announcement-bar.liquid
@@ -73,7 +73,7 @@
           "id": "marquee",
           "default": false,
           "label": "t:sections.announcement-bar.blocks.announcement.settings.marquee.label"
-        },
+        }
       ]
     }
   ],

--- a/sections/announcement-bar.liquid
+++ b/sections/announcement-bar.liquid
@@ -6,7 +6,7 @@
           {%- if block.settings.link != blank -%}
             <a href="{{ block.settings.link }}" class="announcement-bar__link link link--text focus-inset animate-arrow">
           {%- endif -%}
-              <p class="announcement-bar__message h5">
+              <p class="announcement-bar__message h5{% if block.settings.marquee %} marquee-text{% endif %}">
                 {{ block.settings.text | escape }}
                 {%- if block.settings.link != blank -%}
                   {% render 'icon-arrow' %}
@@ -67,7 +67,13 @@
           "type": "url",
           "id": "link",
           "label": "t:sections.announcement-bar.blocks.announcement.settings.link.label"
-        }
+        },
+        {
+          "type": "checkbox",
+          "id": "marquee",
+          "default": false,
+          "label": "t:sections.announcement-bar.blocks.announcement.settings.marquee.label"
+        },
       ]
     }
   ],

--- a/sections/announcement-bar.liquid
+++ b/sections/announcement-bar.liquid
@@ -1,12 +1,12 @@
 {%- for block in section.blocks -%}
   {%- case block.type -%}
     {%- when 'announcement' -%}
-      <div class="announcement-bar color-{{ block.settings.color_scheme }} gradient" role="region" aria-label="{{ 'sections.header.announcement' | t }}" {{ block.shopify_attributes }}>
+      <div class="announcement-bar color-{{ block.settings.color_scheme }} gradient{% if block.settings.marquee %} marquee{% endif %}" role="region" aria-label="{{ 'sections.header.announcement' | t }}" {{ block.shopify_attributes }}>
         {%- if block.settings.text != blank -%}
           {%- if block.settings.link != blank -%}
             <a href="{{ block.settings.link }}" class="announcement-bar__link link link--text focus-inset animate-arrow">
           {%- endif -%}
-              <p class="announcement-bar__message h5{% if block.settings.marquee %} marquee-text{% endif %}">
+              <p class="announcement-bar__message h5">
                 {{ block.settings.text | escape }}
                 {%- if block.settings.link != blank -%}
                   {% render 'icon-arrow' %}

--- a/templates/collection.json
+++ b/templates/collection.json
@@ -4,7 +4,7 @@
       "type": "main-collection-banner",
       "settings": {
         "show_collection_description": true,
-        "show_collection_image": false,
+        "show_collection_image": true,
         "color_scheme": "background-1"
       }
     },
@@ -17,7 +17,9 @@
         "show_secondary_image": false,
         "show_vendor": false,
         "show_rating": false,
+        "enable_quick_add": false,
         "enable_filtering": true,
+        "filter_type": "horizontal",
         "enable_sorting": true,
         "columns_mobile": "2",
         "padding_top": 36,


### PR DESCRIPTION
**PR Summary:** 

Adds a "Scrolling marquee" option to the announcement bar. 


https://user-images.githubusercontent.com/1202812/173064906-6b8a16f9-d5bd-4181-aabb-2b50afd1b24d.mp4



**Why are these changes introduced?**

Just a proof of concept. 

**What approach did you take?**

The PR uses a simple CSS animation to create an endlessly scrolling marquee. It borrows [this idea](https://codepen.io/fcalderan/pen/GRJeYOL) for using text shadows to repeat the text. This generally works for text, but breaks if you use emoji. 😞 

Aside from the emoji issue, I don't think this is actually a viable option for a couple reasons though:

1. It relies on a hardcoded width for the text. This breaks on smaller screens. 
2. The speed of the animation generally to be adjusted depending on the amount of text present as well. 

Both of these could theoretically be handled by JS, but I think we'd want to explore that outside of this PR anyway. Keeping this as a draft for now, but it should probably be closed once we've taken a look at it. 

**Other considerations**

The PR automatically turns the scrolling off if the user's device has `Prefers reduced motion` set. 

**Testing steps/scenarios**

- [Visit the link here.](https://os2-demo.myshopify.com/admin/themes/128171835414/editor?section=announcement-bar&block=announcement-bar%2Fannouncement-bar-0)
- Try toggling on and off the marquee setting.
- Try changing the text. (Add lots of text, notice that it breaks)
- Check it out at other screen sizes (Notice that it breaks)