### PR TITLE
Add help text to the Variant Pills settings area

### DIFF
--- a/config/settings_schema.json
+++ b/config/settings_schema.json
@@ -273,6 +273,10 @@
     "name": "t:settings_schema.variant_pills.name",
     "settings": [
       {
+        "type": "paragraph",
+        "content": "t:settings_schema.variant_pills.paragraph"
+      },
+      {
         "type": "header",
         "content": "t:settings_schema.global.settings.header__border.content"
       },

--- a/locales/cs.schema.json
+++ b/locales/cs.schema.json
@@ -282,7 +282,8 @@
       "name": "Tlačítka"
     },
     "variant_pills": {
-      "name": "Kulaté přepínače variant"
+      "name": "Kulaté přepínače variant",
+      "paragraph": "Kulaté přepínače variant jsou jedním ze způsobů, jak zobrazit varianty produktu. [Zjistit více](https://help.shopify.com/en/manual/online-store/themes/theme-structure/page-types#variant-picker-block)"
     },
     "inputs": {
       "name": "Vstupy"

--- a/locales/da.schema.json
+++ b/locales/da.schema.json
@@ -282,7 +282,8 @@
       "name": "Knapper"
     },
     "variant_pills": {
-      "name": "Variantetiketter"
+      "name": "Variantetiketter",
+      "paragraph": "Variantetiketter er en måde at vise dine produktvarianter på. [Få mere at vide](https://help.shopify.com/en/manual/online-store/themes/theme-structure/page-types#variant-picker-block)"
     },
     "inputs": {
       "name": "Inputs"

--- a/locales/de.schema.json
+++ b/locales/de.schema.json
@@ -282,7 +282,8 @@
       "name": "Schaltflächen"
     },
     "variant_pills": {
-      "name": "Varianten-Kapseln"
+      "name": "Varianten-Kapseln",
+      "paragraph": "Varianten-Kapseln sind eine Möglichkeit, deine Produktvarianten zu präsentieren. [Mehr Informationen](https://help.shopify.com/en/manual/online-store/themes/theme-structure/page-types#variant-picker-block)"
     },
     "inputs": {
       "name": "Eingaben"

--- a/locales/en.default.schema.json
+++ b/locales/en.default.schema.json
@@ -164,7 +164,7 @@
     },
     "variant_pills": {
       "name": "Variant pills",
-      "paragraph": "Affects the display of product variants on a product page or a featured product section."
+      "paragraph": "Variant pills are one way of displaying your product variants. [Learn more](https://help.shopify.com/en/manual/online-store/themes/theme-structure/page-types#variant-picker-block)"
     },
     "inputs": {
       "name": "Inputs"

--- a/locales/en.default.schema.json
+++ b/locales/en.default.schema.json
@@ -163,7 +163,8 @@
       "name": "Buttons"
     },
     "variant_pills": {
-      "name": "Variant pills"
+      "name": "Variant pills",
+      "paragraph": "Affects the display of product variants on a product page or a featured product section."
     },
     "inputs": {
       "name": "Inputs"

--- a/locales/es.schema.json
+++ b/locales/es.schema.json
@@ -282,7 +282,8 @@
       "name": "Botones"
     },
     "variant_pills": {
-      "name": "Botones de variantes"
+      "name": "Botones de variantes",
+      "paragraph": "Los botones de variantes son una forma de mostrar las variantes de producto. [Más información](https://help.shopify.com/en/manual/online-store/themes/theme-structure/page-types#variant-picker-block)"
     },
     "inputs": {
       "name": "Entradas"

--- a/locales/fi.schema.json
+++ b/locales/fi.schema.json
@@ -282,7 +282,8 @@
       "name": "Painikkeet"
     },
     "variant_pills": {
-      "name": "Versioiden kuvakkeet"
+      "name": "Versioiden kuvakkeet",
+      "paragraph": "Versiopillerit ovat yksi tapa näyttää tuoteversiosi asiakkaille. [Lisätietoja](https://help.shopify.com/en/manual/online-store/themes/theme-structure/page-types#variant-picker-block)"
     },
     "inputs": {
       "name": "Syötteet"

--- a/locales/fr.schema.json
+++ b/locales/fr.schema.json
@@ -282,7 +282,8 @@
       "name": "Boutons"
     },
     "variant_pills": {
-      "name": "Boutons pilule de variante"
+      "name": "Boutons pilule de variante",
+      "paragraph": "Les boutons pilule de variante servent à afficher les variantes de produit. [En savoir plus](https://help.shopify.com/en/manual/online-store/themes/theme-structure/page-types#variant-picker-block)"
     },
     "inputs": {
       "name": "Entrées"

--- a/locales/it.schema.json
+++ b/locales/it.schema.json
@@ -282,7 +282,8 @@
       "name": "Pulsanti"
     },
     "variant_pills": {
-      "name": "Pulsanti di selezione variante"
+      "name": "Pulsanti di selezione variante",
+      "paragraph": "I pulsanti di selezione variante costituiscono uno dei modi in cui puoi visualizzare le varianti di prodotto. [Maggiori informazioni](https://help.shopify.com/en/manual/online-store/themes/theme-structure/page-types#variant-picker-block)"
     },
     "inputs": {
       "name": "Input"

--- a/locales/ja.schema.json
+++ b/locales/ja.schema.json
@@ -282,7 +282,8 @@
       "name": "ボタン"
     },
     "variant_pills": {
-      "name": "バリエーションのピル型ボタン"
+      "name": "バリエーションのピル型ボタン",
+      "paragraph": "バリエーションのピル型ボタンは、商品バリエーションを表示する1つの方法です。[詳しくはこちら](https://help.shopify.com/en/manual/online-store/themes/theme-structure/page-types#variant-picker-block)"
     },
     "inputs": {
       "name": "入力"

--- a/locales/ko.schema.json
+++ b/locales/ko.schema.json
@@ -282,7 +282,8 @@
       "name": "버튼"
     },
     "variant_pills": {
-      "name": "이형 상품 타원형"
+      "name": "이형 상품 타원형",
+      "paragraph": "이형 상품 필은 제품 이형 상품을 표시하는 방법 중 하나입니다. [자세히 알아보기](https://help.shopify.com/en/manual/online-store/themes/theme-structure/page-types#variant-picker-block)"
     },
     "inputs": {
       "name": "입력"

--- a/locales/nb.schema.json
+++ b/locales/nb.schema.json
@@ -282,7 +282,8 @@
       "name": "Knapper"
     },
     "variant_pills": {
-      "name": "Variantknapper"
+      "name": "Variantknapper",
+      "paragraph": "Variantknapper er én måte å presentere produktvarianter på. [Finn ut mer](https://help.shopify.com/en/manual/online-store/themes/theme-structure/page-types#variant-picker-block)"
     },
     "inputs": {
       "name": "Inputs"

--- a/locales/nl.schema.json
+++ b/locales/nl.schema.json
@@ -282,7 +282,8 @@
       "name": "Knoppen"
     },
     "variant_pills": {
-      "name": "Variantopties"
+      "name": "Variantopties",
+      "paragraph": "Variantopties zijn een manier om je productvarianten weer te geven. [Meer informatie](https://help.shopify.com/en/manual/online-store/themes/theme-structure/page-types#variant-picker-block)"
     },
     "inputs": {
       "name": "Invoer"

--- a/locales/pl.schema.json
+++ b/locales/pl.schema.json
@@ -282,7 +282,8 @@
       "name": "Przyciski"
     },
     "variant_pills": {
-      "name": "Okrągłe przełączniki wariantów"
+      "name": "Okrągłe przełączniki wariantów",
+      "paragraph": "Okrągłe przełączniki wariantów to jeden ze sposobów wyświetlania wariantów produktów. [Dowiedz się więcej](https://help.shopify.com/en/manual/online-store/themes/theme-structure/page-types#variant-picker-block)"
     },
     "inputs": {
       "name": "Dane wejściowe"

--- a/locales/pt-BR.schema.json
+++ b/locales/pt-BR.schema.json
@@ -282,7 +282,8 @@
       "name": "Botões"
     },
     "variant_pills": {
-      "name": "Pílulas de variantes"
+      "name": "Pílulas de variantes",
+      "paragraph": "Pílulas de variante são uma forma de apresentar suas variantes do produto. [Saiba mais](https://help.shopify.com/en/manual/online-store/themes/theme-structure/page-types#variant-picker-block)"
     },
     "inputs": {
       "name": "Entradas"

--- a/locales/pt-PT.schema.json
+++ b/locales/pt-PT.schema.json
@@ -282,7 +282,8 @@
       "name": "Botões"
     },
     "variant_pills": {
-      "name": "Variantes com forma de comprimidos"
+      "name": "Variantes com forma de comprimidos",
+      "paragraph": "As variantes com forma de comprimidos são uma forma de apresentar as variantes do seu produto. [Saber mais](https://help.shopify.com/en/manual/online-store/themes/theme-structure/page-types#variant-picker-block)"
     },
     "inputs": {
       "name": "Entradas"

--- a/locales/sv.schema.json
+++ b/locales/sv.schema.json
@@ -282,7 +282,8 @@
       "name": "Knappar"
     },
     "variant_pills": {
-      "name": "Variantkapslar"
+      "name": "Variantkapslar",
+      "paragraph": "Variantpiller är ett sätt att visa produktvarianter på. [Mer information](https://help.shopify.com/en/manual/online-store/themes/theme-structure/page-types#variant-picker-block)"
     },
     "inputs": {
       "name": "Inmatningar"

--- a/locales/th.schema.json
+++ b/locales/th.schema.json
@@ -282,7 +282,8 @@
       "name": "ปุ่ม"
     },
     "variant_pills": {
-      "name": "ตัวเลือกสินค้าทรงเม็ดยา"
+      "name": "ตัวเลือกสินค้าทรงเม็ดยา",
+      "paragraph": "แคปซูลตัวเลือกสินค้าเป็นวิธีหนึ่งในการแสดงตัวเลือกสินค้าของคุณ [ดูข้อมูลเพิ่มเติม](https://help.shopify.com/en/manual/online-store/themes/theme-structure/page-types#variant-picker-block)"
     },
     "inputs": {
       "name": "อินพุต"

--- a/locales/tr.schema.json
+++ b/locales/tr.schema.json
@@ -282,7 +282,8 @@
       "name": "Düğmeler"
     },
     "variant_pills": {
-      "name": "Varyasyon seçenekleri"
+      "name": "Varyasyon seçenekleri",
+      "paragraph": "Varyasyon seçenekleri, ürün varyasyonlarınızı göstermenin bir yoludur. [Daha fazla bilgi edinin](https://help.shopify.com/en/manual/online-store/themes/theme-structure/page-types#variant-picker-block)"
     },
     "inputs": {
       "name": "Girdiler"

--- a/locales/vi.schema.json
+++ b/locales/vi.schema.json
@@ -282,7 +282,8 @@
       "name": "Nút"
     },
     "variant_pills": {
-      "name": "Ô chọn mẫu mã"
+      "name": "Ô chọn mẫu mã",
+      "paragraph": "Ô chọn mẫu mã là một cách để hiển thị mẫu mã sản phẩm. [Tìm hiểu thêm](https://help.shopify.com/en/manual/online-store/themes/theme-structure/page-types#variant-picker-block)"
     },
     "inputs": {
       "name": "Thông tin đầu vào"

--- a/locales/zh-CN.schema.json
+++ b/locales/zh-CN.schema.json
@@ -282,7 +282,8 @@
       "name": "按钮"
     },
     "variant_pills": {
-      "name": "多属性椭圆形框"
+      "name": "多属性椭圆形框",
+      "paragraph": "多属性椭圆形框是显示产品多属性的一种方式。[了解详细信息](https://help.shopify.com/en/manual/online-store/themes/theme-structure/page-types#variant-picker-block)"
     },
     "inputs": {
       "name": "输入"

--- a/locales/zh-TW.schema.json
+++ b/locales/zh-TW.schema.json
@@ -282,7 +282,8 @@
       "name": "按鈕"
     },
     "variant_pills": {
-      "name": "子類藥丸"
+      "name": "子類藥丸",
+      "paragraph": "子類藥丸是顯示商品子類選項的一種方式。[瞭解詳情](https://help.shopify.com/en/manual/online-store/themes/theme-structure/page-types#variant-picker-block)"
     },
     "inputs": {
       "name": "輸入"


### PR DESCRIPTION
**PR Summary:** 

Adds help text to the "Variant Pills" settings area. 

Before|After
--|--
<img width="286" alt="Screen Shot 2022-06-13 at 8 00 39 AM" src="https://user-images.githubusercontent.com/1202812/173349096-dbfcdf47-54b8-4f3a-aadd-dc44f039c4af.png">|<img width="286" alt="Screen Shot 2022-06-13 at 7 54 14 AM" src="https://user-images.githubusercontent.com/1202812/173349100-861a357b-455a-45e5-8f1c-348d6499dc8e.png">


**Why are these changes introduced?**

The "Variant Pills" name sounds quite technical. Providing some additional context to the user can help with that. 

**What approach did you take?**

I added some help text based on the description of this area from Shopify's help pages: 
https://help.shopify.com/en/manual/online-store/themes/theme-structure/theme-settings#variant-pills

Visually, I copied [the approach we already use](https://screenshot.click/Image_hTmqBgki2J.png) for help text in the "Dropdowns and Pop-ups" area. 

**Other considerations**

- This could use a content review. (cc @katycobb)
- Not sure how translation works here. Guidance would be appreciated!

**Testing steps/scenarios**

- [Open this link.](https://os2-demo.myshopify.com/admin/themes/128182583318/editor?context=theme)
- Open the "Variant Pills" section, and observe the new help text. 

**Checklist**
- [x] Added PR summary for [release notes](https://themes.shopify.com/themes/dawn/styles/default#ReleaseNotes)
- [ ] Notified the [help.shopify.com](https://help.shopify.com) team about updates to theme settings (current contact: Kimli)
- [x] Followed [theme code principles](https://github.com/Shopify/dawn/blob/main/.github/CONTRIBUTING.md#theme-code-principles)
- [x] Linted with [Theme Check](https://github.com/Shopify/theme-check)
- [x] Tested on [mobile](https://shopify.dev/themes/store/requirements#mobile-browser-requirements)
- [x] Tested on [multiple browsers](https://shopify.dev/themes/store/requirements#desktop-browser-requirements)
- [x] Tested for [accessibility](https://shopify.dev/themes/best-practices/accessibility)
