### PR TITLE
Switch to clamp for (most) responsive font sizes

### DIFF
--- a/assets/base.css
+++ b/assets/base.css
@@ -391,78 +391,36 @@ h5,
 }
 
 .hxl {
-  font-size: calc(var(--font-heading-scale) * 5rem);
-}
-
-@media only screen and (min-width: 750px) {
-  .hxl {
-    font-size: calc(var(--font-heading-scale) * 6.2rem);
-  }
+  font-size: clamp(calc(var(--font-heading-scale) * 5rem), 6.2vw, calc(var(--font-heading-scale) * 6.2rem));
 }
 
 .h0 {
-  font-size: calc(var(--font-heading-scale) * 4rem);
-}
-
-@media only screen and (min-width: 750px) {
-  .h0 {
-    font-size: calc(var(--font-heading-scale) * 5.2rem);
-  }
+  font-size: clamp(calc(var(--font-heading-scale) * 4rem), 5.2vw, calc(var(--font-heading-scale) * 5.2rem));
 }
 
 h1,
 .h1 {
-  font-size: calc(var(--font-heading-scale) * 3rem);
-}
-
-@media only screen and (min-width: 750px) {
-  h1,
-  .h1 {
-    font-size: calc(var(--font-heading-scale) * 4rem);
-  }
+	font-size: clamp(calc(var(--font-heading-scale) * 3rem), 4vw, calc(var(--font-heading-scale) * 4rem));
 }
 
 h2,
 .h2 {
-  font-size: calc(var(--font-heading-scale) * 2rem);
-}
-
-@media only screen and (min-width: 750px) {
-  h2,
-  .h2 {
-    font-size: calc(var(--font-heading-scale) * 2.4rem);
-  }
+	font-size: clamp(calc(var(--font-heading-scale) * 2rem), 2.4vw, calc(var(--font-heading-scale) * 2.4rem));
 }
 
 h3,
 .h3 {
-  font-size: calc(var(--font-heading-scale) * 1.7rem);
-}
-
-@media only screen and (min-width: 750px) {
-  h3,
-  .h3 {
-    font-size: calc(var(--font-heading-scale) * 1.8rem);
-  }
+	font-size: clamp(calc(var(--font-heading-scale) * 1.7rem), 1.8vw, calc(var(--font-heading-scale) * 1.8rem));
 }
 
 h4,
 .h4 {
-  font-family: var(--font-heading-family);
-  font-style: var(--font-heading-style);
   font-size: calc(var(--font-heading-scale) * 1.5rem);
 }
 
 h5,
 .h5 {
-  font-size: calc(var(--font-heading-scale) * 1.2rem);
-}
-
-@media only screen and (min-width: 750px) {
-  h5,
-  .h5 {
-    font-size: calc(var(--font-heading-scale) * 1.3rem);
-  }
+	font-size: clamp(calc(var(--font-heading-scale) * 1.2rem), 1.3vw, calc(var(--font-heading-scale) * 1.3rem));
 }
 
 h6,
@@ -486,15 +444,9 @@ blockquote {
 }
 
 .caption {
-  font-size: 1rem;
+  font-size: clamp(1rem, 5vw, 1.2rem);
   letter-spacing: 0.07rem;
   line-height: calc(1 + 0.7 / var(--font-body-scale));
-}
-
-@media screen and (min-width: 750px) {
-  .caption {
-    font-size: 1.2rem;
-  }
 }
 
 .caption-with-letter-spacing {

--- a/assets/component-collection-hero.css
+++ b/assets/component-collection-hero.css
@@ -43,13 +43,12 @@
 .collection-hero__title + .collection-hero__description {
   margin-top: 1.5rem;
   margin-bottom: 1.5rem;
-  font-size: 1.6rem;
+  font-size: clamp(1.6rem, 1.8vw, 1.8rem);
   line-height: calc(1 + 0.5 / var(--font-body-scale));
 }
 
 @media screen and (min-width: 750px) {
   .collection-hero__title + .collection-hero__description {
-    font-size: 1.8rem;
     margin-top: 2rem;
     margin-bottom: 2rem;
   }

--- a/assets/component-price.css
+++ b/assets/component-price.css
@@ -37,15 +37,9 @@
 }
 
 .price--large {
-  font-size: 1.6rem;
+  font-size: clamp(1.6rem, 1.8vw, 1.8rem);
   line-height: calc(1 + 0.5 / var(--font-body-scale));
   letter-spacing: 0.13rem;
-}
-
-@media screen and (min-width: 750px) {
-  .price--large {
-    font-size: 1.8rem;
-  }
 }
 
 .price--sold-out .price__availability,

--- a/assets/customer.css
+++ b/assets/customer.css
@@ -36,13 +36,7 @@
 }
 
 .customer h2.form__message {
-  font-size: calc(var(--font-heading-scale) * 1.8rem);
-}
-
-@media only screen and (min-width: 750px) {
-  .customer h2.form__message {
-    font-size: calc(var(--font-heading-scale) * 2.2rem);
-  }
+  font-size: clamp(calc(var(--font-heading-scale) * 1.8rem), 2.2vw, calc(var(--font-heading-scale) * 2.2rem);
 }
 
 .customer .field {
@@ -706,14 +700,8 @@ li[data-address] {
 
 li[data-address] > h2 {
   text-align: center;
-  font-size: calc(var(--font-heading-scale) * 1.8rem);
+  font-size: clamp(calc(var(--font-heading-scale) * 1.8rem), 4.4vw, calc(var(--font-heading-scale) * 2.2rem));
   margin-bottom: 0;
-}
-
-@media only screen and (min-width: 750px) {
-  li[data-address] > h2 {
-    font-size: calc(var(--font-heading-scale) * 2.2rem);
-  }
 }
 
 .addresses ul p {

--- a/assets/section-footer.css
+++ b/assets/section-footer.css
@@ -149,13 +149,7 @@
 .footer-block__heading {
   margin-bottom: 2rem;
   margin-top: 0;
-  font-size: calc(var(--font-heading-scale) * 1.6rem);
-}
-
-@media screen and (min-width: 990px) {
-  .footer-block__heading {
-    font-size: calc(var(--font-heading-scale) * 1.8rem);
-  }
+  font-size: clamp(calc(var(--font-heading-scale) * 1.6rem), 1.8vw, calc(var(--font-heading-scale) * 1.8rem));
 }
 
 .footer__list-social:empty,

--- a/assets/section-password.css
+++ b/assets/section-password.css
@@ -14,7 +14,7 @@ html {
 body {
   background-color: rgb(var(--color-background));
   color: rgb(var(--color-foreground));
-  font-size: 1.5rem;
+  font-size: clamp(1.5rem, 1.6, 1.6rem;);
   letter-spacing: 0.07rem;
   line-height: calc(1 + 0.8 / var(--font-body-scale));
   margin: 0;
@@ -24,13 +24,6 @@ body {
   font-family: var(--font-body-family);
   font-style: var(--font-body-style);
   font-weight: var(--font-body-weight);
-}
-
-@media screen and (min-width: 750px) {
-  body {
-    font-size: 1.6rem;
-    line-height: calc(1 + 0.8 / var(--font-body-scale));
-  }
 }
 
 .password-modal__content-heading {

--- a/assets/template-giftcard.css
+++ b/assets/template-giftcard.css
@@ -30,7 +30,7 @@ html {
 body {
   background-color: rgb(var(--color-base-background-1));
   color: rgb(var(--color-base-text));
-  font-size: 1.5rem;
+  font-size: calc(1.5rem, 1.6vw, 1.6rem);
   letter-spacing: 0.07rem;
   line-height: calc(1 + 0.8 / var(--font-body-scale));
   max-width: var(--page-width);
@@ -44,8 +44,6 @@ body {
 
 @media only screen and (min-width: 750px) {
   body {
-    font-size: 1.6rem;
-    line-height: calc(1 + 0.8 / var(--font-body-scale));
     padding: 0 5rem;
   }
 }
@@ -67,26 +65,12 @@ h2,
 
 h1,
 .h1 {
-  font-size: calc(var(--font-heading-scale) * 3rem);
-}
-
-@media only screen and (min-width: 750px) {
-  h1,
-  .h1 {
-    font-size: calc(var(--font-heading-scale) * 4rem);
-  }
+	font-size: clamp(calc(var(--font-heading-scale) * 3rem), 4vw, calc(var(--font-heading-scale) * 4rem));
 }
 
 h2,
 .h2 {
-  font-size: calc(var(--font-heading-scale) * 2rem);
-}
-
-@media only screen and (min-width: 750px) {
-  h2,
-  .h2 {
-    font-size: calc(var(--font-heading-scale) * 2.4rem);
-  }
+	font-size: clamp(calc(var(--font-heading-scale) * 2rem), 2.4vw, calc(var(--font-heading-scale) * 2.4rem));
 }
 
 .skip-to-content-link:focus {
@@ -210,7 +194,7 @@ h2,
   display: flex;
   align-items: center;
   justify-content: center;
-  font-size: 1.6rem;
+  font-size: clamp(1.6rem, 2vw, 2rem);
   font-weight: 400;
   letter-spacing: 1px;
   line-height: calc(1 + 0.5 / var(--font-body-scale));
@@ -219,12 +203,6 @@ h2,
 
 .gift-card__price > p:first-child {
   margin-bottom: 1rem;
-}
-
-@media only screen and (min-width: 750px) {
-  .gift-card__price {
-    font-size: 2rem;
-  }
 }
 
 .gift-card__label:not(.badge) {

--- a/layout/theme.liquid
+++ b/layout/theme.liquid
@@ -179,18 +179,12 @@
         grid-template-columns: 100%;
         min-height: 100%;
         margin: 0;
-        font-size: 1.5rem;
+        font-size: clamp(1.5rem, 1.6vw, 1.6rem);
         letter-spacing: 0.06rem;
         line-height: calc(1 + 0.8 / var(--font-body-scale));
         font-family: var(--font-body-family);
         font-style: var(--font-body-style);
         font-weight: var(--font-body-weight);
-      }
-
-      @media screen and (min-width: 750px) {
-        body {
-          font-size: 1.6rem;
-        }
       }
     {% endstyle %}
 


### PR DESCRIPTION
## PR Summary:

This PR converts some (most) of Dawn's breakpoint-based font sizes to use `clamp()` instead. This provides a more natural set of font sizes for devices using a middle viewport.

The PR takes the font sizes currently used for large and small breakpoints, and uses those values as the `min` and `max` inputs for `clamp()` instead. **The "preferred" middle values are generalized just to show the effect.** We'd need to fine-tune them if we actually wanted to implement this. 

**Before**

Note that there's an abrupt change in font sizes around `750px`.

https://user-images.githubusercontent.com/1202812/173438276-eee2043b-bdd3-4543-b6fa-7165a215c5ad.mp4

**After**

Note that the abrupt change is gone, and font sizes transition fluidly from the large font size down to the smaller one.

https://user-images.githubusercontent.com/1202812/173438405-51b33f85-7822-4e67-bb57-c9b3d07f4f21.mp4

## Testing steps/scenarios

1. [Visit the OS-2 demo site](https://os2-demo.myshopify.com/admin/themes).
2. Find the `try/responsive-type-sizes` branch in the theme library.
3. Preview the theme, try a variety of viewports.