### PR TITLE
Add padding control to collection banner

### DIFF
--- a/assets/component-collection-hero.css
+++ b/assets/component-collection-hero.css
@@ -55,10 +55,6 @@
   }
 }
 
-.collection-hero--with-image .collection-hero__title {
-  margin: 0;
-}
-
 .collection-hero--with-image .collection-hero__text-wrapper {
   padding-bottom: 4rem;
 }

--- a/assets/component-collection-hero.css
+++ b/assets/component-collection-hero.css
@@ -9,12 +9,6 @@
 }
 
 @media screen and (min-width: 750px) {
-  .collection-hero.collection-hero--with-image {
-    padding: calc(4rem + var(--page-width-margin)) 0
-      calc(4rem + var(--page-width-margin));
-    overflow: hidden;
-  }
-
   .collection-hero--with-image .collection-hero__inner {
     padding-bottom: 0;
   }
@@ -22,6 +16,14 @@
 
 .collection-hero__text-wrapper {
   flex-basis: 100%;
+}
+
+.collection-hero__text-wrapper > *:first-child  {
+  margin-top: 0;
+}
+
+.collection-hero__text-wrapper > *:last-child  {
+  margin-bottom: 0;
 }
 
 @media screen and (min-width: 750px) {

--- a/assets/component-collection-hero.css
+++ b/assets/component-collection-hero.css
@@ -18,14 +18,6 @@
   flex-basis: 100%;
 }
 
-.collection-hero__text-wrapper > *:first-child  {
-  margin-top: 0;
-}
-
-.collection-hero__text-wrapper > *:last-child  {
-  margin-bottom: 0;
-}
-
 @media screen and (min-width: 750px) {
   .collection-hero {
     padding: 0;
@@ -39,12 +31,11 @@
 }
 
 .collection-hero__title {
-  margin: 2.5rem 0;
+  margin: 0;
 }
 
 .collection-hero__title + .collection-hero__description {
   margin-top: 1.5rem;
-  margin-bottom: 1.5rem;
   font-size: 1.6rem;
   line-height: calc(1 + 0.5 / var(--font-body-scale));
 }
@@ -53,7 +44,6 @@
   .collection-hero__title + .collection-hero__description {
     font-size: 1.8rem;
     margin-top: 2rem;
-    margin-bottom: 2rem;
   }
 
   .collection-hero__description {
@@ -70,7 +60,7 @@
 }
 
 .collection-hero--with-image .collection-hero__text-wrapper {
-  padding: 5rem 0 4rem;
+  padding-bottom: 4rem;
 }
 
 .collection-hero__image-container {

--- a/sections/main-collection-banner.liquid
+++ b/sections/main-collection-banner.liquid
@@ -116,7 +116,7 @@
       "step": 4,
       "unit": "px",
       "label": "t:sections.all.padding.padding_top",
-      "default": 0
+      "default": 24
     },
     {
       "type": "range",
@@ -126,7 +126,7 @@
       "step": 4,
       "unit": "px",
       "label": "t:sections.all.padding.padding_bottom",
-      "default": 0
+      "default": 24
     }
   ]
 }

--- a/sections/main-collection-banner.liquid
+++ b/sections/main-collection-banner.liquid
@@ -7,16 +7,12 @@
     padding-bottom: {{ section.settings.padding_bottom | times: 0.75 | round: 0 }}px;
   }
 
-  {%- if section.settings.padding_top != 0 or section.settings.padding_bottom != 0 -%}
   @media screen and (min-width: 750px) {
-    .section-{{ section.id }}-padding,
-    .collection-hero--with-image.section-{{ section.id }}-padding {
-      {%- if section.settings.padding_top != 0 -%}padding-top: {{ section.settings.padding_top }}px;{%- endif -%}
-      {%- if section.settings.padding_bottom != 0 -%}padding-bottom: {{ section.settings.padding_bottom }}px;{%- endif -%}
+    .section-{{ section.id }}-padding {
+      padding-top: {{ section.settings.padding_top }}px;
+      padding-bottom: {{ section.settings.padding_bottom }}px;
     }
   }
-  {%- endif -%}
-
   @media screen and (max-width: 749px) {
     .collection-hero--with-image .collection-hero__inner {
       padding-bottom: calc({{ settings.media_shadow_vertical_offset | at_least: 0 }}px + 2rem);

--- a/sections/main-collection-banner.liquid
+++ b/sections/main-collection-banner.liquid
@@ -7,12 +7,16 @@
     padding-bottom: {{ section.settings.padding_bottom | times: 0.75 | round: 0 }}px;
   }
 
+  {%- if section.settings.padding_top != 0 or section.settings.padding_bottom != 0 -%}
   @media screen and (min-width: 750px) {
-    .section-{{ section.id }}-padding {
-      padding-top: {{ section.settings.padding_top }}px;
-      padding-bottom: {{ section.settings.padding_bottom }}px;
+    .section-{{ section.id }}-padding,
+    .collection-hero--with-image.section-{{ section.id }}-padding {
+      {%- if section.settings.padding_top != 0 -%}padding-top: {{ section.settings.padding_top }}px;{%- endif -%}
+      {%- if section.settings.padding_bottom != 0 -%}padding-bottom: {{ section.settings.padding_bottom }}px;{%- endif -%}
     }
   }
+  {%- endif -%}
+
   @media screen and (max-width: 749px) {
     .collection-hero--with-image .collection-hero__inner {
       padding-bottom: calc({{ settings.media_shadow_vertical_offset | at_least: 0 }}px + 2rem);

--- a/sections/main-collection-banner.liquid
+++ b/sections/main-collection-banner.liquid
@@ -116,7 +116,7 @@
       "step": 4,
       "unit": "px",
       "label": "t:sections.all.padding.padding_top",
-      "default": 24
+      "default": 36
     },
     {
       "type": "range",
@@ -126,7 +126,7 @@
       "step": 4,
       "unit": "px",
       "label": "t:sections.all.padding.padding_bottom",
-      "default": 24
+      "default": 0
     }
   ]
 }

--- a/sections/main-collection-banner.liquid
+++ b/sections/main-collection-banner.liquid
@@ -2,6 +2,17 @@
 {{ 'component-collection-hero.css' | asset_url | stylesheet_tag }}
 
 {%- style -%}
+  .section-{{ section.id }}-padding {
+    padding-top: {{ section.settings.padding_top | times: 0.75 | round: 0 }}px;
+    padding-bottom: {{ section.settings.padding_bottom | times: 0.75 | round: 0 }}px;
+  }
+
+  @media screen and (min-width: 750px) {
+    .section-{{ section.id }}-padding {
+      padding-top: {{ section.settings.padding_top }}px;
+      padding-bottom: {{ section.settings.padding_bottom }}px;
+    }
+  }
   @media screen and (max-width: 749px) {
     .collection-hero--with-image .collection-hero__inner {
       padding-bottom: calc({{ settings.media_shadow_vertical_offset | at_least: 0 }}px + 2rem);
@@ -9,7 +20,7 @@
   }
 {%- endstyle -%}
 
-<div class="collection-hero{% if section.settings.show_collection_image and collection.image %} collection-hero--with-image{% endif %} color-{{ section.settings.color_scheme }} gradient">
+<div class="collection-hero{% if section.settings.show_collection_image and collection.image %} collection-hero--with-image{% endif %} color-{{ section.settings.color_scheme }} gradient section-{{ section.id }}-padding">
   <div class="collection-hero__inner page-width">
     <div class="collection-hero__text-wrapper">
       <h1 class="collection-hero__title">
@@ -92,6 +103,30 @@
       ],
       "default": "background-1",
       "label": "t:sections.all.colors.label"
+    },
+    {
+      "type": "header",
+      "content": "t:sections.all.padding.section_padding_heading"
+    },
+    {
+      "type": "range",
+      "id": "padding_top",
+      "min": 0,
+      "max": 100,
+      "step": 4,
+      "unit": "px",
+      "label": "t:sections.all.padding.padding_top",
+      "default": 0
+    },
+    {
+      "type": "range",
+      "id": "padding_bottom",
+      "min": 0,
+      "max": 100,
+      "step": 4,
+      "unit": "px",
+      "label": "t:sections.all.padding.padding_bottom",
+      "default": 0
     }
   ]
 }


### PR DESCRIPTION
**PR Summary:** 

- Adds padding controls to the collection banner.
- Trims down spacing around the collection banner to be more balanced. This may result in unexpected behavior if the merchant has removed the top padding from the subsequent block on their Collection template. 

---

![collection-banner-padding](https://user-images.githubusercontent.com/1202812/173589151-a4a3f127-ce65-4d9d-90b8-0952a2fca59f.gif)


**Why are these changes introduced?**

Greater design flexibility. 

**What approach did you take?**

Mirrors the approach taken for adding padding controls to other sections. 

**Other considerations**

This one starts with the values at zero, since we currently don't include any padding here. 

**Testing steps/scenarios**

- [Open the test store](https://os2-demo.myshopify.com/admin/themes/128193626134/editor?previewPath=%2Fcollections%2Fsets&section=template--15274442063894__banner)
- Try adjusting the new padding control on the Collection Banner. 

**Checklist**
- [ ] Added PR summary for [release notes](https://themes.shopify.com/themes/dawn/styles/default#ReleaseNotes)
- [ ] Notified the [help.shopify.com](https://help.shopify.com) team about updates to theme settings (current contact: Kimli)
- [ ] Followed [theme code principles](https://github.com/Shopify/dawn/blob/main/.github/CONTRIBUTING.md#theme-code-principles)
- [ ] Linted with [Theme Check](https://github.com/Shopify/theme-check)
- [ ] Tested on [mobile](https://shopify.dev/themes/store/requirements#mobile-browser-requirements)
- [ ] Tested on [multiple browsers](https://shopify.dev/themes/store/requirements#desktop-browser-requirements)
- [ ] Tested for [accessibility](https://shopify.dev/themes/best-practices/accessibility)
