### PR TITLE
Allow transparent backgrounds for banners

### DIFF
--- a/assets/base.css
+++ b/assets/base.css
@@ -1196,7 +1196,6 @@ summary::-webkit-details-marker {
 /* component-media */
 .media {
   display: block;
-  background-color: rgba(var(--color-foreground), 0.1);
   position: relative;
   overflow: hidden;
 }

--- a/assets/section-image-banner.css
+++ b/assets/section-image-banner.css
@@ -318,19 +318,10 @@
 @media screen and (min-width: 750px) {
   .banner--desktop-transparent .banner__box {
     background: transparent;
-    --color-foreground: 255, 255, 255;
-    --color-button: 255, 255, 255;
-    --color-button-text: 0, 0, 0;
     max-width: 89rem;
     border: none;
     border-radius: 0;
     box-shadow: none;
-  }
-
-  .banner--desktop-transparent .button--secondary {
-    --color-button: 255, 255, 255;
-    --color-button-text: 255, 255, 255;
-    --alpha-button-background: 0;
   }
 
   .banner--desktop-transparent .content-container:after {


### PR DESCRIPTION
**PR Summary:** 

Removing the 0.1 opacity default background, and "magic" colours when overlays are applied so they stay true to the colour palletes.

**Why are these changes introduced?**

More creativity with banners

**Testing steps/scenarios**
- [ ] Open the [editor](https://os2-demo.myshopify.com/admin/themes/128199163926/editor?section=template--15275289149462__image_banner)
- [ ] Click on the image banner
- [ ] Upload a transparent png for an image

