### PR TITLE
Setting border-top to 0.1rem to match with header navigation

### DIFF
--- a/assets/component-facets.css
+++ b/assets/component-facets.css
@@ -964,7 +964,7 @@ input.mobile-facets__checkbox {
   }
 
   .facets__disclosure-vertical {
-    border-top: solid rgba(var(--color-foreground), 0.1);
+    border-top: 0.1rem solid rgba(var(--color-foreground), 0.1);
     margin-right: 0;
   }
   


### PR DESCRIPTION
updating component-facets.css to match div line width from the header (0.1 rem)

**PR Summary:** 
This should fix the border on vertical filters to 0.1rem.

**Why are these changes introduced?**
Create visual consistency and reduce the visual hierarchy on those lines.

**What approach did you take?**
Added 0.1 rem to the border-top definition.

**Other considerations**
This needs to be changed if we decide to allow for user-set height.

**Testing steps/scenarios**
Open store editor, activate vertical filters on the collection page product grid, check against separator lines from header and announcement bar.

**Demo links**
- [Store](https://5k1oven6i7db6ky0-45840990230.shopifypreview.com)
- [Editor](https://os2-demo.myshopify.com/admin/themes/128205226006/)

**Checklist**
- [ ] Added PR summary for [release notes](https://themes.shopify.com/themes/dawn/styles/default#ReleaseNotes)
- [ ] Notified the [help.shopify.com](https://help.shopify.com) team about updates to theme settings (current contact: Kimli)
- [ ] Followed [theme code principles](https://github.com/Shopify/dawn/blob/main/.github/CONTRIBUTING.md#theme-code-principles)
- [ ] Linted with [Theme Check](https://github.com/Shopify/theme-check)
- [ ] Tested on [mobile](https://shopify.dev/themes/store/requirements#mobile-browser-requirements)
- [ ] Tested on [multiple browsers](https://shopify.dev/themes/store/requirements#desktop-browser-requirements)
- [ ] Tested for [accessibility](https://shopify.dev/themes/best-practices/accessibility)
