### PR TITLE
Add padding to collection banner section

### DIFF
--- a/assets/component-collection-hero.css
+++ b/assets/component-collection-hero.css
@@ -10,8 +10,6 @@
 
 @media screen and (min-width: 750px) {
   .collection-hero.collection-hero--with-image {
-    padding: calc(4rem + var(--page-width-margin)) 0
-      calc(4rem + var(--page-width-margin));
     overflow: hidden;
   }
 

--- a/layout/password.liquid
+++ b/layout/password.liquid
@@ -75,7 +75,7 @@
         --media-shadow-visible: {% if settings.media_shadow_opacity > 0 %}1{% else %}0{% endif %};
 
         --page-width: {{ settings.page_width | divided_by: 10 }}rem;
-        --page-width-margin: {% if settings.page_width == '1600' %}2{% else %}0{% endif %}rem;
+        --page-width-margin: {% if settings.page_width == 1600 %}2{% else %}0{% endif %}rem;
 
         --card-image-padding: {{ settings.card_image_padding | divided_by: 10.0 }}rem;
         --card-corner-radius: {{ settings.card_corner_radius | divided_by: 10.0 }}rem;

--- a/layout/theme.liquid
+++ b/layout/theme.liquid
@@ -84,7 +84,7 @@
         --media-shadow-visible: {% if settings.media_shadow_opacity > 0 %}1{% else %}0{% endif %};
 
         --page-width: {{ settings.page_width | divided_by: 10 }}rem;
-        --page-width-margin: {% if settings.page_width == '1600' %}2{% else %}0{% endif %}rem;
+        --page-width-margin: {% if settings.page_width == 1600 %}2{% else %}0{% endif %}rem;
 
         --card-image-padding: {{ settings.card_image_padding | divided_by: 10.0 }}rem;
         --card-corner-radius: {{ settings.card_corner_radius | divided_by: 10.0 }}rem;

--- a/sections/main-collection-banner.liquid
+++ b/sections/main-collection-banner.liquid
@@ -2,6 +2,25 @@
 {{ 'component-collection-hero.css' | asset_url | stylesheet_tag }}
 
 {%- style -%}
+  .section-{{ section.id }}-padding {
+    padding-top: {{ section.settings.padding_top | times: 0.75 | round: 0 }}px;
+    padding-bottom: {{ section.settings.padding_bottom | times: 0.75 | round: 0 }}px;
+  }
+
+  @media screen and (min-width: 750px) {
+    .section-{{ section.id }}-padding {
+      padding-top: {{ section.settings.padding_top }}px;
+      padding-bottom: {{ section.settings.padding_bottom }}px;
+    }
+
+    {%- if section.settings.show_collection_image and collection.image %}
+      .collection-hero--with-image.section-{{ section.id }}-padding {
+        padding-top: calc(4rem + var(--page-width-margin) + {{ section.settings.padding_top }}px);
+        padding-bottom: calc(4rem + var(--page-width-margin) + {{ section.settings.padding_bottom }}px);
+      }
+    {%- endif %}
+  }
+
   @media screen and (max-width: 749px) {
     .collection-hero--with-image .collection-hero__inner {
       padding-bottom: calc({{ settings.media_shadow_vertical_offset | at_least: 0 }}px + 2rem);
@@ -9,7 +28,7 @@
   }
 {%- endstyle -%}
 
-<div class="collection-hero{% if section.settings.show_collection_image and collection.image %} collection-hero--with-image{% endif %} color-{{ section.settings.color_scheme }} gradient">
+<div class="collection-hero{% if section.settings.show_collection_image and collection.image %} collection-hero--with-image{% endif %} color-{{ section.settings.color_scheme }} gradient section-{{ section.id }}-padding">
   <div class="collection-hero__inner page-width">
     <div class="collection-hero__text-wrapper">
       <h1 class="collection-hero__title">
@@ -92,6 +111,30 @@
       ],
       "default": "background-1",
       "label": "t:sections.all.colors.label"
+    },
+    {
+      "type": "header",
+      "content": "t:sections.all.padding.section_padding_heading"
+    },
+    {
+      "type": "range",
+      "id": "padding_top",
+      "min": 0,
+      "max": 100,
+      "step": 4,
+      "unit": "px",
+      "label": "t:sections.all.padding.padding_top",
+      "default": 0
+    },
+    {
+      "type": "range",
+      "id": "padding_bottom",
+      "min": 0,
+      "max": 100,
+      "step": 4,
+      "unit": "px",
+      "label": "t:sections.all.padding.padding_bottom",
+      "default": 0
     }
   ]
 }

--- a/templates/gift_card.liquid
+++ b/templates/gift_card.liquid
@@ -64,7 +64,7 @@
         --gradient-base-background-1: {% if settings.gradient_background_1 != blank %}{{ settings.gradient_background_1 }}{% else %}{{ settings.colors_background_1 }}{% endif %};
 
         --page-width: {{ settings.page_width | divided_by: 10 }}rem;
-        --page-width-margin: {% if settings.page_width == '1600' %}2{% else %}0{% endif %}rem;
+        --page-width-margin: {% if settings.page_width == 1600 %}2{% else %}0{% endif %}rem;
 
         --buttons-radius: {{ settings.buttons_radius }}px;
         --buttons-border-width: {% if settings.buttons_border_opacity > 0 %}{{ settings.buttons_border_thickness }}{% else %}0{% endif %}px;


### PR DESCRIPTION
This is draft PR to show an alternative solution for: https://github.com/Shopify/dawn/pull/1790

### Store demo link

- [Editor](https://os2-demo.myshopify.com/admin/themes/128217481238/editor)

### Testing steps/scenarios

- Layout > Page width has been set to `1600px`:
  - Test by adjusting these values.
- Media > Shadow > Horizontal and Vertical offsets have been set to the max negative setting:
  - Test by adjusting these values.
- Navigate to any collection and enable/disable the "Show collection image" setting.
  - Go to the Collection list page and click on the [13 products collection](https://user-images.githubusercontent.com/28404165/174185834-66ce450a-d85c-412a-99dc-0d19711ecdd1.png) as I was using this for testing.
  - Adjust the top and bottom section padding.

### Notes for this draft PR

(We should probably fix this in another PR)

While I was testing the removal of:

https://github.com/Shopify/dawn/blob/8d0e9fb92f73e2354d8e81f777616c78dd3012dc/assets/component-collection-hero.css#L13-L14

I realized the condition of the `--page-width-margin` CSS variable in layout > `password.liquid`, `theme.liquid`, and `gift_card.liquid` didn't work correctly due to `1600` being wrapper in single quotes (not sure if this was a recent change in the backend):

https://github.com/Shopify/dawn/blob/8d0e9fb92f73e2354d8e81f777616c78dd3012dc/layout/theme.liquid#L87

So when you set the global settings > **Layout** > **Page width** to `1600px`, the CSS variable of `--page-width-margin` was still `0rem` and not the expected `2rem`. This still needs to work since this PR uses the same CSS but moved into the section file of `main-collection-banner.liquid`.

**TL;DR** - for this draft PR, I removed those single quotes and validated that it works as expected:

<img src="https://user-images.githubusercontent.com/28404165/174183146-7501d664-4364-47e0-81b2-29aeb62b485c.png" width="500" height="auto">

---

CC: @kjellr 