### PR TITLE
Remove duplicate .hidden class in base.css

### DIFF
--- a/assets/base.css
+++ b/assets/base.css
@@ -544,10 +544,6 @@ table:not([class]) th {
   border: 0.1rem solid rgba(var(--color-foreground), 0.2);
 }
 
-.hidden {
-  display: none !important;
-}
-
 @media screen and (max-width: 749px) {
   .small-hide {
     display: none !important;


### PR DESCRIPTION
**PR Summary:** 

Removed duplicate `.hidden` class from `base.css`


**Why are these changes introduced?**

Optimisation

**What approach did you take?**

N/A

**Other considerations**

N/A

**Testing steps/scenarios**

N/A

**Demo links**

N/A

**Checklist**
- [x] Added PR summary for [release notes](https://themes.shopify.com/themes/dawn/styles/default#ReleaseNotes)
- [ ] Notified the [help.shopify.com](https://help.shopify.com) team about updates to theme settings (current contact: Kimli)
- [x] Followed [theme code principles](https://github.com/Shopify/dawn/blob/main/.github/CONTRIBUTING.md#theme-code-principles)
- [x] Linted with [Theme Check](https://github.com/Shopify/theme-check)
- [x] Tested on [mobile](https://shopify.dev/themes/store/requirements#mobile-browser-requirements)
- [x] Tested on [multiple browsers](https://shopify.dev/themes/store/requirements#desktop-browser-requirements)
- [x] Tested for [accessibility](https://shopify.dev/themes/best-practices/accessibility)
