### PR TITLE
[Slideshow] Fix empty text content gap on mobile

### DIFF
--- a/assets/section-image-banner.css
+++ b/assets/section-image-banner.css
@@ -305,7 +305,6 @@
 }
 
 .banner__box {
-  padding: 4rem 3.5rem;
   position: relative;
   height: fit-content;
   align-items: center;
@@ -313,6 +312,10 @@
   width: 100%;
   word-wrap: break-word;
   z-index: 1;
+}
+
+.banner__box-padding {
+  padding: 4rem 3.5rem;
 }
 
 @media screen and (min-width: 750px) {

--- a/sections/slideshow.liquid
+++ b/sections/slideshow.liquid
@@ -114,7 +114,7 @@
           {%- endif -%}
         </div>
         <div class="slideshow__text-wrapper banner__content banner__content--{{ block.settings.box_align }} page-width{% if block.settings.show_text_box == false %} banner--desktop-transparent{% endif %}">
-          <div class="slideshow__text banner__box content-container content-container--full-width-mobile color-{{ block.settings.color_scheme }} gradient slideshow__text--{{ block.settings.text_alignment }} slideshow__text-mobile--{{ block.settings.text_alignment_mobile }}">
+          <div class="slideshow__text banner__box {% if block.settings.heading != blank or block.settings.subheading != blank or block.settings.button_label != blank %}banner__box-padding {% endif %}content-container content-container--full-width-mobile color-{{ block.settings.color_scheme }} gradient slideshow__text--{{ block.settings.text_alignment }} slideshow__text-mobile--{{ block.settings.text_alignment_mobile }}">
             {%- if block.settings.heading != blank -%}
               <h2 class="banner__heading {{ block.settings.heading_size }}">{{ block.settings.heading | escape }}</h2>
             {%- endif -%}


### PR DESCRIPTION
**PR Summary:** 

Currently if you use a Slideshow section, with no content, it creates a gap underneath the image.
<img width="401" alt="Screen Shot 2022-07-05 at 11 29 16 AM" src="https://user-images.githubusercontent.com/17570703/177363753-1f80466f-95d0-4ffd-9972-632c876bcffc.png">

This PR checks if there is any text content and introduces padding if there is.
No text:
<img width="1076" alt="Screen Shot 2022-07-05 at 11 37 28 AM" src="https://user-images.githubusercontent.com/17570703/177365269-8242d306-1aad-4be2-9ccf-029c3dfe2e75.png">
With text:
<img width="1061" alt="Screen Shot 2022-07-05 at 11 37 16 AM" src="https://user-images.githubusercontent.com/17570703/177365298-70c08bc1-f0ac-4a15-8261-68a27b3035b2.png">

**Testing steps/scenarios**
- [ ] [Open this branch in the editor](https://os2-demo.myshopify.com/admin/themes/128316899350/editor)
- [ ] Add a slidshow
- [ ] Experiment with adding and removing content