### PR TITLE
Different heading sizes for Multicolumn

### DIFF
--- a/sections/multicolumn.liquid
+++ b/sections/multicolumn.liquid
@@ -87,7 +87,7 @@
               {%- endif -%}
               <div class="multicolumn-card__info">
                 {%- if block.settings.title != blank -%}
-                  <h3>{{ block.settings.title | escape }}</h3>
+                  <h3 class="{{ block.settings.heading_size }}">{{ block.settings.title | escape }}</h3>
                 {%- endif -%}
                 {%- if block.settings.text != blank -%}
                   <div class="rte">{{ block.settings.text }}</div>
@@ -346,6 +346,30 @@
           "id": "title",
           "default": "Column",
           "label": "t:sections.multicolumn.blocks.column.settings.title.label"
+        },
+        {
+          "type": "select",
+          "id": "heading_size",
+          "options": [
+            {
+              "value": "h2",
+              "label": "t:sections.all.heading_size.options__1.label"
+            },
+            {
+              "value": "h1",
+              "label": "t:sections.all.heading_size.options__2.label"
+            },
+            {
+              "value": "h0",
+              "label": "t:sections.all.heading_size.options__3.label"
+            },
+            {
+              "value": "hxl",
+              "label": "t:sections.all.heading_size.options__4.label"
+            }
+          ],
+          "default": "h1",
+          "label": "t:sections.all.heading_size.label"
         },
         {
           "type": "richtext",

--- a/sections/multicolumn.liquid
+++ b/sections/multicolumn.liquid
@@ -368,7 +368,7 @@
               "label": "t:sections.all.heading_size.options__4.label"
             }
           ],
-          "default": "h1",
+          "default": "h2",
           "label": "t:sections.all.heading_size.label"
         },
         {


### PR DESCRIPTION
**PR Summary:** 

This introduces different size options for headers in Multicolumn
<img width="810" alt="Screen Shot 2022-07-05 at 12 01 06 PM" src="https://user-images.githubusercontent.com/17570703/177382550-363a563c-0f5f-43f1-a372-67f9e71d16b2.png">

**Testing steps/scenarios**
- [ ] Open the [editor](https://os2-demo.myshopify.com/admin/themes/128317259798/editor)
- [ ] Add a Multicolumn Section
- [ ] Experiment with sizing
