### PR TITLE
Add proper product title to data-shopify-title for thumbnail

### DIFF
--- a/snippets/product-thumbnail.liquid
+++ b/snippets/product-thumbnail.liquid
@@ -181,7 +181,7 @@
         aria-label="{{ 'products.product.xr_button_label' | t }}"
         data-shopify-xr
         data-shopify-model3d-id="{{ media.id }}"
-        data-shopify-title="title"
+        data-shopify-title="{{ product.title | escape }}"
         data-shopify-xr-hidden
         >
         {% render 'icon-3d-model' %}


### PR DESCRIPTION
**PR Summary:** 

XR button for product media now uses "title" as the value of title attribute. This PR changes title value to product title as seen on Shopify's documentation:


**Why are these changes introduced?**

Bug fix that follows up on https://github.com/Shopify/dawn/pull/1667

**What approach did you take?**

Added the product title

**Checklist**
- [ ] Added PR summary for [release notes](https://themes.shopify.com/themes/dawn/styles/default#ReleaseNotes)
- [ ] Notified the [help.shopify.com](https://help.shopify.com) team about updates to theme settings (current contact: Kimli)
- [ ] Followed [theme code principles](https://github.com/Shopify/dawn/blob/main/.github/CONTRIBUTING.md#theme-code-principles)
- [ ] Linted with [Theme Check](https://github.com/Shopify/theme-check)
- [ ] Tested on [mobile](https://shopify.dev/themes/store/requirements#mobile-browser-requirements)
- [ ] Tested on [multiple browsers](https://shopify.dev/themes/store/requirements#desktop-browser-requirements)
- [ ] Tested for [accessibility](https://shopify.dev/themes/best-practices/accessibility)
