### PR TITLE
Add vendor to popup notification when vendor checkbox is ticked

### DIFF
--- a/sections/cart-notification-product.liquid
+++ b/sections/cart-notification-product.liquid
@@ -13,34 +13,37 @@
         </div>
       {%- endif -%}
       <div>
+        {%- if settings.show_vendor -%}
+          <p class="caption-with-letter-spacing light">{{ item.product.vendor }}</p>
+        {%- endif -%}
         <h3 class="cart-notification-product__name h4">{{ item.product.title | escape }}</h3>
-          <dl>
-            {%- unless item.product.has_only_default_variant -%}
-              {%- for option in item.options_with_values -%}
-                <div class="product-option">
-                  <dt>{{ option.name }}: </dt>
-                  <dd>{{ option.value }}</dd>
-                </div>
-              {%- endfor -%}
-            {%- endunless -%}
-            {%- for property in item.properties -%}
-              {%- assign property_first_char = property.first | slice: 0 -%}
-              {%- if property.last != blank and property_first_char != '_' -%}
-                <div class="product-option">
-                  <dt>{{ property.first }}: </dt>
-                  <dd>
-                    {%- if property.last contains '/uploads/' -%}
-                      <a href="{{ property.last }}" class="link" target="_blank">
-                        {{ property.last | split: '/' | last }}
-                      </a>
-                    {%- else -%}
-                      {{ property.last }}
-                    {%- endif -%}
-                  </dd>
-                </div>
-              {%- endif -%}
+        <dl>
+          {%- unless item.product.has_only_default_variant -%}
+            {%- for option in item.options_with_values -%}
+              <div class="product-option">
+                <dt>{{ option.name }}:</dt>
+                <dd>{{ option.value }}</dd>
+              </div>
             {%- endfor -%}
-          </dl>
+          {%- endunless -%}
+          {%- for property in item.properties -%}
+            {%- assign property_first_char = property.first | slice: 0 -%}
+            {%- if property.last != blank and property_first_char != '_' -%}
+              <div class="product-option">
+                <dt>{{ property.first }}:</dt>
+                <dd>
+                  {%- if property.last contains '/uploads/' -%}
+                    <a href="{{ property.last }}" class="link" target="_blank">
+                      {{ property.last | split: '/' | last }}
+                    </a>
+                  {%- else -%}
+                    {{ property.last }}
+                  {%- endif -%}
+                </dd>
+              </div>
+            {%- endif -%}
+          {%- endfor -%}
+        </dl>
         {%- if item.selling_plan_allocation != nil -%}
           <p class="product-option">{{ item.selling_plan_allocation.selling_plan.name }}</p>
         {%- endif -%}


### PR DESCRIPTION
**PR Summary:** 
Vendor name was not displaying on the popup notification, when "Show vendor" is ticked.

**Why are these changes introduced?**

Fixes #1771 

**What approach did you take?**
Used existing code that displays Vendor name in cart drawer and added it to notification popup.

**Other considerations**

**Testing steps/scenarios**
1. Go to theme editor
2. Click Settings
3. Go to "Cart"
4. Select "Popup notification" from the dropdown
5. Check the "Show vendor" checkbox
6. Add an item to the cart to display popup

**Demo links**
- [Store](https://os2-demo.myshopify.com/?preview_theme_id=128389709846)
- [Editor](https://os2-demo.myshopify.com/admin/themes/128389709846/editor)

**Checklist**
- [x] Added PR summary for [release notes](https://themes.shopify.com/themes/dawn/styles/default#ReleaseNotes)
- [ ] Notified the [help.shopify.com](https://help.shopify.com) team about updates to theme settings (current contact: Kimli)
- [x] Followed [theme code principles](https://github.com/Shopify/dawn/blob/main/.github/CONTRIBUTING.md#theme-code-principles)
- [x] Linted with [Theme Check](https://github.com/Shopify/theme-check)
- [x] Tested on [mobile](https://shopify.dev/themes/store/requirements#mobile-browser-requirements)
- [ ] Tested on [multiple browsers](https://shopify.dev/themes/store/requirements#desktop-browser-requirements)
- [ ] Tested for [accessibility](https://shopify.dev/themes/best-practices/accessibility)
