### PR TITLE
Add `reopened` activity type

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -2,7 +2,7 @@ name: Contributor License Agreement (CLA)
 
 on:
   pull_request_target:
-    types: [opened, synchronize]
+    types: [opened, synchronize, reopened]
   issue_comment:
     types: [created]
 


### PR DESCRIPTION
### PR Summary

This PR updates the recently added `cla.yml` workflow by adding the `reopened` activity type which will allow us to close and reopen existing PRs that previously passed the probot-CLA status check.

### Context

The way contributors sign the Shopify Contributor License Agreement (CLA) was recently updated. As a result, all existing PRs that previously passed the Probot-CLA will now look like this:

<img src="https://user-images.githubusercontent.com/28404165/180855492-602da28a-09ac-47bc-a548-1670963fa169.png" width="600" height="auto">

In order to dismiss the new required CLA check, an author can simply push another commit, even an empty one. Adding the `reopened` activity will allow authors to close and reopen existing PRs to dismiss the new required CLA check instead of pushing new commits.

**Note**: This is only relevant for existing PRs that passed the Probot-CLA check. All newly created PRs will *not encounter this.

**Related**: https://github.com/Shopify/dawn/pull/1859