### PR TITLE
update predictive search container width

### DIFF
--- a/assets/component-predictive-search.css
+++ b/assets/component-predictive-search.css
@@ -1,4 +1,5 @@
 .predictive-search {
+  width: calc(100% + 0.2rem);
   display: none;
   position: absolute;
   top: calc(100% + 0.1rem);
@@ -36,7 +37,6 @@
 @media screen and (min-width: 750px) {
   .predictive-search {
     border-top: none;
-    width: calc(100% + 0.2rem);
   }
 
   .header predictive-search {

--- a/assets/component-predictive-search.css
+++ b/assets/component-predictive-search.css
@@ -1,5 +1,4 @@
 .predictive-search {
-  width: calc(100% + 0.2rem);
   display: none;
   position: absolute;
   top: calc(100% + 0.1rem);
@@ -15,7 +14,8 @@
 }
 
 .predictive-search--search-template {
-  z-index: 2
+  z-index: 2;
+  width: calc(100% + 0.2rem);
 }
 
 @media screen and (max-width: 749px) {
@@ -37,6 +37,7 @@
 @media screen and (min-width: 750px) {
   .predictive-search {
     border-top: none;
+    width: calc(100% + 0.2rem);
   }
 
   .header predictive-search {


### PR DESCRIPTION
**PR Summary:** 
The predictive search container width does not take up the full width of the search bar on tablets and small screens. This PR aims to correct that.

**Why are these changes introduced?**

Fixes #1431 

**What approach did you take?**
- update the width of the parent container, `predictive-search--search-template`, to 100%

**Testing steps/scenarios**
- go to https://os2-demo.myshopify.com/?preview_theme_id=128404094998
- type something into the top search bar (for example "shoe", "bag", "art") and hit "Enter"
- click the input under "Search results" to expand the list of items found for your search
- with the list expanded, shrink your browser window and verify that the width of the results container matches that of the "Search" bar

**Demo links**
_Before_

https://user-images.githubusercontent.com/22390758/181294885-e0e1fe81-5dbc-41de-9118-8c0e1a476504.mov

_After_

https://user-images.githubusercontent.com/22390758/181294933-4ab05149-8ab8-4530-9b8d-26a30e1e76e2.mov


- [Store](https://os2-demo.myshopify.com/?preview_theme_id=128404094998)
- [Editor](https://os2-demo.myshopify.com/admin/themes/128404094998/editor)

**Checklist**
- [x] Added PR summary for [release notes](https://themes.shopify.com/themes/dawn/styles/default#ReleaseNotes)
- [ ] Notified the [help.shopify.com](https://help.shopify.com) team about updates to theme settings (current contact: Kimli)
- [x] Followed [theme code principles](https://github.com/Shopify/dawn/blob/main/.github/CONTRIBUTING.md#theme-code-principles)
- [x] Linted with [Theme Check](https://github.com/Shopify/theme-check)
- [x] Tested on [mobile](https://shopify.dev/themes/store/requirements#mobile-browser-requirements)
- [x] Tested on [multiple browsers](https://shopify.dev/themes/store/requirements#desktop-browser-requirements)
- [x] Tested for [accessibility](https://shopify.dev/themes/best-practices/accessibility)
