### PR TITLE
Increase left and top edge for zoom-icon element

### DIFF
--- a/assets/section-main-product.css
+++ b/assets/section-main-product.css
@@ -572,8 +572,8 @@ a.product__text {
   height: 3rem;
   width: 3rem;
   position: absolute;
-  left: calc(1.3rem + var(--media-border-width));
-  top: calc(1.3rem + var(--media-border-width));
+  left: calc(1.2rem + var(--media-border-width));
+  top: calc(1.2rem + var(--media-border-width));
   z-index: 1;
   transition: color var(--duration-short) ease,
     opacity var(--duration-short) ease;


### PR DESCRIPTION
**PR Summary:** 

Fix an issue that causes improper displaying of the `zoom icon` on a product's image when its corner radius is set >= 36px.

**Why are these changes introduced?**

Fixes #1812.

**What approach did you take?**

Increase left and top edge in CSS for the element.

**Demo links**
- [Editor](https://os2-demo.myshopify.com/admin/themes/128464125974/editor?previewPath=%2Fproducts%2Fpuppy&context=theme&category=gid%3A%2F%2Fshopify%2FOnlineStoreThemeSettingsCategory%2FMedia%3Ftheme_id%3D128464125974%26first_setting_id%3Dmedia_border_thickness)

**Checklist**
- [x] Added PR summary for [release notes](https://themes.shopify.com/themes/dawn/styles/default#ReleaseNotes)
- [ ] Notified the [help.shopify.com](https://help.shopify.com) team about updates to theme settings (current contact: Kimli)
- [x] Followed [theme code principles](https://github.com/Shopify/dawn/blob/main/.github/CONTRIBUTING.md#theme-code-principles)
- [x] Linted with [Theme Check](https://github.com/Shopify/theme-check)
- [x] Tested on [mobile](https://shopify.dev/themes/store/requirements#mobile-browser-requirements)
- [x] Tested on [multiple browsers](https://shopify.dev/themes/store/requirements#desktop-browser-requirements)
- [x] Tested for [accessibility](https://shopify.dev/themes/best-practices/accessibility)
