### PR TITLE
Prevent menu drawer double scrollbar (Chrome & Safari)

### DIFF
--- a/assets/component-menu-drawer.css
+++ b/assets/component-menu-drawer.css
@@ -93,7 +93,6 @@ details[open].menu-opening > .menu-drawer__submenu {
   display: grid;
   grid-template-rows: 1fr auto;
   align-content: space-between;
-  overflow-y: auto;
   height: 100%;
 }
 


### PR DESCRIPTION
**PR Summary:** 

Prevents a double scrollbar from displaying on the menu drawer when navigation contents are taller than the viewport.

**Before**
![image](https://user-images.githubusercontent.com/1671933/183819831-f84c10af-a84d-4a74-ae01-4e737ae4a4d3.png)

**After**
![image](https://user-images.githubusercontent.com/1671933/183819933-67582347-89e1-4958-ae42-1a1ee7458d45.png)

**Checklist**
- [√] Added PR summary for [release notes](https://themes.shopify.com/themes/dawn/styles/default#ReleaseNotes)
- [√] Followed [theme code principles](https://github.com/Shopify/dawn/blob/main/.github/CONTRIBUTING.md#theme-code-principles)
- [√] Linted with [Theme Check](https://github.com/Shopify/theme-check)
- [√] Tested on [mobile](https://shopify.dev/themes/store/requirements#mobile-browser-requirements)
- [√] Tested on [multiple browsers](https://shopify.dev/themes/store/requirements#desktop-browser-requirements)
