### PR TITLE
Offset the address index in `aria-label` with pagination

### DIFF
--- a/sections/main-addresses.liquid
+++ b/sections/main-addresses.liquid
@@ -117,6 +117,7 @@
     <ul role="list">
       {%- for address in customer.addresses -%}
         <li data-address>
+          {%- assign address_index = paginate.current_offset | plus: forloop.index -%}
           {%- if address == customer.default_address -%}
             <h2>{{ 'customer.addresses.default' | t }}</h2>
           {%- endif -%}
@@ -124,7 +125,7 @@
           <button
             type="button"
             id="EditFormButton_{{ address.id }}"
-            aria-label="{{ 'customer.addresses.edit_address' | t }} {{ forloop.index }}"
+            aria-label="{{ 'customer.addresses.edit_address' | t }} {{ address_index }}"
             aria-controls="EditAddress_{{ address.id }}"
             aria-expanded="false"
             data-address-id="{{ address.id }}"
@@ -133,7 +134,7 @@
           </button>
           <button
             type="button"
-            aria-label="{{ 'customer.addresses.delete' | t }} {{ forloop.index }}"
+            aria-label="{{ 'customer.addresses.delete' | t }} {{ address_index }}"
             data-target="{{ address.url }}"
             data-confirm-message="{{ 'customer.addresses.delete_confirm' | t }}"
           >


### PR DESCRIPTION
**PR Summary:** 

The accessibility attribute `aria-label` could benefit from the proper index reference when pagination takes effect for more than 5 addresses in the account. This PR offsets the index in `aria-label` with the pagination's offset parameter.

_Bonus:_ The same variable can also be used to numerically label the address in other places like headings, buttons or confirmation dialogs.

**Why are these changes introduced?**

I think it makes sense that the addresses from second page are referred with numbers 6, 7 .. 10 rather than repeating 1, 2 .. 5 again. Similarly, on third page, it should be 11, 12 .. 15, and so on for subsequent pages.

**What approach did you take?**

Add `forloop.index` to `paginate.current_offset` and store this in a variable `address_index`. Use this variable instead of `forloop.index`.

**Other considerations**

We did the same in our store theme, so I thought it will be a good contribution. Hence I skipped directly to PR without opening an issue. We can discuss here.

**Decision log**

| # | Decision | Alternatives | Rationale | Downsides |
|---|---|---|---|---|
| 1 |   |   |   |   |

**Testing steps/scenarios**
- [ ] In a store with the changes, log in to an account.
- [ ] Create enough addresses in the account to activate pagination.
- [ ] Check page 2 or page 3 of the addresses pagination.

**Demo links**
_Nil_

**Checklist**
- [x] Added PR summary for [release notes](https://themes.shopify.com/themes/dawn/styles/default#ReleaseNotes)
- [ ] Notified the [help.shopify.com](https://help.shopify.com) team about updates to theme settings (current contact: Kimli) **_[what's this?]_**
- [x] Followed [theme code principles](https://github.com/Shopify/dawn/blob/main/.github/CONTRIBUTING.md#theme-code-principles)
- [x] Linted with [Theme Check](https://github.com/Shopify/theme-check) _(250 files inspected, 0 offenses detected, 0 offenses auto-correctable)_
- [x] Tested on [mobile](https://shopify.dev/themes/store/requirements#mobile-browser-requirements)
- [x] Tested on [multiple browsers](https://shopify.dev/themes/store/requirements#desktop-browser-requirements)
- [x] Tested for [accessibility](https://shopify.dev/themes/best-practices/accessibility)
