### PR TITLE
Fix popup cart notification overlap in the latest Safari version

### DIFF
--- a/assets/base.css
+++ b/assets/base.css
@@ -2241,7 +2241,7 @@ input[type='checkbox'] {
   display: block;
   position: relative;
   background-color: rgb(var(--color-background));
-  z-index: 1;
+  /* z-index: 1; */
 }
 
 .header-wrapper--border-bottom {

--- a/assets/base.css
+++ b/assets/base.css
@@ -154,7 +154,7 @@
 .color-icon-outline-button {
   --color-icon: rgb(var(--color-base-outline-button-labels));
 }
- 
+
 .product-card-wrapper .card {
   --border-radius: var(--product-card-corner-radius);
   --border-width: var(--product-card-border-width);
@@ -2241,6 +2241,7 @@ input[type='checkbox'] {
   display: block;
   position: relative;
   background-color: rgb(var(--color-background));
+  z-index: 1;
 }
 
 .header-wrapper--border-bottom {

--- a/assets/base.css
+++ b/assets/base.css
@@ -2241,7 +2241,7 @@ input[type='checkbox'] {
   display: block;
   position: relative;
   background-color: rgb(var(--color-background));
-  /* z-index: 1; */
+  z-index: 1;
 }
 
 .header-wrapper--border-bottom {

--- a/assets/cart-notification.js
+++ b/assets/cart-notification.js
@@ -25,7 +25,6 @@ class CartNotification extends HTMLElement {
 
   close() {
     this.notification.classList.remove('active');
-
     document.body.removeEventListener('click', this.onBodyClick);
 
     removeTrapFocus(this.activeElement);

--- a/assets/component-cart-notification.css
+++ b/assets/component-cart-notification.css
@@ -18,12 +18,17 @@
   transform: translateY(-100%);
   visibility: hidden;
   width: 100%;
-  filter: drop-shadow(
-    var(--popup-shadow-horizontal-offset)
-    var(--popup-shadow-vertical-offset)
-    var(--popup-shadow-blur-radius)
-    rgba(var(--color-shadow), var(--popup-shadow-opacity))
-  );
+  box-shadow: var(--popup-shadow-horizontal-offset) var(--popup-shadow-vertical-offset) var(--popup-shadow-blur-radius) rgba(var(--color-shadow), var(--popup-shadow-opacity));
+}
+
+.cart-notification.focused {
+  box-shadow: 0 0 .2rem 0 rgba(var(--color-foreground), .3),
+  var(--popup-shadow-horizontal-offset) var(--popup-shadow-vertical-offset) var(--popup-shadow-blur-radius) rgba(var(--color-shadow), var(--popup-shadow-opacity));
+}
+
+.cart-notification:focus-visible {
+  box-shadow: 0 0 .2rem 0 rgba(var(--color-foreground), .3),
+  var(--popup-shadow-horizontal-offset) var(--popup-shadow-vertical-offset) var(--popup-shadow-blur-radius) rgba(var(--color-shadow), var(--popup-shadow-opacity));
 }
 
 @media screen and (min-width: 750px) {

--- a/assets/component-cart-notification.css
+++ b/assets/component-cart-notification.css
@@ -18,7 +18,6 @@
   transform: translateY(-100%);
   visibility: hidden;
   width: 100%;
-  z-index: -1;
   filter: drop-shadow(
     var(--popup-shadow-horizontal-offset)
     var(--popup-shadow-vertical-offset)


### PR DESCRIPTION
**PR Summary:** 

Fixing an issue where the popup notification for the cart, once you've added an item to your cart was showing up behind the product image and product information. 


**Why are these changes introduced?**

Fixes https://github.com/Shopify/dawn/issues/1911

**What approach did you take?**

Removed the negative `z-index` on the `.cart-notification` element and added a `z-index: 1;` on the `.header-wrapper`. 

**Other considerations**

**Testing steps/scenarios**
<!-- List all the testing tasks that applies to your fix to help peers review your work. -->
- [ ] Test in Safari on version 15.6 and also older version
- [ ] Make sure it still looks fine in other browsers
- [ ] Test with different header layout (mega menu, drawer on mobile, etc)
- [ ] Test with global settings applied
- [ ] Test how the popup notification overlaps with other sections

**Demo links**

- [Store](https://os2-demo.myshopify.com/?preview_theme_id=128483754006)
- [Editor](https://os2-demo.myshopify.com/admin/themes/128483754006/editor)

**Checklist**
- [ ] Added PR summary for [release notes](https://themes.shopify.com/themes/dawn/styles/default#ReleaseNotes)
- [ ] Requested review from UX (Only for changes that are affecting the experience or perceivable visual details)
- [ ] Created a ticket for the [help.shopify.com](https://help.shopify.com) documentation team about updates to theme settings. (Internal-only task)
- [ ] Followed [theme code principles](https://github.com/Shopify/dawn/blob/main/.github/CONTRIBUTING.md#theme-code-principles)
- [ ] Linted with [Theme Check](https://github.com/Shopify/theme-check)
- [ ] Tested on [mobile](https://shopify.dev/themes/store/requirements#mobile-browser-requirements)
- [ ] Tested on [multiple browsers](https://shopify.dev/themes/store/requirements#desktop-browser-requirements)
- [ ] Tested for [accessibility](https://shopify.dev/themes/best-practices/accessibility)
