### PR TITLE
Remove Text Block for Product Subtitle

### DIFF
--- a/templates/product.json
+++ b/templates/product.json
@@ -13,13 +13,6 @@
         "title": {
           "type": "title"
         },
-        "caption": {
-          "type": "text",
-          "settings": {
-            "text": "{{ product.metafields.descriptors.subtitle.value }}",
-            "text_style": "subtitle"
-          }
-        },
         "price": {
           "type": "price"
         },


### PR DESCRIPTION
**PR Summary:** 
Remove Text Block for Product Subtitle on Dawn's pre-configured Product Page Section.

**Why are these changes introduced?**

Fixes #1914 .

**Demo links**

- [Editor](https://os2-demo.myshopify.com/admin/themes/128493486102/editor?previewPath=%2Fproducts%2Fpuppy)

**Checklist**
- [ ] Added PR summary for [release notes](https://themes.shopify.com/themes/dawn/styles/default#ReleaseNotes)
- [ ] Requested review from UX (Only for changes that are affecting the experience or perceivable visual details)
- [ ] Created a ticket for the [help.shopify.com](https://help.shopify.com) documentation team about updates to theme settings. (Internal-only task)
- [ ] Followed [theme code principles](https://github.com/Shopify/dawn/blob/main/.github/CONTRIBUTING.md#theme-code-principles)
- [ ] Linted with [Theme Check](https://github.com/Shopify/theme-check)
- [ ] Tested on [mobile](https://shopify.dev/themes/store/requirements#mobile-browser-requirements)
- [ ] Tested on [multiple browsers](https://shopify.dev/themes/store/requirements#desktop-browser-requirements)
- [ ] Tested for [accessibility](https://shopify.dev/themes/best-practices/accessibility)
