### PR TITLE
Update card style default for collage

### DIFF
--- a/sections/collage.liquid
+++ b/sections/collage.liquid
@@ -227,7 +227,7 @@
           "label": "t:sections.collage.settings.card_styles.options__2.label"
         }
       ],
-      "default": "none",
+      "default": "product-card-wrapper",
       "info": "t:sections.collage.settings.card_styles.info",
       "label": "t:sections.collage.settings.card_styles.label"
     },


### PR DESCRIPTION
**PR Summary:** 

The impact on defaulting the collage card style to `none` will have visual changes for merchants doing manual updates of their theme when we make the next release

If the merchants made changes to the Media theme settings, keeping it to `none` [would introduce this](https://screenshot.click/13-05-14lf3-g10ct.png).

[This is before on Dawn](https://screenshot.click/13-58-p6nbw-cqrqa.png), where all Collage blocks are styled from Cards, not Media. You can see it as I added styling to it on the section below.

**Why are these changes introduced?**

Fixes https://github.com/Shopify/dawn/pull/1834/files#r945090461

**Demo links**

- [Editor](https://os2-demo.myshopify.com/admin/themes/131422945302/editor)

**Checklist**
- [ ] Added PR summary for [release notes](https://themes.shopify.com/themes/dawn/styles/default#ReleaseNotes)
- [ ] Requested review from UX (Only for changes that are affecting the experience or perceivable visual details)
- [ ] Created a ticket for the [help.shopify.com](https://help.shopify.com) documentation team about updates to theme settings. (Internal-only task)
- [ ] Followed [theme code principles](https://github.com/Shopify/dawn/blob/main/.github/CONTRIBUTING.md#theme-code-principles)
- [ ] Linted with [Theme Check](https://github.com/Shopify/theme-check)
- [ ] Tested on [mobile](https://shopify.dev/themes/store/requirements#mobile-browser-requirements)
- [ ] Tested on [multiple browsers](https://shopify.dev/themes/store/requirements#desktop-browser-requirements)
- [ ] Tested for [accessibility](https://shopify.dev/themes/best-practices/accessibility)
