### PR TITLE
[Product page] "Icon with text" block

### DIFF
--- a/assets/section-main-product.css
+++ b/assets/section-main-product.css
@@ -1203,3 +1203,56 @@ a.product__text {
   margin-left: 1.2rem;
   flex-shrink: 0;
 }
+
+/* Icon with text */
+.icon-large .icon {
+  width: 3rem;
+  height: 3rem;
+  margin-bottom: 1rem;
+}
+
+.image-large {
+  height: 3rem;
+  margin-bottom: 1rem;
+}
+
+.icon-large {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+.icon-small .icon {
+  min-width: 2rem;
+  min-height: 2rem;
+  margin-right: 1rem;
+}
+
+.icon-small {
+  display: flex;
+  align-items: center;
+  margin: 0 0 1rem 0;
+}
+
+.image-small {
+  width: 2rem;
+  margin-right: 1rem;
+}
+
+.icon-container-vertical {
+  padding-top: 1.5rem;
+}
+
+.icon-container-horizontal--space-between {
+  display: flex;
+  flex-direction: row;
+  justify-content: space-between;
+  padding-top: 2rem;
+}
+
+.icon-container-horizontal--space-evenly {
+  display: flex;
+  flex-direction: row;
+  justify-content: space-evenly;
+  padding-top: 2rem;
+}

--- a/locales/en.default.schema.json
+++ b/locales/en.default.schema.json
@@ -1868,7 +1868,53 @@
               "content": "To display a rating, add a product rating app. [Learn more](https://help.shopify.com/manual/online-store/themes/theme-structure/page-types#product-rating-block)"
             }
           }
-        }
+        },
+
+        "icon_with_text": {
+            "name": "Icon with text",
+            "settings": {
+              "layout": {
+                "label": "Layout",
+                "options__1": {
+                  "label": "Horizontal"
+                },
+                "options__2": {
+                  "label": "Vertical"
+                }
+              },
+              "content": {
+                "label": "CONTENT",
+                "info": "Choose an icon or add an image for each column or row."
+              },
+              "first_icon": {
+                "label": "First icon"
+              },
+              "first_image": {
+                "label": "First image"
+              },
+              "first_heading": {
+                "label": "First heading"
+              },
+              "second_icon": {
+                "label": "Second icon"
+              },
+              "second_image": {
+                "label": "Second image"
+              },
+              "second_heading": {
+                "label": "Second heading"
+              },
+              "third_icon": {
+                "label": "Third icon"
+              },
+              "third_image": {
+                "label": "Third image"
+              },
+              "third_heading": {
+                "label": "Third heading"
+              }
+            }
+          }
       },
       "settings": {
         "header": {

--- a/sections/main-product.liquid
+++ b/sections/main-product.liquid
@@ -1496,7 +1496,7 @@
     },
     {
       "type": "icon-with-text",
-      "name": "Icon with text",
+      "name": "t:sections.main-product.blocks.icon_with_text.name",
       "settings": [
         {
           "type": "select",
@@ -1504,20 +1504,20 @@
           "options": [
             {
               "value": "horizontal",
-              "label": "Horizontal"
+              "label": "t:sections.main-product.blocks.icon_with_text.settings.layout.options__1.label"
             },
             {
               "value": "vertical",
-              "label": "Vertical"
+              "label": "t:sections.main-product.blocks.icon_with_text.settings.layout.options__2.label"
             }
           ],
           "default": "horizontal",
-          "label": "Layout"
+          "label": "t:sections.main-product.blocks.icon_with_text.settings.layout.label"
         },
         {
           "type": "header",
-          "content": "CONTENT",
-          "info": "Choose an icon or add an image for each column or row."
+          "content": "t:sections.main-product.blocks.icon_with_text.settings.content.label",
+          "info": "t:sections.main-product.blocks.icon_with_text.settings.content.info"
         },
         {
           "type": "select",
@@ -1701,18 +1701,18 @@
             }
           ],
           "default": "heart",
-          "label": "First icon"
+          "label": "t:sections.main-product.blocks.icon_with_text.settings.first_icon.label"
         },
         {
           "type": "image_picker",
           "id": "first_image",
-          "label": "First image"
+          "label": "t:sections.main-product.blocks.icon_with_text.settings.first_image.label"
         },
         {
           "type": "text",
           "id": "first_heading",
           "default": "Heading",
-          "label": "First heading"
+          "label": "t:sections.main-product.blocks.icon_with_text.settings.first_heading.label"
         },
         {
           "type": "select",
@@ -1896,18 +1896,18 @@
             }
           ],
           "default": "leaf",
-          "label": "Second icon"
+          "label": "t:sections.main-product.blocks.icon_with_text.settings.second_icon.label"
         },
         {
           "type": "image_picker",
           "id": "second_image",
-          "label": "Second image"
+          "label": "t:sections.main-product.blocks.icon_with_text.settings.second_image.label"
         },
         {
           "type": "text",
           "id": "second_heading",
           "default": "Heading",
-          "label": "Second heading"
+          "label": "t:sections.main-product.blocks.icon_with_text.settings.second_heading.label"
         },
         {
           "type": "select",
@@ -2091,18 +2091,18 @@
             }
           ],
           "default": "truck",
-          "label": "Third icon"
+          "label": "t:sections.main-product.blocks.icon_with_text.settings.third_icon.label"
         },
         {
           "type": "image_picker",
           "id": "third_image",
-          "label": "Third image"
+          "label": "t:sections.main-product.blocks.icon_with_text.settings.third_image.label"
         },
         {
           "type": "text",
           "id": "third_heading",
           "default": "Heading",
-          "label": "Third heading"
+          "label": "t:sections.main-product.blocks.icon_with_text.settings.third_heading.label"
         }
       ]
     }

--- a/sections/main-product.liquid
+++ b/sections/main-product.liquid
@@ -61,7 +61,7 @@
         <div id="GalleryStatus-{{ section.id }}" class="visually-hidden" role="status"></div>
         <slider-component id="GalleryViewer-{{ section.id }}" class="slider-mobile-gutter">
           <a class="skip-to-content-link button visually-hidden quick-add-hidden" href="#ProductInfo-{{ section.id }}">
-            {{ "accessibility.skip_to_product_info" | t }}
+            {{ 'accessibility.skip_to_product_info' | t }}
           </a>
           <ul
             id="Slider-Gallery-{{ section.id }}"
@@ -689,10 +689,67 @@
                   <span aria-hidden="true">({{ product.metafields.reviews.rating_count }})</span>
                   <span class="visually-hidden">
                     {{- product.metafields.reviews.rating_count }}
-                    {{ "accessibility.total_reviews" | t -}}
+                    {{ 'accessibility.total_reviews' | t -}}
                   </span>
                 </p>
               {%- endif -%}
+            {%- when 'icon-with-text' -%}
+              {%- if block.settings.first_icon == 'none' and block.settings.first_image == nil -%}
+                {%- assign isIconImage_1 = false -%}
+              {%- else -%}
+                {%- assign isIconImage_1 = true -%}
+              {%- endif -%}
+              {%- if block.settings.second_icon == 'none' and block.settings.second_image == nil -%}
+                {%- assign isIconImage_2 = false -%}
+              {%- else -%}
+                {%- assign isIconImage_2 = true -%}
+              {%- endif -%}
+              {%- if block.settings.third_icon == 'none' and block.settings.third_image == nil -%}
+                {%- assign isIconImage_3 = false -%}
+              {%- else -%}
+                {%- assign isIconImage_3 = true -%}
+              {%- endif -%}
+              <div class="{% if block.settings.layout == 'horizontal' %}icon-container-horizontal--space-{% if isIconImage_1 == false or isIconImage_2 == false or isIconImage_3 == false %}evenly{% else %}between{% endif %}{% else %}icon-container-vertical{% endif %}">
+                {%- unless block.settings.first_icon == 'none' and block.settings.first_image == nil -%}
+                  <div class="{% if block.settings.layout == 'horizontal' %}icon-large{%else%}icon-small{% endif %}">
+                    {%- if block.settings.first_image == nil -%}
+                      {%- render 'icon-accordion', icon: block.settings.first_icon -%}
+                    {%- else -%}
+                      <img
+                        src="{{ block.settings.first_image | image_url }}"
+                        class="{% if block.settings.layout == 'horizontal' %}image-large{% else %}image-small{% endif%}"
+                      >
+                    {%- endif -%}
+                    <span>{{- block.settings.first_heading -}}</span>
+                  </div>
+                {%- endunless -%}
+                {%- unless block.settings.second_icon == 'none' and block.settings.second_image == nil -%}
+                  <div class="{% if block.settings.layout == 'horizontal' %}icon-large{%else%}icon-small{% endif %}">
+                    {%- if block.settings.second_image == nil -%}
+                      {% render 'icon-accordion', icon: block.settings.second_icon -%}
+                    {%- else -%}
+                      <img
+                        src="{{ block.settings.second_image | image_url }}"
+                        class="{% if block.settings.layout == 'horizontal' %}image-large{% else %}image-small{% endif%}"
+                      >
+                    {%- endif -%}
+                    <span>{{- block.settings.second_heading -}}</span>
+                  </div>
+                {%- endunless -%}
+                {%- unless block.settings.third_icon == 'none' and block.settings.third_image == nil -%}
+                  <div class="{% if block.settings.layout == 'horizontal' %}icon-large{%else%}icon-small{% endif %}">
+                    {%- if block.settings.third_image == nil -%}
+                      {% render 'icon-accordion', icon: block.settings.third_icon -%}
+                    {%- else -%}
+                      <img
+                        src="{{ block.settings.third_image | image_url }}"
+                        class="{% if block.settings.layout == 'horizontal' %}image-large{% else %}image-small{% endif%}"
+                      >
+                    {%- endif -%}
+                    <span>{{- block.settings.third_heading -}}</span>
+                  </div>
+                {%- endunless -%}
+              </div>
           {%- endcase -%}
         {%- endfor -%}
         <a href="{{ product.url }}" class="link product__view-details animate-arrow">
@@ -1434,6 +1491,618 @@
         {
           "type": "paragraph",
           "content": "t:sections.main-product.blocks.rating.settings.paragraph.content"
+        }
+      ]
+    },
+    {
+      "type": "icon-with-text",
+      "name": "Icon with text",
+      "settings": [
+        {
+          "type": "select",
+          "id": "layout",
+          "options": [
+            {
+              "value": "horizontal",
+              "label": "Horizontal"
+            },
+            {
+              "value": "vertical",
+              "label": "Vertical"
+            }
+          ],
+          "default": "horizontal",
+          "label": "Layout"
+        },
+        {
+          "type": "header",
+          "content": "CONTENT",
+          "info": "Choose an icon or add an image for each column or row."
+        },
+        {
+          "type": "select",
+          "id": "first_icon",
+          "options": [
+            {
+              "value": "none",
+              "label": "t:sections.main-product.blocks.collapsible_tab.settings.icon.options__1.label"
+            },
+            {
+              "value": "apple",
+              "label": "t:sections.main-product.blocks.collapsible_tab.settings.icon.options__2.label"
+            },
+            {
+              "value": "banana",
+              "label": "t:sections.main-product.blocks.collapsible_tab.settings.icon.options__3.label"
+            },
+            {
+              "value": "bottle",
+              "label": "t:sections.main-product.blocks.collapsible_tab.settings.icon.options__4.label"
+            },
+            {
+              "value": "box",
+              "label": "t:sections.main-product.blocks.collapsible_tab.settings.icon.options__5.label"
+            },
+            {
+              "value": "carrot",
+              "label": "t:sections.main-product.blocks.collapsible_tab.settings.icon.options__6.label"
+            },
+            {
+              "value": "chat_bubble",
+              "label": "t:sections.main-product.blocks.collapsible_tab.settings.icon.options__7.label"
+            },
+            {
+              "value": "check_mark",
+              "label": "t:sections.main-product.blocks.collapsible_tab.settings.icon.options__8.label"
+            },
+            {
+              "value": "clipboard",
+              "label": "t:sections.main-product.blocks.collapsible_tab.settings.icon.options__9.label"
+            },
+            {
+              "value": "dairy",
+              "label": "t:sections.main-product.blocks.collapsible_tab.settings.icon.options__10.label"
+            },
+            {
+              "value": "dairy_free",
+              "label": "t:sections.main-product.blocks.collapsible_tab.settings.icon.options__11.label"
+            },
+            {
+              "value": "dryer",
+              "label": "t:sections.main-product.blocks.collapsible_tab.settings.icon.options__12.label"
+            },
+            {
+              "value": "eye",
+              "label": "t:sections.main-product.blocks.collapsible_tab.settings.icon.options__13.label"
+            },
+            {
+              "value": "fire",
+              "label": "t:sections.main-product.blocks.collapsible_tab.settings.icon.options__14.label"
+            },
+            {
+              "value": "gluten_free",
+              "label": "t:sections.main-product.blocks.collapsible_tab.settings.icon.options__15.label"
+            },
+            {
+              "value": "heart",
+              "label": "t:sections.main-product.blocks.collapsible_tab.settings.icon.options__16.label"
+            },
+            {
+              "value": "iron",
+              "label": "t:sections.main-product.blocks.collapsible_tab.settings.icon.options__17.label"
+            },
+            {
+              "value": "leaf",
+              "label": "t:sections.main-product.blocks.collapsible_tab.settings.icon.options__18.label"
+            },
+            {
+              "value": "leather",
+              "label": "t:sections.main-product.blocks.collapsible_tab.settings.icon.options__19.label"
+            },
+            {
+              "value": "lightning_bolt",
+              "label": "t:sections.main-product.blocks.collapsible_tab.settings.icon.options__20.label"
+            },
+            {
+              "value": "lipstick",
+              "label": "t:sections.main-product.blocks.collapsible_tab.settings.icon.options__21.label"
+            },
+            {
+              "value": "lock",
+              "label": "t:sections.main-product.blocks.collapsible_tab.settings.icon.options__22.label"
+            },
+            {
+              "value": "map_pin",
+              "label": "t:sections.main-product.blocks.collapsible_tab.settings.icon.options__23.label"
+            },
+            {
+              "value": "nut_free",
+              "label": "t:sections.main-product.blocks.collapsible_tab.settings.icon.options__24.label"
+            },
+            {
+              "value": "pants",
+              "label": "t:sections.main-product.blocks.collapsible_tab.settings.icon.options__25.label"
+            },
+            {
+              "value": "paw_print",
+              "label": "t:sections.main-product.blocks.collapsible_tab.settings.icon.options__26.label"
+            },
+            {
+              "value": "pepper",
+              "label": "t:sections.main-product.blocks.collapsible_tab.settings.icon.options__27.label"
+            },
+            {
+              "value": "perfume",
+              "label": "t:sections.main-product.blocks.collapsible_tab.settings.icon.options__28.label"
+            },
+            {
+              "value": "plane",
+              "label": "t:sections.main-product.blocks.collapsible_tab.settings.icon.options__29.label"
+            },
+            {
+              "value": "plant",
+              "label": "t:sections.main-product.blocks.collapsible_tab.settings.icon.options__30.label"
+            },
+            {
+              "value": "price_tag",
+              "label": "t:sections.main-product.blocks.collapsible_tab.settings.icon.options__31.label"
+            },
+            {
+              "value": "question_mark",
+              "label": "t:sections.main-product.blocks.collapsible_tab.settings.icon.options__32.label"
+            },
+            {
+              "value": "recycle",
+              "label": "t:sections.main-product.blocks.collapsible_tab.settings.icon.options__33.label"
+            },
+            {
+              "value": "return",
+              "label": "t:sections.main-product.blocks.collapsible_tab.settings.icon.options__34.label"
+            },
+            {
+              "value": "ruler",
+              "label": "t:sections.main-product.blocks.collapsible_tab.settings.icon.options__35.label"
+            },
+            {
+              "value": "serving_dish",
+              "label": "t:sections.main-product.blocks.collapsible_tab.settings.icon.options__36.label"
+            },
+            {
+              "value": "shirt",
+              "label": "t:sections.main-product.blocks.collapsible_tab.settings.icon.options__37.label"
+            },
+            {
+              "value": "shoe",
+              "label": "t:sections.main-product.blocks.collapsible_tab.settings.icon.options__38.label"
+            },
+            {
+              "value": "silhouette",
+              "label": "t:sections.main-product.blocks.collapsible_tab.settings.icon.options__39.label"
+            },
+            {
+              "value": "snowflake",
+              "label": "t:sections.main-product.blocks.collapsible_tab.settings.icon.options__40.label"
+            },
+            {
+              "value": "star",
+              "label": "t:sections.main-product.blocks.collapsible_tab.settings.icon.options__41.label"
+            },
+            {
+              "value": "stopwatch",
+              "label": "t:sections.main-product.blocks.collapsible_tab.settings.icon.options__42.label"
+            },
+            {
+              "value": "truck",
+              "label": "t:sections.main-product.blocks.collapsible_tab.settings.icon.options__43.label"
+            },
+            {
+              "value": "washing",
+              "label": "t:sections.main-product.blocks.collapsible_tab.settings.icon.options__44.label"
+            }
+          ],
+          "default": "heart",
+          "label": "First icon"
+        },
+        {
+          "type": "image_picker",
+          "id": "first_image",
+          "label": "First image"
+        },
+        {
+          "type": "text",
+          "id": "first_heading",
+          "default": "Heading",
+          "label": "First heading"
+        },
+        {
+          "type": "select",
+          "id": "second_icon",
+          "options": [
+            {
+              "value": "none",
+              "label": "t:sections.main-product.blocks.collapsible_tab.settings.icon.options__1.label"
+            },
+            {
+              "value": "apple",
+              "label": "t:sections.main-product.blocks.collapsible_tab.settings.icon.options__2.label"
+            },
+            {
+              "value": "banana",
+              "label": "t:sections.main-product.blocks.collapsible_tab.settings.icon.options__3.label"
+            },
+            {
+              "value": "bottle",
+              "label": "t:sections.main-product.blocks.collapsible_tab.settings.icon.options__4.label"
+            },
+            {
+              "value": "box",
+              "label": "t:sections.main-product.blocks.collapsible_tab.settings.icon.options__5.label"
+            },
+            {
+              "value": "carrot",
+              "label": "t:sections.main-product.blocks.collapsible_tab.settings.icon.options__6.label"
+            },
+            {
+              "value": "chat_bubble",
+              "label": "t:sections.main-product.blocks.collapsible_tab.settings.icon.options__7.label"
+            },
+            {
+              "value": "check_mark",
+              "label": "t:sections.main-product.blocks.collapsible_tab.settings.icon.options__8.label"
+            },
+            {
+              "value": "clipboard",
+              "label": "t:sections.main-product.blocks.collapsible_tab.settings.icon.options__9.label"
+            },
+            {
+              "value": "dairy",
+              "label": "t:sections.main-product.blocks.collapsible_tab.settings.icon.options__10.label"
+            },
+            {
+              "value": "dairy_free",
+              "label": "t:sections.main-product.blocks.collapsible_tab.settings.icon.options__11.label"
+            },
+            {
+              "value": "dryer",
+              "label": "t:sections.main-product.blocks.collapsible_tab.settings.icon.options__12.label"
+            },
+            {
+              "value": "eye",
+              "label": "t:sections.main-product.blocks.collapsible_tab.settings.icon.options__13.label"
+            },
+            {
+              "value": "fire",
+              "label": "t:sections.main-product.blocks.collapsible_tab.settings.icon.options__14.label"
+            },
+            {
+              "value": "gluten_free",
+              "label": "t:sections.main-product.blocks.collapsible_tab.settings.icon.options__15.label"
+            },
+            {
+              "value": "heart",
+              "label": "t:sections.main-product.blocks.collapsible_tab.settings.icon.options__16.label"
+            },
+            {
+              "value": "iron",
+              "label": "t:sections.main-product.blocks.collapsible_tab.settings.icon.options__17.label"
+            },
+            {
+              "value": "leaf",
+              "label": "t:sections.main-product.blocks.collapsible_tab.settings.icon.options__18.label"
+            },
+            {
+              "value": "leather",
+              "label": "t:sections.main-product.blocks.collapsible_tab.settings.icon.options__19.label"
+            },
+            {
+              "value": "lightning_bolt",
+              "label": "t:sections.main-product.blocks.collapsible_tab.settings.icon.options__20.label"
+            },
+            {
+              "value": "lipstick",
+              "label": "t:sections.main-product.blocks.collapsible_tab.settings.icon.options__21.label"
+            },
+            {
+              "value": "lock",
+              "label": "t:sections.main-product.blocks.collapsible_tab.settings.icon.options__22.label"
+            },
+            {
+              "value": "map_pin",
+              "label": "t:sections.main-product.blocks.collapsible_tab.settings.icon.options__23.label"
+            },
+            {
+              "value": "nut_free",
+              "label": "t:sections.main-product.blocks.collapsible_tab.settings.icon.options__24.label"
+            },
+            {
+              "value": "pants",
+              "label": "t:sections.main-product.blocks.collapsible_tab.settings.icon.options__25.label"
+            },
+            {
+              "value": "paw_print",
+              "label": "t:sections.main-product.blocks.collapsible_tab.settings.icon.options__26.label"
+            },
+            {
+              "value": "pepper",
+              "label": "t:sections.main-product.blocks.collapsible_tab.settings.icon.options__27.label"
+            },
+            {
+              "value": "perfume",
+              "label": "t:sections.main-product.blocks.collapsible_tab.settings.icon.options__28.label"
+            },
+            {
+              "value": "plane",
+              "label": "t:sections.main-product.blocks.collapsible_tab.settings.icon.options__29.label"
+            },
+            {
+              "value": "plant",
+              "label": "t:sections.main-product.blocks.collapsible_tab.settings.icon.options__30.label"
+            },
+            {
+              "value": "price_tag",
+              "label": "t:sections.main-product.blocks.collapsible_tab.settings.icon.options__31.label"
+            },
+            {
+              "value": "question_mark",
+              "label": "t:sections.main-product.blocks.collapsible_tab.settings.icon.options__32.label"
+            },
+            {
+              "value": "recycle",
+              "label": "t:sections.main-product.blocks.collapsible_tab.settings.icon.options__33.label"
+            },
+            {
+              "value": "return",
+              "label": "t:sections.main-product.blocks.collapsible_tab.settings.icon.options__34.label"
+            },
+            {
+              "value": "ruler",
+              "label": "t:sections.main-product.blocks.collapsible_tab.settings.icon.options__35.label"
+            },
+            {
+              "value": "serving_dish",
+              "label": "t:sections.main-product.blocks.collapsible_tab.settings.icon.options__36.label"
+            },
+            {
+              "value": "shirt",
+              "label": "t:sections.main-product.blocks.collapsible_tab.settings.icon.options__37.label"
+            },
+            {
+              "value": "shoe",
+              "label": "t:sections.main-product.blocks.collapsible_tab.settings.icon.options__38.label"
+            },
+            {
+              "value": "silhouette",
+              "label": "t:sections.main-product.blocks.collapsible_tab.settings.icon.options__39.label"
+            },
+            {
+              "value": "snowflake",
+              "label": "t:sections.main-product.blocks.collapsible_tab.settings.icon.options__40.label"
+            },
+            {
+              "value": "star",
+              "label": "t:sections.main-product.blocks.collapsible_tab.settings.icon.options__41.label"
+            },
+            {
+              "value": "stopwatch",
+              "label": "t:sections.main-product.blocks.collapsible_tab.settings.icon.options__42.label"
+            },
+            {
+              "value": "truck",
+              "label": "t:sections.main-product.blocks.collapsible_tab.settings.icon.options__43.label"
+            },
+            {
+              "value": "washing",
+              "label": "t:sections.main-product.blocks.collapsible_tab.settings.icon.options__44.label"
+            }
+          ],
+          "default": "leaf",
+          "label": "Second icon"
+        },
+        {
+          "type": "image_picker",
+          "id": "second_image",
+          "label": "Second image"
+        },
+        {
+          "type": "text",
+          "id": "second_heading",
+          "default": "Heading",
+          "label": "Second heading"
+        },
+        {
+          "type": "select",
+          "id": "third_icon",
+          "options": [
+            {
+              "value": "none",
+              "label": "t:sections.main-product.blocks.collapsible_tab.settings.icon.options__1.label"
+            },
+            {
+              "value": "apple",
+              "label": "t:sections.main-product.blocks.collapsible_tab.settings.icon.options__2.label"
+            },
+            {
+              "value": "banana",
+              "label": "t:sections.main-product.blocks.collapsible_tab.settings.icon.options__3.label"
+            },
+            {
+              "value": "bottle",
+              "label": "t:sections.main-product.blocks.collapsible_tab.settings.icon.options__4.label"
+            },
+            {
+              "value": "box",
+              "label": "t:sections.main-product.blocks.collapsible_tab.settings.icon.options__5.label"
+            },
+            {
+              "value": "carrot",
+              "label": "t:sections.main-product.blocks.collapsible_tab.settings.icon.options__6.label"
+            },
+            {
+              "value": "chat_bubble",
+              "label": "t:sections.main-product.blocks.collapsible_tab.settings.icon.options__7.label"
+            },
+            {
+              "value": "check_mark",
+              "label": "t:sections.main-product.blocks.collapsible_tab.settings.icon.options__8.label"
+            },
+            {
+              "value": "clipboard",
+              "label": "t:sections.main-product.blocks.collapsible_tab.settings.icon.options__9.label"
+            },
+            {
+              "value": "dairy",
+              "label": "t:sections.main-product.blocks.collapsible_tab.settings.icon.options__10.label"
+            },
+            {
+              "value": "dairy_free",
+              "label": "t:sections.main-product.blocks.collapsible_tab.settings.icon.options__11.label"
+            },
+            {
+              "value": "dryer",
+              "label": "t:sections.main-product.blocks.collapsible_tab.settings.icon.options__12.label"
+            },
+            {
+              "value": "eye",
+              "label": "t:sections.main-product.blocks.collapsible_tab.settings.icon.options__13.label"
+            },
+            {
+              "value": "fire",
+              "label": "t:sections.main-product.blocks.collapsible_tab.settings.icon.options__14.label"
+            },
+            {
+              "value": "gluten_free",
+              "label": "t:sections.main-product.blocks.collapsible_tab.settings.icon.options__15.label"
+            },
+            {
+              "value": "heart",
+              "label": "t:sections.main-product.blocks.collapsible_tab.settings.icon.options__16.label"
+            },
+            {
+              "value": "iron",
+              "label": "t:sections.main-product.blocks.collapsible_tab.settings.icon.options__17.label"
+            },
+            {
+              "value": "leaf",
+              "label": "t:sections.main-product.blocks.collapsible_tab.settings.icon.options__18.label"
+            },
+            {
+              "value": "leather",
+              "label": "t:sections.main-product.blocks.collapsible_tab.settings.icon.options__19.label"
+            },
+            {
+              "value": "lightning_bolt",
+              "label": "t:sections.main-product.blocks.collapsible_tab.settings.icon.options__20.label"
+            },
+            {
+              "value": "lipstick",
+              "label": "t:sections.main-product.blocks.collapsible_tab.settings.icon.options__21.label"
+            },
+            {
+              "value": "lock",
+              "label": "t:sections.main-product.blocks.collapsible_tab.settings.icon.options__22.label"
+            },
+            {
+              "value": "map_pin",
+              "label": "t:sections.main-product.blocks.collapsible_tab.settings.icon.options__23.label"
+            },
+            {
+              "value": "nut_free",
+              "label": "t:sections.main-product.blocks.collapsible_tab.settings.icon.options__24.label"
+            },
+            {
+              "value": "pants",
+              "label": "t:sections.main-product.blocks.collapsible_tab.settings.icon.options__25.label"
+            },
+            {
+              "value": "paw_print",
+              "label": "t:sections.main-product.blocks.collapsible_tab.settings.icon.options__26.label"
+            },
+            {
+              "value": "pepper",
+              "label": "t:sections.main-product.blocks.collapsible_tab.settings.icon.options__27.label"
+            },
+            {
+              "value": "perfume",
+              "label": "t:sections.main-product.blocks.collapsible_tab.settings.icon.options__28.label"
+            },
+            {
+              "value": "plane",
+              "label": "t:sections.main-product.blocks.collapsible_tab.settings.icon.options__29.label"
+            },
+            {
+              "value": "plant",
+              "label": "t:sections.main-product.blocks.collapsible_tab.settings.icon.options__30.label"
+            },
+            {
+              "value": "price_tag",
+              "label": "t:sections.main-product.blocks.collapsible_tab.settings.icon.options__31.label"
+            },
+            {
+              "value": "question_mark",
+              "label": "t:sections.main-product.blocks.collapsible_tab.settings.icon.options__32.label"
+            },
+            {
+              "value": "recycle",
+              "label": "t:sections.main-product.blocks.collapsible_tab.settings.icon.options__33.label"
+            },
+            {
+              "value": "return",
+              "label": "t:sections.main-product.blocks.collapsible_tab.settings.icon.options__34.label"
+            },
+            {
+              "value": "ruler",
+              "label": "t:sections.main-product.blocks.collapsible_tab.settings.icon.options__35.label"
+            },
+            {
+              "value": "serving_dish",
+              "label": "t:sections.main-product.blocks.collapsible_tab.settings.icon.options__36.label"
+            },
+            {
+              "value": "shirt",
+              "label": "t:sections.main-product.blocks.collapsible_tab.settings.icon.options__37.label"
+            },
+            {
+              "value": "shoe",
+              "label": "t:sections.main-product.blocks.collapsible_tab.settings.icon.options__38.label"
+            },
+            {
+              "value": "silhouette",
+              "label": "t:sections.main-product.blocks.collapsible_tab.settings.icon.options__39.label"
+            },
+            {
+              "value": "snowflake",
+              "label": "t:sections.main-product.blocks.collapsible_tab.settings.icon.options__40.label"
+            },
+            {
+              "value": "star",
+              "label": "t:sections.main-product.blocks.collapsible_tab.settings.icon.options__41.label"
+            },
+            {
+              "value": "stopwatch",
+              "label": "t:sections.main-product.blocks.collapsible_tab.settings.icon.options__42.label"
+            },
+            {
+              "value": "truck",
+              "label": "t:sections.main-product.blocks.collapsible_tab.settings.icon.options__43.label"
+            },
+            {
+              "value": "washing",
+              "label": "t:sections.main-product.blocks.collapsible_tab.settings.icon.options__44.label"
+            }
+          ],
+          "default": "truck",
+          "label": "Third icon"
+        },
+        {
+          "type": "image_picker",
+          "id": "third_image",
+          "label": "Third image"
+        },
+        {
+          "type": "text",
+          "id": "third_heading",
+          "default": "Heading",
+          "label": "Third heading"
         }
       ]
     }

--- a/snippets/icon-accordion.liquid
+++ b/snippets/icon-accordion.liquid
@@ -1,5 +1,14 @@
 {%- if icon != 'none' -%}
-  <svg class="icon icon-accordion color-foreground-{{ settings.accent_icons }}" aria-hidden="true" focusable="false" role="presentation" xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 20 20">
+  <svg
+    class="icon icon-accordion color-foreground-{{ settings.accent_icons }}"
+    aria-hidden="true"
+    focusable="false"
+    role="presentation"
+    xmlns="http://www.w3.org/2000/svg"
+    width="20"
+    height="20"
+    viewBox="0 0 20 20"
+  >
     {%- case icon -%}
     {%- when 'apple' -%}
       <path d="M10.6616 1.84311C11.4997 0.994336 12.5829 0.555929 13.3364 0.406304C13.4671 0.380359 13.6027 0.407635 13.7132 0.48208C13.8237 0.556525 13.8999 0.671982 13.9249 0.802834C14.2685 2.59987 13.7042 3.90202 12.8265 4.77303C11.9732 5.61989 10.8528 6.03394 10.0739 6.16284C9.94237 6.1846 9.80763 6.15297 9.69957 6.07495C9.59151 5.99694 9.51906 5.87901 9.49832 5.74735C9.22227 3.99494 9.8034 2.71219 10.6616 1.84311ZM10.4322 5.05051C10.9838 4.87866 11.6201 4.56143 12.1221 4.06324C12.6862 3.5034 13.1028 2.69625 13.0153 1.52987C12.4847 1.71504 11.8688 2.04373 11.3731 2.54573C10.8104 3.1156 10.3882 3.92035 10.4322 5.05051Z" />


### PR DESCRIPTION
### PR Summary: 

Create a new `Icon with text` block. This block allows users to add up to three icons/images with headings to the Product page. There are two different layouts. If a user uploads an image it overrides the icon selection. If there are no icon and image selected the heading is not displayed. 

### Why are these changes introduced?

[Figma](https://www.figma.com/file/mYV4VA1cld0UYcAIMe2Y8N/Product-Page?node-id=265%3A32841)

Fixes #1719 .

### What approach did you take?

- Create a logic to apply different css classes depending on selected layout.
- Add css classes that allow to change icon/image aligning depending on how many icons/images are displayed.
- To implement the ability of rendering a Heading only if there is at least an icon or image selected I check pair of icon/image first. Then I assign a result to a variable and use it in the final condition to check if any of the pairs is false.

### Other considerations

### Testing steps/scenarios
- [ ] Delete one of the icons and leave only two any icons.
- [ ] Delete any two of the icons and leave only one.
- [ ] Delete icon and image of any ones among three.
- [ ] Upload an image for an existing icon.
- [ ] Change layout from Horizontal to Vertical.

### Screenshots

<details>
<summary><strong>Horizontal Layout - three icon/images</strong></summary>
<img width="1148" alt="Screen Shot 2022-08-24 at 10 30 30 AM" src="https://user-images.githubusercontent.com/105315663/186485168-24b672f8-a77c-4125-b4f7-7f00ace65448.png">
</details>
<details>
<summary><strong>Horizontal Layout - two icon/images</strong></summary>
<img width="1139" alt="Screen Shot 2022-08-24 at 10 30 40 AM" src="https://user-images.githubusercontent.com/105315663/186485222-8cd4f0f1-7fe5-410c-a17c-16456ca1ef59.png">
</details>
<details>
<summary><strong>Horizontal Layout - one icon/images</strong></summary>
<img width="1141" alt="Screen Shot 2022-08-24 at 10 30 55 AM" src="https://user-images.githubusercontent.com/105315663/186485250-17da67a1-f04b-45a6-bd78-707547fa4e20.png">
</details>
<details>
<summary><strong>Vertical Layout - three icon/images</strong></summary>
<img width="1260" alt="Screen Shot 2022-08-24 at 10 30 03 AM" src="https://user-images.githubusercontent.com/105315663/186485273-6f372a17-1e78-451f-990b-a0744da45135.png">
</details>
<details>
<summary><strong>Vertical Layout - two icon/images</strong></summary>
<img width="1171" alt="Screen Shot 2022-08-24 at 10 30 15 AM" src="https://user-images.githubusercontent.com/105315663/186485356-6b72bd07-6e5a-46a4-a10a-aed2c1d7678f.png">
</details>

### Demo links

- [Editor](https://os2-demo.myshopify.com/admin/themes/128406454294/editor?previewPath=%2Fproducts%2Fno-featured-image&section=template--15848218165270__main&block=template--15848218165270__main%2Fd014c413-880c-49b5-be6c-536e7970ba39)


### Checklist
- [ ] Added PR summary for [release notes](https://themes.shopify.com/themes/dawn/styles/default#ReleaseNotes)
- [ ] Requested review from UX (Only for changes that are affecting the experience or perceivable visual details)
- [ ] Created a ticket for the [help.shopify.com](https://help.shopify.com) documentation team about updates to theme settings. (Internal-only task)
- [ ] Followed [theme code principles](https://github.com/Shopify/dawn/blob/main/.github/CONTRIBUTING.md#theme-code-principles)
- [ ] Linted with [Theme Check](https://github.com/Shopify/theme-check)
- [ ] Tested on [mobile](https://shopify.dev/themes/store/requirements#mobile-browser-requirements)
- [ ] Tested on [multiple browsers](https://shopify.dev/themes/store/requirements#desktop-browser-requirements)
- [ ] Tested for [accessibility](https://shopify.dev/themes/best-practices/accessibility)
