### PR TITLE
Currency and price alignment issue

### DIFF
--- a/assets/component-cart-drawer.css
+++ b/assets/component-cart-drawer.css
@@ -17,7 +17,7 @@
 
 .drawer__inner {
   height: 100%;
-  width: 40rem;
+  width: 44rem;
   max-width: calc(100vw - 3rem);
   padding: 0 1.5rem;
   border: 0.1rem solid rgba(var(--color-foreground), 0.2);


### PR DESCRIPTION
Since the drawer width was set to 40rem, price was shown below the currency symbol on cart type drawer.

### PR Summary: 

Increased the width of the cart drawer so that currency symbol and price are shown in one line
<img width="1440" alt="Screenshot 2022-08-25 at 9 56 40 AM" src="https://user-images.githubusercontent.com/16396462/186574963-8df2d6da-0ce2-4b85-8a94-bd64d16385cc.png">

### Why are these changes introduced?
To show the price and currency symbol in one line

### What approach did you take?
increased the width of drawer


### Visual impact on existing themes
<!-- How will this visually affect merchants who upgrade to a new theme version with this change? -->
This will not impact but will show price properly next to currency

### Testing steps/scenarios
<!-- List all the testing tasks that applies to your fix to help peers review your work. -->
1. Use cart type as drawer
2. Add products to cart
3. Cart drawer will show currency symbol i.e Rs above price

### Demo links
(https://devstoregoa.myshopify.com/)


- [Store](url) https://devstoregoa.myshopify.com/