### PR TITLE
Fix issue #1957

### DIFF
--- a/assets/component-cart-drawer.css
+++ b/assets/component-cart-drawer.css
@@ -48,7 +48,6 @@
 
 cart-drawer.is-empty .drawer__inner {
   display: grid;
-  grid-template-rows: 1fr;
   align-items: center;
   padding: 0;
 }


### PR DESCRIPTION
Price will be shown in 1 line for any currency

### PR Summary: 

Regardless of the currency format, price will be shown in 1 line on cart drawer.


### Why are these changes introduced?
Removed grid-template style for .cart-drawer .cart-item
