### PR TITLE
[Complementary product] Keep text alignment to the left for horizontal cards

### DIFF
--- a/assets/component-card.css
+++ b/assets/component-card.css
@@ -18,6 +18,7 @@
 
 .card.card--horizontal {
   --text-alignment: left;
+  --image-padding: 0rem;
   flex-direction: row;
   align-items: flex-start;
   gap: 1.5rem;

--- a/assets/component-card.css
+++ b/assets/component-card.css
@@ -17,6 +17,7 @@
 }
 
 .card.card--horizontal {
+  --text-alignment: left;
   flex-direction: row;
   align-items: flex-start;
   gap: 1.5rem;


### PR DESCRIPTION
### PR Summary: 

Here after testing on some of our free themes, we noticed it makes more sense to always align the content to the left for the horizontal product cards. 
Similarly we don't want to apply the image padding as the horizontal cards are already fairly small. 

### What approach did you take?

I set the `--text-alignment` variable to be `left` on `.card.card--horizontal`
I set `--image-padding` to `0rem`

### Other considerations

### Decision log

| # | Decision | Alternatives | Rationale | Downsides |
|---|---|---|---|---|
| 1 |   |   |   |   |


### Visual impact on existing themes
Won't impact them


### Testing steps/scenarios
<!-- List all the testing tasks that applies to your fix to help peers review your work. -->
- [ ] Add complementary product block
- [ ] Set the product cards global settings to center or right alignment and make sure it's not impacting the complementary products cards
- [ ] Set the image padding for Product cards to a high value and make sure it doesn't impact anything. test with standard and card styles as well as different border and shadow values.

### Demo links

- [Editor](https://os2-demo.myshopify.com/admin/themes/131548348438/editor)

### Checklist
- [ ] Added PR summary for [release notes](https://themes.shopify.com/themes/dawn/styles/default#ReleaseNotes)
- [ ] Requested review from UX (Only for changes that are affecting the experience or perceivable visual details)
- [ ] Created a ticket for the [help.shopify.com](https://help.shopify.com) documentation team about updates to theme settings. (Internal-only task)
- [ ] Followed [theme code principles](https://github.com/Shopify/dawn/blob/main/.github/CONTRIBUTING.md#theme-code-principles)
- [ ] Linted with [Theme Check](https://github.com/Shopify/theme-check)
- [ ] Tested on [mobile](https://shopify.dev/themes/store/requirements#mobile-browser-requirements)
- [ ] Tested on [multiple browsers](https://shopify.dev/themes/store/requirements#desktop-browser-requirements)
- [ ] Tested for [accessibility](https://shopify.dev/themes/best-practices/accessibility)
