### PR TITLE
[Header] fix margin-top on middle center header option

### DIFF
--- a/assets/base.css
+++ b/assets/base.css
@@ -2282,7 +2282,7 @@ input[type='checkbox'] {
       'navigation navigation navigation';
   }
 
-  .header:not(.header--middle-left) .header__inline-menu {
+  .header:not(.header--middle-left, .header--middle-center) .header__inline-menu {
     margin-top: 1.05rem;
   }
 }


### PR DESCRIPTION
### PR Summary: 

<!-- Please include a short description (using non-technical terms, 1-2 sentences) about the changes you are introducing, what problem is being fixed and/or describe the benefit to merchants. This content will be used in our release notes for Dawn on [themes.shopify.com](https://themes.shopify.com/themes/dawn/styles/default#ReleaseNotes). -->

We introduced a new `middle center` setting for the logo position in the header and nav is receiving a top margin that it should not. 
This PR is here to fix that and remove the extra margin top applied. 

### Why are these changes introduced?

Fix misalignment. 

### What approach did you take?

Add the new class in an existing selector to prevent the margin from being applied. 

