### PR TITLE
Add inventory status block

### DIFF
--- a/assets/global.js
+++ b/assets/global.js
@@ -849,10 +849,20 @@ class VariantSelects extends HTMLElement {
         if (source && destination) destination.innerHTML = source.innerHTML;
 
         const price = document.getElementById(`price-${this.dataset.section}`);
+        const inventory = document.getElementById(`inventory-${this.dataset.section}`);
 
         if (price) price.classList.remove('visibility-hidden');
+        if (inventory) inventory.classList.remove('visibility-hidden'), this.updateInventory(html);
         this.toggleAddButton(!this.currentVariant.available, window.variantStrings.soldOut);
       });
+  }
+
+  updateInventory(html) {
+    const id = `inventory-${this.dataset.section}`;
+    const destination = document.getElementById(id);
+    const source = html.getElementById(id);
+
+    if (source && destination) destination.innerHTML = source.innerHTML;
   }
 
   toggleAddButton(disable = true, text, modifyClass = true) {
@@ -878,9 +888,11 @@ class VariantSelects extends HTMLElement {
     const addButton = button.querySelector('[name="add"]');
     const addButtonText = button.querySelector('[name="add"] > span');
     const price = document.getElementById(`price-${this.dataset.section}`);
+    const inventory = document.getElementById(`inventory-${this.dataset.section}`);
     if (!addButton) return;
     addButtonText.textContent = window.variantStrings.unavailable;
     if (price) price.classList.add('visibility-hidden');
+    if (inventory) inventory.classList.add('visibility-hidden');
   }
 
   getVariantData() {

--- a/locales/en.default.json
+++ b/locales/en.default.json
@@ -108,6 +108,7 @@
       "choose_options": "Choose options",
       "choose_product_options": "Choose options for {{ product_name }}",
       "description": "Description",
+      "inventory": "{{ quantity }} in stock",
       "on_sale": "Sale",
       "product_variants": "Product variants",
       "media": {

--- a/locales/en.default.schema.json
+++ b/locales/en.default.schema.json
@@ -773,6 +773,23 @@
         "price": {
           "name": "Price"
         },
+        "inventory": {
+          "name": "Inventory status",
+          "settings": {
+            "text_style": {
+              "label": "Text style",
+              "options__1": {
+                "label": "Body"
+              },
+              "options__2": {
+                "label": "Subtitle"
+              },
+              "options__3": {
+                "label": "Uppercase"
+              }
+            }
+          }
+        },
         "quantity_selector": {
           "name": "Quantity selector"
         },
@@ -1644,6 +1661,23 @@
         },
         "price": {
           "name": "Price"
+        },
+        "inventory": {
+          "name": "Inventory status",
+          "settings": {
+            "text_style": {
+              "label": "Text style",
+              "options__1": {
+                "label": "Body"
+              },
+              "options__2": {
+                "label": "Subtitle"
+              },
+              "options__3": {
+                "label": "Uppercase"
+              }
+            }
+          }
         },
         "quantity_selector": {
           "name": "Quantity selector"

--- a/sections/featured-product.liquid
+++ b/sections/featured-product.liquid
@@ -134,6 +134,17 @@
                     {%- endform -%}
                   </div>
                 {%- endif -%}
+              {%- when 'inventory' -%}
+                <p
+                  class="product__text product__text--inventory no-js-hidden{% if block.settings.text_style == 'uppercase' %} caption-with-letter-spacing{% elsif block.settings.text_style == 'subtitle' %} subtitle{% endif %}"
+                  id="inventory-{{ section.id }}"
+                  {{ block.shopify_attributes }}
+                >
+                  {{- block.settings.text -}}
+                  {%- if product.selected_or_first_available_variant.available and product.selected_or_first_available_variant.inventory_management == 'shopify' -%}
+                    {{ 'products.product.inventory' | t: quantity: product.selected_or_first_available_variant.inventory_quantity }}
+                  {%- endif -%}
+                </p>
               {%- when 'quantity_selector' -%}
                 <div
                   class="product-form__input product-form__quantity{% if settings.inputs_shadow_vertical_offset != 0 and settings.inputs_shadow_vertical_offset < 0 %} product-form__quantity-top{% endif %}"
@@ -306,6 +317,7 @@
                             {{ variant.title }}
                             {%- if variant.available == false %} - {{ 'products.product.sold_out' | t }}{% endif %}
                             - {{ variant.price | money | strip_html }}
+                            {% if variant.available and variant.inventory_management == 'shopify' -%} - {{ 'products.product.inventory' | t: quantity: variant.inventory_quantity }}{% endif %}
                           </option>
                         {%- endfor -%}
                       </select>
@@ -694,6 +706,33 @@
       "type": "price",
       "name": "t:sections.featured-product.blocks.price.name",
       "limit": 1
+    },
+    {
+      "type": "inventory",
+      "name": "t:sections.featured-product.blocks.inventory.name",
+      "limit": 1,
+      "settings": [
+        {
+          "type": "select",
+          "id": "text_style",
+          "options": [
+            {
+              "value": "body",
+              "label": "t:sections.featured-product.blocks.inventory.settings.text_style.options__1.label"
+            },
+            {
+              "value": "subtitle",
+              "label": "t:sections.featured-product.blocks.inventory.settings.text_style.options__2.label"
+            },
+            {
+              "value": "uppercase",
+              "label": "t:sections.featured-product.blocks.inventory.settings.text_style.options__3.label"
+            }
+          ],
+          "default": "body",
+          "label": "t:sections.featured-product.blocks.inventory.settings.text_style.label"
+        }
+      ]
     },
     {
       "type": "quantity_selector",

--- a/sections/main-product.liquid
+++ b/sections/main-product.liquid
@@ -353,6 +353,17 @@
                   {{ form | payment_terms }}
                 {%- endform -%}
               </div>
+            {%- when 'inventory' -%}
+              <p
+                class="product__text product__text--inventory no-js-hidden{% if block.settings.text_style == 'uppercase' %} caption-with-letter-spacing{% elsif block.settings.text_style == 'subtitle' %} subtitle{% endif %}"
+                id="inventory-{{ section.id }}"
+                {{ block.shopify_attributes }}
+              >
+                {{- block.settings.text -}}
+                {%- if product.selected_or_first_available_variant.available and product.selected_or_first_available_variant.inventory_management == 'shopify' -%}
+                  {{ 'products.product.inventory' | t: quantity: product.selected_or_first_available_variant.inventory_quantity }}
+                {%- endif -%}
+              </p>
             {%- when 'description' -%}
               {%- if product.description != blank -%}
                 <div class="product__description rte quick-add-hidden">
@@ -572,6 +583,7 @@
                           {{ variant.title }}
                           {%- if variant.available == false %} - {{ 'products.product.sold_out' | t }}{% endif %}
                           - {{ variant.price | money | strip_html }}
+                          {% if variant.available and variant.inventory_management == 'shopify' -%} - {{ 'products.product.inventory' | t: quantity: variant.inventory_quantity }}{% endif %}
                         </option>
                       {%- endfor -%}
                     </select>
@@ -1214,6 +1226,33 @@
       "type": "price",
       "name": "t:sections.main-product.blocks.price.name",
       "limit": 1
+    },
+    {
+      "type": "inventory",
+      "name": "t:sections.main-product.blocks.inventory.name",
+      "limit": 1,
+      "settings": [
+        {
+          "type": "select",
+          "id": "text_style",
+          "options": [
+            {
+              "value": "body",
+              "label": "t:sections.main-product.blocks.inventory.settings.text_style.options__1.label"
+            },
+            {
+              "value": "subtitle",
+              "label": "t:sections.main-product.blocks.inventory.settings.text_style.options__2.label"
+            },
+            {
+              "value": "uppercase",
+              "label": "t:sections.main-product.blocks.inventory.settings.text_style.options__3.label"
+            }
+          ],
+          "default": "body",
+          "label": "t:sections.main-product.blocks.inventory.settings.text_style.label"
+        }
+      ]
     },
     {
       "type": "quantity_selector",


### PR DESCRIPTION
_Work in progress..._

https://os2-demo.myshopify.com/admin/themes/131574693910/editor

### PR Summary:

Add an inventory status block to the product page and featured product section.

Phase 1: Allowing inventory count only

- [Figma](https://www.figma.com/file/mYV4VA1cld0UYcAIMe2Y8N/Product-Page?version-id=2358541732&node-id=202%3A15976)

This PR is will serve as a continuation of: https://github.com/Shopify/dawn/pull/876

### Screenshots

<details>
  <summary>Product page</summary>

  ![image](https://user-images.githubusercontent.com/28404165/191115369-26db524d-a415-466f-bd48-19c473df9a19.png)

</details>

<details>
  <summary>Featured product section</summary>

  ![image](https://user-images.githubusercontent.com/28404165/191115414-45054c4d-00a3-498c-af9e-14cccdc7b760.png)

</details>

### Why are these changes introduced?

Fixes https://github.com/Shopify/dawn/issues/870

### Other considerations

UX: 👀 page jump scenarios with sold out variants, unit pricing, etc. 

<details>
  <summary>Video</summary>

  https://user-images.githubusercontent.com/28404165/191287079-c0ea425a-357a-4e1e-b4e4-7a63a2b681db.mp4

</details>

### Demo links

- https://os2-demo.myshopify.com/admin/themes/131574693910/editor