### PR TITLE
Variant media modal fix

### DIFF
--- a/sections/main-product.liquid
+++ b/sections/main-product.liquid
@@ -739,7 +739,7 @@
                                         card_product: product,
                                         media_aspect_ratio: block.settings.image_ratio,
                                         show_secondary_image: false,
-                                        lazy_load: lazy_load,
+                                        lazy_load: false,
                                         show_quick_add: block.settings.enable_quick_add,
                                         section_id: section.id,
                                         horizontal_class: true

--- a/snippets/product-media.liquid
+++ b/snippets/product-media.liquid
@@ -4,7 +4,7 @@
     Accepts:
     - media: {Object} Product Media object
     - loop: {Boolean} Enable video looping (optional)
-    - variant_image: {Boolean} The media associated with a variant
+    - variant_image: {Boolean} Whether or not media is associated with a variant
 
     Usage:
     {% render 'product-media',
@@ -16,7 +16,7 @@
 
 {%- if media.media_type == 'image' -%}
   <img
-    class="global-media-settings global-media-settings--no-shadow"
+    class="global-media-settings global-media-settings--no-shadow{% if variant_image %} product__media-item--variant{% endif %}"
     srcset="{%- if media.preview_image.width >= 550 -%}{{ media.preview_image | image_url: width: 550 }} 550w,{%- endif -%}
             {%- if media.preview_image.width >= 1100 -%}{{ media.preview_image | image_url: width: 1100 }} 1100w,{%- endif -%}
             {%- if media.preview_image.width >= 1445 -%}{{ media.preview_image | image_url: width: 1445 }} 1445w,{%- endif -%}
@@ -33,7 +33,6 @@
     width="1100"
     height="{{ 1100 | divided_by: media.preview_image.aspect_ratio | ceil }}"
     data-media-id="{{ media.id }}"
-    {% if variant_image %}class="product__media-item--variant"{% endif %}
   >
 {%- else -%}
   {%- if media.media_type == 'model' -%}


### PR DESCRIPTION
### PR Summary: 

Resolves an issue where hidden variant images are always shown in product media modals.

### Why are these changes introduced?

Fixes #1984 

### What approach did you take?

Fixed liquid class logic in product-media snippet. This change affects `main-product` and `featured-product` sections.

### Visual impact on existing themes

Product variant images will no longer display in product modal if the hide variant media setting is checked.

### Testing steps/scenarios
- Test with `Hide other variants’ media after selecting a variant` setting on and off
- Test on featured product and main product sections
- Ensure other variant images only show in the modal when setting is off

### Demo links
<!-- Please include a link to a demo store that includes preconfigured sections and settings to allow reviewers to easily test the features you are working on. -->

- [Store](https://pzgi53383aqudgxb-45840990230.shopifypreview.com)
- [Editor](https://os2-demo.myshopify.com/admin/themes/131594223638/editor)

### Checklist
- [ ] Added PR summary for [release notes](https://themes.shopify.com/themes/dawn/styles/default#ReleaseNotes)
- [ ] Requested review from UX (Only for changes that are affecting the experience or perceivable visual details)
- [ ] Created a ticket for the [help.shopify.com](https://help.shopify.com) documentation team about updates to theme settings. (Internal-only task)
- [ ] Followed [theme code principles](https://github.com/Shopify/dawn/blob/main/.github/CONTRIBUTING.md#theme-code-principles)
- [ ] Linted with [Theme Check](https://github.com/Shopify/theme-check)
- [ ] Tested on [mobile](https://shopify.dev/themes/store/requirements#mobile-browser-requirements)
- [ ] Tested on [multiple browsers](https://shopify.dev/themes/store/requirements#desktop-browser-requirements)
- [ ] Tested for [accessibility](https://shopify.dev/themes/best-practices/accessibility)
