### PR TITLE
Complementary products missing styles fix

### DIFF
--- a/sections/main-product.liquid
+++ b/sections/main-product.liquid
@@ -779,6 +779,7 @@
                       </div>
                     </aside>
                   {%- endif -%}
+                  {{ 'component-card.css' | asset_url | stylesheet_tag }}
                   {{ 'section-product-recommendations.css' | asset_url | stylesheet_tag }}
                   {{ 'component-complementary-products.css' | asset_url | stylesheet_tag }}
                   {%- if block.settings.enable_quick_add -%}


### PR DESCRIPTION
### PR Summary: 

Resolves an issue where images in the complementary products block wouldn't be visible

### Why are these changes introduced?

Fixes #1990 

### What approach did you take?

Added the stylesheet inline with the others required by complementary products. We could also load it by default in main-product, but there is the possibility that nothing on the page would require it.

### Testing steps/scenarios
- Hide the default product recommendations section (and any other section that may render cards) from main-product
- Add a complementary products block to main-product
- Ensure complementary cards display as expected
Note: you will need to test with a product with complementary products configured (like Puppy)

### Demo links

- [Editor](https://os2-demo.myshopify.com/admin/themes/131615195158/editor)

### Checklist
- [ ] Added PR summary for [release notes](https://themes.shopify.com/themes/dawn/styles/default#ReleaseNotes)
- [ ] Requested review from UX (Only for changes that are affecting the experience or perceivable visual details)
- [ ] Created a ticket for the [help.shopify.com](https://help.shopify.com) documentation team about updates to theme settings. (Internal-only task)
- [ ] Followed [theme code principles](https://github.com/Shopify/dawn/blob/main/.github/CONTRIBUTING.md#theme-code-principles)
- [ ] Linted with [Theme Check](https://github.com/Shopify/theme-check)
- [ ] Tested on [mobile](https://shopify.dev/themes/store/requirements#mobile-browser-requirements)
- [ ] Tested on [multiple browsers](https://shopify.dev/themes/store/requirements#desktop-browser-requirements)
- [ ] Tested for [accessibility](https://shopify.dev/themes/best-practices/accessibility)
