### PR TITLE
Change visibility-hidden class to hidden

### DIFF
--- a/assets/global.js
+++ b/assets/global.js
@@ -850,7 +850,7 @@ class VariantSelects extends HTMLElement {
 
         const price = document.getElementById(`price-${this.dataset.section}`);
 
-        if (price) price.classList.remove('visibility-hidden');
+        if (price) price.classList.remove('hidden');
         this.toggleAddButton(!this.currentVariant.available, window.variantStrings.soldOut);
       });
   }
@@ -880,7 +880,7 @@ class VariantSelects extends HTMLElement {
     const price = document.getElementById(`price-${this.dataset.section}`);
     if (!addButton) return;
     addButtonText.textContent = window.variantStrings.unavailable;
-    if (price) price.classList.add('visibility-hidden');
+    if (price) price.classList.add('hidden');
   }
 
   getVariantData() {


### PR DESCRIPTION
### PR Summary: 

This PR removes whitespace in a price block on a product page for unavailable variants. 

### Why are these changes introduced?

Over the last couple weeks this question came up a few times in internal discussions so I decided to implement it and show how it may look like without whitespace to make a final decision on it. 

### What approach did you take?

Change `.visibility-hidden` class to `.hidden`.

### Other considerations
Removing whitespace will cause content shifting. I believe this was the original reason why we have whitespace in the price block for unavailable variants. However, since we have added new blocks (SKU and Inventory Status) which will likely be sitting next to the price and will be hidden for unavailable or unfilled (SKU) variants, keeping whitespace, in my opinion, doesn't make sense any more.

### Visual impact on existing themes
Content shifting in case a selected variant is unavailable. 

### Demo links
<!-- Please include a link to a demo store that includes preconfigured sections and settings to allow reviewers to easily test the features you are working on. -->

- [Store](url)
- [Editor](url)

### Checklist
- [ ] Added PR summary for [release notes](https://themes.shopify.com/themes/dawn/styles/default#ReleaseNotes)
- [ ] Requested review from UX (Only for changes that are affecting the experience or perceivable visual details)
- [ ] Created a ticket for the [help.shopify.com](https://help.shopify.com) documentation team about updates to theme settings. (Internal-only task)
- [ ] Followed [theme code principles](https://github.com/Shopify/dawn/blob/main/.github/CONTRIBUTING.md#theme-code-principles)
- [ ] Linted with [Theme Check](https://github.com/Shopify/theme-check)
- [ ] Tested on [mobile](https://shopify.dev/themes/store/requirements#mobile-browser-requirements)
- [ ] Tested on [multiple browsers](https://shopify.dev/themes/store/requirements#desktop-browser-requirements)
- [ ] Tested for [accessibility](https://shopify.dev/themes/best-practices/accessibility)
