### PR TITLE
Minor improvements to product media liquid [Refactor]

### DIFF
--- a/assets/section-main-product.css
+++ b/assets/section-main-product.css
@@ -674,11 +674,11 @@ a.product__text {
   margin: 0;
   padding: 0;
   position: absolute;
-  top: 0;
-  left: 0;
+  top: calc(var(--border-width) * -1);
+  right: calc(var(--border-width) * -1);
+  bottom: calc(var(--border-width) * -1);
+  left: calc(var(--border-width) * -1);
   z-index: 2;
-  height: 100%;
-  width: 100%;
 }
 
 .product__media-toggle:focus-visible {
@@ -1314,4 +1314,30 @@ a.product__text {
 
 .icon-with-text--vertical .icon-with-text__item {
   margin-bottom: var(--icon-size);
+}
+
+
+/* Product-thumbnail snippet */
+
+@media screen and (max-width: 749px) {
+  .product-media-container {
+    width: 100%;
+    max-width: calc(100% - calc(var(--border-width) * 2));
+  }
+}
+
+.product-media-container .product__modal-opener {
+  display: block;
+  position: relative;
+}
+
+@media screen and (min-width: 750px) {
+  .product-media-container .product__modal-opener:not(.product__modal-opener--image) {
+    display: none;
+  }
+}
+
+.product-media-container .product__media,
+.product-media-container .deferred-media {
+  padding-top: var(--ratio-percent);
 }

--- a/snippets/product-thumbnail.liquid
+++ b/snippets/product-thumbnail.liquid
@@ -37,125 +37,132 @@
   if mobile_layout == 'columns' and media_count > 1
     assign mobile_columns = 2
   endif
+
+  assign preview_ratio = 1 | divided_by: media.preview_image.aspect_ratio | times: 100
+  assign media_ratio = 1 | divided_by: media.aspect_ratio | times: 100
 -%}
 
 {%- capture sizes -%}
   (min-width: {{ settings.page_width }}px) {{ settings.page_width | minus: 100 | times: media_width | divided_by: desktop_columns | round }}px, (min-width: 990px) calc({{ media_width | times: 100 | divided_by: desktop_columns }}vw - 10rem), (min-width: 750px) calc((100vw - 11.5rem) / 2), calc(100vw / {{ mobile_columns }} - 4rem)
 {%- endcapture -%}
 
-<noscript>
-  {%- if media.media_type == 'video' or media.media_type == 'external_video' -%}
-    <span class="product__media-icon motion-reduce quick-add-hidden">{% render 'icon-play' %}</span>
-    <div class="product__media media gradient global-media-settings" style="padding-top: {{ 1 | divided_by: media.preview_image.aspect_ratio | times: 100 }}%;">
-      {{ media.preview_image | image_url: width: 1946 | image_tag:
-        loading: lazy,
-        sizes: sizes,
-        widths: '246, 493, 600, 713, 823, 990, 1100, 1206, 1346, 1426, 1646, 1946',
-        alt: media.preview_image.alt | escape
-      }}
-    </div>
-    <a href="{% if media.media_type == 'video' %}{{ media.sources[1].url }}{% else %}{{ media | external_video_url }}{% endif %}" class="product__media-toggle">
-      <span class="visually-hidden">{{ 'products.product.video_exit_message' | t: title: product.title | escape }}</span>
-    </a>
-  {%- else -%}
-    <div class="product__media media gradient global-media-settings" style="padding-top: {{ 1 | divided_by: media.preview_image.aspect_ratio | times: 100 }}%;">
-      {{ media.preview_image | image_url: width: 1946 | image_tag:
-        loading: lazy,
-        sizes: sizes,
-        widths: '246, 493, 600, 713, 823, 990, 1100, 1206, 1346, 1426, 1646, 1946',
-        alt: media.preview_image.alt | escape
-      }}
-    </div>
-  {%- endif -%}
-</noscript>
-
-<modal-opener class="product__modal-opener product__modal-opener--{{ media.media_type }} no-js-hidden" data-modal="#ProductModal-{{ modal_id }}">
-  <span class="product__media-icon motion-reduce quick-add-hidden" aria-hidden="true">
-    {%- liquid
-      case media.media_type
-      when 'video' or 'external_video'
-        render 'icon-play'
-      when 'model'
-        render 'icon-3d-model'
-      else
-        render 'icon-zoom'
-      endcase
-    -%}
-  </span>
-
-  <div class="product__media media media--transparent gradient global-media-settings" style="padding-top: {{ 1 | divided_by: media.preview_image.aspect_ratio | times: 100 }}%;">
-    {{ media.preview_image | image_url: width: 1946 | image_tag:
-      loading: lazy,
-      sizes: sizes,
-      widths: '246, 493, 600, 713, 823, 990, 1100, 1206, 1346, 1426, 1646, 1946',
-      alt: media.preview_image.alt | escape
-    }}
-  </div>
-  <button class="product__media-toggle quick-add-hidden" type="button" aria-haspopup="dialog" data-media-id="{{ media.id }}">
-    <span class="visually-hidden">
-      {{ 'products.product.media.open_media' | t: index: position }}
-    </span>
-  </button>
-</modal-opener>
-
-{%- if media.media_type != 'image' -%}
-  {%- if media.media_type == 'model' -%}
-    <product-model class="deferred-media media media--transparent gradient global-media-settings no-js-hidden" style="padding-top: 100%" data-media-id="{{ media.id }}">
-  {%- else -%}
-    <deferred-media class="deferred-media gradient global-media-settings media no-js-hidden" style="padding-top: {{ 1 | divided_by: media.aspect_ratio | times: 100 }}%" data-media-id="{{ media.id }}">
-  {%- endif -%}
-  <button id="Deferred-Poster-Modal-{{ media.id }}" class="deferred-media__poster" type="button">
-    <span class="deferred-media__poster-button motion-reduce">
-      {%- if media.media_type == 'model' -%}
-        <span class="visually-hidden">{{ 'products.product.media.play_model' | t }}</span>
-        {%- render 'icon-3d-model' -%}
-      {%- else -%}
-        <span class="visually-hidden">{{ 'products.product.media.play_video' | t }}</span>
-        {%- render 'icon-play' -%}
-      {%- endif -%}
-    </span>
-    {{ media.preview_image | image_url: width: 1946 | image_tag:
-      loading: lazy,
-      sizes: sizes,
-      widths: '246, 493, 600, 713, 823, 990, 1100, 1206, 1346, 1426, 1646, 1946',
-      alt: media.preview_image.alt | escape
-    }}
-  </button>
-  <template>
-    {%- liquid
-      case media.media_type
-      when 'external_video'
-        assign video_class = 'js-' | append: media.host
-        if media.host == 'youtube'
-          echo media | external_video_url: autoplay: true, loop: loop, playlist: media.external_id | external_video_tag: class: video_class, loading: "lazy"
-        else
-          echo media | external_video_url: autoplay: true, loop: loop | external_video_tag: class: video_class, loading: "lazy"
-        endif
-      when 'video'
-        echo media | media_tag: image_size: "2048x", autoplay: true, loop: loop, controls: true, preload: "none"
-      when 'model'
-        echo media | media_tag: image_size: "2048x", toggleable: true
-      endcase
-    -%}
-  </template>
-
-  {%- if media.media_type == 'model' -%}
-    </product-model>
-    {%- if xr_button -%}
-      <button
-        class="button button--full-width product__xr-button"
-        type="button"
-        aria-label="{{ 'products.product.xr_button_label' | t }}"
-        data-shopify-xr
-        data-shopify-model3d-id="{{ media.id }}"
-        data-shopify-title="{{ product.title | escape }}"
-        data-shopify-xr-hidden
-        >
-        {% render 'icon-3d-model' %}
-        {{ 'products.product.xr_button' | t }}
-      </button>
+<div
+  class="product-media-container gradient global-media-settings"
+  style="--ratio-percent: {{ preview_ratio }}%;"
+>
+  <noscript>
+    {%- if media.media_type == 'video' or media.media_type == 'external_video' -%}
+      <span class="product__media-icon motion-reduce quick-add-hidden">{% render 'icon-play' %}</span>
+      <div class="product__media media">
+        {{ media.preview_image | image_url: width: 1946 | image_tag:
+          loading: lazy,
+          sizes: sizes,
+          widths: '246, 493, 600, 713, 823, 990, 1100, 1206, 1346, 1426, 1646, 1946',
+          alt: media.preview_image.alt | escape
+        }}
+      </div>
+      <a href="{% if media.media_type == 'video' %}{{ media.sources[1].url }}{% else %}{{ media | external_video_url }}{% endif %}" class="product__media-toggle">
+        <span class="visually-hidden">{{ 'products.product.video_exit_message' | t: title: product.title | escape }}</span>
+      </a>
+    {%- else -%}
+      <div class="product__media media">
+        {{ media.preview_image | image_url: width: 1946 | image_tag:
+          loading: lazy,
+          sizes: sizes,
+          widths: '246, 493, 600, 713, 823, 990, 1100, 1206, 1346, 1426, 1646, 1946',
+          alt: media.preview_image.alt | escape
+        }}
+      </div>
     {%- endif -%}
-  {%- else -%}
-    </deferred-media>
+  </noscript>
+
+  <modal-opener class="product__modal-opener product__modal-opener--{{ media.media_type }} no-js-hidden" data-modal="#ProductModal-{{ modal_id }}">
+    <span class="product__media-icon motion-reduce quick-add-hidden" aria-hidden="true">
+      {%- liquid
+        case media.media_type
+        when 'video' or 'external_video'
+          render 'icon-play'
+        when 'model'
+          render 'icon-3d-model'
+        else
+          render 'icon-zoom'
+        endcase
+      -%}
+    </span>
+    <div class="product__media media media--transparent">
+      {{ media.preview_image | image_url: width: 1946 | image_tag:
+        loading: lazy,
+        sizes: sizes,
+        widths: '246, 493, 600, 713, 823, 990, 1100, 1206, 1346, 1426, 1646, 1946',
+        alt: media.preview_image.alt | escape
+      }}
+    </div>
+    <button class="product__media-toggle quick-add-hidden" type="button" aria-haspopup="dialog" data-media-id="{{ media.id }}">
+      <span class="visually-hidden">
+        {{ 'products.product.media.open_media' | t: index: position }}
+      </span>
+    </button>
+  </modal-opener>
+
+  {%- if media.media_type != 'image' -%}
+    {%- if media.media_type == 'model' -%}
+      <product-model class="deferred-media media media--transparent no-js-hidden" style="--ratio-percent: 100%;" data-media-id="{{ media.id }}">
+    {%- else -%}
+      <deferred-media class="deferred-media media no-js-hidden" style="--ratio-percent: {{ media_ratio }}%;" data-media-id="{{ media.id }}">
+    {%- endif -%}
+    <button id="Deferred-Poster-Modal-{{ media.id }}" class="deferred-media__poster" type="button">
+      <span class="deferred-media__poster-button motion-reduce">
+        {%- if media.media_type == 'model' -%}
+          <span class="visually-hidden">{{ 'products.product.media.play_model' | t }}</span>
+          {%- render 'icon-3d-model' -%}
+        {%- else -%}
+          <span class="visually-hidden">{{ 'products.product.media.play_video' | t }}</span>
+          {%- render 'icon-play' -%}
+        {%- endif -%}
+      </span>
+      {{ media.preview_image | image_url: width: 1946 | image_tag:
+        loading: lazy,
+        sizes: sizes,
+        widths: '246, 493, 600, 713, 823, 990, 1100, 1206, 1346, 1426, 1646, 1946',
+        alt: media.preview_image.alt | escape
+      }}
+    </button>
+    <template>
+      {%- liquid
+        case media.media_type
+        when 'external_video'
+          assign video_class = 'js-' | append: media.host
+          if media.host == 'youtube'
+            echo media | external_video_url: autoplay: true, loop: loop, playlist: media.external_id | external_video_tag: class: video_class, loading: "lazy"
+          else
+            echo media | external_video_url: autoplay: true, loop: loop | external_video_tag: class: video_class, loading: "lazy"
+          endif
+        when 'video'
+          echo media | media_tag: image_size: "2048x", autoplay: true, loop: loop, controls: true, preload: "none"
+        when 'model'
+          echo media | media_tag: image_size: "2048x", toggleable: true
+        endcase
+      -%}
+    </template>
+
+    {%- if media.media_type == 'model' -%}
+      </product-model>
+      {%- if xr_button -%}
+        <button
+          class="button button--full-width product__xr-button"
+          type="button"
+          aria-label="{{ 'products.product.xr_button_label' | t }}"
+          data-shopify-xr
+          data-shopify-model3d-id="{{ media.id }}"
+          data-shopify-title="{{ product.title | escape }}"
+          data-shopify-xr-hidden
+          >
+          {% render 'icon-3d-model' %}
+          {{ 'products.product.xr_button' | t }}
+        </button>
+      {%- endif -%}
+    {%- else -%}
+      </deferred-media>
+    {%- endif -%}
   {%- endif -%}
-{%- endif -%}
+</div>


### PR DESCRIPTION
### PR Summary: 

Minor code improvements to better facilitate future product page work.

### Why are these changes introduced?

Refs #1931 #1936 

Upcoming PDP image improvements would benefit from some structural changes to the product-thumbnail snippet that consolidate some of the liquid logic used for image ratios and applying global media styles.

### What approach did you take?

**Added a `div.product-media-container` parent element** 
This element wraps the entirety of the product-thumbnail snippet and serves as its root element. It will now the sole instance of the `global-media-settings` class and also sets css its default variable scope for `--ratio-percent`.

**Aspect ratio styles have been moved to CSS**
Rather than inlining the various ratio calculations and instances of `padding-top` on each element in the snippet, much of this was offloaded to the CSS where these styles are more easily applied and, importantly, easily overridden. This is similar to how we apply fixed image ratios to cards where we use a `.ratio` class along with a `--ratio-percent` variable.

### Decision log

| # | Decision | Alternatives | Rationale | Downsides |
|---|---|---|---|---|
| 1 | Named new element `product-media-container` | -`product__media-container`<br>-`product-media-wrapper`<br>| - Several forms of "product media wrapper or container" already exist or have existed <br>- The best solution here would probably be to use `product__media` for this root element rather than as a child<br>- The naming conventions within the product page and the media gallery specifically need significant refactoring anyway and _all_ adjacent elements should be considered at the same time when making those decisions. | - I hate the `my-element-wrapper > my-element` retrofit pattern regardless of any effort to enforce BEM conventions. |

### Visual impact on existing themes

This is a code only refactor and there should be no visual impact on existing themes.

### Testing steps/scenarios
- [ ] All instances of the product-thumbnail snippet
- [ ] All desktop product media layouts
- [ ] All mobile product media layouts
- [ ] Images, videos, and models (desktop, tablet, and mobile)
- [ ] With global media border and shadow settings
- [ ] With background gradients
- [ ] Featured product section

### Demo links
<!-- Please include a link to a demo store that includes preconfigured sections and settings to allow reviewers to easily test the features you are working on. -->

- [Store](url)
- [Editor](url)

### Checklist
- [ ] Added PR summary for [release notes](https://themes.shopify.com/themes/dawn/styles/default#ReleaseNotes)
- [ ] Requested review from UX (Only for changes that are affecting the experience or perceivable visual details)
- [ ] Created a ticket for the [help.shopify.com](https://help.shopify.com) documentation team about updates to theme settings. (Internal-only task)
- [ ] Followed [theme code principles](https://github.com/Shopify/dawn/blob/main/.github/CONTRIBUTING.md#theme-code-principles)
- [ ] Linted with [Theme Check](https://github.com/Shopify/theme-check)
- [ ] Tested on [mobile](https://shopify.dev/themes/store/requirements#mobile-browser-requirements)
- [ ] Tested on [multiple browsers](https://shopify.dev/themes/store/requirements#desktop-browser-requirements)
- [ ] Tested for [accessibility](https://shopify.dev/themes/best-practices/accessibility)
