### PR TITLE
Prevent queued UI changes from variant selections

### DIFF
--- a/assets/global.js
+++ b/assets/global.js
@@ -840,10 +840,14 @@ class VariantSelects extends HTMLElement {
   }
 
   renderProductInfo() {
+    const requestedVariantId = this.currentVariant.id;
     const activeElementId = document.activeElement.id;
-    fetch(`${this.dataset.url}?variant=${this.currentVariant.id}&section_id=${this.dataset.originalSection ? this.dataset.originalSection : this.dataset.section}`)
+    fetch(`${this.dataset.url}?variant=${requestedVariantId}&section_id=${this.dataset.originalSection ? this.dataset.originalSection : this.dataset.section}`)
       .then((response) => response.text())
       .then((responseText) => {
+        // prevent unnecessary ui changes from abandoned selections
+        if (this.currentVariant.id !== requestedVariantId) return;
+
         const html = new DOMParser().parseFromString(responseText, 'text/html')
         const destination = document.getElementById(`price-${this.dataset.section}`);
         const source = html.getElementById(`price-${this.dataset.originalSection ? this.dataset.originalSection : this.dataset.section}`);
@@ -857,7 +861,7 @@ class VariantSelects extends HTMLElement {
 
         if (price) price.classList.remove('visibility-hidden');
         this.toggleAddButton(!this.currentVariant.available, window.variantStrings.soldOut);
-        
+
         document.querySelector('variant-radios') ? this.querySelector(`[for="${activeElementId}"]`).focus() : this.querySelector(`#${activeElementId}`).focus();
       });
   }


### PR DESCRIPTION
### PR Summary: 
Improves unideal selection behavior introduced with new the sold out variant functionality.

### Why are these changes introduced?

Fixes #2028 

When a product variant is selected, a request is made. When a response is received we update the UI (price, availability, focus, etc) to reflect the new variant. If a user makes multiple variant selections in quick enough succession, the still in-progress requests are not canceled and some of the resulting UI changes effectively get queued and "playback" as the requests complete.

### What approach did you take?

The simplest approach I found is to just prevent any UI changes for outdated requests from variants that are no longer the latest selection. I achieved this by capturing the most recently selected variant id and comparing it to the variant id associated with each request. The result of this should be basically the same behavior Dawn previously had.

**Alternative techical implementation**
Probably the ideal solution would be to _actually_ queue the requests and abort them as they become outdated using an abort controller. This could have a very minor performance benefit, but it would be a slightly larger refactor effort and accomplishes the same thing.

**Alternative UX approach**
We could consider is completely blocking (disabling) the variant selects/pills until the current selection fully loads and is reflected in the UI. This would be similar to how we currently disable the add to cart button during this same timeframe. This is easy enough to do if we'd prefer, but from a UX perspective I find this more disruptive.

### Visual impact on existing themes

Quick changes to variant selections should not result in a visual "lag" or jumping effect. Should behave similarly to the last stable version of Dawn in this regard.

### Testing steps/scenarios

- Test using the Louise sandal product
- Quickly switch between different variants in the variant picker (easiest using keyboard)
- Ensure the variant selection (and/or focus) doesn't jump back to previously selected variants)
- Ensure the correct price, badge, etc always displays
- Test pills and dropdowns
- Test unavailable and sold out variants behave the same

### Demo links

- [Editor](https://os2-demo.myshopify.com/admin/themes/131698950166/editor?)

### Checklist
- [ ] Added PR summary for [release notes](https://themes.shopify.com/themes/dawn/styles/default#ReleaseNotes)
- [ ] Requested review from UX (Only for changes that are affecting the experience or perceivable visual details)
- [ ] Created a ticket for the [help.shopify.com](https://help.shopify.com) documentation team about updates to theme settings. (Internal-only task)
- [ ] Followed [theme code principles](https://github.com/Shopify/dawn/blob/main/.github/CONTRIBUTING.md#theme-code-principles)
- [ ] Linted with [Theme Check](https://github.com/Shopify/theme-check)
- [ ] Tested on [mobile](https://shopify.dev/themes/store/requirements#mobile-browser-requirements)
- [ ] Tested on [multiple browsers](https://shopify.dev/themes/store/requirements#desktop-browser-requirements)
- [ ] Tested for [accessibility](https://shopify.dev/themes/best-practices/accessibility)
