### PR TITLE
Fix Variant Select breaking Quick Add

### DIFF
--- a/assets/quick-add.js
+++ b/assets/quick-add.js
@@ -61,7 +61,7 @@ if (!customElements.get('quick-add-modal')) {
     }
 
     preventVariantURLSwitching() {
-      this.modalContent.querySelector('variant-radios,variant-selects').setAttribute('data-update-url', 'false');
+      this.modalContent.querySelectorAll('variant-radios,variant-selects').forEach((variantSelect) => variantSelect.setAttribute('data-update-url', 'false'));
     }
 
     removeDOMElements() {

--- a/assets/quick-add.js
+++ b/assets/quick-add.js
@@ -61,7 +61,10 @@ if (!customElements.get('quick-add-modal')) {
     }
 
     preventVariantURLSwitching() {
-      this.modalContent.querySelectorAll('variant-radios,variant-selects').forEach((variantSelect) => variantSelect.setAttribute('data-update-url', 'false'));
+      const variantPicker = this.modalContent.querySelector('variant-radios,variant-selects');
+      if (!variantPicker) return;
+
+      variantPicker.setAttribute('data-update-url', 'false');
     }
 
     removeDOMElements() {


### PR DESCRIPTION
### PR Summary: 
We fixed an issue that could prevent the Quick Add functionality from working correctly if variant picker block was hidden on the product page.

### Why are these changes introduced?
Fixes #2048.

### What approach did you take?
Check if variantPicker exists before updating attributes.

### Testing steps/scenarios
- [ ] Enable Quick Add on the Collection Page
- [ ] Hide the Variant Picker block on the Product Page
- [ ] Navigate to the collection page, find a product with multiple variants and click the `Choose options` button
- [ ] The Quick Add modal should open.

### Demo links
- [Store](https://os2-demo.myshopify.com/?preview_theme_id=131724804118)
- [Editor](https://os2-demo.myshopify.com/admin/themes/131724804118/editor)

### Checklist
- [x] Added PR summary for [release notes](https://themes.shopify.com/themes/dawn/styles/default#ReleaseNotes)
- [x] Requested review from UX (Only for changes that are affecting the experience or perceivable visual details)
- [x] Created a ticket for the [help.shopify.com](https://help.shopify.com) documentation team about updates to theme settings. (Internal-only task)
- [x] Followed [theme code principles](https://github.com/Shopify/dawn/blob/main/.github/CONTRIBUTING.md#theme-code-principles)
- [x] Linted with [Theme Check](https://github.com/Shopify/theme-check)
- [x] Tested on [mobile](https://shopify.dev/themes/store/requirements#mobile-browser-requirements)
- [x ] Tested on [multiple browsers](https://shopify.dev/themes/store/requirements#desktop-browser-requirements)
- [x] Tested for [accessibility](https://shopify.dev/themes/best-practices/accessibility)