### PR TITLE
close image modal when block or section selected

### DIFF
--- a/assets/theme-editor.js
+++ b/assets/theme-editor.js
@@ -1,4 +1,10 @@
+function hideProductModal() {
+  const productModal = document.querySelectorAll('product-modal[open]');
+  productModal && productModal.forEach(modal => modal.hide());
+}
+
 document.addEventListener('shopify:block:select', function(event) {
+  hideProductModal();
   const blockSelectedIsSlide = event.target.classList.contains('slideshow__slide');
   if (!blockSelectedIsSlide) return;
 
@@ -20,6 +26,7 @@ document.addEventListener('shopify:block:deselect', function(event) {
 });
 
 document.addEventListener('shopify:section:load', () => {
+  hideProductModal();
   const zoomOnHoverScript = document.querySelector('[id^=EnableZoomOnHover]');
   if (!zoomOnHoverScript) return;
   if (zoomOnHoverScript) {
@@ -28,3 +35,13 @@ document.addEventListener('shopify:section:load', () => {
     zoomOnHoverScript.parentNode.replaceChild(newScriptTag, zoomOnHoverScript);
   }
 });
+
+document.addEventListener('shopify:section:reorder', () => hideProductModal());
+
+document.addEventListener('shopify:section:select', () => hideProductModal());
+
+document.addEventListener('shopify:section:deselect', () => hideProductModal());
+
+document.addEventListener('shopify:inspector:activate', () => hideProductModal());
+
+document.addEventListener('shopify:inspector:deactivate', () => hideProductModal());


### PR DESCRIPTION
### PR Summary: 
Once you open an image modal in the theme editor, the modal stays open until you click either the image or the "Close" button. To improve the user experience, we want the modal to close when a sections/block is selected in the sidebar.

### Why are these changes introduced?
Fixes #2035.

### What approach did you take?
Leveraged the [Themes API](https://shopify.dev/themes/architecture/sections/integrate-sections-with-the-theme-editor#javascript-events) and updated `ModalDialog` with new event listeners, to hide the modal on `shopify:block:select` and `shopify:section:select`.

### Other considerations
The `reorder` event doesn't seem to be triggered within the "Image with text", "Multicolumn", or "Footer" sections, but it works for "Product information". It would be helpful to have an event for `shopify:block:reorder` as well, but this isn't currently available through the [Themes API](https://shopify.dev/themes/architecture/sections/integrate-sections-with-the-theme-editor#javascript-events).

### Visual impact on existing themes
An open image modal will now close when a merchant selects a block or section in the sidebar.

_Before_

https://user-images.githubusercontent.com/22390758/200613392-c88e81d4-539b-406b-8157-5314eba3bfa6.mp4


_After_

https://user-images.githubusercontent.com/22390758/200613443-69631be2-b0dc-49ce-8408-b6b6e6e7d775.mp4



### Testing steps/scenarios
- [ ] Go to the [editor](https://os2-demo.myshopify.com/admin/themes/137429811222/editor) and select a product
- [ ] Click a product image to open the large version in a modal
- [ ] With the modal still open, change any setting in the editor
- [ ] Verify that the modal closes when you select/deselect something in the editor
- [ ] Test with different sections, blocks, and settings

### Demo links

- [Store]( https://os2-demo.myshopify.com/?preview_theme_id=137429811222)
- [Editor](https://os2-demo.myshopify.com/admin/themes/137429811222/editor)

### Checklist
- [x] Added PR summary for [release notes](https://themes.shopify.com/themes/dawn/styles/default#ReleaseNotes)
- [ ] Requested review from UX (Only for changes that are affecting the experience or perceivable visual details)
- [ ] Created a ticket for the [help.shopify.com](https://help.shopify.com) documentation team about updates to theme settings. (Internal-only task)
- [x] Followed [theme code principles](https://github.com/Shopify/dawn/blob/main/.github/CONTRIBUTING.md#theme-code-principles)
- [x] Linted with [Theme Check](https://github.com/Shopify/theme-check)
- [x] Tested on [mobile](https://shopify.dev/themes/store/requirements#mobile-browser-requirements)
- [x] Tested on [multiple browsers](https://shopify.dev/themes/store/requirements#desktop-browser-requirements)
- [x] Tested for [accessibility](https://shopify.dev/themes/best-practices/accessibility)
