### PR TITLE
[Header] Move 'Logo' to Global Theme settings

### DIFF
--- a/config/settings_schema.json
+++ b/config/settings_schema.json
@@ -8,12 +8,22 @@
     "theme_support_url": "https://support.shopify.com/"
   },
   {
-    "name": "Logo",
+    "name": "t:settings_schema.logo.name",
     "settings": [
       {
         "type": "image_picker",
         "id": "logo",
-        "label": "Logo"
+        "label": "t:settings_schema.logo.settings.logo_image.label"
+      },
+      {
+        "type": "range",
+        "id": "logo_width",
+        "min": 50,
+        "max": 250,
+        "step": 10,
+        "default": 100,
+        "unit": "t:settings_schema.logo.settings.logo_width.unit",
+        "label": "t:settings_schema.logo.settings.logo_width.label"
       }
     ]
   },

--- a/config/settings_schema.json
+++ b/config/settings_schema.json
@@ -8,6 +8,17 @@
     "theme_support_url": "https://support.shopify.com/"
   },
   {
+    "name": "Logo",
+    "settings": [
+      {
+        "type": "image_picker",
+        "id": "logo",
+        "label": "Logo",
+        "info": "t:settings_schema.favicon.settings.favicon.info"
+      }
+    ]
+  },
+  {
     "name": "t:settings_schema.colors.name",
     "settings": [
       {

--- a/config/settings_schema.json
+++ b/config/settings_schema.json
@@ -13,8 +13,7 @@
       {
         "type": "image_picker",
         "id": "logo",
-        "label": "Logo",
-        "info": "t:settings_schema.favicon.settings.favicon.info"
+        "label": "Logo"
       }
     ]
   },

--- a/locales/en.default.schema.json
+++ b/locales/en.default.schema.json
@@ -962,6 +962,9 @@
         "logo": {
           "label": "Logo image"
         },
+        "logo_help": {
+          "content": "Logo image can be updated in Theme Settings"
+        },
         "logo_width": {
           "unit": "px",
           "label": "Custom logo width"
@@ -1626,6 +1629,9 @@
       "settings": {
         "logo": {
           "label": "Logo image"
+        },
+        "logo_help": {
+          "content": "Logo image can be updated in Theme Settings"
         },
         "logo_max_width": {
           "label": "Custom logo width",

--- a/locales/en.default.schema.json
+++ b/locales/en.default.schema.json
@@ -1636,7 +1636,7 @@
       "name": "Password header",
       "settings": {
         "logo_header": {
-          "label": "Logo"
+          "content": "Logo"
         },
         "logo_help": {
           "content": "Edit your logo in theme settings."

--- a/locales/en.default.schema.json
+++ b/locales/en.default.schema.json
@@ -159,6 +159,18 @@
         }
       }
     },
+    "logo": {
+      "name": "Logo",
+      "settings": {
+        "logo_image": {
+          "label": "Logo image"
+        },
+        "logo_width": {
+          "unit": "px",
+          "label": "Custom logo width"
+        }
+      }
+    },
     "typography": {
       "name": "Typography",
       "settings": {
@@ -959,15 +971,11 @@
     "header": {
       "name": "Header",
       "settings": {
-        "logo": {
-          "label": "Logo image"
+        "logo_header": {
+          "content": "Logo"
         },
         "logo_help": {
-          "content": "Logo image can be updated in Theme Settings"
-        },
-        "logo_width": {
-          "unit": "px",
-          "label": "Custom logo width"
+          "content": "Edit your logo in theme settings."
         },
         "logo_position": {
           "label": "Desktop logo position",
@@ -1627,15 +1635,11 @@
     "main-password-header": {
       "name": "Password header",
       "settings": {
-        "logo": {
-          "label": "Logo image"
+        "logo_header": {
+          "label": "Logo"
         },
         "logo_help": {
-          "content": "Logo image can be updated in Theme Settings"
-        },
-        "logo_max_width": {
-          "label": "Custom logo width",
-          "unit": "px"
+          "content": "Edit your logo in theme settings."
         }
       }
     },

--- a/sections/header.liquid
+++ b/sections/header.liquid
@@ -797,6 +797,10 @@
       "label": "t:sections.all.colors.label"
     },
     {
+      "type": "paragraph",
+      "content": "t:sections.header.settings.logo_help.content"
+    },
+    {
       "type": "range",
       "id": "logo_width",
       "min": 50,

--- a/sections/header.liquid
+++ b/sections/header.liquid
@@ -374,14 +374,14 @@
         <h1 class="header__heading">
       {%- endif -%}
           <a href="{{ routes.root_url }}" class="header__heading-link link link--text focus-inset">
-            {%- if section.settings.logo != blank -%}
-              {%- assign logo_alt = section.settings.logo.alt | default: shop.name | escape -%}
-              {%- assign logo_height = section.settings.logo_width | divided_by: section.settings.logo.aspect_ratio -%}
-              {{ section.settings.logo | image_url: width: section.settings.width | image_tag:
+            {%- if settings.logo != blank -%}
+              {%- assign logo_alt = settings.logo.alt | default: shop.name | escape -%}
+              {%- assign logo_height = settings.logo_width | divided_by: settings.logo.aspect_ratio -%}
+              {{ settings.logo | image_url: width: section.settings.width | image_tag:
                 class: 'header__heading-logo',
                 widths: '50, 100, 150, 200, 250, 300, 400, 500',
                 height: logo_height,
-                width: section.settings.logo_width,
+                width: settings.logo_width,
                 alt: logo_alt
               }}
             {%- else -%}
@@ -497,8 +497,8 @@
         <h1 class="header__heading">
       {%- endif -%}
           <a href="{{ routes.root_url }}" class="header__heading-link link link--text focus-inset">
-            {%- if section.settings.logo != blank -%}
-              {%- assign logo_alt = section.settings.logo.alt | default: shop.name | escape -%}
+            {%- if settings.logo != blank -%}
+              {%- assign logo_alt = settings.logo.alt | default: shop.name | escape -%}
               {%- assign logo_height = section.settings.logo_width | divided_by: section.settings.logo.aspect_ratio -%}
               {{ section.settings.logo | image_url: width: section.settings.width | image_tag:
                 class: 'header__heading-logo',
@@ -728,8 +728,8 @@
     "@context": "http://schema.org",
     "@type": "Organization",
     "name": {{ shop.name | json }},
-    {% if section.settings.logo %}
-      "logo": {{ section.settings.logo | image_url: width: section.settings.logo.width | prepend: "https:" | json }},
+    {% if settings.logo %}
+      "logo": {{ settings.logo | image_url: width: settings.logo.width | prepend: "https:" | json }},
     {% endif %}
     "sameAs": [
       {{ settings.social_twitter_link | json }},
@@ -795,11 +795,6 @@
       ],
       "default": "background-1",
       "label": "t:sections.all.colors.label"
-    },
-    {
-      "type": "image_picker",
-      "id": "logo",
-      "label": "t:sections.header.settings.logo.label"
     },
     {
       "type": "range",

--- a/sections/header.liquid
+++ b/sections/header.liquid
@@ -33,7 +33,7 @@
   }
 
   .header__heading-logo {
-    max-width: {{ section.settings.logo_width }}px;
+    max-width: {{ settings.logo_width }}px;
   }
 
   @media screen and (min-width: 990px) {
@@ -499,12 +499,12 @@
           <a href="{{ routes.root_url }}" class="header__heading-link link link--text focus-inset">
             {%- if settings.logo != blank -%}
               {%- assign logo_alt = settings.logo.alt | default: shop.name | escape -%}
-              {%- assign logo_height = section.settings.logo_width | divided_by: section.settings.logo.aspect_ratio -%}
+              {%- assign logo_height = settings.logo_width | divided_by: section.settings.logo.aspect_ratio -%}
               {{ section.settings.logo | image_url: width: section.settings.width | image_tag:
                 class: 'header__heading-logo',
                 widths: '50, 100, 150, 200, 250, 300, 400, 500',
                 height: logo_height,
-                width: section.settings.logo_width,
+                width: settings.logo_width,
                 alt: logo_alt
               }}
             {%- else -%}
@@ -797,18 +797,12 @@
       "label": "t:sections.all.colors.label"
     },
     {
-      "type": "paragraph",
-      "content": "t:sections.header.settings.logo_help.content"
+      "type": "header",
+      "content": "t:sections.header.settings.logo_header.content"
     },
     {
-      "type": "range",
-      "id": "logo_width",
-      "min": 50,
-      "max": 250,
-      "step": 10,
-      "default": 100,
-      "unit": "t:sections.header.settings.logo_width.unit",
-      "label": "t:sections.header.settings.logo_width.label"
+      "type": "paragraph",
+      "content": "t:sections.header.settings.logo_help.content"
     },
     {
       "type": "select",

--- a/sections/main-password-header.liquid
+++ b/sections/main-password-header.liquid
@@ -90,9 +90,8 @@
   "name": "t:sections.main-password-header.name",
   "settings": [
     {
-      "type": "image_picker",
-      "id": "logo",
-      "label": "t:sections.main-password-header.settings.logo.label"
+      "type": "paragraph",
+      "content": "t:sections.main-password-header.settings.logo_help.content"
     },
     {
       "type": "range",

--- a/sections/main-password-header.liquid
+++ b/sections/main-password-header.liquid
@@ -6,10 +6,10 @@
 
 <div class="color-{{ section.settings.color_scheme }} gradient">
   <div class="password-header">
-    {%- if section.settings.logo != blank -%}
-      {%- assign logo_alt = section.settings.logo.alt | default: shop.name | escape -%}
-      {%- assign logo_height = section.settings.logo_max_width | divided_by: section.settings.logo.aspect_ratio -%}
-      {{ section.settings.logo | image_url: width: section.settings.logo.width | image_tag:
+    {%- if settings.logo != blank -%}
+      {%- assign logo_alt = settings.logo.alt | default: shop.name | escape -%}
+      {%- assign logo_height = section.settings.logo_max_width | divided_by: settings.logo.aspect_ratio -%}
+      {{ settings.logo | image_url: width: settings.logo.width | image_tag:
         class: 'password-logo',
         widths: '50, 100, 150, 200, 250, 300, 400, 500',
         width: section.settings.logo_max_width,

--- a/sections/main-password-header.liquid
+++ b/sections/main-password-header.liquid
@@ -1,6 +1,6 @@
 <style type="text/css">
   .password-logo {
-    max-width: {{ section.settings.logo_max_width }}px;
+    max-width: {{ settings.logo_width }}px;
   }
 </style>
 
@@ -8,11 +8,11 @@
   <div class="password-header">
     {%- if settings.logo != blank -%}
       {%- assign logo_alt = settings.logo.alt | default: shop.name | escape -%}
-      {%- assign logo_height = section.settings.logo_max_width | divided_by: settings.logo.aspect_ratio -%}
+      {%- assign logo_height = settings.logo_width | divided_by: settings.logo.aspect_ratio -%}
       {{ settings.logo | image_url: width: settings.logo.width | image_tag:
         class: 'password-logo',
         widths: '50, 100, 150, 200, 250, 300, 400, 500',
-        width: section.settings.logo_max_width,
+        width: settings.logo_width,
         height: logo_height,
         alt: logo_alt
       }}
@@ -90,18 +90,12 @@
   "name": "t:sections.main-password-header.name",
   "settings": [
     {
-      "type": "paragraph",
-      "content": "t:sections.main-password-header.settings.logo_help.content"
+      "type": "header",
+      "content": "t:sections.main-password-header.settings.logo_header.content"
     },
     {
-      "type": "range",
-      "id": "logo_max_width",
-      "min": 50,
-      "max": 250,
-      "step": 10,
-      "default": 100,
-      "unit": "t:sections.main-password-header.settings.logo_max_width.unit",
-      "label": "t:sections.main-password-header.settings.logo_max_width.label"
+      "type": "paragraph",
+      "content": "t:sections.main-password-header.settings.logo_help.content"
     },
     {
       "type": "select",


### PR DESCRIPTION
### PR Summary: 
Important: We moved “Logo” and “Logo width” settings from the header and password header sections to the global theme settings under the heading “Logo”. This update may cause a visual change to your logo.

### Why are these changes introduced?
Moves logo to so it can be configured in a single place and used in multiple parts of the theme.

### Visual impact on existing themes
The `header` and `password-header` sections will no longer have different logo pickers. A single logo is now used across both section, with the same width setting. This may require merchants to make some adjustments to either their logo image or to the settings in these sections.

### Testing steps/scenarios
- [ ] Add a logo under Global Theme Settings
- [ ] Update the maximum logo width on Global Theme Settings
- [ ] Check if the changes are reflected on the Header section on the homepage
- [ ] Check if the changes are reflected on the Header section on the password page

### Demo links
- [Store](url)
- [Editor](url)

### Checklist
- [x] Added PR summary for [release notes](https://themes.shopify.com/themes/dawn/styles/default#ReleaseNotes)
- [ ] Requested review from UX (Only for changes that are affecting the experience or perceivable visual details)
- [ ] Created a ticket for the [help.shopify.com](https://help.shopify.com) documentation team about updates to theme settings. (Internal-only task)
- [x] Followed [theme code principles](https://github.com/Shopify/dawn/blob/main/.github/CONTRIBUTING.md#theme-code-principles)
- [ x Linted with [Theme Check](https://github.com/Shopify/theme-check)
- [x] Tested on [mobile](https://shopify.dev/themes/store/requirements#mobile-browser-requirements)
- [x] Tested on [multiple browsers](https://shopify.dev/themes/store/requirements#desktop-browser-requirements)
- [x] Tested for [accessibility](https://shopify.dev/themes/best-practices/accessibility)
