### PR TITLE
[Featured Collection] Update maximum products to show to 24

### DIFF
--- a/sections/featured-collection.liquid
+++ b/sections/featured-collection.liquid
@@ -177,7 +177,7 @@
       "type": "range",
       "id": "products_to_show",
       "min": 2,
-      "max": 12,
+      "max": 24,
       "step": 1,
       "default": 4,
       "label": "t:sections.featured-collection.settings.products_to_show.label"


### PR DESCRIPTION
### PR Summary: 
We updated the maximum amount of products displayed on the Featured Collection to be 24.

### Why are these changes introduced?
Fixes #2093 

### What approach did you take?
Update the setting maximum value to 24.

### Testing steps/scenarios
- [ ] Add a featured collection section to any page on your theme
- [ ] Change values from 13-24 and ensure they all look as expected on desktop
  - [ ] On mobile, test with both `Enable swipe on mobile` on and off

### Demo links
<!-- Please include a link to a demo store that includes preconfigured sections and settings to allow reviewers to easily test the features you are working on. -->

- [Store](https://os2-demo.myshopify.com/admin/?preview_theme_id=137419030550)
- [Editor](https://os2-demo.myshopify.com/admin/themes/137419030550/editor)

### Checklist
- [x] Added PR summary for [release notes](https://themes.shopify.com/themes/dawn/styles/default#ReleaseNotes)
- [x] Requested review from UX (Only for changes that are affecting the experience or perceivable visual details)
- [ ] Created a ticket for the [help.shopify.com](https://help.shopify.com) documentation team about updates to theme settings. (Internal-only task)
- [x] Followed [theme code principles](https://github.com/Shopify/dawn/blob/main/.github/CONTRIBUTING.md#theme-code-principles)
- [x] Linted with [Theme Check](https://github.com/Shopify/theme-check)
- [x] Tested on [mobile](https://shopify.dev/themes/store/requirements#mobile-browser-requirements)
- [x] Tested on [multiple browsers](https://shopify.dev/themes/store/requirements#desktop-browser-requirements)
- [x] Tested for [accessibility](https://shopify.dev/themes/best-practices/accessibility)
