### PR TITLE
[cart-notification] Reposition style tag before element

### DIFF
--- a/snippets/cart-notification.liquid
+++ b/snippets/cart-notification.liquid
@@ -8,6 +8,12 @@
     {% render 'cart-notification' %}
 {% endcomment %}
 
+{% style %}
+  .cart-notification {
+     display: none;
+  }
+{% endstyle %}
+
 <cart-notification>
   <div class="cart-notification-wrapper page-width">
     <div id="cart-notification" class="cart-notification focus-inset{% if color_scheme %} color-{{ color_scheme }} gradient{% endif %}" aria-modal="true" aria-label="{{ 'general.cart.item_added' | t }}" role="dialog" tabindex="-1">
@@ -28,8 +34,3 @@
     </div>
   </div>
 </cart-notification>
-{% style %}
-  .cart-notification {
-     display: none;
-  }
-{% endstyle %}


### PR DESCRIPTION
### PR Summary: 

There is occasionally an issue where a large checkmark flashes on the screen on page load. It originates from cart-notification and comes down to stylesheets not being loaded yet. It sometimes happens after modification of theme files. There is a style tag after the element that immediately hides the element in an attempt to prevent this. However, this needs to be before the element instead of after it (where it currently sits).

### Why are these changes introduced?

To prevent a short flash of a large, fullscreen checkmark on page load.

Fixes #1.

### What approach did you take?

The style tag has been repositioned from after the cart-notification element to before it.

### Other considerations

### Decision log

| # | Decision | Alternatives | Rationale | Downsides |
|---|---|---|---|---|
| 1 |   |   |   |   |


### Visual impact on existing themes

Likely no impact or change to most users as it's an edgecase scenario when working with modified themes.

### Testing steps/scenarios
- Test site across various pages to ensure no flash on screen (difficult to test on non-modified themes as it's intermittent on modified themes).
- Test cart-notification operation

### Checklist
- [ ] Added PR summary for [release notes](https://themes.shopify.com/themes/dawn/styles/default#ReleaseNotes)
- [ ] Requested review from UX (Only for changes that are affecting the experience or perceivable visual details)
- [ ] Created a ticket for the [help.shopify.com](https://help.shopify.com) documentation team about updates to theme settings. (Internal-only task)
- [ ] Followed [theme code principles](https://github.com/Shopify/dawn/blob/main/.github/CONTRIBUTING.md#theme-code-principles)
- [ ] Linted with [Theme Check](https://github.com/Shopify/theme-check)
- [ ] Tested on [mobile](https://shopify.dev/themes/store/requirements#mobile-browser-requirements)
- [ ] Tested on [multiple browsers](https://shopify.dev/themes/store/requirements#desktop-browser-requirements)
- [ ] Tested for [accessibility](https://shopify.dev/themes/best-practices/accessibility)
