### PR TITLE
Select text input content on trapFocus

### DIFF
--- a/assets/global.js
+++ b/assets/global.js
@@ -68,6 +68,13 @@ function trapFocus(container, elementToFocus = container) {
   document.addEventListener('focusin', trapFocusHandlers.focusin);
 
   elementToFocus.focus();
+
+  if (elementToFocus.tagName === 'INPUT' &&
+    ['search', 'text', 'email', 'url'].includes(elementToFocus.type) &&
+    elementToFocus.value) {
+    const end = elementToFocus.value.length;
+    elementToFocus.setSelectionRange(0, end);
+  }
 }
 
 // Here run the querySelector to figure out if the browser supports :focus-visible or not and run code based on it.


### PR DESCRIPTION
### PR Summary: 

Select text input's content when automatically focusing it

### Why are these changes introduced?

This affects the search input on the header, that gets focused automatically when the user clicks on the "search" icon. The behaviour mimics the browser default when tabbing into an input, but I restricted it to text types to avoid causing UX problems or bugs on other kinds of inputs (passwords, dates, etc).

### What approach did you take?

Use the native `setSelectionRange` function


### Visual impact on existing themes
<details>
<summary>Gif preview</summary>
<img src="https://screenshot.click/07-36-30cav-1myl5.gif"/>
</details>


### Demo links
- [Store](https://pakichu.myshopify.com/?_ab=0&_fd=0&_sc=1)
- [Editor](https://admin.shopify.com/store/pakichu/themes/129287651384/editor)

### Checklist
- [ ] Added PR summary for [release notes](https://themes.shopify.com/themes/dawn/styles/default#ReleaseNotes)
- [ ] Requested review from UX (Only for changes that are affecting the experience or perceivable visual details)
- [ ] Created a ticket for the [help.shopify.com](https://help.shopify.com) documentation team about updates to theme settings. (Internal-only task)
- [ ] Followed [theme code principles](https://github.com/Shopify/dawn/blob/main/.github/CONTRIBUTING.md#theme-code-principles)
- [ ] Linted with [Theme Check](https://github.com/Shopify/theme-check)
- [ ] Tested on [mobile](https://shopify.dev/themes/store/requirements#mobile-browser-requirements)
- [ ] Tested on [multiple browsers](https://shopify.dev/themes/store/requirements#desktop-browser-requirements)
- [ ] Tested for [accessibility](https://shopify.dev/themes/best-practices/accessibility)
