### PR TITLE
Add media sizing settings to featured product

### DIFF
--- a/sections/featured-product.liquid
+++ b/sections/featured-product.liquid
@@ -21,7 +21,17 @@
 
 <link rel="stylesheet" href="{{ 'component-deferred-media.css' | asset_url }}" media="print" onload="this.media='all'">
 
-{%- assign product = section.settings.product -%}
+{%- liquid
+  assign product = section.settings.product
+
+  if section.settings.media_size == 'large'
+    assign media_width = 0.65
+  elsif section.settings.media_size == 'medium'
+    assign media_width = 0.55
+  elsif section.settings.media_size == 'small'
+    assign media_width = 0.45
+  endif
+-%}
 
 {%- assign first_3d_model = product.media | where: 'media_type', 'model' | first -%}
 {%- if first_3d_model -%}
@@ -44,7 +54,7 @@
 
 <section class="color-{{ section.settings.color_scheme }} {% if section.settings.secondary_background %}background-secondary{% else %}gradient{% endif %}">
   <div class="page-width section-{{ section.id }}-padding{% if section.settings.secondary_background %} isolate{% endif %}">
-    <div class="featured-product product grid grid--1-col gradient color-{{ section.settings.color_scheme }} product--{{ section.settings.media_position }}{% if section.settings.secondary_background == false %} isolate{% endif %} {% if product.media.size > 0 %}grid--2-col-tablet{% else %}product--no-media{% endif %}">
+    <div class="featured-product product product--{{ section.settings.media_size }} grid grid--1-col gradient color-{{ section.settings.color_scheme }} product--{{ section.settings.media_position }}{% if section.settings.secondary_background == false %} isolate{% endif %} {% if product.media.size > 0 %}grid--2-col-tablet{% else %}product--no-media{% endif %}">
       <div class="grid__item product__media-wrapper{% if section.settings.media_position == 'right' %} medium-hide large-up-hide{% endif %}">
         <media-gallery
           id="MediaGallery-{{ section.id }}"
@@ -62,7 +72,9 @@
                   loop: section.settings.enable_video_looping,
                   modal_id: section.id,
                   xr_button: false,
-                  media_width: 0.5
+                  media_width: media_width,
+                  media_fit: section.settings.media_fit,
+                  constrain_to_viewport: section.settings.constrain_to_viewport
                 %}
               </div>
             {%- endif -%}
@@ -83,7 +95,9 @@
                     loop: section.settings.enable_video_looping,
                     modal_id: section.id,
                     xr_button: false,
-                    media_width: 0.5
+                    media_width: media_width,
+                    media_fit: section.settings.media_fit,
+                    constrain_to_viewport: section.settings.constrain_to_viewport
                   %}
                 </div>
               {%- endif -%}
@@ -541,7 +555,9 @@
                     loop: section.settings.enable_video_looping,
                     modal_id: section.id,
                     xr_button: false,
-                    media_width: 0.5
+                    media_width: media_width,
+                    media_fit: section.settings.media_fit,
+                    constrain_to_viewport: section.settings.constrain_to_viewport
                   %}
                 </div>
               {%- endif -%}
@@ -556,7 +572,9 @@
                       loop: section.settings.enable_video_looping,
                       modal_id: section.id,
                       xr_button: false,
-                      media_width: 0.5
+                      media_width: media_width,
+                      media_fit: section.settings.media_fit,
+                      constrain_to_viewport: section.settings.constrain_to_viewport
                     %}
                   </div>
                 {%- endif -%}
@@ -1529,6 +1547,49 @@
       "type": "header",
       "content": "t:sections.featured-product.settings.header.content",
       "info": "t:sections.featured-product.settings.header.info"
+    },
+    {
+      "type": "select",
+      "id": "media_size",
+      "options": [
+        {
+          "value": "small",
+          "label": "t:sections.main-product.settings.media_size.options__1.label"
+        },
+        {
+          "value": "medium",
+          "label": "t:sections.main-product.settings.media_size.options__2.label"
+        },
+        {
+          "value": "large",
+          "label": "t:sections.main-product.settings.media_size.options__3.label"
+        }
+      ],
+      "default": "medium",
+      "label": "t:sections.main-product.settings.media_size.label",
+      "info": "t:sections.main-product.settings.media_size.info"
+    },
+    {
+      "type": "checkbox",
+      "id": "constrain_to_viewport",
+      "default": false,
+      "label": "t:sections.main-product.settings.constrain_to_viewport.label"
+    },
+    {
+      "type": "select",
+      "id": "media_fit",
+      "options": [
+        {
+          "value": "contain",
+          "label": "t:sections.main-product.settings.media_fit.options__1.label"
+        },
+        {
+          "value": "cover",
+          "label": "t:sections.main-product.settings.media_fit.options__2.label"
+        }
+      ],
+      "default": "contain",
+      "label": "t:sections.main-product.settings.media_fit.label"
     },
     {
       "type": "select",


### PR DESCRIPTION
### PR Summary: 

Brings two new settings from the product page, aimed at improving media sizing flexibility, to the featured product section.

### Why are these changes introduced?

Fixes #2024 

This is a follow up to #2052 that adds the same main product `Constrain media to screen height` and `Media fit` settings to the Featured product section. This PR also adds the existing main product `Desktop media width` setting (which has already been released) to Featured product.

### What approach did you take?
If needed, general context around these new settings can be found there and in #2052 and linked issues.

**Settings schema**
The settings schema was copied directly main-product.liquid and added to featured-product.liquid and currently translated strings are directly referencing the main-product entries. I'm not sure it is necessary to duplicate all those identical strings, though there's probably an opportunity to create shared product entry that main and featured can reference for identical settings.

**Duplicate media gallery liquid**
Some liquid code for assigning media width values and passing the new settings to product-thumbnail.liquid has effectively been duplicated from product-media-gallery.liquid because featured product doesn't _yet_ utilize that snippet. The addition of the media width settings here does bring the media gallery usage in featured-product closer to parity with the main product instance though, so I expect we'll be able to remove this and the existing duplicated code in the future.

**Constrained and minimum height values**
Right now, featured product is just inheriting the same values for `--viewport-offset` and `--constrained-min-height` from main product. I found these to work reasonably with and without the `Secondary background` setting applied, but we can easily add overrides for featured product as needed.

### Other considerations

**Changes to the media width**
With the addition of the media width setting options (small 45%, medium 55%, and large 65%) there is no longer a 1:1 equivalent for the [hardcoded 50% width](https://github.com/Shopify/dawn/blob/main/sections/featured-product.liquid#L65) featured product was originally using. Unlike main product, which defaults to "Large", featured product will default to "Medium" so the default appearance is closer to what it was. The result will be a slight visual change in default behavior.

### Visual impact on existing themes

The default media width has been slightly increased from 50% of the available space to 55%. If for some reason an existing theme doesn't have a `settings_data.json` entry for the `media_size` setting and is relying on the default value, there would be slight change in the default image/info column widths upon upgrading.

If the constrain is unchecked and media fit is set to the default "original" setting, no other visual changes should be observable.

### Testing steps/scenarios
- Test a variety of first/featured product media aspect ratios
- Test with and without background secondary
- Test with multiple desktop media width options
- Test mobile, tablet, desktop
- Test combinations of constrain and media fit
- Test with and without media borders and shadows
- Test a variety of viewport heights
- Test with different page width settings up to 1600px
- Test with image zoom

### Demo links

- [Editor](https://os2-demo.myshopify.com/admin/themes/137440526358/editor)

### Checklist
- [ ] Added PR summary for [release notes](https://themes.shopify.com/themes/dawn/styles/default#ReleaseNotes)
- [ ] Requested review from UX (Only for changes that are affecting the experience or perceivable visual details)
- [ ] Created a ticket for the [help.shopify.com](https://help.shopify.com) documentation team about updates to theme settings. (Internal-only task)
- [ ] Followed [theme code principles](https://github.com/Shopify/dawn/blob/main/.github/CONTRIBUTING.md#theme-code-principles)
- [ ] Linted with [Theme Check](https://github.com/Shopify/theme-check)
- [ ] Tested on [mobile](https://shopify.dev/themes/store/requirements#mobile-browser-requirements)
- [ ] Tested on [multiple browsers](https://shopify.dev/themes/store/requirements#desktop-browser-requirements)
- [ ] Tested for [accessibility](https://shopify.dev/themes/best-practices/accessibility)
