### PR TITLE
Collage settings updates

### DIFF
--- a/assets/collage.css
+++ b/assets/collage.css
@@ -195,7 +195,3 @@
   outline: none;
   box-shadow: none;
 }
-
-.collage .collage-card-spacing img {
-  object-fit: contain;
-}

--- a/locales/en.default.schema.json
+++ b/locales/en.default.schema.json
@@ -480,10 +480,6 @@
           "settings": {
             "image": {
               "label": "Image"
-            },
-            "image_padding": {
-              "label": "Use original image ratio",
-              "info": "Select if you don't want your image to be cropped."
             }
           }
         },
@@ -519,10 +515,6 @@
               "label": "URL",
               "info": "Video plays in a pop-up if the section contains other blocks.",
               "placeholder": "Use a YouTube or Vimeo URL"
-            },
-            "image_padding": {
-              "label": "Use original image ratio",
-              "info": "Select if you don't want your image to be cropped."
             },
             "description": {
               "label": "Video alt text",

--- a/sections/collage.liquid
+++ b/sections/collage.liquid
@@ -59,7 +59,7 @@
             {%- when 'video' -%}
               <div class="collage-card {% if section.settings.card_styles == 'none' %}global-media-settings{% else %}{{ section.settings.card_styles }} color-{{ settings.card_color_scheme }}{% endif %}">
                 <noscript>
-                  <a href="{{ block.settings.video_url }}" class="collage-card__link{% if block.settings.image_padding %} collage-card-spacing{% endif %}">
+                  <a href="{{ block.settings.video_url }}" class="collage-card__link">
                     <div class="media media--transparent ratio"{% if block.settings.cover_image != blank %} style="--ratio-percent: {{ 1 | divided_by: block.settings.cover_image.aspect_ratio | times: 100 }}%"{% else %} style="--ratio-percent: 100%"{% endif %}>
                       {%- if block.settings.cover_image != blank -%}
                         {%- capture sizes -%}(min-width: {{ settings.page_width }}px) {% if section.blocks.size == 1 %}calc({{ settings.page_width }}px - 100px){% else %}{{ settings.page_width | minus: 100 | times: 0.67 | round }}px{% endif %}, (min-width: 750px){% if section.blocks.size == 1 %} calc(100vw - 100px){% else %} 500px{% endif %}, calc(100vw - 30px){%- endcapture -%}
@@ -76,7 +76,7 @@
                 </noscript>
                 <modal-opener class="no-js-hidden" data-modal="#PopupModal-{{ block.id }}">
                   <div class="deferred-media">
-                    <button class="deferred-media__poster full-unstyled-link{% if block.settings.image_padding %} collage-card-spacing{% endif %}" type="button" aria-label="{{ 'sections.video.load_video' | t: description: block.settings.description | escape }}" aria-haspopup="dialog" data-media-id="{{ block.settings.video_url.id }}">
+                    <button class="deferred-media__poster full-unstyled-link" type="button" aria-label="{{ 'sections.video.load_video' | t: description: block.settings.description | escape }}" aria-haspopup="dialog" data-media-id="{{ block.settings.video_url.id }}">
                       <div class="media media--transparent ratio"{% if block.settings.cover_image != blank %} style="--ratio-percent: {{ 1 | divided_by: block.settings.cover_image.aspect_ratio | times: 100 }}%"{% else %} style="--ratio-percent: 100%"{% endif %}>
                         <span class="deferred-media__poster-button motion-reduce">
                           {%- render 'icon-play' -%}
@@ -181,7 +181,7 @@
           "label": "t:sections.collage.settings.mobile_layout.options__2.label"
         }
       ],
-      "default": "collage",
+      "default": "column",
       "label": "t:sections.collage.settings.mobile_layout.label"
     },
     {
@@ -264,13 +264,6 @@
           "type": "image_picker",
           "id": "image",
           "label": "t:sections.collage.blocks.image.settings.image.label"
-        },
-        {
-          "type": "checkbox",
-          "id": "image_padding",
-          "default": false,
-          "label": "t:sections.collage.blocks.image.settings.image_padding.label",
-          "info": "t:sections.collage.blocks.image.settings.image_padding.info"
         }
       ]
     },
@@ -329,13 +322,6 @@
           "default": "Describe the video",
           "label": "t:sections.collage.blocks.video.settings.description.label",
           "info": "t:sections.collage.blocks.video.settings.description.info"
-        },
-        {
-          "type": "checkbox",
-          "id": "image_padding",
-          "default": false,
-          "label": "t:sections.collage.blocks.video.settings.image_padding.label",
-          "info": "t:sections.collage.blocks.video.settings.image_padding.info"
         }
       ]
     }
@@ -346,7 +332,7 @@
       "name": "t:sections.collage.presets.name",
       "blocks": [
         {
-          "type": "video"
+          "type": "image"
         },
         {
           "type": "product"


### PR DESCRIPTION
### PR Summary: 

Updated some collage settings and presets.

Important: Removed a block setting from collage.

### Why are these changes introduced?

Fixes #2134 

### What approach did you take?

- Removed `Use original aspect ratio` block setting from image and video blocks. Note: This was actually broken on image blocks.
- Changed first block preset from `video` to `image`
- Changed `Mobile layout` setting default from `Collage` to `Column`

### Other considerations


### Visual impact on existing themes

Video collage blocks configured to use original aspect ratio will no longer fit the space using the default "cover" (or crop/fill) method rather than "contain" method.
[Before](https://screenshot.click/28-55-8i5w1-0xf1q.png)
[After](https://screenshot.click/28-55-dy0lq-p66pe.png)

### Testing steps/scenarios
<!-- List all the testing tasks that applies to your fix to help peers review your work. -->
- [ ] Step 1

### Demo links

- [Editor](https://os2-demo.myshopify.com/admin/themes/137483026454/editor)

### Checklist
- [ ] Added PR summary for [release notes](https://themes.shopify.com/themes/dawn/styles/default#ReleaseNotes)
- [ ] Requested review from UX (Only for changes that are affecting the experience or perceivable visual details)
- [ ] Created a ticket for the [help.shopify.com](https://help.shopify.com) documentation team about updates to theme settings. (Internal-only task)
- [ ] Followed [theme code principles](https://github.com/Shopify/dawn/blob/main/.github/CONTRIBUTING.md#theme-code-principles)
- [ ] Linted with [Theme Check](https://github.com/Shopify/theme-check)
- [ ] Tested on [mobile](https://shopify.dev/themes/store/requirements#mobile-browser-requirements)
- [ ] Tested on [multiple browsers](https://shopify.dev/themes/store/requirements#desktop-browser-requirements)
- [ ] Tested for [accessibility](https://shopify.dev/themes/best-practices/accessibility)
