### PR TITLE
Add multirow section

### DIFF
--- a/assets/component-image-with-text.css
+++ b/assets/component-image-with-text.css
@@ -329,6 +329,23 @@
   margin-bottom: 1rem;
 }
 
+@media screen and (max-width: 749px) {
+  .collapse-padding .image-with-text__grid .image-with-text__content {
+    padding-left: 0;
+    padding-right: 0;
+  }
+}
+
+@media screen and (min-width: 750px) {
+  .collapse-padding .image-with-text__grid:not(.image-with-text__grid--reverse) .image-with-text__content {
+    padding-right: 0;
+  }
+
+  .collapse-padding .image-with-text__grid--reverse .image-with-text__content {
+    padding-left: 0;
+  }
+}
+
 /* check for flexbox gap in older Safari versions */
 @supports not (inset: 10px) {
   .image-with-text .grid {
@@ -338,7 +355,7 @@
 
 /*
   Multirow
-  note: move out of this stylesheet if the number of multirow-specific styles grows
+  note: remove from this stylesheet if multirow-specific styles increase signficantly
 */
 .multirow .image-with-text {
   margin-bottom: var(--grid-mobile-vertical-spacing)

--- a/assets/component-image-with-text.css
+++ b/assets/component-image-with-text.css
@@ -355,14 +355,16 @@
 
 /*
   Multirow
-  note: remove from this stylesheet if multirow-specific styles increase signficantly
+  note: consider removing from this stylesheet if multirow-specific styles increase signficantly
 */
-.multirow .image-with-text {
-  margin-bottom: var(--grid-mobile-vertical-spacing)
+.multirow__inner {
+  display: flex;
+  flex-direction: column;
+  row-gap: var(--grid-mobile-vertical-spacing);
 }
 
 @media screen and (min-width: 750px) {
-  .multirow .image-with-text {
-    margin-bottom: var(--grid-desktop-vertical-spacing)
+  .multirow__inner {
+    row-gap: var(--grid-desktop-vertical-spacing);
   }
 }

--- a/assets/component-image-with-text.css
+++ b/assets/component-image-with-text.css
@@ -283,6 +283,7 @@
     var(--text-boxes-shadow-vertical-offset)
     var(--text-boxes-shadow-blur-radius)
     rgba(var(--color-shadow), var(--text-boxes-shadow-opacity));
+  word-break: break-word;
 }
 
 @media screen and (min-width: 990px) {
@@ -319,12 +320,10 @@
 }
 
 .image-with-text__heading {
-  word-break: break-word;
   margin-bottom: 0;
 }
 
 .image-with-text__text p {
-  word-break: break-word;
   margin-top: 0;
   margin-bottom: 1rem;
 }
@@ -337,11 +336,11 @@
 }
 
 @media screen and (min-width: 750px) {
-  .collapse-padding .image-with-text__grid:not(.image-with-text__grid--reverse) .image-with-text__content {
+  .collapse-padding .image-with-text__grid:not(.image-with-text__grid--reverse) .image-with-text__content:not(.image-with-text__content--desktop-center) {
     padding-right: 0;
   }
 
-  .collapse-padding .image-with-text__grid--reverse .image-with-text__content {
+  .collapse-padding .image-with-text__grid--reverse .image-with-text__content:not(.image-with-text__content--desktop-center) {
     padding-left: 0;
   }
 }

--- a/assets/component-image-with-text.css
+++ b/assets/component-image-with-text.css
@@ -335,3 +335,17 @@
     margin-left: 0;
   }
 }
+
+/*
+  Multirow
+  note: move out of this stylesheet if the number of multirow-specific styles grows
+*/
+.multirow .image-with-text {
+  margin-bottom: var(--grid-mobile-vertical-spacing)
+}
+
+@media screen and (min-width: 750px) {
+  .multirow .image-with-text {
+    margin-bottom: var(--grid-desktop-vertical-spacing)
+  }
+}

--- a/locales/cs.schema.json
+++ b/locales/cs.schema.json
@@ -154,7 +154,7 @@
           "content": "Mřížka"
         },
         "paragraph__grid": {
-          "content": "Ovlivňuje oblasti s rozvržením s více sloupci."
+          "content": "Ovlivňuje oblasti s více sloupci nebo řádky."
         },
         "spacing_grid_horizontal": {
           "label": "Mezera ve vodorovném směru"
@@ -3040,6 +3040,159 @@
             "label": "2 sloupce"
           }
         }
+      }
+    },
+    "multirow": {
+      "name": "Více řádků",
+      "settings": {
+        "image": {
+          "label": "Obrázek"
+        },
+        "image_height": {
+          "options__1": {
+            "label": "Přizpůsobení obrázku"
+          },
+          "options__2": {
+            "label": "Malý"
+          },
+          "options__3": {
+            "label": "Střední"
+          },
+          "options__4": {
+            "label": "Velký"
+          },
+          "label": "Výška obrázku"
+        },
+        "desktop_image_width": {
+          "options__1": {
+            "label": "Malý"
+          },
+          "options__2": {
+            "label": "Střední"
+          },
+          "options__3": {
+            "label": "Velký"
+          },
+          "label": "Šířka obrázku v počítači",
+          "info": "Obrázek se automaticky optimalizuje pro mobilní prostředí."
+        },
+        "heading_size": {
+          "options__1": {
+            "label": "Malý"
+          },
+          "options__2": {
+            "label": "Střední"
+          },
+          "options__3": {
+            "label": "Velký"
+          },
+          "label": "Velikost nadpisu"
+        },
+        "text_style": {
+          "options__1": {
+            "label": "Hlavní část"
+          },
+          "options__2": {
+            "label": "Podtitul"
+          },
+          "label": "Textový styl"
+        },
+        "button_style": {
+          "options__1": {
+            "label": "Tlačítko v jednolité barvě"
+          },
+          "options__2": {
+            "label": "Tlačítko s obrysem"
+          },
+          "label": "Styl tlačítka"
+        },
+        "desktop_content_alignment": {
+          "options__1": {
+            "label": "Doleva"
+          },
+          "options__2": {
+            "label": "Na střed"
+          },
+          "options__3": {
+            "label": "Doprava"
+          },
+          "label": "Zarovnání obsahu v počítači"
+        },
+        "desktop_content_position": {
+          "options__1": {
+            "label": "Nahoře"
+          },
+          "options__2": {
+            "label": "Uprostřed"
+          },
+          "options__3": {
+            "label": "Dole"
+          },
+          "label": "Pozice obsahu v počítači",
+          "info": "Pozice se automaticky optimalizuje pro mobilní prostředí."
+        },
+        "image_layout": {
+          "options__1": {
+            "label": "Prostřídání zleva"
+          },
+          "options__2": {
+            "label": "Prostřídání zprava"
+          },
+          "options__3": {
+            "label": "Zarovnání doleva"
+          },
+          "options__4": {
+            "label": "Zarovnání doprava"
+          },
+          "label": "Poloha obrázku v počítači",
+          "info": "Poloha se automaticky optimalizuje pro mobilní prostředí."
+        },
+        "container_color_scheme": {
+          "label": "Barevné schéma kontejneru"
+        },
+        "mobile_content_alignment": {
+          "options__1": {
+            "label": "Doleva"
+          },
+          "options__2": {
+            "label": "Na střed"
+          },
+          "options__3": {
+            "label": "Doprava"
+          },
+          "label": "Zarovnání obsahu v mobilním prostředí"
+        },
+        "header_mobile": {
+          "content": "Mobilní rozvržení"
+        }
+      },
+      "blocks": {
+        "row": {
+          "name": "Řádek",
+          "settings": {
+            "image": {
+              "label": "Obrázek"
+            },
+            "caption": {
+              "label": "Titulek"
+            },
+            "heading": {
+              "label": "Nadpis"
+            },
+            "text": {
+              "label": "Text"
+            },
+            "button_label": {
+              "label": "Text tlačítka"
+            },
+            "button_link": {
+              "label": "Tlačítkový odkaz"
+            }
+          }
+        }
+      },
+      "presets": {
+        "name": "Více řádků"
       }
     }
   }

--- a/locales/da.schema.json
+++ b/locales/da.schema.json
@@ -154,7 +154,7 @@
           "content": "Gitter"
         },
         "paragraph__grid": {
-          "content": "Påvirker områder med et layout med flere kolonner."
+          "content": "Påvirker områder med flere kolonner eller rækker."
         },
         "spacing_grid_horizontal": {
           "label": "Lodret afstand"
@@ -3040,6 +3040,159 @@
             "label": "2 kolonner"
           }
         }
+      }
+    },
+    "multirow": {
+      "name": "Flere rækker",
+      "settings": {
+        "image": {
+          "label": "Billede"
+        },
+        "image_height": {
+          "options__1": {
+            "label": "Tilpas til billede"
+          },
+          "options__2": {
+            "label": "Lille"
+          },
+          "options__3": {
+            "label": "Mellem"
+          },
+          "options__4": {
+            "label": "Stor"
+          },
+          "label": "Billedhøjde"
+        },
+        "desktop_image_width": {
+          "options__1": {
+            "label": "Lille"
+          },
+          "options__2": {
+            "label": "Mellem"
+          },
+          "options__3": {
+            "label": "Stor"
+          },
+          "label": "Billedbredde på computer",
+          "info": "Billedet er automatisk optimeret til mobiltelefoner."
+        },
+        "heading_size": {
+          "options__1": {
+            "label": "Lille"
+          },
+          "options__2": {
+            "label": "Mellem"
+          },
+          "options__3": {
+            "label": "Stor"
+          },
+          "label": "Størrelse for overskrift"
+        },
+        "text_style": {
+          "options__1": {
+            "label": "Brødtekst"
+          },
+          "options__2": {
+            "label": "Underoverskrift"
+          },
+          "label": "Teksttypografi"
+        },
+        "button_style": {
+          "options__1": {
+            "label": "Udfyldt knap"
+          },
+          "options__2": {
+            "label": "Rammeknap"
+          },
+          "label": "Knaptypografi"
+        },
+        "desktop_content_alignment": {
+          "options__1": {
+            "label": "Venstre"
+          },
+          "options__2": {
+            "label": "Centreret"
+          },
+          "options__3": {
+            "label": "Højre"
+          },
+          "label": "Justering af indhold på computer"
+        },
+        "desktop_content_position": {
+          "options__1": {
+            "label": "Top"
+          },
+          "options__2": {
+            "label": "I midten"
+          },
+          "options__3": {
+            "label": "Bund"
+          },
+          "label": "Placering af indhold på computer",
+          "info": "Placeringen optimeres automatisk til mobil."
+        },
+        "image_layout": {
+          "options__1": {
+            "label": "Skift fra venstre"
+          },
+          "options__2": {
+            "label": "Skift fra højre"
+          },
+          "options__3": {
+            "label": "Venstrejusteret"
+          },
+          "options__4": {
+            "label": "Højrejusteret"
+          },
+          "label": "Billedplacering på computer",
+          "info": "Placeringen er automatisk optimeret til mobiltelefoner."
+        },
+        "container_color_scheme": {
+          "label": "Objektbeholder til farveskema"
+        },
+        "mobile_content_alignment": {
+          "options__1": {
+            "label": "Venstre"
+          },
+          "options__2": {
+            "label": "Centreret"
+          },
+          "options__3": {
+            "label": "Højre"
+          },
+          "label": "Justering af indhold på mobil"
+        },
+        "header_mobile": {
+          "content": "Mobillayout"
+        }
+      },
+      "blocks": {
+        "row": {
+          "name": "Række",
+          "settings": {
+            "image": {
+              "label": "Billede"
+            },
+            "caption": {
+              "label": "Billedtekst"
+            },
+            "heading": {
+              "label": "Overskrift"
+            },
+            "text": {
+              "label": "Sms"
+            },
+            "button_label": {
+              "label": "Knaptekst"
+            },
+            "button_link": {
+              "label": "Knaplink"
+            }
+          }
+        }
+      },
+      "presets": {
+        "name": "Flere rækker"
       }
     }
   }

--- a/locales/de.schema.json
+++ b/locales/de.schema.json
@@ -154,7 +154,7 @@
           "content": "Raster"
         },
         "paragraph__grid": {
-          "content": "Wirkt sich auf Bereiche mit einem Layout mit mehreren Spalten aus."
+          "content": "Wirkt sich auf Bereiche mit mehreren Spalten oder Reihen aus."
         },
         "spacing_grid_horizontal": {
           "label": "Horizontaler Abstand"
@@ -3040,6 +3040,159 @@
             "label": "2 Spalten"
           }
         }
+      }
+    },
+    "multirow": {
+      "name": "Mehrreihig",
+      "settings": {
+        "image": {
+          "label": "Bild"
+        },
+        "image_height": {
+          "options__1": {
+            "label": "An Bild anpassen"
+          },
+          "options__2": {
+            "label": "Klein"
+          },
+          "options__3": {
+            "label": "Mittel"
+          },
+          "options__4": {
+            "label": "Groß"
+          },
+          "label": "Bildhöhe"
+        },
+        "desktop_image_width": {
+          "options__1": {
+            "label": "Klein"
+          },
+          "options__2": {
+            "label": "Mittel"
+          },
+          "options__3": {
+            "label": "Groß"
+          },
+          "label": "Desktop-Bildbreite",
+          "info": "Bild wird automatisch für die mobile Nutzung optimiert."
+        },
+        "heading_size": {
+          "options__1": {
+            "label": "Klein"
+          },
+          "options__2": {
+            "label": "Mittel"
+          },
+          "options__3": {
+            "label": "Groß"
+          },
+          "label": "Größe der Überschrift"
+        },
+        "text_style": {
+          "options__1": {
+            "label": "Nachricht"
+          },
+          "options__2": {
+            "label": "Untertitel"
+          },
+          "label": "Textstil"
+        },
+        "button_style": {
+          "options__1": {
+            "label": "Durchgehende Schaltfläche"
+          },
+          "options__2": {
+            "label": "Umriss-Schaltfläche"
+          },
+          "label": "Schaltflächenstil"
+        },
+        "desktop_content_alignment": {
+          "options__1": {
+            "label": "Links"
+          },
+          "options__2": {
+            "label": "Zentriert"
+          },
+          "options__3": {
+            "label": "Rechts"
+          },
+          "label": "Desktop-Inhaltsausrichtung"
+        },
+        "desktop_content_position": {
+          "options__1": {
+            "label": "Oben"
+          },
+          "options__2": {
+            "label": "Mitte"
+          },
+          "options__3": {
+            "label": "Unten"
+          },
+          "label": "Desktop-Inhaltsposition",
+          "info": "Positionen werden automatisch für die mobile Nutzung optimiert."
+        },
+        "image_layout": {
+          "options__1": {
+            "label": "Abwechselnd von links"
+          },
+          "options__2": {
+            "label": "Abwechselnd von rechts"
+          },
+          "options__3": {
+            "label": "Linksbündig"
+          },
+          "options__4": {
+            "label": "Rechtsbündig"
+          },
+          "label": "Desktop-Bildplatzierung",
+          "info": "Platzierung wird automatisch für die mobile Nutzung optimiert."
+        },
+        "container_color_scheme": {
+          "label": "Farbschema für Container"
+        },
+        "mobile_content_alignment": {
+          "options__1": {
+            "label": "Links"
+          },
+          "options__2": {
+            "label": "Zentriert"
+          },
+          "options__3": {
+            "label": "Rechts"
+          },
+          "label": "Mobile Inhaltsausrichtung"
+        },
+        "header_mobile": {
+          "content": "Mobiles Layout"
+        }
+      },
+      "blocks": {
+        "row": {
+          "name": "Reihe",
+          "settings": {
+            "image": {
+              "label": "Bild"
+            },
+            "caption": {
+              "label": "Bildtext"
+            },
+            "heading": {
+              "label": "Überschrift"
+            },
+            "text": {
+              "label": "Text"
+            },
+            "button_label": {
+              "label": "Schaltflächenbeschriftung"
+            },
+            "button_link": {
+              "label": "Schaltflächenlink"
+            }
+          }
+        }
+      },
+      "presets": {
+        "name": "Mehrreihig"
       }
     }
   }

--- a/locales/en.default.schema.json
+++ b/locales/en.default.schema.json
@@ -1453,7 +1453,7 @@
             "label": "Zig zag from right"
           },
           "options__3": {
-            "label": "Altgn left"
+            "label": "Align left"
           },
           "options__4": {
             "label": "Align right"

--- a/locales/en.default.schema.json
+++ b/locales/en.default.schema.json
@@ -353,7 +353,7 @@
           "content": "Grid"
         },
         "paragraph__grid": {
-          "content": "Affects areas with a multicolumn layout."
+          "content": "Affects areas with multiple columns or rows."
         },
         "spacing_grid_horizontal": {
           "label": "Horizontal space"
@@ -1443,23 +1443,24 @@
           "options__3": {
             "label": "Bottom"
           },
-          "label": "Desktop content position"
+          "label": "Desktop content position",
+          "info": "Position is automatically optimized for mobile."
         },
         "image_layout": {
           "options__1": {
-            "label": "Zig zag from left"
+            "label": "Alternate from left"
           },
           "options__2": {
-            "label": "Zig zag from right"
+            "label": "Alternate from right"
           },
           "options__3": {
-            "label": "Align left"
+            "label": "Aligned left"
           },
           "options__4": {
-            "label": "Align right"
+            "label": "Aligned right"
           },
-          "label": "Desktop image layout",
-          "info": "Image first is the default mobile layout."
+          "label": "Desktop image placement",
+          "info": "Placement is automatically optimized for mobile."
         },
         "container_color_scheme": {
           "label": "Container color scheme"

--- a/locales/en.default.schema.json
+++ b/locales/en.default.schema.json
@@ -1393,18 +1393,15 @@
         },
         "heading_size": {
           "options__1": {
-            "label": "Adapt to image"
-          },
-          "options__2": {
             "label": "Small"
           },
-          "options__3": {
+          "options__2": {
             "label": "Medium"
           },
-          "options__4": {
+          "options__3": {
             "label": "Large"
           },
-          "label": "Image height"
+          "label": "Heading size"
         },
         "text_style": {
           "options__1": {
@@ -1478,6 +1475,9 @@
             "label": "Right"
           },
           "label": "Mobile content alignment"
+        },
+        "header_mobile": {
+          "content": "Mobile Layout"
         }
       },
       "blocks": {

--- a/locales/en.default.schema.json
+++ b/locales/en.default.schema.json
@@ -1357,6 +1357,158 @@
         "name": "Image with text"
       }
     },
+    "multirow": {
+      "name": "Multirow",
+      "settings": {
+        "image": {
+          "label": "Image"
+        },
+        "image_height": {
+          "options__1": {
+            "label": "Adapt to image"
+          },
+          "options__2": {
+            "label": "Small"
+          },
+          "options__3": {
+            "label": "Medium"
+          },
+          "options__4": {
+            "label": "Large"
+          },
+          "label": "Image height"
+        },
+        "desktop_image_width": {
+          "options__1": {
+            "label": "Small"
+          },
+          "options__2": {
+            "label": "Medium"
+          },
+          "options__3": {
+            "label": "Large"
+          },
+          "label": "Desktop image width",
+          "info": "Image is automatically optimized for mobile."
+        },
+        "heading_size": {
+          "options__1": {
+            "label": "Adapt to image"
+          },
+          "options__2": {
+            "label": "Small"
+          },
+          "options__3": {
+            "label": "Medium"
+          },
+          "options__4": {
+            "label": "Large"
+          },
+          "label": "Image height"
+        },
+        "text_style": {
+          "options__1": {
+            "label": "Body"
+          },
+          "options__2": {
+            "label": "Subtitle"
+          },
+          "label": "Text style"
+        },
+        "button_style": {
+          "options__1": {
+            "label": "Solid button"
+          },
+          "options__2": {
+            "label": "Outline button"
+          },
+          "label": "Button style"
+        },
+        "desktop_content_alignment": {
+          "options__1": {
+            "label": "Left"
+          },
+          "options__2": {
+            "label": "Center"
+          },
+          "options__3": {
+            "label": "Right"
+          },
+          "label": "Desktop content alignment"
+        },
+        "desktop_content_position": {
+          "options__1": {
+            "label": "Top"
+          },
+          "options__2": {
+            "label": "Middle"
+          },
+          "options__3": {
+            "label": "Bottom"
+          },
+          "label": "Desktop content position"
+        },
+        "image_layout": {
+          "options__1": {
+            "label": "Zig zag from left"
+          },
+          "options__2": {
+            "label": "Zig zag from right"
+          },
+          "options__3": {
+            "label": "Altgn left"
+          },
+          "options__4": {
+            "label": "Align right"
+          },
+          "label": "Desktop image layout",
+          "info": "Image first is the default mobile layout."
+        },
+        "container_color_scheme": {
+          "label": "Container color scheme"
+        },
+        "mobile_content_alignment": {
+          "options__1": {
+            "label": "Left"
+          },
+          "options__2": {
+            "label": "Center"
+          },
+          "options__3": {
+            "label": "Right"
+          },
+          "label": "Mobile content alignment"
+        }
+      },
+      "blocks": {
+        "row": {
+          "name": "Row",
+          "settings": {
+            "image": {
+              "label": "Image"
+            },
+            "caption": {
+              "label": "Caption"
+            },
+            "heading": {
+              "label": "Heading"
+            },
+            "text": {
+              "label": "Text"
+            },
+            "button_label": {
+              "label": "Button label"
+            },
+            "button_link": {
+              "label": "Button link"
+            }
+          }
+        }
+      },
+      "presets": {
+        "name": "Multirow"
+      }
+    },
     "main-account": {
       "name": "Account"
     },

--- a/locales/es.schema.json
+++ b/locales/es.schema.json
@@ -154,7 +154,7 @@
           "content": "Cuadrícula"
         },
         "paragraph__grid": {
-          "content": "Afecta áreas con diseño de multicolumna"
+          "content": "Afecta a áreas con varias columnas o filas."
         },
         "spacing_grid_horizontal": {
           "label": "Espacio horizontal"
@@ -3040,6 +3040,159 @@
             "label": "Dos columnas"
           }
         }
+      }
+    },
+    "multirow": {
+      "name": "Varias filas",
+      "settings": {
+        "image": {
+          "label": "Imagen"
+        },
+        "image_height": {
+          "options__1": {
+            "label": "Adaptar a la imagen"
+          },
+          "options__2": {
+            "label": "Pequeña"
+          },
+          "options__3": {
+            "label": "Mediana"
+          },
+          "options__4": {
+            "label": "Grande"
+          },
+          "label": "Altura de imagen"
+        },
+        "desktop_image_width": {
+          "options__1": {
+            "label": "Pequeña"
+          },
+          "options__2": {
+            "label": "Mediana"
+          },
+          "options__3": {
+            "label": "Grande"
+          },
+          "label": "Ancho de la imagen en la computadora",
+          "info": "La imagen se optimiza automáticamente para el celular."
+        },
+        "heading_size": {
+          "options__1": {
+            "label": "Pequeña"
+          },
+          "options__2": {
+            "label": "Mediana"
+          },
+          "options__3": {
+            "label": "Grande"
+          },
+          "label": "Tamaño del título"
+        },
+        "text_style": {
+          "options__1": {
+            "label": "Cuerpo"
+          },
+          "options__2": {
+            "label": "Subtítulo"
+          },
+          "label": "Estilo de texto"
+        },
+        "button_style": {
+          "options__1": {
+            "label": "Botón sólido"
+          },
+          "options__2": {
+            "label": "Botón con contorno"
+          },
+          "label": "Estilo del botón"
+        },
+        "desktop_content_alignment": {
+          "options__1": {
+            "label": "Izquierda"
+          },
+          "options__2": {
+            "label": "Centro"
+          },
+          "options__3": {
+            "label": "Derecha"
+          },
+          "label": "Alineación del contenido en computadoras"
+        },
+        "desktop_content_position": {
+          "options__1": {
+            "label": "Arriba"
+          },
+          "options__2": {
+            "label": "Centrado"
+          },
+          "options__3": {
+            "label": "Abajo"
+          },
+          "label": "Posición del contenido en computadoras",
+          "info": "La posición se optimiza automáticamente para dispositivos móviles."
+        },
+        "image_layout": {
+          "options__1": {
+            "label": "Alternar desde la izquierda"
+          },
+          "options__2": {
+            "label": "Alternar desde la derecha"
+          },
+          "options__3": {
+            "label": "Alineada a la izquierda"
+          },
+          "options__4": {
+            "label": "Alineada a la derecha"
+          },
+          "label": "Ubicación de la imagen en computadoras",
+          "info": "La colocación se optimiza automáticamente para dispositivos móviles."
+        },
+        "container_color_scheme": {
+          "label": "Esquema de color del contenedor"
+        },
+        "mobile_content_alignment": {
+          "options__1": {
+            "label": "Izquierda"
+          },
+          "options__2": {
+            "label": "Centro"
+          },
+          "options__3": {
+            "label": "Derecha"
+          },
+          "label": "Alineación del contenido en el celular"
+        },
+        "header_mobile": {
+          "content": "Diseño para móviles"
+        }
+      },
+      "blocks": {
+        "row": {
+          "name": "Fila",
+          "settings": {
+            "image": {
+              "label": "Imagen"
+            },
+            "caption": {
+              "label": "Leyenda"
+            },
+            "heading": {
+              "label": "Encabezado"
+            },
+            "text": {
+              "label": "Texto"
+            },
+            "button_label": {
+              "label": "Etiqueta de botón"
+            },
+            "button_link": {
+              "label": "Enlace de botón"
+            }
+          }
+        }
+      },
+      "presets": {
+        "name": "Varias filas"
       }
     }
   }

--- a/locales/fi.schema.json
+++ b/locales/fi.schema.json
@@ -154,7 +154,7 @@
           "content": "Ruudukko"
         },
         "paragraph__grid": {
-          "content": "Vaikuttaa alueisiin, joissa on monisarakeasettelu."
+          "content": "Vaikuttaa alueisiin, joissa on monta saraketta tai riviä."
         },
         "spacing_grid_horizontal": {
           "label": "Vaakasuuntainen tila"
@@ -3040,6 +3040,159 @@
             "label": "2 saraketta"
           }
         }
+      }
+    },
+    "multirow": {
+      "name": "Monirivinen",
+      "settings": {
+        "image": {
+          "label": "Kuva"
+        },
+        "image_height": {
+          "options__1": {
+            "label": "Sovita kuvaan"
+          },
+          "options__2": {
+            "label": "Pieni"
+          },
+          "options__3": {
+            "label": "Keskisuuri"
+          },
+          "options__4": {
+            "label": "Suuri"
+          },
+          "label": "Kuvan korkeus"
+        },
+        "desktop_image_width": {
+          "options__1": {
+            "label": "Pieni"
+          },
+          "options__2": {
+            "label": "Keskisuuri"
+          },
+          "options__3": {
+            "label": "Suuri"
+          },
+          "label": "Työpöytäkuvan leveys",
+          "info": "Kuva optimoidaan automaattisesti mobiililaitteille."
+        },
+        "heading_size": {
+          "options__1": {
+            "label": "Pieni"
+          },
+          "options__2": {
+            "label": "Keskisuuri"
+          },
+          "options__3": {
+            "label": "Suuri"
+          },
+          "label": "Otsikon koko"
+        },
+        "text_style": {
+          "options__1": {
+            "label": "Leipäteksti"
+          },
+          "options__2": {
+            "label": "Alaotsikko"
+          },
+          "label": "Tekstityyli"
+        },
+        "button_style": {
+          "options__1": {
+            "label": "Yhtenäinen painike"
+          },
+          "options__2": {
+            "label": "Kehyspainike"
+          },
+          "label": "Painikkeen tyyli"
+        },
+        "desktop_content_alignment": {
+          "options__1": {
+            "label": "Vasen"
+          },
+          "options__2": {
+            "label": "Keskitetty"
+          },
+          "options__3": {
+            "label": "Oikea"
+          },
+          "label": "Työpöytäsisällön tasaus"
+        },
+        "desktop_content_position": {
+          "options__1": {
+            "label": "Ylös"
+          },
+          "options__2": {
+            "label": "Keskelle"
+          },
+          "options__3": {
+            "label": "Alas"
+          },
+          "label": "Työpöytäsisällön sijainti",
+          "info": "Sijainti optimoidaan automaattisesti mobiililaitteille."
+        },
+        "image_layout": {
+          "options__1": {
+            "label": "Vuorottelu vasemmalta"
+          },
+          "options__2": {
+            "label": "Vuorottelu oikealta"
+          },
+          "options__3": {
+            "label": "Tasattu vasemmalle"
+          },
+          "options__4": {
+            "label": "Tasattu oikealle"
+          },
+          "label": "Työpöytäkuvan sijoitus",
+          "info": "Sijoitus optimoidaan automaattisesti mobiililaitteille."
+        },
+        "container_color_scheme": {
+          "label": "Säiliön värimalli"
+        },
+        "mobile_content_alignment": {
+          "options__1": {
+            "label": "Vasen"
+          },
+          "options__2": {
+            "label": "Keskitetty"
+          },
+          "options__3": {
+            "label": "Oikea"
+          },
+          "label": "Mobiilisisällön tasaus"
+        },
+        "header_mobile": {
+          "content": "Mobiilipohja"
+        }
+      },
+      "blocks": {
+        "row": {
+          "name": "Rivi",
+          "settings": {
+            "image": {
+              "label": "Kuva"
+            },
+            "caption": {
+              "label": "Kuvateksti"
+            },
+            "heading": {
+              "label": "Otsikko"
+            },
+            "text": {
+              "label": "Teksti"
+            },
+            "button_label": {
+              "label": "Tekstipainike"
+            },
+            "button_link": {
+              "label": "Painikelinkki"
+            }
+          }
+        }
+      },
+      "presets": {
+        "name": "Monirivinen"
       }
     }
   }

--- a/locales/fr.schema.json
+++ b/locales/fr.schema.json
@@ -154,7 +154,7 @@
           "content": "Grille"
         },
         "paragraph__grid": {
-          "content": "Affecte les zones ayant une mise en page multicolonne."
+          "content": "Affecte les zones présentant plusieurs colonnes ou lignes."
         },
         "spacing_grid_horizontal": {
           "label": "Espace horizontal"
@@ -3040,6 +3040,159 @@
             "label": "2 colonnes"
           }
         }
+      }
+    },
+    "multirow": {
+      "name": "Multiligne",
+      "settings": {
+        "image": {
+          "label": "Image"
+        },
+        "image_height": {
+          "options__1": {
+            "label": "Adapter à l’image"
+          },
+          "options__2": {
+            "label": "Petit"
+          },
+          "options__3": {
+            "label": "Moyen"
+          },
+          "options__4": {
+            "label": "Grand"
+          },
+          "label": "Hauteur de l’image"
+        },
+        "desktop_image_width": {
+          "options__1": {
+            "label": "Petit"
+          },
+          "options__2": {
+            "label": "Moyen"
+          },
+          "options__3": {
+            "label": "Grand"
+          },
+          "label": "Largeur de l’image sur ordinateur",
+          "info": "L’image est automatiquement optimisée pour les mobiles."
+        },
+        "heading_size": {
+          "options__1": {
+            "label": "Petit"
+          },
+          "options__2": {
+            "label": "Moyen"
+          },
+          "options__3": {
+            "label": "Grand"
+          },
+          "label": "Taille du titre"
+        },
+        "text_style": {
+          "options__1": {
+            "label": "Corps"
+          },
+          "options__2": {
+            "label": "Sous‑titre"
+          },
+          "label": "Style de texte"
+        },
+        "button_style": {
+          "options__1": {
+            "label": "Bouton plein"
+          },
+          "options__2": {
+            "label": "Bouton en relief"
+          },
+          "label": "Style de bouton"
+        },
+        "desktop_content_alignment": {
+          "options__1": {
+            "label": "Gauche"
+          },
+          "options__2": {
+            "label": "Centre"
+          },
+          "options__3": {
+            "label": "Droite"
+          },
+          "label": "Alignement du contenu sur ordinateur"
+        },
+        "desktop_content_position": {
+          "options__1": {
+            "label": "En haut"
+          },
+          "options__2": {
+            "label": "Au milieu"
+          },
+          "options__3": {
+            "label": "En bas"
+          },
+          "label": "Position du contenu sur ordinateur",
+          "info": "La position est automatiquement optimisée pour les mobiles."
+        },
+        "image_layout": {
+          "options__1": {
+            "label": "Alterner depuis la gauche"
+          },
+          "options__2": {
+            "label": "Alterner depuis la droite"
+          },
+          "options__3": {
+            "label": "Aligner à gauche"
+          },
+          "options__4": {
+            "label": "Aligner à droite"
+          },
+          "label": "Placement de l’image sur ordinateur",
+          "info": "Le placement est automatiquement optimisé pour les mobiles."
+        },
+        "container_color_scheme": {
+          "label": "Combinaison de couleurs du conteneur"
+        },
+        "mobile_content_alignment": {
+          "options__1": {
+            "label": "Gauche"
+          },
+          "options__2": {
+            "label": "Centre"
+          },
+          "options__3": {
+            "label": "Droite"
+          },
+          "label": "Alignement du contenu sur mobile"
+        },
+        "header_mobile": {
+          "content": "Mise en page sur mobile"
+        }
+      },
+      "blocks": {
+        "row": {
+          "name": "Rangé",
+          "settings": {
+            "image": {
+              "label": "Image"
+            },
+            "caption": {
+              "label": "Légende"
+            },
+            "heading": {
+              "label": "En-tête"
+            },
+            "text": {
+              "label": "Texte"
+            },
+            "button_label": {
+              "label": "Texte du bouton"
+            },
+            "button_link": {
+              "label": "Lien du bouton"
+            }
+          }
+        }
+      },
+      "presets": {
+        "name": "Multiligne"
       }
     }
   }

--- a/locales/it.schema.json
+++ b/locales/it.schema.json
@@ -154,7 +154,7 @@
           "content": "Griglia"
         },
         "paragraph__grid": {
-          "content": "Incide sulle aree con layout multicolonna."
+          "content": "Incide sulle aree con colonne o righe multiple."
         },
         "spacing_grid_horizontal": {
           "label": "Spazio orizzontale"
@@ -3040,6 +3040,159 @@
             "label": "2 colonne"
           }
         }
+      }
+    },
+    "multirow": {
+      "name": "Riga multipla",
+      "settings": {
+        "image": {
+          "label": "Immagine"
+        },
+        "image_height": {
+          "options__1": {
+            "label": "Adatta all'immagine"
+          },
+          "options__2": {
+            "label": "Piccola"
+          },
+          "options__3": {
+            "label": "Medio"
+          },
+          "options__4": {
+            "label": "Grande"
+          },
+          "label": "Altezza immagine"
+        },
+        "desktop_image_width": {
+          "options__1": {
+            "label": "Piccola"
+          },
+          "options__2": {
+            "label": "Media"
+          },
+          "options__3": {
+            "label": "Grande"
+          },
+          "label": "Larghezza immagine su desktop",
+          "info": "L'immagine viene automaticamente ottimizzata per il mobile."
+        },
+        "heading_size": {
+          "options__1": {
+            "label": "Piccola"
+          },
+          "options__2": {
+            "label": "Media"
+          },
+          "options__3": {
+            "label": "Grande"
+          },
+          "label": "Dimensione titolo"
+        },
+        "text_style": {
+          "options__1": {
+            "label": "Corpo"
+          },
+          "options__2": {
+            "label": "Sottotitolo"
+          },
+          "label": "Stile del testo"
+        },
+        "button_style": {
+          "options__1": {
+            "label": "Pulsante in tinta unita"
+          },
+          "options__2": {
+            "label": "Contorno pulsante"
+          },
+          "label": "Stile pulsante"
+        },
+        "desktop_content_alignment": {
+          "options__1": {
+            "label": "A sinistra"
+          },
+          "options__2": {
+            "label": "Al centro"
+          },
+          "options__3": {
+            "label": "A destra"
+          },
+          "label": "Allineamento contenuto su desktop"
+        },
+        "desktop_content_position": {
+          "options__1": {
+            "label": "In alto"
+          },
+          "options__2": {
+            "label": "Al centro"
+          },
+          "options__3": {
+            "label": "In basso"
+          },
+          "label": "Posizione contenuto su desktop",
+          "info": "Posizione automaticamente ottimizzata per i dispositivi mobili."
+        },
+        "image_layout": {
+          "options__1": {
+            "label": "Alterna da sinistra"
+          },
+          "options__2": {
+            "label": "Alterna da destra"
+          },
+          "options__3": {
+            "label": "Allineata a sinistra"
+          },
+          "options__4": {
+            "label": "Allineata a destra"
+          },
+          "label": "Posizionamento immagine su desktop",
+          "info": "Il posizionamento viene automaticamente ottimizzato per i dispositivi mobili."
+        },
+        "container_color_scheme": {
+          "label": "Schema di colori dei contenitori"
+        },
+        "mobile_content_alignment": {
+          "options__1": {
+            "label": "A sinistra"
+          },
+          "options__2": {
+            "label": "Al centro"
+          },
+          "options__3": {
+            "label": "A destra"
+          },
+          "label": "Allineamento contenuto su dispositivi mobili"
+        },
+        "header_mobile": {
+          "content": "Layout dispositivo mobile"
+        }
+      },
+      "blocks": {
+        "row": {
+          "name": "Riga",
+          "settings": {
+            "image": {
+              "label": "Immagine"
+            },
+            "caption": {
+              "label": "Didascalia"
+            },
+            "heading": {
+              "label": "Titolo"
+            },
+            "text": {
+              "label": "Testo"
+            },
+            "button_label": {
+              "label": "Etichetta pulsante"
+            },
+            "button_link": {
+              "label": "Link pulsante"
+            }
+          }
+        }
+      },
+      "presets": {
+        "name": "Riga multipla"
       }
     }
   }

--- a/locales/ja.schema.json
+++ b/locales/ja.schema.json
@@ -154,7 +154,7 @@
           "content": "グリッド"
         },
         "paragraph__grid": {
-          "content": "マルチカラムレイアウトのエリアに影響します。"
+          "content": "複数の列または行のある部分に影響します。"
         },
         "spacing_grid_horizontal": {
           "label": "水平スペース"
@@ -3040,6 +3040,159 @@
             "label": "2列"
           }
         }
+      }
+    },
+    "multirow": {
+      "name": "複数列",
+      "settings": {
+        "image": {
+          "label": "画像"
+        },
+        "image_height": {
+          "options__1": {
+            "label": "画像に合わせる"
+          },
+          "options__2": {
+            "label": "小"
+          },
+          "options__3": {
+            "label": "中"
+          },
+          "options__4": {
+            "label": "大"
+          },
+          "label": "画像の高さ"
+        },
+        "desktop_image_width": {
+          "options__1": {
+            "label": "小"
+          },
+          "options__2": {
+            "label": "中"
+          },
+          "options__3": {
+            "label": "大"
+          },
+          "label": "デスクトップ画像の幅",
+          "info": "画像はモバイル用に自動で最適化されます。"
+        },
+        "heading_size": {
+          "options__1": {
+            "label": "小"
+          },
+          "options__2": {
+            "label": "中"
+          },
+          "options__3": {
+            "label": "大"
+          },
+          "label": "見出しのサイズ"
+        },
+        "text_style": {
+          "options__1": {
+            "label": "本文"
+          },
+          "options__2": {
+            "label": "サブタイトル"
+          },
+          "label": "テキストスタイル"
+        },
+        "button_style": {
+          "options__1": {
+            "label": "ソリッドカラーのボタン"
+          },
+          "options__2": {
+            "label": "アウトラインボタン"
+          },
+          "label": "ボタンのスタイル"
+        },
+        "desktop_content_alignment": {
+          "options__1": {
+            "label": "左"
+          },
+          "options__2": {
+            "label": "中央"
+          },
+          "options__3": {
+            "label": "右"
+          },
+          "label": "デスクトップのコンテンツ配置"
+        },
+        "desktop_content_position": {
+          "options__1": {
+            "label": "上"
+          },
+          "options__2": {
+            "label": "中央"
+          },
+          "options__3": {
+            "label": "下"
+          },
+          "label": "デスクトップのコンテンツ位置",
+          "info": "位置はモバイル用に自動で最適化されます。"
+        },
+        "image_layout": {
+          "options__1": {
+            "label": "左から交互に"
+          },
+          "options__2": {
+            "label": "右から交互に"
+          },
+          "options__3": {
+            "label": "左寄せ"
+          },
+          "options__4": {
+            "label": "右寄せ"
+          },
+          "label": "デスクトップ画像の配置",
+          "info": "配置はモバイル用に自動で最適化されます。"
+        },
+        "container_color_scheme": {
+          "label": "コンテナの配色"
+        },
+        "mobile_content_alignment": {
+          "options__1": {
+            "label": "左"
+          },
+          "options__2": {
+            "label": "中央"
+          },
+          "options__3": {
+            "label": "右"
+          },
+          "label": "モバイルのコンテンツ配置"
+        },
+        "header_mobile": {
+          "content": "モバイルのレイアウト"
+        }
+      },
+      "blocks": {
+        "row": {
+          "name": "行",
+          "settings": {
+            "image": {
+              "label": "画像"
+            },
+            "caption": {
+              "label": "キャプション"
+            },
+            "heading": {
+              "label": "見出し"
+            },
+            "text": {
+              "label": "テキスト"
+            },
+            "button_label": {
+              "label": "ボタンのラベル"
+            },
+            "button_link": {
+              "label": "ボタンのリンク"
+            }
+          }
+        }
+      },
+      "presets": {
+        "name": "複数列"
       }
     }
   }

--- a/locales/ko.schema.json
+++ b/locales/ko.schema.json
@@ -154,7 +154,7 @@
           "content": "그리드"
         },
         "paragraph__grid": {
-          "content": "다중 열 레이아웃이 있는 영역에 영향을 줍니다."
+          "content": "여러 열이나 행이 있는 영역에 영향을 미칩니다."
         },
         "spacing_grid_horizontal": {
           "label": "수평 영역"
@@ -3040,6 +3040,159 @@
             "label": "열 2개"
           }
         }
+      }
+    },
+    "multirow": {
+      "name": "여러 행",
+      "settings": {
+        "image": {
+          "label": "이미지"
+        },
+        "image_height": {
+          "options__1": {
+            "label": "이미지에 맞춤"
+          },
+          "options__2": {
+            "label": "작게"
+          },
+          "options__3": {
+            "label": "보통"
+          },
+          "options__4": {
+            "label": "크게"
+          },
+          "label": "이미지 높이"
+        },
+        "desktop_image_width": {
+          "options__1": {
+            "label": "작게"
+          },
+          "options__2": {
+            "label": "보통"
+          },
+          "options__3": {
+            "label": "크게"
+          },
+          "label": "데스크톱 이미지 너비",
+          "info": "이미지는 자동으로 모바일에 최적화됩니다."
+        },
+        "heading_size": {
+          "options__1": {
+            "label": "작게"
+          },
+          "options__2": {
+            "label": "보통"
+          },
+          "options__3": {
+            "label": "크게"
+          },
+          "label": "제목 크기"
+        },
+        "text_style": {
+          "options__1": {
+            "label": "본문"
+          },
+          "options__2": {
+            "label": "부제목"
+          },
+          "label": "텍스트 스타일"
+        },
+        "button_style": {
+          "options__1": {
+            "label": "단색 버튼"
+          },
+          "options__2": {
+            "label": "윤곽선 버튼"
+          },
+          "label": "버튼 스타일"
+        },
+        "desktop_content_alignment": {
+          "options__1": {
+            "label": "왼쪽"
+          },
+          "options__2": {
+            "label": "가운데"
+          },
+          "options__3": {
+            "label": "오른쪽"
+          },
+          "label": "데스크톱 콘텐츠 정렬"
+        },
+        "desktop_content_position": {
+          "options__1": {
+            "label": "위쪽"
+          },
+          "options__2": {
+            "label": "중간"
+          },
+          "options__3": {
+            "label": "아래쪽"
+          },
+          "label": "데스크톱 콘텐츠 위치",
+          "info": "위치는 자동으로 모바일에 최적화됩니다."
+        },
+        "image_layout": {
+          "options__1": {
+            "label": "왼쪽에서 번갈아"
+          },
+          "options__2": {
+            "label": "오른쪽에서 번갈아"
+          },
+          "options__3": {
+            "label": "왼쪽 맞춤"
+          },
+          "options__4": {
+            "label": "오른쪽 맞춤"
+          },
+          "label": "데스크톱 이미지 배치",
+          "info": "배치는 자동으로 모바일에 최적화됩니다."
+        },
+        "container_color_scheme": {
+          "label": "컨테이너 색상 구성표"
+        },
+        "mobile_content_alignment": {
+          "options__1": {
+            "label": "왼쪽"
+          },
+          "options__2": {
+            "label": "가운데"
+          },
+          "options__3": {
+            "label": "오른쪽"
+          },
+          "label": "모바일 콘텐츠 정렬"
+        },
+        "header_mobile": {
+          "content": "모바일 레이아웃"
+        }
+      },
+      "blocks": {
+        "row": {
+          "name": "열",
+          "settings": {
+            "image": {
+              "label": "이미지"
+            },
+            "caption": {
+              "label": "캡션"
+            },
+            "heading": {
+              "label": "제목"
+            },
+            "text": {
+              "label": "텍스트"
+            },
+            "button_label": {
+              "label": "버튼 레이블"
+            },
+            "button_link": {
+              "label": "버튼 링크"
+            }
+          }
+        }
+      },
+      "presets": {
+        "name": "여러 행"
       }
     }
   }

--- a/locales/nb.schema.json
+++ b/locales/nb.schema.json
@@ -154,7 +154,7 @@
           "content": "Rutenett"
         },
         "paragraph__grid": {
-          "content": "Påvirker områder med multikolonne-layout"
+          "content": "Påvirker områder med flere kolonner eller rader."
         },
         "spacing_grid_horizontal": {
           "label": "Horisontal plass"
@@ -3040,6 +3040,159 @@
             "label": "2 kolonner"
           }
         }
+      }
+    },
+    "multirow": {
+      "name": "Flere rader",
+      "settings": {
+        "image": {
+          "label": "Bilde"
+        },
+        "image_height": {
+          "options__1": {
+            "label": "Tilpass til bilde"
+          },
+          "options__2": {
+            "label": "Liten"
+          },
+          "options__3": {
+            "label": "Middels"
+          },
+          "options__4": {
+            "label": "Stor"
+          },
+          "label": "Bildehøyde"
+        },
+        "desktop_image_width": {
+          "options__1": {
+            "label": "Liten"
+          },
+          "options__2": {
+            "label": "Middels"
+          },
+          "options__3": {
+            "label": "Stor"
+          },
+          "label": "Bildebredde på datamaskiner",
+          "info": "Bildet optimaliseres automatisk for mobil."
+        },
+        "heading_size": {
+          "options__1": {
+            "label": "Liten"
+          },
+          "options__2": {
+            "label": "Middels"
+          },
+          "options__3": {
+            "label": "Stor"
+          },
+          "label": "Overskriftsstørrelse"
+        },
+        "text_style": {
+          "options__1": {
+            "label": "Brødtekst"
+          },
+          "options__2": {
+            "label": "Undertekst"
+          },
+          "label": "Tekststil"
+        },
+        "button_style": {
+          "options__1": {
+            "label": "Helfarget knapp"
+          },
+          "options__2": {
+            "label": "Omriss rundt knapp"
+          },
+          "label": "Knappestil"
+        },
+        "desktop_content_alignment": {
+          "options__1": {
+            "label": "Venstre"
+          },
+          "options__2": {
+            "label": "Sentrert"
+          },
+          "options__3": {
+            "label": "Høyre"
+          },
+          "label": "Innholdsjustering på datamaskin"
+        },
+        "desktop_content_position": {
+          "options__1": {
+            "label": "Topp"
+          },
+          "options__2": {
+            "label": "Midten"
+          },
+          "options__3": {
+            "label": "Bunn"
+          },
+          "label": "Innholdsplassering på datamaskin",
+          "info": "Posisjonen optimaliseres automatisk for mobil."
+        },
+        "image_layout": {
+          "options__1": {
+            "label": "Annenhver fra venstre"
+          },
+          "options__2": {
+            "label": "Annenhver fra høyre"
+          },
+          "options__3": {
+            "label": "Justert mot venstre"
+          },
+          "options__4": {
+            "label": "Justert mot høyre"
+          },
+          "label": "Bildeplassering på datamaskin",
+          "info": "Plasseringen optimaliseres automatisk for mobil."
+        },
+        "container_color_scheme": {
+          "label": "Fargetema for beholder"
+        },
+        "mobile_content_alignment": {
+          "options__1": {
+            "label": "Venstre"
+          },
+          "options__2": {
+            "label": "Sentrert"
+          },
+          "options__3": {
+            "label": "Høyre"
+          },
+          "label": "Innholdsjustering på mobiltelefon"
+        },
+        "header_mobile": {
+          "content": "Mobillayout"
+        }
+      },
+      "blocks": {
+        "row": {
+          "name": "Rad",
+          "settings": {
+            "image": {
+              "label": "Bilde"
+            },
+            "caption": {
+              "label": "Bildetekst"
+            },
+            "heading": {
+              "label": "Overskrift"
+            },
+            "text": {
+              "label": "Tekst"
+            },
+            "button_label": {
+              "label": "Knappetikett"
+            },
+            "button_link": {
+              "label": "Knappekobling"
+            }
+          }
+        }
+      },
+      "presets": {
+        "name": "Flere rader"
       }
     }
   }

--- a/locales/nl.schema.json
+++ b/locales/nl.schema.json
@@ -154,7 +154,7 @@
           "content": "Grid"
         },
         "paragraph__grid": {
-          "content": "Is van invloed op gedeeltes met een opmaak met meerdere kolommen."
+          "content": "Is van invloed op secties met meerdere kolommen of rijen."
         },
         "spacing_grid_horizontal": {
           "label": "Horizontale ruimte"
@@ -3040,6 +3040,159 @@
             "label": "2 kolommen"
           }
         }
+      }
+    },
+    "multirow": {
+      "name": "Meerdere rijen",
+      "settings": {
+        "image": {
+          "label": "Afbeelding"
+        },
+        "image_height": {
+          "options__1": {
+            "label": "Aanpassen aan afbeelding"
+          },
+          "options__2": {
+            "label": "Klein"
+          },
+          "options__3": {
+            "label": "Gemiddeld"
+          },
+          "options__4": {
+            "label": "Groot"
+          },
+          "label": "Hoogte afbeelding"
+        },
+        "desktop_image_width": {
+          "options__1": {
+            "label": "Klein"
+          },
+          "options__2": {
+            "label": "Gemiddeld"
+          },
+          "options__3": {
+            "label": "Groot"
+          },
+          "label": "Breedte van bureaubladafbeelding",
+          "info": "De afbeelding wordt automatisch geoptimaliseerd voor mobiel."
+        },
+        "heading_size": {
+          "options__1": {
+            "label": "Klein"
+          },
+          "options__2": {
+            "label": "Gemiddeld"
+          },
+          "options__3": {
+            "label": "Groot"
+          },
+          "label": "Grootte koptekst"
+        },
+        "text_style": {
+          "options__1": {
+            "label": "Hoofdtekst"
+          },
+          "options__2": {
+            "label": "Ondertitel"
+          },
+          "label": "Tekststijl"
+        },
+        "button_style": {
+          "options__1": {
+            "label": "Knop Doorgetrokken"
+          },
+          "options__2": {
+            "label": "Knop Omlijnen"
+          },
+          "label": "Knopstijl"
+        },
+        "desktop_content_alignment": {
+          "options__1": {
+            "label": "Links"
+          },
+          "options__2": {
+            "label": "Midden"
+          },
+          "options__3": {
+            "label": "Rechts"
+          },
+          "label": "Uitlijning van content op bureaublad"
+        },
+        "desktop_content_position": {
+          "options__1": {
+            "label": "Boven"
+          },
+          "options__2": {
+            "label": "Midden"
+          },
+          "options__3": {
+            "label": "Onder"
+          },
+          "label": "Positie van content op bureaublad",
+          "info": "De positie wordt automatisch geoptimaliseerd voor mobiele weergave."
+        },
+        "image_layout": {
+          "options__1": {
+            "label": "Afwisselend van links"
+          },
+          "options__2": {
+            "label": "Afwisselend van rechts"
+          },
+          "options__3": {
+            "label": "Links uitgelijnd"
+          },
+          "options__4": {
+            "label": "Rechts uitgelijnd"
+          },
+          "label": "Plaatsing van afbeelding op bureaublad",
+          "info": "De plaatsing wordt automatisch geoptimaliseerd voor mobiel."
+        },
+        "container_color_scheme": {
+          "label": "Kleurschema van container"
+        },
+        "mobile_content_alignment": {
+          "options__1": {
+            "label": "Links"
+          },
+          "options__2": {
+            "label": "Midden"
+          },
+          "options__3": {
+            "label": "Rechts"
+          },
+          "label": "Uitlijning van content op mobiel"
+        },
+        "header_mobile": {
+          "content": "Opmaak op mobiel"
+        }
+      },
+      "blocks": {
+        "row": {
+          "name": "Rij",
+          "settings": {
+            "image": {
+              "label": "Afbeelding"
+            },
+            "caption": {
+              "label": "Bijschrift"
+            },
+            "heading": {
+              "label": "Koptekst"
+            },
+            "text": {
+              "label": "Tekst"
+            },
+            "button_label": {
+              "label": "Knoplabel"
+            },
+            "button_link": {
+              "label": "Knoplink"
+            }
+          }
+        }
+      },
+      "presets": {
+        "name": "Meerdere rijen"
       }
     }
   }

--- a/locales/pl.schema.json
+++ b/locales/pl.schema.json
@@ -154,7 +154,7 @@
           "content": "Siatka"
         },
         "paragraph__grid": {
-          "content": "Dotyczy obszarów z układem wielokolumnowym."
+          "content": "Dotyczy obszarów z wieloma kolumnami lub wierszami."
         },
         "spacing_grid_horizontal": {
           "label": "Przestrzeń pozioma"
@@ -3040,6 +3040,159 @@
             "label": "2 kolumny"
           }
         }
+      }
+    },
+    "multirow": {
+      "name": "Wiele wierszy",
+      "settings": {
+        "image": {
+          "label": "Obraz"
+        },
+        "image_height": {
+          "options__1": {
+            "label": "Dostosuj do obrazu"
+          },
+          "options__2": {
+            "label": "Mały"
+          },
+          "options__3": {
+            "label": "Średni"
+          },
+          "options__4": {
+            "label": "Duży"
+          },
+          "label": "Wysokość obrazu"
+        },
+        "desktop_image_width": {
+          "options__1": {
+            "label": "Mały"
+          },
+          "options__2": {
+            "label": "Średni"
+          },
+          "options__3": {
+            "label": "Duży"
+          },
+          "label": "Szerokość obrazu na komputerze",
+          "info": "Obraz jest automatycznie optymalizowany dla urządzeń mobilnych."
+        },
+        "heading_size": {
+          "options__1": {
+            "label": "Mały"
+          },
+          "options__2": {
+            "label": "Średni"
+          },
+          "options__3": {
+            "label": "Duży"
+          },
+          "label": "Rozmiar nagłówka"
+        },
+        "text_style": {
+          "options__1": {
+            "label": "Tekst podstawowy"
+          },
+          "options__2": {
+            "label": "Podtytuł"
+          },
+          "label": "Styl tekstu"
+        },
+        "button_style": {
+          "options__1": {
+            "label": "Przycisk w jednolitym kolorze"
+          },
+          "options__2": {
+            "label": "Przycisk konspektu"
+          },
+          "label": "Styl przycisku"
+        },
+        "desktop_content_alignment": {
+          "options__1": {
+            "label": "Lewa strona"
+          },
+          "options__2": {
+            "label": "Środek"
+          },
+          "options__3": {
+            "label": "Prawa strona"
+          },
+          "label": "Wyrównanie treści na komputerze"
+        },
+        "desktop_content_position": {
+          "options__1": {
+            "label": "Góra"
+          },
+          "options__2": {
+            "label": "Środek"
+          },
+          "options__3": {
+            "label": "Dół"
+          },
+          "label": "Pozycja treści na komputerze",
+          "info": "Pozycja jest automatycznie optymalizowana dla urządzeń mobilnych."
+        },
+        "image_layout": {
+          "options__1": {
+            "label": "Naprzemiennie od lewej strony"
+          },
+          "options__2": {
+            "label": "Naprzemiennie od prawej strony"
+          },
+          "options__3": {
+            "label": "Wyrównano do lewej"
+          },
+          "options__4": {
+            "label": "Wyrównano do prawej"
+          },
+          "label": "Umieszczanie obrazów na komputerze",
+          "info": "Umieszczanie jest automatycznie optymalizowane pod kątem urządzeń mobilnych."
+        },
+        "container_color_scheme": {
+          "label": "Kolorystyka kontenera"
+        },
+        "mobile_content_alignment": {
+          "options__1": {
+            "label": "Lewa strona"
+          },
+          "options__2": {
+            "label": "Środek"
+          },
+          "options__3": {
+            "label": "Prawa strona"
+          },
+          "label": "Wyrównanie treści na urządzeniu mobilnym"
+        },
+        "header_mobile": {
+          "content": "Układ na urządzeniu mobilnym"
+        }
+      },
+      "blocks": {
+        "row": {
+          "name": "Wiersz",
+          "settings": {
+            "image": {
+              "label": "Obraz"
+            },
+            "caption": {
+              "label": "Napisy"
+            },
+            "heading": {
+              "label": "Nagłówek"
+            },
+            "text": {
+              "label": "Tekst"
+            },
+            "button_label": {
+              "label": "Przycisk z etykietą"
+            },
+            "button_link": {
+              "label": "Link przycisku"
+            }
+          }
+        }
+      },
+      "presets": {
+        "name": "Wiele wierszy"
       }
     }
   }

--- a/locales/pt-BR.schema.json
+++ b/locales/pt-BR.schema.json
@@ -154,7 +154,7 @@
           "content": "Grade"
         },
         "paragraph__grid": {
-          "content": "Afeta áreas com layout multicoluna."
+          "content": "Afeta áreas com várias colunas ou linhas."
         },
         "spacing_grid_horizontal": {
           "label": "Espaço horizontal"
@@ -3040,6 +3040,159 @@
             "label": "2 colunas"
           }
         }
+      }
+    },
+    "multirow": {
+      "name": "Várias linhas",
+      "settings": {
+        "image": {
+          "label": "Imagem"
+        },
+        "image_height": {
+          "options__1": {
+            "label": "Adaptar à imagem"
+          },
+          "options__2": {
+            "label": "Pequeno"
+          },
+          "options__3": {
+            "label": "Médio"
+          },
+          "options__4": {
+            "label": "Grande"
+          },
+          "label": "Altura da imagem"
+        },
+        "desktop_image_width": {
+          "options__1": {
+            "label": "Pequeno"
+          },
+          "options__2": {
+            "label": "Médio"
+          },
+          "options__3": {
+            "label": "Grande"
+          },
+          "label": "Largura da imagem no desktop",
+          "info": "A imagem é otimizada automaticamente em dispositivos móveis."
+        },
+        "heading_size": {
+          "options__1": {
+            "label": "Pequeno"
+          },
+          "options__2": {
+            "label": "Médio"
+          },
+          "options__3": {
+            "label": "Grande"
+          },
+          "label": "Tamanho do título"
+        },
+        "text_style": {
+          "options__1": {
+            "label": "Corpo"
+          },
+          "options__2": {
+            "label": "Subtítulo"
+          },
+          "label": "Estilo de texto"
+        },
+        "button_style": {
+          "options__1": {
+            "label": "Botão sólido"
+          },
+          "options__2": {
+            "label": "Botão com contorno"
+          },
+          "label": "Estilo de botão"
+        },
+        "desktop_content_alignment": {
+          "options__1": {
+            "label": "Esquerda"
+          },
+          "options__2": {
+            "label": "Centro"
+          },
+          "options__3": {
+            "label": "Direita"
+          },
+          "label": "Alinhamento de conteúdo no desktop"
+        },
+        "desktop_content_position": {
+          "options__1": {
+            "label": "Parte superior"
+          },
+          "options__2": {
+            "label": "Meio"
+          },
+          "options__3": {
+            "label": "Parte inferior"
+          },
+          "label": "Posição do conteúdo no desktop",
+          "info": "A posição é otimizada automaticamente para dispositivos móveis."
+        },
+        "image_layout": {
+          "options__1": {
+            "label": "Alternar da esquerda"
+          },
+          "options__2": {
+            "label": "Alternar da direita"
+          },
+          "options__3": {
+            "label": "Alinhado à esquerda"
+          },
+          "options__4": {
+            "label": "Alinhado à direita"
+          },
+          "label": "Posicionamento da imagem no desktop",
+          "info": "O posicionamento é otimizado automaticamente para dispositivos móveis."
+        },
+        "container_color_scheme": {
+          "label": "Esquema de cores do contêiner"
+        },
+        "mobile_content_alignment": {
+          "options__1": {
+            "label": "Esquerda"
+          },
+          "options__2": {
+            "label": "Centro"
+          },
+          "options__3": {
+            "label": "Direita"
+          },
+          "label": "Alinhamento de conteúdo em dispositivos móveis"
+        },
+        "header_mobile": {
+          "content": "Layout em dispositivos móveis"
+        }
+      },
+      "blocks": {
+        "row": {
+          "name": "Linha",
+          "settings": {
+            "image": {
+              "label": "Imagem"
+            },
+            "caption": {
+              "label": "Legenda"
+            },
+            "heading": {
+              "label": "Título"
+            },
+            "text": {
+              "label": "Texto"
+            },
+            "button_label": {
+              "label": "Etiqueta de botão"
+            },
+            "button_link": {
+              "label": "Link de botão"
+            }
+          }
+        }
+      },
+      "presets": {
+        "name": "Várias linhas"
       }
     }
   }

--- a/locales/pt-PT.schema.json
+++ b/locales/pt-PT.schema.json
@@ -154,7 +154,7 @@
           "content": "Grelha"
         },
         "paragraph__grid": {
-          "content": "Afeta áreas com um esquema de várias colunas."
+          "content": "Afeta áreas com várias colunas ou linhas."
         },
         "spacing_grid_horizontal": {
           "label": "Espaço horizontal"
@@ -3040,6 +3040,159 @@
             "label": "2 colunas"
           }
         }
+      }
+    },
+    "multirow": {
+      "name": "Várias linhas",
+      "settings": {
+        "image": {
+          "label": "Imagem"
+        },
+        "image_height": {
+          "options__1": {
+            "label": "Adaptar à imagem"
+          },
+          "options__2": {
+            "label": "Pequeno"
+          },
+          "options__3": {
+            "label": "Médio"
+          },
+          "options__4": {
+            "label": "Grande"
+          },
+          "label": "Altura da imagem"
+        },
+        "desktop_image_width": {
+          "options__1": {
+            "label": "Pequeno"
+          },
+          "options__2": {
+            "label": "Médio"
+          },
+          "options__3": {
+            "label": "Grande"
+          },
+          "label": "Largura da imagem em computador",
+          "info": "A imagem é otimizada automaticamente em dispositivos móveis."
+        },
+        "heading_size": {
+          "options__1": {
+            "label": "Pequeno"
+          },
+          "options__2": {
+            "label": "Médio"
+          },
+          "options__3": {
+            "label": "Grande"
+          },
+          "label": "Tamanho do título"
+        },
+        "text_style": {
+          "options__1": {
+            "label": "Corpo"
+          },
+          "options__2": {
+            "label": "Legenda"
+          },
+          "label": "Estilo de texto"
+        },
+        "button_style": {
+          "options__1": {
+            "label": "Botão sólido"
+          },
+          "options__2": {
+            "label": "Botão de contorno"
+          },
+          "label": "Estilo do botão"
+        },
+        "desktop_content_alignment": {
+          "options__1": {
+            "label": "Esquerda"
+          },
+          "options__2": {
+            "label": "Centro"
+          },
+          "options__3": {
+            "label": "Direita"
+          },
+          "label": "Alinhamento do conteúdo em computador"
+        },
+        "desktop_content_position": {
+          "options__1": {
+            "label": "Em cima"
+          },
+          "options__2": {
+            "label": "Ao meio"
+          },
+          "options__3": {
+            "label": "Em baixo"
+          },
+          "label": "Posição do conteúdo para computador",
+          "info": "A posição é automaticamente otimizada para dispositivos móveis."
+        },
+        "image_layout": {
+          "options__1": {
+            "label": "Alternar da esquerda"
+          },
+          "options__2": {
+            "label": "Alternar da direita"
+          },
+          "options__3": {
+            "label": "Alinhado à esquerda"
+          },
+          "options__4": {
+            "label": "Alinhado à direita"
+          },
+          "label": "Posicionamento da imagem em computador",
+          "info": "O posicionamento é otimizado automaticamente para dispositivos móveis."
+        },
+        "container_color_scheme": {
+          "label": "Esquema de cores do contentor"
+        },
+        "mobile_content_alignment": {
+          "options__1": {
+            "label": "Esquerda"
+          },
+          "options__2": {
+            "label": "Centro"
+          },
+          "options__3": {
+            "label": "Direita"
+          },
+          "label": "Alinhamento do conteúdo em dispositivos móveis"
+        },
+        "header_mobile": {
+          "content": "Esquema para dispositivo móvel"
+        }
+      },
+      "blocks": {
+        "row": {
+          "name": "Linha",
+          "settings": {
+            "image": {
+              "label": "Imagem"
+            },
+            "caption": {
+              "label": "Legenda"
+            },
+            "heading": {
+              "label": "Título"
+            },
+            "text": {
+              "label": "Texto"
+            },
+            "button_label": {
+              "label": "Etiqueta do botão"
+            },
+            "button_link": {
+              "label": "Ligação do botão"
+            }
+          }
+        }
+      },
+      "presets": {
+        "name": "Várias linhas"
       }
     }
   }

--- a/locales/sv.schema.json
+++ b/locales/sv.schema.json
@@ -154,7 +154,7 @@
           "content": "Rutnät"
         },
         "paragraph__grid": {
-          "content": "Påverkar områden med en flerkolumnslayout."
+          "content": "Påverkar områden med flera kolumner eller rader."
         },
         "spacing_grid_horizontal": {
           "label": "Horisontellt utrymme"
@@ -3040,6 +3040,159 @@
             "label": "2 kolumner"
           }
         }
+      }
+    },
+    "multirow": {
+      "name": "Flera rader",
+      "settings": {
+        "image": {
+          "label": "Bild"
+        },
+        "image_height": {
+          "options__1": {
+            "label": "Anpassa till bild"
+          },
+          "options__2": {
+            "label": "Liten"
+          },
+          "options__3": {
+            "label": "Medel"
+          },
+          "options__4": {
+            "label": "Stor"
+          },
+          "label": "Bildhöjd"
+        },
+        "desktop_image_width": {
+          "options__1": {
+            "label": "Liten"
+          },
+          "options__2": {
+            "label": "Medel"
+          },
+          "options__3": {
+            "label": "Stor"
+          },
+          "label": "Bildbredd för dator",
+          "info": "Bilden optimeras automatiskt för mobilen."
+        },
+        "heading_size": {
+          "options__1": {
+            "label": "Liten"
+          },
+          "options__2": {
+            "label": "Medel"
+          },
+          "options__3": {
+            "label": "Stor"
+          },
+          "label": "Rubrikstorlek"
+        },
+        "text_style": {
+          "options__1": {
+            "label": "Brödtext"
+          },
+          "options__2": {
+            "label": "Underrubrik"
+          },
+          "label": "Textstil"
+        },
+        "button_style": {
+          "options__1": {
+            "label": "Tydlig knapp"
+          },
+          "options__2": {
+            "label": "Knappkontur"
+          },
+          "label": "Knappstil"
+        },
+        "desktop_content_alignment": {
+          "options__1": {
+            "label": "Vänster"
+          },
+          "options__2": {
+            "label": "Centrera"
+          },
+          "options__3": {
+            "label": "Höger"
+          },
+          "label": "Justering av innehåll på skrivbord"
+        },
+        "desktop_content_position": {
+          "options__1": {
+            "label": "Högst upp"
+          },
+          "options__2": {
+            "label": "Mitten"
+          },
+          "options__3": {
+            "label": "Längst ner"
+          },
+          "label": "Innehållsposition på skrivbord",
+          "info": "Positionen optimeras automatiskt för mobilen."
+        },
+        "image_layout": {
+          "options__1": {
+            "label": "Alternera från vänster"
+          },
+          "options__2": {
+            "label": "Alternera från höger"
+          },
+          "options__3": {
+            "label": "Vänsterjusterad"
+          },
+          "options__4": {
+            "label": "Högerjusterad"
+          },
+          "label": "Placering av datorbild",
+          "info": "Placeringen optimeras automatiskt för mobilen."
+        },
+        "container_color_scheme": {
+          "label": "Färgschema för container"
+        },
+        "mobile_content_alignment": {
+          "options__1": {
+            "label": "Vänster"
+          },
+          "options__2": {
+            "label": "Centrera"
+          },
+          "options__3": {
+            "label": "Höger"
+          },
+          "label": "Linjering av innehåll på mobil"
+        },
+        "header_mobile": {
+          "content": "Mobil layout"
+        }
+      },
+      "blocks": {
+        "row": {
+          "name": "Rad",
+          "settings": {
+            "image": {
+              "label": "Bild"
+            },
+            "caption": {
+              "label": "Rubrik"
+            },
+            "heading": {
+              "label": "Rubrik"
+            },
+            "text": {
+              "label": "Text"
+            },
+            "button_label": {
+              "label": "Knappetikett"
+            },
+            "button_link": {
+              "label": "Knapplänk"
+            }
+          }
+        }
+      },
+      "presets": {
+        "name": "Flera rader"
       }
     }
   }

--- a/locales/th.schema.json
+++ b/locales/th.schema.json
@@ -154,7 +154,7 @@
           "content": "กริด"
         },
         "paragraph__grid": {
-          "content": "ส่งผลต่อพื้นที่ที่มีเลย์เอาต์แบบหลายคอลัมน์"
+          "content": "ส่งผลต่อพื้นที่ที่มีหลายคอลัมน์หรือหลายแถว"
         },
         "spacing_grid_horizontal": {
           "label": "ช่องว่างแนวนอน"
@@ -3040,6 +3040,159 @@
             "label": "2 คอลัมน์"
           }
         }
+      }
+    },
+    "multirow": {
+      "name": "หลายแถว",
+      "settings": {
+        "image": {
+          "label": "รูปภาพ"
+        },
+        "image_height": {
+          "options__1": {
+            "label": "ปรับตามรูปภาพ"
+          },
+          "options__2": {
+            "label": "เล็ก"
+          },
+          "options__3": {
+            "label": "ปานกลาง"
+          },
+          "options__4": {
+            "label": "ใหญ่"
+          },
+          "label": "ความสูงของรูปภาพ"
+        },
+        "desktop_image_width": {
+          "options__1": {
+            "label": "เล็ก"
+          },
+          "options__2": {
+            "label": "ปานกลาง"
+          },
+          "options__3": {
+            "label": "ใหญ่"
+          },
+          "label": "ความกว้างของรูปภาพบนเดสก์ท็อป",
+          "info": "ระบบจะปรับรูปภาพให้เหมาะสมกับมือถือโดยอัตโนมัติ"
+        },
+        "heading_size": {
+          "options__1": {
+            "label": "เล็ก"
+          },
+          "options__2": {
+            "label": "ปานกลาง"
+          },
+          "options__3": {
+            "label": "ใหญ่"
+          },
+          "label": "ขนาดของส่วนหัว"
+        },
+        "text_style": {
+          "options__1": {
+            "label": "เนื้อหา"
+          },
+          "options__2": {
+            "label": "หัวเรื่องย่อย"
+          },
+          "label": "รูปแบบข้อความ"
+        },
+        "button_style": {
+          "options__1": {
+            "label": "ปุ่มทึบ"
+          },
+          "options__2": {
+            "label": "ปุ่มแบบเค้าโครง"
+          },
+          "label": "รูปแบบปุ่ม"
+        },
+        "desktop_content_alignment": {
+          "options__1": {
+            "label": "ซ้าย"
+          },
+          "options__2": {
+            "label": "กึ่งกลาง"
+          },
+          "options__3": {
+            "label": "ขวา"
+          },
+          "label": "การจัดวางเนื้อหาบนเดสก์ท็อป"
+        },
+        "desktop_content_position": {
+          "options__1": {
+            "label": "บน"
+          },
+          "options__2": {
+            "label": "ตรงกลาง"
+          },
+          "options__3": {
+            "label": "ล่าง"
+          },
+          "label": "ตำแหน่งเนื้อหาบนเดสก์ท็อป",
+          "info": "ระบบจะปรับตำแหน่งให้เหมาะสมกับมือถือโดยอัตโนมัติ"
+        },
+        "image_layout": {
+          "options__1": {
+            "label": "สลับจากด้านซ้าย"
+          },
+          "options__2": {
+            "label": "สลับจากด้านขวา"
+          },
+          "options__3": {
+            "label": "จัดให้ชิดซ้าย"
+          },
+          "options__4": {
+            "label": "จัดให้ชิดขวา"
+          },
+          "label": "การวางตำแหน่งรูปภาพบนเดสก์ท็อป",
+          "info": "ระบบจะปรับการวางตำแหน่งให้เหมาะสมกับมือถือโดยอัตโนมัติ"
+        },
+        "container_color_scheme": {
+          "label": "รูปแบบสีของกรอบ"
+        },
+        "mobile_content_alignment": {
+          "options__1": {
+            "label": "ซ้าย"
+          },
+          "options__2": {
+            "label": "กึ่งกลาง"
+          },
+          "options__3": {
+            "label": "ขวา"
+          },
+          "label": "การจัดวางเนื้อหาบนมือถือ"
+        },
+        "header_mobile": {
+          "content": "เลย์เอาต์สำหรับมือถือ"
+        }
+      },
+      "blocks": {
+        "row": {
+          "name": "แถว",
+          "settings": {
+            "image": {
+              "label": "รูปภาพ"
+            },
+            "caption": {
+              "label": "คำบรรยาย"
+            },
+            "heading": {
+              "label": "หัวเรื่อง"
+            },
+            "text": {
+              "label": "ข้อความ"
+            },
+            "button_label": {
+              "label": "ป้ายกำกับปุ่ม"
+            },
+            "button_link": {
+              "label": "ลิงก์ปุ่ม"
+            }
+          }
+        }
+      },
+      "presets": {
+        "name": "หลายแถว"
       }
     }
   }

--- a/locales/tr.schema.json
+++ b/locales/tr.schema.json
@@ -154,7 +154,7 @@
           "content": "Izgara"
         },
         "paragraph__grid": {
-          "content": "Çoklu sütun düzeni içeren alanları etkiler."
+          "content": "Birden fazla sütun veya satır içeren alanları etkiler."
         },
         "spacing_grid_horizontal": {
           "label": "Yatay boşluk"
@@ -3040,6 +3040,159 @@
             "label": "2 sütun"
           }
         }
+      }
+    },
+    "multirow": {
+      "name": "Çok satırlı",
+      "settings": {
+        "image": {
+          "label": "Görsel"
+        },
+        "image_height": {
+          "options__1": {
+            "label": "Görsele uyarla"
+          },
+          "options__2": {
+            "label": "Küçük"
+          },
+          "options__3": {
+            "label": "Orta"
+          },
+          "options__4": {
+            "label": "Büyük"
+          },
+          "label": "Görsel yüksekliği"
+        },
+        "desktop_image_width": {
+          "options__1": {
+            "label": "Küçük"
+          },
+          "options__2": {
+            "label": "Orta"
+          },
+          "options__3": {
+            "label": "Büyük"
+          },
+          "label": "Masaüstü görsel genişliği",
+          "info": "Görsel, mobil cihazlar için otomatik olarak optimize edilir."
+        },
+        "heading_size": {
+          "options__1": {
+            "label": "Küçük"
+          },
+          "options__2": {
+            "label": "Orta"
+          },
+          "options__3": {
+            "label": "Büyük"
+          },
+          "label": "Başlık boyutu"
+        },
+        "text_style": {
+          "options__1": {
+            "label": "Gövde"
+          },
+          "options__2": {
+            "label": "Alt yazı"
+          },
+          "label": "Metin stili"
+        },
+        "button_style": {
+          "options__1": {
+            "label": "Sabit düğme"
+          },
+          "options__2": {
+            "label": "Dış çizgi düğmesi"
+          },
+          "label": "Düğme stili"
+        },
+        "desktop_content_alignment": {
+          "options__1": {
+            "label": "Sol"
+          },
+          "options__2": {
+            "label": "Orta"
+          },
+          "options__3": {
+            "label": "Sağ"
+          },
+          "label": "Masaüstü içerik hizalaması"
+        },
+        "desktop_content_position": {
+          "options__1": {
+            "label": "Üst"
+          },
+          "options__2": {
+            "label": "Orta"
+          },
+          "options__3": {
+            "label": "Alt"
+          },
+          "label": "Masaüstü içerik konumu",
+          "info": "Konum, mobil cihazlar için otomatik olarak optimize edilir."
+        },
+        "image_layout": {
+          "options__1": {
+            "label": "Alternatif (soldan)"
+          },
+          "options__2": {
+            "label": "Alternatif (sağdan)"
+          },
+          "options__3": {
+            "label": "Sola hizalanmış"
+          },
+          "options__4": {
+            "label": "Sağa hizalanmış"
+          },
+          "label": "Masaüstü görsel yerleşimi",
+          "info": "Görsel, mobil cihazlar için otomatik olarak optimize edilir."
+        },
+        "container_color_scheme": {
+          "label": "Kapsayıcı renk şeması"
+        },
+        "mobile_content_alignment": {
+          "options__1": {
+            "label": "Sol"
+          },
+          "options__2": {
+            "label": "Orta"
+          },
+          "options__3": {
+            "label": "Sağ"
+          },
+          "label": "Mobil içerik hizalaması"
+        },
+        "header_mobile": {
+          "content": "Mobil Düzen"
+        }
+      },
+      "blocks": {
+        "row": {
+          "name": "Satır",
+          "settings": {
+            "image": {
+              "label": "Görsel"
+            },
+            "caption": {
+              "label": "Alt yazı"
+            },
+            "heading": {
+              "label": "Başlık"
+            },
+            "text": {
+              "label": "Metin"
+            },
+            "button_label": {
+              "label": "Düğme etiketi"
+            },
+            "button_link": {
+              "label": "Düğme bağlantısı"
+            }
+          }
+        }
+      },
+      "presets": {
+        "name": "Çok satırlı"
       }
     }
   }

--- a/locales/vi.schema.json
+++ b/locales/vi.schema.json
@@ -154,7 +154,7 @@
           "content": "Lưới"
         },
         "paragraph__grid": {
-          "content": "Ảnh hưởng đến vùng có bố cục gồm nhiều cột."
+          "content": "Ảnh hưởng đến vùng có nhiều cột hoặc hàng."
         },
         "spacing_grid_horizontal": {
           "label": "Không gian ngang"
@@ -3040,6 +3040,159 @@
             "label": "2 cột"
           }
         }
+      }
+    },
+    "multirow": {
+      "name": "Multirow",
+      "settings": {
+        "image": {
+          "label": "Hình ảnh"
+        },
+        "image_height": {
+          "options__1": {
+            "label": "Điều chỉnh theo hình ảnh"
+          },
+          "options__2": {
+            "label": "Nhỏ"
+          },
+          "options__3": {
+            "label": "Trung bình"
+          },
+          "options__4": {
+            "label": "Lớn"
+          },
+          "label": "Chiều cao hình ảnh"
+        },
+        "desktop_image_width": {
+          "options__1": {
+            "label": "Nhỏ"
+          },
+          "options__2": {
+            "label": "Trung bình"
+          },
+          "options__3": {
+            "label": "Lớn"
+          },
+          "label": "Chiều rộng hình ảnh trên màn hình nền",
+          "info": "Hình ảnh được tự động tối ưu hóa cho thiết bị di động."
+        },
+        "heading_size": {
+          "options__1": {
+            "label": "Nhỏ"
+          },
+          "options__2": {
+            "label": "Trung bình"
+          },
+          "options__3": {
+            "label": "Lớn"
+          },
+          "label": "Cỡ tiêu đề"
+        },
+        "text_style": {
+          "options__1": {
+            "label": "Nội dung"
+          },
+          "options__2": {
+            "label": "Tiêu đề phụ"
+          },
+          "label": "Kiểu văn bản"
+        },
+        "button_style": {
+          "options__1": {
+            "label": "Nút đặc"
+          },
+          "options__2": {
+            "label": "Nút viền ngoài"
+          },
+          "label": "Kiểu nút"
+        },
+        "desktop_content_alignment": {
+          "options__1": {
+            "label": "Bên trái"
+          },
+          "options__2": {
+            "label": "Ở giữa"
+          },
+          "options__3": {
+            "label": "Bên phải"
+          },
+          "label": "Căn chỉnh nội dung trên màn hình nền"
+        },
+        "desktop_content_position": {
+          "options__1": {
+            "label": "Bên trên"
+          },
+          "options__2": {
+            "label": "Ở giữa"
+          },
+          "options__3": {
+            "label": "Bên dưới"
+          },
+          "label": "Vị trí nội dung trên màn hình nền",
+          "info": "Vị trí được tự động tối ưu hóa cho thiết bị di động."
+        },
+        "image_layout": {
+          "options__1": {
+            "label": "Thay thế từ bên trái"
+          },
+          "options__2": {
+            "label": "Thay thế từ bên phải"
+          },
+          "options__3": {
+            "label": "Đã căn trái"
+          },
+          "options__4": {
+            "label": "Đã căn phải"
+          },
+          "label": "Vị trí hình ảnh trên màn hình nền",
+          "info": "Vị trí được tự động tối ưu hóa cho thiết bị di động."
+        },
+        "container_color_scheme": {
+          "label": "Bảng màu cho khoảng chứa"
+        },
+        "mobile_content_alignment": {
+          "options__1": {
+            "label": "Bên trái"
+          },
+          "options__2": {
+            "label": "Ở giữa"
+          },
+          "options__3": {
+            "label": "Bên phải"
+          },
+          "label": "Căn chỉnh nội dung trên thiết bị di động"
+        },
+        "header_mobile": {
+          "content": "Bố cục trên thiết bị di động"
+        }
+      },
+      "blocks": {
+        "row": {
+          "name": "Hàng",
+          "settings": {
+            "image": {
+              "label": "Hình ảnh"
+            },
+            "caption": {
+              "label": "Phụ đề"
+            },
+            "heading": {
+              "label": "Tiêu đề"
+            },
+            "text": {
+              "label": "Văn bản"
+            },
+            "button_label": {
+              "label": "Nhãn nút"
+            },
+            "button_link": {
+              "label": "Liên kết trên nút"
+            }
+          }
+        }
+      },
+      "presets": {
+        "name": "Multirow"
       }
     }
   }

--- a/locales/zh-CN.schema.json
+++ b/locales/zh-CN.schema.json
@@ -154,7 +154,7 @@
           "content": "网格"
         },
         "paragraph__grid": {
-          "content": "影响采用多列布局的区域。"
+          "content": "影响具有多列或行的区域。"
         },
         "spacing_grid_horizontal": {
           "label": "水平间距"
@@ -3040,6 +3040,159 @@
             "label": "2 列"
           }
         }
+      }
+    },
+    "multirow": {
+      "name": "多行",
+      "settings": {
+        "image": {
+          "label": "图片"
+        },
+        "image_height": {
+          "options__1": {
+            "label": "适应图片"
+          },
+          "options__2": {
+            "label": "小"
+          },
+          "options__3": {
+            "label": "中"
+          },
+          "options__4": {
+            "label": "大"
+          },
+          "label": "图片高度"
+        },
+        "desktop_image_width": {
+          "options__1": {
+            "label": "小"
+          },
+          "options__2": {
+            "label": "中"
+          },
+          "options__3": {
+            "label": "大"
+          },
+          "label": "台式设备图片宽度",
+          "info": "图片会针对移动设备进行自动优化。"
+        },
+        "heading_size": {
+          "options__1": {
+            "label": "小"
+          },
+          "options__2": {
+            "label": "中"
+          },
+          "options__3": {
+            "label": "大"
+          },
+          "label": "标题大小"
+        },
+        "text_style": {
+          "options__1": {
+            "label": "正文"
+          },
+          "options__2": {
+            "label": "副标题"
+          },
+          "label": "文本样式"
+        },
+        "button_style": {
+          "options__1": {
+            "label": "实心按钮"
+          },
+          "options__2": {
+            "label": "轮廓按钮"
+          },
+          "label": "按钮样式"
+        },
+        "desktop_content_alignment": {
+          "options__1": {
+            "label": "左"
+          },
+          "options__2": {
+            "label": "居中"
+          },
+          "options__3": {
+            "label": "右"
+          },
+          "label": "台式设备内容对齐方式"
+        },
+        "desktop_content_position": {
+          "options__1": {
+            "label": "顶部"
+          },
+          "options__2": {
+            "label": "中间"
+          },
+          "options__3": {
+            "label": "底部"
+          },
+          "label": "台式设备内容位置",
+          "info": "位置会针对移动设备进行自动优化。"
+        },
+        "image_layout": {
+          "options__1": {
+            "label": "从左侧交替"
+          },
+          "options__2": {
+            "label": "从右侧交替"
+          },
+          "options__3": {
+            "label": "左对齐"
+          },
+          "options__4": {
+            "label": "右对齐"
+          },
+          "label": "台式设备图片放置",
+          "info": "放置位置会针对移动设备进行自动优化。"
+        },
+        "container_color_scheme": {
+          "label": "容器配色方案"
+        },
+        "mobile_content_alignment": {
+          "options__1": {
+            "label": "左"
+          },
+          "options__2": {
+            "label": "居中"
+          },
+          "options__3": {
+            "label": "右"
+          },
+          "label": "移动设备内容对齐方式"
+        },
+        "header_mobile": {
+          "content": "移动设备布局"
+        }
+      },
+      "blocks": {
+        "row": {
+          "name": "行",
+          "settings": {
+            "image": {
+              "label": "图片"
+            },
+            "caption": {
+              "label": "字幕"
+            },
+            "heading": {
+              "label": "标题"
+            },
+            "text": {
+              "label": "文本"
+            },
+            "button_label": {
+              "label": "按钮标签"
+            },
+            "button_link": {
+              "label": "按钮链接"
+            }
+          }
+        }
+      },
+      "presets": {
+        "name": "多行"
       }
     }
   }

--- a/locales/zh-TW.schema.json
+++ b/locales/zh-TW.schema.json
@@ -154,7 +154,7 @@
           "content": "網格"
         },
         "paragraph__grid": {
-          "content": "影響具有多欄版面配置的區域。"
+          "content": "影響具有多欄或多列的區域。"
         },
         "spacing_grid_horizontal": {
           "label": "水平空間"
@@ -3040,6 +3040,159 @@
             "label": "2 欄"
           }
         }
+      }
+    },
+    "multirow": {
+      "name": "多列",
+      "settings": {
+        "image": {
+          "label": "圖片"
+        },
+        "image_height": {
+          "options__1": {
+            "label": "配合圖片"
+          },
+          "options__2": {
+            "label": "小"
+          },
+          "options__3": {
+            "label": "中"
+          },
+          "options__4": {
+            "label": "大"
+          },
+          "label": "圖片高度"
+        },
+        "desktop_image_width": {
+          "options__1": {
+            "label": "小"
+          },
+          "options__2": {
+            "label": "中"
+          },
+          "options__3": {
+            "label": "大"
+          },
+          "label": "桌面版圖片寬度",
+          "info": "行動版的圖片會自動調整大小。"
+        },
+        "heading_size": {
+          "options__1": {
+            "label": "小"
+          },
+          "options__2": {
+            "label": "中"
+          },
+          "options__3": {
+            "label": "大"
+          },
+          "label": "標題大小"
+        },
+        "text_style": {
+          "options__1": {
+            "label": "內文"
+          },
+          "options__2": {
+            "label": "副標題"
+          },
+          "label": "文字樣式"
+        },
+        "button_style": {
+          "options__1": {
+            "label": "純色按鈕"
+          },
+          "options__2": {
+            "label": "外框按鈕"
+          },
+          "label": "按鈕樣式"
+        },
+        "desktop_content_alignment": {
+          "options__1": {
+            "label": "靠左"
+          },
+          "options__2": {
+            "label": "置中"
+          },
+          "options__3": {
+            "label": "靠右"
+          },
+          "label": "桌面版內容對齊方式"
+        },
+        "desktop_content_position": {
+          "options__1": {
+            "label": "靠上"
+          },
+          "options__2": {
+            "label": "置中"
+          },
+          "options__3": {
+            "label": "靠下"
+          },
+          "label": "桌面版內容位置",
+          "info": "行動版會自動調整為最佳位置。"
+        },
+        "image_layout": {
+          "options__1": {
+            "label": "從左側開始交叉顯示"
+          },
+          "options__2": {
+            "label": "從右側開始交叉顯示"
+          },
+          "options__3": {
+            "label": "靠左對齊"
+          },
+          "options__4": {
+            "label": "靠右對齊"
+          },
+          "label": "桌面版圖片位置",
+          "info": "行動版的圖片會自動調整位置。"
+        },
+        "container_color_scheme": {
+          "label": "容器顏色配置"
+        },
+        "mobile_content_alignment": {
+          "options__1": {
+            "label": "靠左"
+          },
+          "options__2": {
+            "label": "置中"
+          },
+          "options__3": {
+            "label": "靠右"
+          },
+          "label": "行動版內容對齊方式"
+        },
+        "header_mobile": {
+          "content": "行動版版面配置"
+        }
+      },
+      "blocks": {
+        "row": {
+          "name": "列",
+          "settings": {
+            "image": {
+              "label": "圖片"
+            },
+            "caption": {
+              "label": "說明"
+            },
+            "heading": {
+              "label": "標題"
+            },
+            "text": {
+              "label": "文字"
+            },
+            "button_label": {
+              "label": "按鈕標籤"
+            },
+            "button_link": {
+              "label": "按鈕連結"
+            }
+          }
+        }
+      },
+      "presets": {
+        "name": "多列"
       }
     }
   }

--- a/sections/multirow.liquid
+++ b/sections/multirow.liquid
@@ -27,18 +27,21 @@
     assign transparent_content = true
   endif
 
+  if transparent_content and settings.text_boxes_shadow_opacity == 0 and settings.text_boxes_border_thickness == 0 or settings.text_boxes_border_opacity == 0
+    assign padding_class = ' collapse-padding'
+  endif
   if settings.text_boxes_border_thickness > 0 and settings.text_boxes_border_opacity > 0 and settings.media_border_thickness > 0 and settings.media_border_opacity > 0
-    assign borders_class = 'collapse-borders'
+    assign borders_class = ' collapse-borders'
   endif
   unless transparent_content and settings.media_border_thickness > 0 and settings.text_boxes_shadow_opacity == 0 and settings.text_boxes_border_thickness == 0 or settings.text_boxes_border_opacity == 0
-    assign corners_class = 'collapse-corners'
+    assign corners_class = ' collapse-corners'
   endunless
 -%}
 
 <div class="multirow section-{{ section.id }}-padding gradient color-{{ section.settings.section_color_scheme }}">
   <div class="page-width">
     {%- for block in section.blocks -%}
-      <div class="image-with-text isolate {{ borders_class }} {{ corners_class }}">
+      <div class="image-with-text isolate{{ borders_class }}{{ corners_class }}{{ padding_class }}">
         <div class="image-with-text__grid grid grid--gapless grid--1-col grid--{% if section.settings.desktop_image_width == 'medium' %}2-col-tablet{% else %}3-col-tablet{% endif %}{% if section.settings.image_layout contains 'alternate' %} {% cycle odd_class, even_class %}{% else %} {{ odd_class }}{% endif %}">
           <div class="image-with-text__media-item image-with-text__media-item--{{ section.settings.desktop_image_width }} image-with-text__media-item--{{ section.settings.desktop_content_position }} grid__item">
             <div

--- a/sections/multirow.liquid
+++ b/sections/multirow.liquid
@@ -15,37 +15,41 @@
 {%- endstyle -%}
 
 {%- liquid
-  assign odd_class = 'image-with-text__grid--standard'
-  assign even_class = 'image-with-text__grid--reverse'
   if section.settings.image_layout contains 'right'
-    assign odd_class = 'image-with-text__grid--reverse'
-    assign even_class = 'image-with-text__grid--standard'
+    assign odd_class = ' image-with-text__grid--reverse'
+  else
+    assign even_class = ' image-with-text__grid--reverse'
   endif
 
-  assign transparent_content = false
   if section.settings.row_color_scheme == section.settings.section_color_scheme
-    assign transparent_content = true
+    assign no_content_background = true
   endif
 
-  if transparent_content and settings.text_boxes_shadow_opacity == 0 and settings.text_boxes_border_thickness == 0 or settings.text_boxes_border_opacity == 0
+  if settings.text_boxes_shadow_opacity == 0 and settings.text_boxes_border_thickness == 0 or settings.text_boxes_border_opacity == 0
+    assign no_content_styles = true
+  endif
+
+  if no_content_background and no_content_styles and section.settings.desktop_content_alignment != 'center'
     assign padding_class = ' collapse-padding'
   endif
+
   if settings.text_boxes_border_thickness > 0 and settings.text_boxes_border_opacity > 0 and settings.media_border_thickness > 0 and settings.media_border_opacity > 0
     assign borders_class = ' collapse-borders'
   endif
-  unless transparent_content and settings.media_border_thickness > 0 and settings.text_boxes_shadow_opacity == 0 and settings.text_boxes_border_thickness == 0 or settings.text_boxes_border_opacity == 0
+
+  unless no_content_background and no_content_styles
     assign corners_class = ' collapse-corners'
   endunless
 -%}
 
 <div class="multirow section-{{ section.id }}-padding gradient color-{{ section.settings.section_color_scheme }}">
-  <div class="page-width">
+  <div class="multirow__inner page-width">
     {%- for block in section.blocks -%}
       <div class="image-with-text isolate{{ borders_class }}{{ corners_class }}{{ padding_class }}">
-        <div class="image-with-text__grid grid grid--gapless grid--1-col grid--{% if section.settings.desktop_image_width == 'medium' %}2-col-tablet{% else %}3-col-tablet{% endif %}{% if section.settings.image_layout contains 'alternate' %} {% cycle odd_class, even_class %}{% else %} {{ odd_class }}{% endif %}">
+        <div class="image-with-text__grid grid grid--gapless grid--1-col grid--{% if section.settings.desktop_image_width == 'medium' %}2-col-tablet{% else %}3-col-tablet{% endif %}{% if section.settings.image_layout contains 'alternate' %}{% cycle odd_class, even_class %}{% else %}{{ odd_class }}{% endif %}">
           <div class="image-with-text__media-item image-with-text__media-item--{{ section.settings.desktop_image_width }} image-with-text__media-item--{{ section.settings.desktop_content_position }} grid__item">
             <div
-              class="image-with-text__media image-with-text__media--{{ section.settings.image_height }} gradient color-{{ section.settings.row_color_scheme }} global-media-settings {% if block.settings.image != blank %}media{% else %}image-with-text__media--placeholder placeholder{% endif %}"
+              class="image-with-text__media image-with-text__media--{{ section.settings.image_height }} gradient color-{{ section.settings.row_color_scheme }} global-media-settings{% if block.settings.image != blank %} media{% else %} image-with-text__media--placeholder placeholder{% endif %}"
               {% if section.settings.image_height == 'adapt' and block.settings.image != blank %}
                 style="padding-bottom: {{ 1 | divided_by: block.settings.image.aspect_ratio | times: 100 }}%;"
               {% endif %}
@@ -66,18 +70,15 @@
             </div>
           </div>
           <div class="image-with-text__text-item grid__item">
-            <div
-              id="ImageWithText--{{ section.id }}"
-              class="image-with-text__content image-with-text__content--{{ section.settings.desktop_content_position }} image-with-text__content--desktop-{{ section.settings.desktop_content_alignment }} image-with-text__content--mobile-{{ section.settings.mobile_content_alignment }} image-with-text__content--{{ section.settings.image_height }} content-container{% unless transparent_content %} gradient color-{{ section.settings.row_color_scheme }}{% endunless %}"
-            >
+            <div class="image-with-text__content image-with-text__content--{{ section.settings.desktop_content_position }} image-with-text__content--desktop-{{ section.settings.desktop_content_alignment }} image-with-text__content--mobile-{{ section.settings.mobile_content_alignment }} image-with-text__content--{{ section.settings.image_height }} content-container{% unless no_content_background and no_content_styles %} gradient color-{{ section.settings.row_color_scheme }}{% endunless %}">
               {%- if block.settings.caption -%}
                 <p class="image-with-text__text image-with-text__text--caption caption-with-letter-spacing caption-with-letter-spacing--medium">
                   {{ block.settings.caption | escape }}
                 </p>
               {%- endif -%}
               {%- if block.settings.heading -%}
-                <h2 class="image-with-text__heading {{ section.settings.heading_size }}">
-                  {{ block.settings.heading | escape }}
+                <h2 class="image-with-text__heading {{ section.settings.heading_size }} rte">
+                  {{ block.settings.heading }}
                 </h2>
               {%- endif -%}
               {%- if block.settings.text -%}
@@ -393,7 +394,7 @@
           "label": "t:sections.multirow.blocks.row.settings.caption.label"
         },
         {
-          "type": "text",
+          "type": "inline_richtext",
           "id": "heading",
           "default": "Row",
           "label": "t:sections.multirow.blocks.row.settings.heading.label"

--- a/sections/multirow.liquid
+++ b/sections/multirow.liquid
@@ -1,3 +1,4 @@
+{{ 'component-rte.css' | asset_url | stylesheet_tag }}
 {{ 'component-image-with-text.css' | asset_url | stylesheet_tag }}
 
 {%- style -%}
@@ -29,12 +30,12 @@
     assign no_content_styles = true
   endif
 
-  if no_content_background and no_content_styles and section.settings.desktop_content_alignment != 'center'
-    assign padding_class = ' collapse-padding'
-  endif
-
   if settings.text_boxes_border_thickness > 0 and settings.text_boxes_border_opacity > 0 and settings.media_border_thickness > 0 and settings.media_border_opacity > 0
     assign borders_class = ' collapse-borders'
+  endif
+
+  if no_content_background and no_content_styles
+    assign padding_class = ' collapse-padding'
   endif
 
   unless no_content_background and no_content_styles

--- a/sections/multirow.liquid
+++ b/sections/multirow.liquid
@@ -1,0 +1,405 @@
+{{ 'component-image-with-text.css' | asset_url | stylesheet_tag }}
+
+{%- style -%}
+  .section-{{ section.id }}-padding {
+    padding-top: {{ section.settings.padding_top | times: 0.75 | round: 0 }}px;
+    padding-bottom: {{ section.settings.padding_bottom | times: 0.75 | round: 0 }}px;
+  }
+
+  @media screen and (min-width: 750px) {
+    .section-{{ section.id }}-padding {
+      padding-top: {{ section.settings.padding_top }}px;
+      padding-bottom: {{ section.settings.padding_bottom }}px;
+    }
+  }
+{%- endstyle -%}
+
+{%- liquid
+  assign odd_class = 'image-with-text__grid--standard'
+  assign even_class = 'image-with-text__grid--reverse'
+  if section.settings.image_layout contains 'right'
+    assign odd_class = 'image-with-text__grid--reverse'
+    assign even_class = 'image-with-text__grid--standard'
+  endif
+-%}
+
+<div class="multirow section-{{ section.id }}-padding gradient color-{{ section.settings.section_color_scheme }}">
+  <div class="page-width">
+    {%- for block in section.blocks -%}
+      <div class="image-with-text image-with-text--{{ section.settings.content_layout }} isolate{% if settings.text_boxes_border_thickness > 0 and settings.text_boxes_border_opacity > 0 and settings.media_border_thickness > 0 and settings.media_border_opacity > 0 %} collapse-borders{% endif %}{% unless section.settings.color_scheme == 'background-1' and settings.media_border_thickness > 0 and settings.text_boxes_shadow_opacity == 0 and settings.text_boxes_border_thickness == 0 or settings.text_boxes_border_opacity == 0 %} collapse-corners{% endunless %}">
+        <div class="image-with-text__grid grid grid--gapless grid--1-col grid--{% if section.settings.desktop_image_width == 'medium' %}2-col-tablet{% else %}3-col-tablet{% endif %}{% if section.settings.image_layout contains 'alternate' %} {% cycle odd_class, even_class %}{% else %} {{ odd_class }}{% endif %}">
+          <div class="image-with-text__media-item image-with-text__media-item--{{ section.settings.desktop_image_width }} image-with-text__media-item--{{ section.settings.desktop_content_position }} grid__item">
+            <div class="image-with-text__media image-with-text__media--{{ section.settings.image_height }} gradient color-{{ section.settings.row_color_scheme }} global-media-settings {% if block.settings.image != blank %}media{% else %}image-with-text__media--placeholder placeholder{% endif %}"
+              {% if section.settings.image_height == 'adapt' and block.settings.image != blank %} style="padding-bottom: {{ 1 | divided_by: block.settings.image.aspect_ratio | times: 100 }}%;"{% endif %}
+            >
+              {%- if block.settings.image != blank -%}
+                {%- capture sizes -%}(min-width: {{ settings.page_width }}px) {{ settings.page_width | minus: 100 | divided_by: 2 }}px, (min-width: 750px) calc((100vw - 130px) / 2), calc((100vw - 50px) / 2){%- endcapture -%}
+                {{ block.settings.image | image_url: width: 1500 | image_tag:
+                  loading: 'lazy',
+                  sizes: sizes,
+                  widths: '165, 360, 535, 750, 1070, 1500'
+                }}
+              {%- else -%}
+                {{ 'image' | placeholder_svg_tag: 'placeholder-svg' }}
+              {%- endif -%}
+            </div>
+          </div>
+          <div class="image-with-text__text-item grid__item">
+            <div id="ImageWithText--{{ section.id }}" class="image-with-text__content image-with-text__content--{{ section.settings.desktop_content_position }} image-with-text__content--desktop-{{ section.settings.desktop_content_alignment }} image-with-text__content--mobile-{{ section.settings.mobile_content_alignment }} image-with-text__content--{{ section.settings.image_height }} gradient color-{{ section.settings.row_color_scheme }} content-container">
+              {%- if block.settings.caption -%}
+                <p class="image-with-text__text image-with-text__text--caption caption-with-letter-spacing caption-with-letter-spacing--medium">{{ block.settings.caption | escape }}</p>
+              {%- endif -%}
+              {%- if block.settings.heading -%}
+                <h2 class="image-with-text__heading {{ section.settings.heading_size }}">
+                  {{ block.settings.heading | escape }}
+                </h2>
+              {%- endif -%}
+              {%- if block.settings.text -%}
+                <div class="image-with-text__text rte {{ section.settings.text_style }}">{{ block.settings.text }}</div>
+              {%- endif -%}
+              {%- if block.settings.button_label != blank -%}
+                <a{% if block.settings.button_link == blank %} role="link" aria-disabled="true"{% else %} href="{{ block.settings.button_link }}"{% endif %} class="button button--{{ section.settings.button_style }}">
+                  {{ block.settings.button_label | escape }}
+                </a>
+              {%- endif -%}
+            </div>
+          </div>
+        </div>
+      </div>
+    {%- endfor -%}
+  </div>
+</div>
+
+{% schema %}
+{
+  "name": "t:sections.multirow.name",
+  "class": "section",
+  "settings": [
+    {
+      "type": "select",
+      "id": "image_height",
+      "options": [
+        {
+          "value": "adapt",
+          "label": "t:sections.multirow.settings.image_height.options__1.label"
+        },
+        {
+          "value": "small",
+          "label": "t:sections.multirow.settings.image_height.options__2.label"
+        },
+        {
+          "value": "medium",
+          "label": "t:sections.multirow.settings.image_height.options__3.label"
+        },
+        {
+          "value": "large",
+          "label": "t:sections.multirow.settings.image_height.options__4.label"
+        }
+      ],
+      "default": "small",
+      "label": "t:sections.multirow.settings.image_height.label"
+    },
+    {
+      "type": "select",
+      "id": "desktop_image_width",
+      "options": [
+        {
+          "value": "small",
+          "label": "t:sections.multirow.settings.desktop_image_width.options__1.label"
+        },
+        {
+          "value": "medium",
+          "label": "t:sections.multirow.settings.desktop_image_width.options__2.label"
+        },
+        {
+          "value": "large",
+          "label": "t:sections.multirow.settings.desktop_image_width.options__3.label"
+        }
+      ],
+      "default": "medium",
+      "label": "t:sections.multirow.settings.desktop_image_width.label",
+      "info": "t:sections.multirow.settings.desktop_image_width.info"
+    },
+    {
+      "type": "select",
+      "id": "heading_size",
+      "options": [
+        {
+          "value": "h2",
+          "label": "Small"
+        },
+        {
+          "value": "h1",
+          "label": "Medium"
+        },
+        {
+          "value": "h0",
+          "label": "Large"
+        }
+      ],
+      "default": "h1",
+      "label": "Heading size"
+    },
+    {
+      "type": "select",
+      "id": "text_style",
+      "options": [
+        {
+          "value": "body",
+          "label": "Body"
+        },
+        {
+          "value": "subtitle",
+          "label": "Subtitle"
+        }
+      ],
+      "default": "body",
+      "label": "Text style"
+    },
+    {
+      "type": "select",
+      "id": "button_style",
+      "options": [
+        {
+          "value": "primary",
+          "label": "Primary"
+        },
+        {
+          "value": "secondary",
+          "label": "Outline"
+        }
+      ],
+      "default": "secondary",
+      "label": "Button style"
+    },
+    {
+      "type": "select",
+      "id": "desktop_content_position",
+      "options": [
+        {
+          "value": "top",
+          "label": "t:sections.multirow.settings.desktop_content_position.options__1.label"
+        },
+        {
+          "value": "middle",
+          "label": "t:sections.multirow.settings.desktop_content_position.options__2.label"
+        },
+        {
+          "value": "bottom",
+          "label": "t:sections.multirow.settings.desktop_content_position.options__3.label"
+        }
+      ],
+      "default": "top",
+      "label": "t:sections.multirow.settings.desktop_content_position.label",
+      "info": "t:sections.multirow.settings.desktop_image_width.info"
+    },
+    {
+      "type": "select",
+      "id": "desktop_content_alignment",
+      "options": [
+        {
+          "value": "left",
+          "label": "t:sections.multirow.settings.desktop_content_alignment.options__1.label"
+        },
+        {
+          "value": "center",
+          "label": "t:sections.multirow.settings.desktop_content_alignment.options__2.label"
+        },
+        {
+          "value": "right",
+          "label": "t:sections.multirow.settings.desktop_content_alignment.options__3.label"
+        }
+      ],
+      "default": "left",
+      "label": "t:sections.multirow.settings.desktop_content_alignment.label"
+    },
+    {
+      "type": "select",
+      "id": "image_layout",
+      "options": [
+        {
+          "value": "alternate-left",
+          "label": "t:sections.multirow.settings.image_layout.options__1.label"
+        },
+        {
+          "value": "alternate-right",
+          "label": "t:sections.multirow.settings.image_layout.options__2.label"
+        },
+        {
+          "value": "align-left",
+          "label": "t:sections.multirow.settings.image_layout.options__3.label"
+        },
+        {
+          "value": "align-right",
+          "label": "t:sections.multirow.settings.image_layout.options__4.label"
+        }
+      ],
+      "default": "alternate-left",
+      "label": "t:sections.multirow.settings.image_layout.label",
+      "info": "t:sections.multirow.settings.image_layout.info"
+    },
+    {
+      "type": "select",
+      "id": "row_color_scheme",
+      "options": [
+        {
+          "value": "accent-1",
+          "label": "t:sections.all.colors.accent_1.label"
+        },
+        {
+          "value": "accent-2",
+          "label": "t:sections.all.colors.accent_2.label"
+        },
+        {
+          "value": "background-1",
+          "label": "t:sections.all.colors.background_1.label"
+        },
+        {
+          "value": "background-2",
+          "label": "t:sections.all.colors.background_2.label"
+        },
+        {
+          "value": "inverse",
+          "label": "t:sections.all.colors.inverse.label"
+        }
+      ],
+      "default": "background-1",
+      "label": "t:sections.multirow.settings.container_color_scheme.label"
+    },
+    {
+      "type": "select",
+      "id": "section_color_scheme",
+      "options": [
+        {
+          "value": "accent-1",
+          "label": "t:sections.all.colors.accent_1.label"
+        },
+        {
+          "value": "accent-2",
+          "label": "t:sections.all.colors.accent_2.label"
+        },
+        {
+          "value": "background-1",
+          "label": "t:sections.all.colors.background_1.label"
+        },
+        {
+          "value": "background-2",
+          "label": "t:sections.all.colors.background_2.label"
+        },
+        {
+          "value": "inverse",
+          "label": "t:sections.all.colors.inverse.label"
+        }
+      ],
+      "default": "background-1",
+      "label": "t:sections.all.colors.label"
+    },
+
+    {
+      "type": "header",
+      "content": "Mobile layout"
+    },
+    {
+      "type": "select",
+      "id": "mobile_content_alignment",
+      "options": [
+        {
+          "value": "left",
+          "label": "t:sections.multirow.settings.mobile_content_alignment.options__1.label"
+        },
+        {
+          "value": "center",
+          "label": "t:sections.multirow.settings.mobile_content_alignment.options__2.label"
+        },
+        {
+          "value": "right",
+          "label": "t:sections.multirow.settings.mobile_content_alignment.options__3.label"
+        }
+      ],
+      "default": "left",
+      "label": "t:sections.multirow.settings.mobile_content_alignment.label"
+    },
+    {
+      "type": "header",
+      "content": "t:sections.all.padding.section_padding_heading"
+    },
+    {
+      "type": "range",
+      "id": "padding_top",
+      "min": 0,
+      "max": 100,
+      "step": 4,
+      "unit": "px",
+      "label": "t:sections.all.padding.padding_top",
+      "default": 36
+    },
+    {
+      "type": "range",
+      "id": "padding_bottom",
+      "min": 0,
+      "max": 100,
+      "step": 4,
+      "unit": "px",
+      "label": "t:sections.all.padding.padding_bottom",
+      "default": 36
+    }
+  ],
+  "blocks": [
+    {
+      "type": "row",
+      "name": "t:sections.multirow.blocks.row.name",
+      "settings": [
+        {
+          "type": "image_picker",
+          "id": "image",
+          "label": "t:sections.multirow.blocks.row.settings.image.label"
+        },
+        {
+          "type": "text",
+          "id": "caption",
+          "default": "Caption",
+          "label": "t:sections.multirow.blocks.row.settings.caption.label"
+        },
+        {
+          "type": "text",
+          "id": "heading",
+          "default": "Row",
+          "label": "t:sections.multirow.blocks.row.settings.heading.label"
+        },
+        {
+          "type": "richtext",
+          "id": "text",
+          "default": "<p>Pair text with an image to focus on your chosen product, collection, or blog post. Add details on availability, style, or even provide a review.</p>",
+          "label": "t:sections.multirow.blocks.row.settings.text.label"
+        },
+        {
+          "type": "text",
+          "id": "button_label",
+          "label": "t:sections.multirow.blocks.row.settings.button_label.label"
+        },
+        {
+          "type": "url",
+          "id": "button_link",
+          "label": "t:sections.multirow.blocks.row.settings.button_link.label"
+        }
+      ]
+    }
+  ],
+  "presets": [
+    {
+      "name": "t:sections.multirow.presets.name",
+      "blocks": [
+        {
+          "type": "row"
+        },
+        {
+          "type": "row"
+        },
+        {
+          "type": "row"
+        }
+      ]
+    }
+  ]
+}
+{% endschema %}

--- a/sections/multirow.liquid
+++ b/sections/multirow.liquid
@@ -130,7 +130,7 @@
           "label": "t:sections.multirow.settings.image_height.options__4.label"
         }
       ],
-      "default": "small",
+      "default": "medium",
       "label": "t:sections.multirow.settings.image_height.label"
     },
     {
@@ -223,9 +223,9 @@
           "label": "t:sections.multirow.settings.desktop_content_position.options__3.label"
         }
       ],
-      "default": "top",
+      "default": "middle",
       "label": "t:sections.multirow.settings.desktop_content_position.label",
-      "info": "t:sections.multirow.settings.desktop_image_width.info"
+      "info": "t:sections.multirow.settings.desktop_content_position.info"
     },
     {
       "type": "select",
@@ -274,34 +274,6 @@
     },
     {
       "type": "select",
-      "id": "row_color_scheme",
-      "options": [
-        {
-          "value": "accent-1",
-          "label": "t:sections.all.colors.accent_1.label"
-        },
-        {
-          "value": "accent-2",
-          "label": "t:sections.all.colors.accent_2.label"
-        },
-        {
-          "value": "background-1",
-          "label": "t:sections.all.colors.background_1.label"
-        },
-        {
-          "value": "background-2",
-          "label": "t:sections.all.colors.background_2.label"
-        },
-        {
-          "value": "inverse",
-          "label": "t:sections.all.colors.inverse.label"
-        }
-      ],
-      "default": "background-1",
-      "label": "t:sections.multirow.settings.container_color_scheme.label"
-    },
-    {
-      "type": "select",
       "id": "section_color_scheme",
       "options": [
         {
@@ -327,6 +299,34 @@
       ],
       "default": "background-1",
       "label": "t:sections.all.colors.label"
+    },
+    {
+      "type": "select",
+      "id": "row_color_scheme",
+      "options": [
+        {
+          "value": "accent-1",
+          "label": "t:sections.all.colors.accent_1.label"
+        },
+        {
+          "value": "accent-2",
+          "label": "t:sections.all.colors.accent_2.label"
+        },
+        {
+          "value": "background-1",
+          "label": "t:sections.all.colors.background_1.label"
+        },
+        {
+          "value": "background-2",
+          "label": "t:sections.all.colors.background_2.label"
+        },
+        {
+          "value": "inverse",
+          "label": "t:sections.all.colors.inverse.label"
+        }
+      ],
+      "default": "background-1",
+      "label": "t:sections.multirow.settings.container_color_scheme.label"
     },
     {
       "type": "header",
@@ -408,6 +408,7 @@
         {
           "type": "text",
           "id": "button_label",
+          "default": "Button label",
           "label": "t:sections.multirow.blocks.row.settings.button_label.label"
         },
         {

--- a/sections/multirow.liquid
+++ b/sections/multirow.liquid
@@ -21,23 +21,41 @@
     assign odd_class = 'image-with-text__grid--reverse'
     assign even_class = 'image-with-text__grid--standard'
   endif
+
+  assign transparent_content = false
+  if section.settings.row_color_scheme == section.settings.section_color_scheme
+    assign transparent_content = true
+  endif
+
+  if settings.text_boxes_border_thickness > 0 and settings.text_boxes_border_opacity > 0 and settings.media_border_thickness > 0 and settings.media_border_opacity > 0
+    assign borders_class = 'collapse-borders'
+  endif
+  unless transparent_content and settings.media_border_thickness > 0 and settings.text_boxes_shadow_opacity == 0 and settings.text_boxes_border_thickness == 0 or settings.text_boxes_border_opacity == 0
+    assign corners_class = 'collapse-corners'
+  endunless
 -%}
 
 <div class="multirow section-{{ section.id }}-padding gradient color-{{ section.settings.section_color_scheme }}">
   <div class="page-width">
     {%- for block in section.blocks -%}
-      <div class="image-with-text image-with-text--{{ section.settings.content_layout }} isolate{% if settings.text_boxes_border_thickness > 0 and settings.text_boxes_border_opacity > 0 and settings.media_border_thickness > 0 and settings.media_border_opacity > 0 %} collapse-borders{% endif %}{% unless section.settings.color_scheme == 'background-1' and settings.media_border_thickness > 0 and settings.text_boxes_shadow_opacity == 0 and settings.text_boxes_border_thickness == 0 or settings.text_boxes_border_opacity == 0 %} collapse-corners{% endunless %}">
+      <div class="image-with-text isolate {{ borders_class }} {{ corners_class }}">
         <div class="image-with-text__grid grid grid--gapless grid--1-col grid--{% if section.settings.desktop_image_width == 'medium' %}2-col-tablet{% else %}3-col-tablet{% endif %}{% if section.settings.image_layout contains 'alternate' %} {% cycle odd_class, even_class %}{% else %} {{ odd_class }}{% endif %}">
           <div class="image-with-text__media-item image-with-text__media-item--{{ section.settings.desktop_image_width }} image-with-text__media-item--{{ section.settings.desktop_content_position }} grid__item">
-            <div class="image-with-text__media image-with-text__media--{{ section.settings.image_height }} gradient color-{{ section.settings.row_color_scheme }} global-media-settings {% if block.settings.image != blank %}media{% else %}image-with-text__media--placeholder placeholder{% endif %}"
-              {% if section.settings.image_height == 'adapt' and block.settings.image != blank %} style="padding-bottom: {{ 1 | divided_by: block.settings.image.aspect_ratio | times: 100 }}%;"{% endif %}
+            <div
+              class="image-with-text__media image-with-text__media--{{ section.settings.image_height }} gradient color-{{ section.settings.row_color_scheme }} global-media-settings {% if block.settings.image != blank %}media{% else %}image-with-text__media--placeholder placeholder{% endif %}"
+              {% if section.settings.image_height == 'adapt' and block.settings.image != blank %}
+                style="padding-bottom: {{ 1 | divided_by: block.settings.image.aspect_ratio | times: 100 }}%;"
+              {% endif %}
             >
               {%- if block.settings.image != blank -%}
-                {%- capture sizes -%}(min-width: {{ settings.page_width }}px) {{ settings.page_width | minus: 100 | divided_by: 2 }}px, (min-width: 750px) calc((100vw - 130px) / 2), calc((100vw - 50px) / 2){%- endcapture -%}
-                {{ block.settings.image | image_url: width: 1500 | image_tag:
-                  loading: 'lazy',
-                  sizes: sizes,
-                  widths: '165, 360, 535, 750, 1070, 1500'
+                {%- capture sizes -%}
+                  (min-width: {{ settings.page_width }}px) {{ settings.page_width | minus: 100 | divided_by: 2 }}px,
+                  (min-width: 750px) calc((100vw - 130px) / 2), calc((100vw - 50px) / 2)
+                {%- endcapture -%}
+                {{
+                  block.settings.image
+                  | image_url: width: 1500
+                  | image_tag: loading: 'lazy', sizes: sizes, widths: '165, 360, 535, 750, 1070, 1500'
                 }}
               {%- else -%}
                 {{ 'image' | placeholder_svg_tag: 'placeholder-svg' }}
@@ -45,9 +63,14 @@
             </div>
           </div>
           <div class="image-with-text__text-item grid__item">
-            <div id="ImageWithText--{{ section.id }}" class="image-with-text__content image-with-text__content--{{ section.settings.desktop_content_position }} image-with-text__content--desktop-{{ section.settings.desktop_content_alignment }} image-with-text__content--mobile-{{ section.settings.mobile_content_alignment }} image-with-text__content--{{ section.settings.image_height }} gradient color-{{ section.settings.row_color_scheme }} content-container">
+            <div
+              id="ImageWithText--{{ section.id }}"
+              class="image-with-text__content image-with-text__content--{{ section.settings.desktop_content_position }} image-with-text__content--desktop-{{ section.settings.desktop_content_alignment }} image-with-text__content--mobile-{{ section.settings.mobile_content_alignment }} image-with-text__content--{{ section.settings.image_height }} content-container{% unless transparent_content %} gradient color-{{ section.settings.row_color_scheme }}{% endunless %}"
+            >
               {%- if block.settings.caption -%}
-                <p class="image-with-text__text image-with-text__text--caption caption-with-letter-spacing caption-with-letter-spacing--medium">{{ block.settings.caption | escape }}</p>
+                <p class="image-with-text__text image-with-text__text--caption caption-with-letter-spacing caption-with-letter-spacing--medium">
+                  {{ block.settings.caption | escape }}
+                </p>
               {%- endif -%}
               {%- if block.settings.heading -%}
                 <h2 class="image-with-text__heading {{ section.settings.heading_size }}">
@@ -58,7 +81,14 @@
                 <div class="image-with-text__text rte {{ section.settings.text_style }}">{{ block.settings.text }}</div>
               {%- endif -%}
               {%- if block.settings.button_label != blank -%}
-                <a{% if block.settings.button_link == blank %} role="link" aria-disabled="true"{% else %} href="{{ block.settings.button_link }}"{% endif %} class="button button--{{ section.settings.button_style }}">
+                <a
+                  {% if block.settings.button_link == blank %}
+                    role="link" aria-disabled="true"
+                  {% else %}
+                    href="{{ block.settings.button_link }}"
+                  {% endif %}
+                  class="button button--{{ section.settings.button_style }}"
+                >
                   {{ block.settings.button_label | escape }}
                 </a>
               {%- endif -%}
@@ -126,19 +156,19 @@
       "options": [
         {
           "value": "h2",
-          "label": "Small"
+          "label": "t:sections.multirow.settings.heading_size.options__1.label"
         },
         {
           "value": "h1",
-          "label": "Medium"
+          "label": "t:sections.multirow.settings.heading_size.options__2.label"
         },
         {
           "value": "h0",
-          "label": "Large"
+          "label": "t:sections.multirow.settings.heading_size.options__3.label"
         }
       ],
       "default": "h1",
-      "label": "Heading size"
+      "label": "t:sections.multirow.settings.heading_size.label"
     },
     {
       "type": "select",
@@ -146,15 +176,15 @@
       "options": [
         {
           "value": "body",
-          "label": "Body"
+          "label": "t:sections.multirow.settings.text_style.options__1.label"
         },
         {
           "value": "subtitle",
-          "label": "Subtitle"
+          "label": "t:sections.multirow.settings.text_style.options__2.label"
         }
       ],
       "default": "body",
-      "label": "Text style"
+      "label": "t:sections.multirow.settings.text_style.label"
     },
     {
       "type": "select",
@@ -162,15 +192,15 @@
       "options": [
         {
           "value": "primary",
-          "label": "Primary"
+          "label": "t:sections.multirow.settings.button_style.options__1.label"
         },
         {
           "value": "secondary",
-          "label": "Outline"
+          "label": "t:sections.multirow.settings.button_style.options__2.label"
         }
       ],
       "default": "secondary",
-      "label": "Button style"
+      "label": "t:sections.multirow.settings.button_style.label"
     },
     {
       "type": "select",
@@ -294,10 +324,9 @@
       "default": "background-1",
       "label": "t:sections.all.colors.label"
     },
-
     {
       "type": "header",
-      "content": "Mobile layout"
+      "content": "t:sections.multirow.settings.header_mobile.content"
     },
     {
       "type": "select",


### PR DESCRIPTION
### PR Summary: 

Added a new Multirow section for displaying related image and text content vertically.

### Why are these changes introduced?

Multirow is a section conceptually similar to `multicolumn`, but designed specifically for quicker and easier vertical content enumeration. Its blocks are aesthetically similar to the current `image with text` section.

Fixes #2169 

<img src="https://screenshot.click/13-35-t7p3r-f0s7q.png" width="350" />

### What approach did you take?

Copied the liquid from image with text into a new section, without creating a shared snippet, so much of the markup will be the same. I'm not certain the added snippet complexity that would be required to support both use cases would be worth it. This may be dependent on how each section functionally evolves in the future.

Multirow loops through blocks and creates a new image with text element for each, so the way existing content elements (heading, caption, etc) are read differs a bit from image with text. Certain image with text classes that were conditional on section settings were either removed or hardcoded if the settings are not offered in multirow.

### Other considerations

**Color scheme + global border settings logic** ([Video of behavior](https://screenshot.click/13-49-ajiff-u0u1z.mp4))
I've included the same "magic" as image with text where if the container color scheme chosen matches the section background and _no_ borders or shadow styles are applied via global content container settings. This allows either a [unified container look](https://screenshot.click/13-49-qnvpx-flt77.png) or a [container-less/transparent look](https://screenshot.click/13-48-ncbh5-h0lu0.png). The only difference here is that multirow also allows the option to change the section background so this logic isn't solely linked to background-1

**Shadow stacking limitations** ([Video of behavior](https://screenshot.click/13-30-dsr8l-av93i.mp4))
When vertical shadow offsets for either the global media or content container settings are negative (upward), the shadow could overlap the row above (natural CSS behavior) if there isn't enough gap. The issue here is there are 2 different child elements within an image with text creating their own shadows with an existing stacking relationship of their own, which further adds to the complexity that we've been able to solve for in other sections. I briefly timeboxed a fix for this and didn't find a configuration that worked, but I don't think it's blocking.

**Color scheme + padding logic** ([Image of behavior](https://screenshot.click/03-18-fewou-8xi43.png))
We also aligned to include additional logic to better align the text content with the standard page margins when both color scheme settings are the same and the rows don't create the "container" look. Basically it just removes the appropriate left or right padding depending on the row's content alignment. An exception is also made for centered text.

### Decision log

| # | Decision | Alternatives | Rationale | Downsides |
|---|---|---|---|---|
| 1 | Each block is a row, rather than a single content element | Basically none | - To allow for multiple rows<br>- To allow for connection to dynamic source groups | - Content elements will not be reorder-able like image with text |
| 2 | Block content style settings at the section level | Include all/more content style settings at the block level | - Focus is around quick and easy configurable<br>- More granularity at the block level would be more tedious and time consuming | - All blocks will display with the same setting choices |
| 3 | Did not include _all_ currently available settings from image with text | Include more or all image with text settings | - Focus on settings most relevant to the purpose of this section<br>- Less options, less configuration time for merchants<br>- Easier to add settings later than take some away | - Rows will not have all the same styling options as image with text (e.g overlap layout) |
| 4 | Did not reuse existing translated strings from image with text | Reuse common strings and only add multirow strings when needed | - Allows image with text and multirow to more easily diverge further in the future<br>- Keeps things simpler | - Inherent redundancy |
| 5 | Did not abstract image with text liquid into a reusable snippet | Consolidate core image with text in a settings-agnostic snippet | - Allows image with text and multirow to more easily diverge further in the future<br>- Snippet would need to be completely agnostic of `section.settings` and `block.settings` references resulting in a lot of props<br>- New logic specific to one component will require adding an exception in the shared snippet<br>- I'm not confident if shared liquid here will be beneficial or a burden | - Inherent redundancy<br>- New shared logic will need to be duplicated  |

### Visual impact on existing themes
Multirow is a new section and any changes to image with text styles should be scoped to the multirow context, with one minor exception.. Long words that might not have broken in image with text captions or buttons before should break now ([example](https://camo.githubusercontent.com/72c9f691fc93175f5fc095db289d1f17c17e80672b82fb1ece00ec306309b85a/68747470733a2f2f73637265656e73686f742e636c69636b2f31302d35312d656c646f6d2d6a357767352e706e67))

### Testing steps/scenarios
- Test Multirow sections with various combinations of section settings
- Ensure all settings/options are labeled correctly and behave as expected
- Test color scheme combinations thoroughly
- Test with different combination of global media and content container settings
- Test with dynamic content sources (Puppy product)

~~Note: `Image height: medium` setting may not apply correctly until the PR that adds the styles for this is merged and this one is rebased.~~

### Demo links

- [Editor](https://os2-demo.myshopify.com/admin/themes/139164581910/editor)

### Checklist
- [ ] Added PR summary for [release notes](https://themes.shopify.com/themes/dawn/styles/default#ReleaseNotes)
- [ ] Requested review from UX (Only for changes that are affecting the experience or perceivable visual details)
- [ ] Created a ticket for the [help.shopify.com](https://help.shopify.com) documentation team about updates to theme settings. (Internal-only task)
- [ ] Followed [theme code principles](https://github.com/Shopify/dawn/blob/main/.github/CONTRIBUTING.md#theme-code-principles)
- [ ] Linted with [Theme Check](https://github.com/Shopify/theme-check)
- [ ] Tested on [mobile](https://shopify.dev/themes/store/requirements#mobile-browser-requirements)
- [ ] Tested on [multiple browsers](https://shopify.dev/themes/store/requirements#desktop-browser-requirements)
- [ ] Tested for [accessibility](https://shopify.dev/themes/best-practices/accessibility)
