### PR TITLE
Remove/Replace unordered list tags in the Rich Text Section's Heading Block

### DIFF
--- a/sections/rich-text.liquid
+++ b/sections/rich-text.liquid
@@ -26,7 +26,7 @@
           {%- case block.type -%}
             {%- when 'heading' -%}
               <h2 class="rich-text__heading rte {{ block.settings.heading_size }}" {{ block.shopify_attributes }}>
-                {{ block.settings.heading | replace: 'p>', 'span>' | replace: 'ul>', 'span>' | remove: '<li>' | remove: '</li>' }}
+                {{ block.settings.heading | replace: 'p>', 'span>' | replace: 'li>', 'span>' | remove: '<ul>' | remove: '</ul>' }}
               </h2>
             {%- when 'caption' -%}
               <p class="rich-text__caption {{ block.settings.text_style }} {{ block.settings.text_style }}--{{ block.settings.text_size }}" {{ block.shopify_attributes }}>

--- a/sections/rich-text.liquid
+++ b/sections/rich-text.liquid
@@ -26,7 +26,7 @@
           {%- case block.type -%}
             {%- when 'heading' -%}
               <h2 class="rich-text__heading rte {{ block.settings.heading_size }}" {{ block.shopify_attributes }}>
-                {{ block.settings.heading | replace: 'p>', 'span>' }}
+                {{ block.settings.heading | replace: 'p>', 'span>' | replace: 'ul>', 'span>' | remove: '<li>' | remove: '</li>' }}
               </h2>
             {%- when 'caption' -%}
               <p class="rich-text__caption {{ block.settings.text_style }} {{ block.settings.text_style }}--{{ block.settings.text_size }}" {{ block.shopify_attributes }}>


### PR DESCRIPTION
### PR Summary: 

- Fixes a bug where unordered lists were allowed in the Rich Text section's Heading block. 

### Why are these changes introduced?

Fixes #2170

### What approach did you take?

The intent of this field is to have it behave like a single-line richtext field, so this PR should strips out the bullets for now. 

**Before**

<img width="1512" alt="Screenshot 2022-12-13 at 2 20 45 PM" src="https://user-images.githubusercontent.com/1202812/207428329-9e2a1ad7-f9cd-44b3-9cfd-f694d58b64a2.png">

**After**

<img width="1512" alt="Screenshot 2022-12-13 at 2 19 21 PM" src="https://user-images.githubusercontent.com/1202812/207428351-2fa20a48-b9e6-4d3a-85c5-0e8e6481228c.png">


### Other considerations

(In the longterm, this `richtext` field should eventually be replaced with a `inline_richtext` to prevent these sorts of issues in the future, but for now this specific bug should be fixed.)

### Visual impact on existing themes

If they have broken-looking bullets in this heading, the broken-looking bullets will disappear. 

### Testing steps/scenarios

1. [Visit the demo store.](https://os2-demo.myshopify.com/admin/themes/139169005590/editor)
2. Select the Heading block within a Rich Text section.
3. Add an unordered list. 
4. Note that the list tags are reformatted into a `<span>` upon render. 

### Checklist
- [x] Added PR summary for [release notes](https://themes.shopify.com/themes/dawn/styles/default#ReleaseNotes)
- [x] Requested review from UX (Only for changes that are affecting the experience or perceivable visual details)
- [ ] Created a ticket for the [help.shopify.com](https://help.shopify.com) documentation team about updates to theme settings. (Internal-only task)
- [x] Followed [theme code principles](https://github.com/Shopify/dawn/blob/main/.github/CONTRIBUTING.md#theme-code-principles)
- [x] Linted with [Theme Check](https://github.com/Shopify/theme-check)
- [x] Tested on [mobile](https://shopify.dev/themes/store/requirements#mobile-browser-requirements)
- [x] Tested on [multiple browsers](https://shopify.dev/themes/store/requirements#desktop-browser-requirements)
- [x] Tested for [accessibility](https://shopify.dev/themes/best-practices/accessibility)
