### PR TITLE
Fix live text announcement bar

### DIFF
--- a/sections/announcement-bar.liquid
+++ b/sections/announcement-bar.liquid
@@ -8,7 +8,7 @@
           {%- endif -%}
               <div class="page-width">
                 <p class="announcement-bar__message {{ block.settings.text_alignment }} h5">
-                  {{ block.settings.text | escape }}
+                  <span>{{ block.settings.text | escape }}</span>
                   {%- if block.settings.link != blank -%}
                     {% render 'icon-arrow' %}
                   {%- endif -%}


### PR DESCRIPTION
### PR Summary: 

Wrap the announcement bar's text setting in a `<span>` element to fix live-text updates in the theme editor. 

Fixes https://github.com/Shopify/storefront-renderer/issues/15595

https://user-images.githubusercontent.com/10181941/211612211-ac902de8-a52e-402e-b6cb-b9f82bad5cc9.mov

### Why are these changes introduced?

Fixes live text updates in the theme editor for the announcement bar.

### What approach did you take?

Wrap the text setting in a span element. The reason for this is that live text only works when the settings is the only child of it's parent element. When that is the case, we add the `data-live-text-setting` data attribute to the parent element. 

### Other considerations
Can wrapping the text in a `span` have any undesired effects on the resulting design? Are there any CSS rules that might affect the look after I add the `span` element?

Can this affect accessibility in any way?

### Visual impact on existing themes
Should be none but would like confirmation from Dawn developers.

### Checklist
- [x] Added PR summary for [release notes](https://themes.shopify.com/themes/dawn/styles/default#ReleaseNotes)
- [x] Followed [theme code principles](https://github.com/Shopify/dawn/blob/main/.github/CONTRIBUTING.md#theme-code-principles)
- [x] Linted with [Theme Check](https://github.com/Shopify/theme-check)
- [ ] Tested on [mobile](https://shopify.dev/themes/store/requirements#mobile-browser-requirements)
- [ ] Tested on [multiple browsers](https://shopify.dev/themes/store/requirements#desktop-browser-requirements)
- [ ] Tested for [accessibility](https://shopify.dev/themes/best-practices/accessibility)
