### PR TITLE
Fix facets nl translations

### DIFF
--- a/locales/nl.json
+++ b/locales/nl.json
@@ -190,7 +190,7 @@
       "reset": "Opnieuw instellen",
       "sort_button": "Sorteren",
       "sort_by_label": "Sorteer op:",
-      "to": "Aan",
+      "to": "Tot",
       "clear_filter": "Filter verwijderen",
       "filter_selected_accessibility": "{{ type }} ({{ count }} filters geselecteerd)",
       "show_more": "Meer weergeven",


### PR DESCRIPTION
### PR Summary

We received merchant feedback that in the context of a range slider, "tot" is the correct translation of "to".

Currently, Price filter says "Aan" in Dutch, [screenshot](https://screenshot.click/11-26-djqy4-8lw7s.png). This translates to "on" in this context, not "to".

This changes it to say "Tot", [screenshot](https://screenshot.click/11-30-cdtcl-z7cev.png)


### What approach did you take?

To see this in your store, you will need Dutch enabled as a **Store language**. Price filters will only appear for the store's default currency - hence why my screenshots above show USD prices with Dutch translations.


### Checklist
- [ ] Added PR summary for [release notes](https://themes.shopify.com/themes/dawn/styles/default#ReleaseNotes)
- [ ] Requested review from UX (Only for changes that are affecting the experience or perceivable visual details)
- [ ] Created a ticket for the [help.shopify.com](https://help.shopify.com) documentation team about updates to theme settings. (Internal-only task)
- [ ] Followed [theme code principles](https://github.com/Shopify/dawn/blob/main/.github/CONTRIBUTING.md#theme-code-principles)
- [x] Linted with [Theme Check](https://github.com/Shopify/theme-check)
- [x] Tested on [mobile](https://shopify.dev/themes/store/requirements#mobile-browser-requirements)
- [x] Tested on [multiple browsers](https://shopify.dev/themes/store/requirements#desktop-browser-requirements)
- [x] Tested for [accessibility](https://shopify.dev/themes/best-practices/accessibility)
