### PR TITLE
Activate show social media setting by default

### DIFF
--- a/sections/footer.liquid
+++ b/sections/footer.liquid
@@ -532,7 +532,7 @@
     {
       "type": "checkbox",
       "id": "show_social",
-      "default": false,
+      "default": true,
       "label": "t:sections.footer.settings.show_social.label"
     },
     {


### PR DESCRIPTION
Since we turn this on always by default when we create the onboarding state, let's have it on to prevent confusion. (Read our internal documentation about creating onboarding state) 

### PR Summary: 

<!-- Please include a short description (using non-technical terms, 1-2 sentences) about the changes you are introducing, what problem is being fixed and/or describe the benefit to merchants. This content will be used in our release notes for Dawn on [themes.shopify.com](https://themes.shopify.com/themes/dawn/styles/default#ReleaseNotes). -->

We enable "Show social media" in the footer so they can appear when you add your social media URL.

### Why are these changes introduced?

To improve the onboarding state for merchants.

### Visual impact on existing themes
<!-- How will this visually affect merchants who upgrade to a new theme version with this change? -->

This will not change how we were already including it turned on by default. We are just adding this by default in the code base.

## Demo links

- [Editor](https://os2-demo.myshopify.com/admin/themes/139259183126/editor)


### Checklist
- [x] Added PR summary for [release notes](https://themes.shopify.com/themes/dawn/styles/default#ReleaseNotes)
- [ ] Requested review from UX (Only for changes that are affecting the experience or perceivable visual details)
- [ ] Created a ticket for the [help.shopify.com](https://help.shopify.com) documentation team about updates to theme settings. (Internal-only task)
- [x] Followed [theme code principles](https://github.com/Shopify/dawn/blob/main/.github/CONTRIBUTING.md#theme-code-principles)
- [ ] Linted with [Theme Check](https://github.com/Shopify/theme-check)
- [ ] Tested on [mobile](https://shopify.dev/themes/store/requirements#mobile-browser-requirements)
- [ ] Tested on [multiple browsers](https://shopify.dev/themes/store/requirements#desktop-browser-requirements)
- [ ] Tested for [accessibility](https://shopify.dev/themes/best-practices/accessibility)
