### PR TITLE
Restrict max quantity in cart

### DIFF
--- a/assets/cart.js
+++ b/assets/cart.js
@@ -42,7 +42,8 @@ class CartItems extends HTMLElement {
   }
 
   onChange(event) {
-    this.updateQuantity(event.target.dataset.index, event.target.value, document.activeElement.getAttribute('name'));
+    const newQuantity = event.target.max ? Math.min(event.target.value, event.target.max) : event.target.value;
+    this.updateQuantity(event.target.dataset.index, newQuantity, document.activeElement.getAttribute('name'));
   }
 
   onCartUpdate() {


### PR DESCRIPTION
### PR Summary: 

Ensure the quantity selector restricts the maximum even when a number is manually entered on the cart page or in the cart drawer.

### Why are these changes introduced?

Currently, it's possible to circumvent the maximum quantity allowed by manually entering a number.

### What approach did you take?

If a maximum quantity is set, use the lowest of the maximum quantity and the number entered.

### Visual impact on existing themes

None

### Testing steps/scenarios
- [ ] Add a product with a tracked inventory and limited quantity to the cart, ensure you add the maximum quantity remaining
- [ ] On either the cart page or inside the cart drawer, clicking to focus the quantity input and adjusting the quantity to be greater than the maximum quantity then focusing away from the input allows the maximum quantity to be bypassed and does not display any feedback or validation.

Screenshots:

![cart-max-qty-issue01](https://user-images.githubusercontent.com/1671933/219740659-0247b075-f59c-483f-83a5-364ee2d3ab32.jpg)
![cart-max-qty-issue02](https://user-images.githubusercontent.com/1671933/219740698-7ba6f150-3917-43de-901d-ccc1dddc368d.jpg)


### Checklist
- [x] Followed [theme code principles](https://github.com/Shopify/dawn/blob/main/.github/CONTRIBUTING.md#theme-code-principles)
- [x] Added PR summary for [release notes](https://themes.shopify.com/themes/dawn/styles/default#ReleaseNotes)
