### PR TITLE
Add `update cart` logic to ATC button

### DIFF
--- a/assets/cart-notification.js
+++ b/assets/cart-notification.js
@@ -30,8 +30,21 @@ class CartNotification extends HTMLElement {
     removeTrapFocus(this.activeElement);
   }
 
-  renderContents(parsedState) {
-      this.cartItemKey = parsedState.key;
+  renderContents(parsedState, selectedVariant) {
+    this.renderSections = true;
+    this.cartItemKey = parsedState.key;
+    if (parsedState.items) {
+      if (parsedState.items.filter(i => i.variant_id === selectedVariant).length === 0) {
+        this.renderSections = false;
+        return
+      }
+      parsedState.items.forEach((item) => {
+        if (item.variant_id === selectedVariant && item.key) {
+          this.cartItemKey = item.key;
+        }
+      })
+    }
+    if (this.renderSections) {
       this.getSectionsToRender().forEach((section => {
         document.getElementById(section.id).innerHTML =
           this.getSectionInnerHTML(parsedState.sections[section.id], section.selector);
@@ -39,6 +52,7 @@ class CartNotification extends HTMLElement {
 
       if (this.header) this.header.reveal();
       this.open();
+    }
   }
 
   getSectionsToRender() {

--- a/assets/cart-notification.js
+++ b/assets/cart-notification.js
@@ -36,7 +36,6 @@ class CartNotification extends HTMLElement {
     if (parsedState.items) {
       if (parsedState.items.filter(i => i.variant_id === selectedVariant).length === 0) {
         this.renderSections = false;
-        return
       }
       parsedState.items.forEach((item) => {
         if (item.variant_id === selectedVariant && item.key) {

--- a/assets/constants.js
+++ b/assets/constants.js
@@ -3,5 +3,6 @@ const ON_CHANGE_DEBOUNCE_TIMER = 300;
 const PUB_SUB_EVENTS = {
   cartUpdate: 'cart-update',
   quantityUpdate: 'quantity-update',
-  variantChange: 'variant-change'
+  variantChange: 'variant-change',
+  quantityChange: 'quantity-change'
 };

--- a/assets/global.js
+++ b/assets/global.js
@@ -801,7 +801,6 @@ class VariantSelects extends HTMLElement {
   onVariantChange() {
     this.updateOptions();
     this.updateMasterId();
-    this.toggleAddButton(true, '', false);
     this.updatePickupAvailability();
     this.removeErrorMessage();
     this.updateVariantStatuses();
@@ -815,6 +814,7 @@ class VariantSelects extends HTMLElement {
       this.updateVariantInput();
       this.renderProductInfo();
       this.updateShareUrl();
+      // this.toggleAddButton(true, '', false);
     }
   }
 
@@ -933,12 +933,15 @@ class VariantSelects extends HTMLElement {
         const price = document.getElementById(`price-${this.dataset.section}`);
         const quantityForm = document.getElementById(`Quantity-Form-${this.dataset.section}`);
 
+        const test = quantityForm.querySelector('.quantity__input').value === quantityForm.querySelector('.quantity__input').dataset.cartQuantity;
+
         if (price) price.classList.remove('visibility-hidden');
 
         if (inventoryDestination) inventoryDestination.classList.toggle('visibility-hidden', inventorySource.innerText === '');
 
         const addButtonUpdated = html.getElementById(`ProductSubmitButton-${sectionId}`);
-        this.toggleAddButton(addButtonUpdated ? addButtonUpdated.hasAttribute('disabled') : true, window.variantStrings.soldOut);
+
+        this.toggleAddButton(addButtonUpdated ? addButtonUpdated.hasAttribute('disabled') : true, window.variantStrings.soldOut, true, addButtonUpdated, test);
 
         publish(PUB_SUB_EVENTS.variantChange, {data: {
           sectionId,
@@ -949,19 +952,25 @@ class VariantSelects extends HTMLElement {
       });
   }
 
-  toggleAddButton(disable = true, text, modifyClass = true) {
+  toggleAddButton(disable = true, text, modifyClass = true, addButtonUpdated, test) {
     const productForm = document.getElementById(`product-form-${this.dataset.section}`);
     if (!productForm) return;
     const addButton = productForm.querySelector('[name="add"]');
-    const addButtonText = productForm.querySelector('[name="add"] > span');
+    const addButtonText = productForm.querySelector('[name="add"] > span > span');
     if (!addButton) return;
 
     if (disable) {
       addButton.setAttribute('disabled', 'disabled');
       if (text) addButtonText.textContent = text;
+    } else if (test) {
+      addButton.removeAttribute('disabled');
+      addButtonUpdated.querySelector('.cart-label-default').classList.add('hidden')
+      addButtonUpdated.querySelector('.added-to-cart').classList.remove('hidden')
     } else {
       addButton.removeAttribute('disabled');
-      addButtonText.textContent = window.variantStrings.addToCart;
+      addButtonUpdated.querySelector('.cart-label-default').classList.remove('hidden')
+      addButtonUpdated.querySelector('.added-to-cart').classList.add('hidden')
+      addButtonText.textContent = addButtonUpdated.querySelector('.cart-label-default').innerText;
     }
 
     if (!modifyClass) return;
@@ -970,7 +979,7 @@ class VariantSelects extends HTMLElement {
   setUnavailable() {
     const button = document.getElementById(`product-form-${this.dataset.section}`);
     const addButton = button.querySelector('[name="add"]');
-    const addButtonText = button.querySelector('[name="add"] > span');
+    const addButtonText = button.querySelector('[name="add"] > span > span');
     const price = document.getElementById(`price-${this.dataset.section}`);
     const inventory = document.getElementById(`Inventory-${this.dataset.section}`);
     const sku = document.getElementById(`Sku-${this.dataset.section}`);

--- a/assets/global.js
+++ b/assets/global.js
@@ -169,6 +169,7 @@ class QuantityInput extends HTMLElement {
 
   onInputChange(event) {
     this.validateQtyRules();
+    publish(PUB_SUB_EVENTS.quantityChange, {data: { value: event.target.value, cartQty: event.target.dataset.cartQuantity }});  
   }
 
   onButtonClick(event) {
@@ -930,6 +931,7 @@ class VariantSelects extends HTMLElement {
         }
 
         const price = document.getElementById(`price-${this.dataset.section}`);
+        const quantityForm = document.getElementById(`Quantity-Form-${this.dataset.section}`);
 
         if (price) price.classList.remove('visibility-hidden');
 
@@ -941,7 +943,8 @@ class VariantSelects extends HTMLElement {
         publish(PUB_SUB_EVENTS.variantChange, {data: {
           sectionId,
           html,
-          variant: this.currentVariant
+          variant: this.currentVariant,
+          quantityForm
         }});
       });
   }

--- a/assets/global.js
+++ b/assets/global.js
@@ -169,7 +169,7 @@ class QuantityInput extends HTMLElement {
 
   onInputChange(event) {
     this.validateQtyRules();
-    publish(PUB_SUB_EVENTS.quantityChange, {data: { value: event.target.value, cartQty: event.target.dataset.cartQuantity }});  
+    publish(PUB_SUB_EVENTS.quantityChange, {data: { value: event.target.value, cartQty: event.target.dataset.cartQuantity, id: event.target.form.id }});  
   }
 
   onButtonClick(event) {

--- a/assets/global.js
+++ b/assets/global.js
@@ -814,7 +814,6 @@ class VariantSelects extends HTMLElement {
       this.updateVariantInput();
       this.renderProductInfo();
       this.updateShareUrl();
-      // this.toggleAddButton(true, '', false);
     }
   }
 
@@ -933,7 +932,7 @@ class VariantSelects extends HTMLElement {
         const price = document.getElementById(`price-${this.dataset.section}`);
         const quantityForm = document.getElementById(`Quantity-Form-${this.dataset.section}`);
 
-        const test = quantityForm.querySelector('.quantity__input').value === quantityForm.querySelector('.quantity__input').dataset.cartQuantity;
+        const qtyMatchesCart = quantityForm.querySelector('.quantity__input').value === quantityForm.querySelector('.quantity__input').dataset.cartQuantity;
 
         if (price) price.classList.remove('visibility-hidden');
 
@@ -941,7 +940,7 @@ class VariantSelects extends HTMLElement {
 
         const addButtonUpdated = html.getElementById(`ProductSubmitButton-${sectionId}`);
 
-        this.toggleAddButton(addButtonUpdated ? addButtonUpdated.hasAttribute('disabled') : true, window.variantStrings.soldOut, true, addButtonUpdated, test);
+        this.toggleAddButton(addButtonUpdated ? addButtonUpdated.hasAttribute('disabled') : true, window.variantStrings.soldOut, true, addButtonUpdated, qtyMatchesCart);
 
         publish(PUB_SUB_EVENTS.variantChange, {data: {
           sectionId,
@@ -952,7 +951,7 @@ class VariantSelects extends HTMLElement {
       });
   }
 
-  toggleAddButton(disable = true, text, modifyClass = true, addButtonUpdated, test) {
+  toggleAddButton(disable = true, text, modifyClass = true, addButtonUpdated, qtyMatchesCart) {
     const productForm = document.getElementById(`product-form-${this.dataset.section}`);
     if (!productForm) return;
     const addButton = productForm.querySelector('[name="add"]');
@@ -962,7 +961,7 @@ class VariantSelects extends HTMLElement {
     if (disable) {
       addButton.setAttribute('disabled', 'disabled');
       if (text) addButtonText.textContent = text;
-    } else if (test) {
+    } else if (qtyMatchesCart) {
       addButton.removeAttribute('disabled');
       addButtonUpdated.querySelector('.cart-label-default').classList.add('hidden')
       addButtonUpdated.querySelector('.added-to-cart').classList.remove('hidden')

--- a/assets/product-form.js
+++ b/assets/product-form.js
@@ -42,7 +42,7 @@ if (!customElements.get('product-form')) {
         this.cartQty = cartQuantity
         this.quantityInputNumber = inputValue
       } else {
-        this.cartQty = parseInt(this.submitButton.dataset.cartqty);
+        this.cartQty = parseInt(this.form.closest('.product__info-container').querySelector('.quantity__input').dataset.cartQuantity);
         this.quantityInputNumber = parseInt(this.form.closest('.product__info-container').querySelector('.quantity__input').value);
       }
 

--- a/assets/product-form.js
+++ b/assets/product-form.js
@@ -33,13 +33,12 @@ if (!customElements.get('product-form')) {
 
     updateCartQty() {
       this.cartQty = parseInt(this.submitButton.dataset.cartqty);
+      this.updateType = routes.cart_add_url;
       if (this.cartQty > 0) {
         this.updateType = routes.cart_change_url;
-      } else {
-        this.updateType = routes.cart_add_url;
       }
       if (this.updateType ===  routes.cart_change_url) {
-        this.selectedVariant = this.form.querySelector(`[name='id']`).value
+        this.selectedVariant = parseInt(this.form.querySelector(`[name='id']`).value);
       }
     }
 
@@ -89,11 +88,11 @@ if (!customElements.get('product-form')) {
           const quickAddModal = this.closest('quick-add-modal');
           if (quickAddModal) {
             document.body.addEventListener('modalClosed', () => {
-              setTimeout(() => { this.cart.renderContents(response, parseInt(this.selectedVariant)) });
+              setTimeout(() => { this.cart.renderContents(response, this.selectedVariant) });
             }, { once: true });
             quickAddModal.hide(true);
           } else {
-            this.cart.renderContents(response, parseInt(this.selectedVariant));
+            this.cart.renderContents(response, this.selectedVariant);
           }
         })
         .catch((e) => {

--- a/assets/product-form.js
+++ b/assets/product-form.js
@@ -8,7 +8,7 @@ if (!customElements.get('product-form')) {
       this.form.addEventListener('submit', this.onSubmitHandler.bind(this));
       this.cart = document.querySelector('cart-notification') || document.querySelector('cart-drawer');
       this.submitButton = this.querySelector('[type="submit"]');
-      this.updateType = routes.cart_add_url;
+      this.cartUrl = routes.cart_add_url;
       this.selectedVariant = undefined
 
       if (document.querySelector('cart-drawer')) this.submitButton.setAttribute('aria-haspopup', 'dialog');
@@ -33,11 +33,11 @@ if (!customElements.get('product-form')) {
 
     updateCartQty() {
       this.cartQty = parseInt(this.submitButton.dataset.cartqty);
-      this.updateType = routes.cart_add_url;
+      this.cartUrl = routes.cart_add_url;
       if (this.cartQty > 0) {
-        this.updateType = routes.cart_change_url;
+        this.cartUrl = routes.cart_change_url;
       }
-      if (this.updateType ===  routes.cart_change_url) {
+      if (this.cartUrl ===  routes.cart_change_url) {
         this.selectedVariant = parseInt(this.form.querySelector(`[name='id']`).value);
       }
     }
@@ -65,7 +65,7 @@ if (!customElements.get('product-form')) {
       }
       config.body = formData;
 
-      fetch(`${this.updateType}`, config)
+      fetch(`${this.cartUrl}`, config)
         .then((response) => response.json())
         .then((response) => {
           if (response.status) {

--- a/assets/product-info.js
+++ b/assets/product-info.js
@@ -91,6 +91,12 @@ if (!customElements.get('product-info')) {
           current.innerHTML = updated.innerHTML;
         }
       }
+
+      const quantityButtonUpdated = html.getElementById(`Buy-Buttons-${sectionId}`);
+      const currentButton = this.submitButton
+      const updatedButton = quantityButtonUpdated.querySelector('.product-form__submit')
+      currentButton.innerHTML = updatedButton.innerHTML
+      currentButton.dataset.cartqty = updatedButton.dataset.cartqty
     }
   }
 )};

--- a/assets/product-info.js
+++ b/assets/product-info.js
@@ -28,7 +28,9 @@ if (!customElements.get('product-info')) {
         this.setQuantityBoundries();
       });
       this.quantityChangeUnsubscriber = subscribe(PUB_SUB_EVENTS.quantityChange, (event) => {
-        this.updateButton(event.data.value, event.data.cartQty);
+        if (event.data.id !== 'CartDrawer-Form') {
+          this.updateButton(event.data.value, event.data.cartQty);
+        }
       });
     }
 

--- a/assets/product-info.js
+++ b/assets/product-info.js
@@ -51,13 +51,13 @@ if (!customElements.get('product-info')) {
 
       this.input.min = min;
       this.input.max = max;
-      this.input.value = min;
+      this.input.value = data.cartQuantity;
       publish(PUB_SUB_EVENTS.quantityUpdate, undefined);  
     }
 
     fetchQuantityRules() {
       if (!this.currentVariant || !this.currentVariant.value) return;
-      this.querySelector('.quantity__rules-cart .loading-overlay').classList.remove('hidden');
+      // this.querySelector('.quantity .loading-overlay').classList.remove('hidden');
       fetch(`${this.dataset.url}?variant=${this.currentVariant.value}&section_id=${this.dataset.section}`).then((response) => {
         return response.text()
       })
@@ -70,13 +70,13 @@ if (!customElements.get('product-info')) {
         console.error(e);
       })
       .finally(() => {
-        this.querySelector('.quantity__rules-cart .loading-overlay').classList.add('hidden');
+        // this.querySelector('.quantity .loading-overlay').classList.add('hidden');
       });
     }
 
     updateQuantityRules(sectionId, html) {
       const quantityFormUpdated = html.getElementById(`Quantity-Form-${sectionId}`);
-      const selectors = ['.quantity__input', '.quantity__rules', '.quantity__label'];
+      const selectors = ['.quantity__input', '.quantity__rules'];
       for (let selector of selectors) { 
         const current = this.quantityForm.querySelector(selector);
         const updated = quantityFormUpdated.querySelector(selector);

--- a/assets/product-info.js
+++ b/assets/product-info.js
@@ -6,10 +6,12 @@ if (!customElements.get('product-info')) {
       this.currentVariant = this.querySelector('.product-variant-id');
       this.variantSelects = this.querySelector('variant-radios')
       this.submitButton = this.querySelector('[type="submit"]');
+      this.updateButton(this.input.value, this.input.dataset.cartQuantity);
     }
 
     cartUpdateUnsubscriber = undefined;
     variantChangeUnsubscriber = undefined;
+    quantityChangeUnsubscriber = undefined;
 
     connectedCallback() {
       if (!this.input) return;
@@ -25,6 +27,9 @@ if (!customElements.get('product-info')) {
         this.updateQuantityRules(event.data.sectionId, event.data.html);
         this.setQuantityBoundries();
       });
+      this.quantityChangeUnsubscriber = subscribe(PUB_SUB_EVENTS.quantityChange, (event) => {
+        this.updateButton(event.data.value, event.data.cartQty);
+      });
     }
 
     disconnectedCallback() {
@@ -33,6 +38,9 @@ if (!customElements.get('product-info')) {
       }
       if (this.variantChangeUnsubscriber) {
         this.variantChangeUnsubscriber();
+      }
+      if (this.quantityChangeUnsubscriber) {
+        this.quantityChangeUnsubscriber();
       }
     }
 
@@ -66,7 +74,7 @@ if (!customElements.get('product-info')) {
       .then((responseText) => {
         const html = new DOMParser().parseFromString(responseText, 'text/html');
         this.updateQuantityRules(this.dataset.section, html);
-        this.setQuantityBoundries();
+        this.setQuantityBoundries(html);
       })
       .catch(e => {
         console.error(e);
@@ -92,10 +100,25 @@ if (!customElements.get('product-info')) {
       }
 
       const quantityButtonUpdated = html.getElementById(`Buy-Buttons-${sectionId}`);
-      const currentButton = this.submitButton
+      const input = quantityFormUpdated.querySelector('.quantity__input');
       const updatedButton = quantityButtonUpdated.querySelector('.product-form__submit')
-      currentButton.innerHTML = updatedButton.innerHTML
+      const currentButton = this.submitButton
+      if (input.dataset.cartQuantity === input.value) {
+        currentButton.querySelector('.cart-label').innerHTML = updatedButton.querySelector('.added-to-cart').innerHTML;
+      } else {
+        currentButton.innerHTML = updatedButton.innerHTML
+      }
       currentButton.dataset.cartqty = updatedButton.dataset.cartqty
+    }
+
+    updateButton(value, cartQty) {
+      if (cartQty === value) {
+        this.submitButton.querySelector('.cart-label').innerHTML = this.submitButton.querySelector('.added-to-cart').innerHTML;
+      } else if (cartQty > 0) {
+        this.submitButton.querySelector('.cart-label').innerText = this.submitButton.querySelector('.cart-label').dataset.updatecart;
+      } else {
+        this.submitButton.querySelector('.cart-label').innerText = this.submitButton.querySelector('.cart-label').dataset.addcart;
+      }
     }
   }
 )};

--- a/assets/product-info.js
+++ b/assets/product-info.js
@@ -63,6 +63,7 @@ if (!customElements.get('product-info')) {
       if (data.cartQuantity > 0) {
         this.input.value = data.cartQuantity;
       }
+      this.updateButton(parseInt(this.input.value), data.cartQuantity)
       publish(PUB_SUB_EVENTS.quantityUpdate, undefined);  
     }
 
@@ -74,7 +75,7 @@ if (!customElements.get('product-info')) {
       .then((responseText) => {
         const html = new DOMParser().parseFromString(responseText, 'text/html');
         this.updateQuantityRules(this.dataset.section, html);
-        this.setQuantityBoundries(html);
+        this.setQuantityBoundries();
       })
       .catch(e => {
         console.error(e);
@@ -98,26 +99,20 @@ if (!customElements.get('product-info')) {
           current.innerHTML = updated.innerHTML;
         }
       }
-
-      const quantityButtonUpdated = html.getElementById(`Buy-Buttons-${sectionId}`);
-      const input = quantityFormUpdated.querySelector('.quantity__input');
-      const updatedButton = quantityButtonUpdated.querySelector('.product-form__submit')
-      const currentButton = this.submitButton
-      if (input.dataset.cartQuantity === input.value) {
-        currentButton.querySelector('.cart-label').innerHTML = updatedButton.querySelector('.added-to-cart').innerHTML;
-      } else {
-        currentButton.innerHTML = updatedButton.innerHTML
-      }
-      currentButton.dataset.cartqty = updatedButton.dataset.cartqty
     }
 
     updateButton(value, cartQty) {
       if (cartQty === value) {
-        this.submitButton.querySelector('.cart-label').innerHTML = this.submitButton.querySelector('.added-to-cart').innerHTML;
+        this.submitButton.querySelector('.added-to-cart').classList.remove('hidden')
+        this.submitButton.querySelector('.cart-label-default').classList.add('hidden')
       } else if (cartQty > 0) {
-        this.submitButton.querySelector('.cart-label').innerText = this.submitButton.querySelector('.cart-label').dataset.updatecart;
+        this.submitButton.querySelector('.added-to-cart').classList.add('hidden')
+        this.submitButton.querySelector('.cart-label-default').classList.remove('hidden')
+        this.submitButton.querySelector('.cart-label-default').innerText = window.variantStrings.updateCart;
       } else {
-        this.submitButton.querySelector('.cart-label').innerText = this.submitButton.querySelector('.cart-label').dataset.addcart;
+        this.submitButton.querySelector('.added-to-cart').classList.add('hidden')
+        this.submitButton.querySelector('.cart-label-default').classList.remove('hidden')
+        this.submitButton.querySelector('.cart-label-default').innerText = window.variantStrings.addToCart;
       }
     }
   }

--- a/assets/product-info.js
+++ b/assets/product-info.js
@@ -62,8 +62,11 @@ if (!customElements.get('product-info')) {
       this.input.min = min;
       this.input.max = max;
       this.input.value = min;
+
       if (data.cartQuantity > 0) {
         this.input.value = data.cartQuantity;
+        this.input.min = data.min;
+        this.input.max = data.max;
       }
       this.updateButton(parseInt(this.input.value), data.cartQuantity)
       publish(PUB_SUB_EVENTS.quantityUpdate, undefined);  

--- a/assets/product-info.js
+++ b/assets/product-info.js
@@ -51,7 +51,10 @@ if (!customElements.get('product-info')) {
 
       this.input.min = min;
       this.input.max = max;
-      this.input.value = data.cartQuantity;
+      this.input.value = min;
+      if (data.cartQuantity > 0) {
+        this.input.value = data.cartQuantity;
+      }
       publish(PUB_SUB_EVENTS.quantityUpdate, undefined);  
     }
 

--- a/assets/product-info.js
+++ b/assets/product-info.js
@@ -105,16 +105,20 @@ if (!customElements.get('product-info')) {
 
     updateButton(value, cartQty) {
       if (cartQty === value) {
+        this.submitButton.querySelector('.added-to-cart-text').innerText = window.variantStrings.addedToCart.replace('[quantity]', cartQty);
         this.submitButton.querySelector('.added-to-cart').classList.remove('hidden')
         this.submitButton.querySelector('.cart-label-default').classList.add('hidden')
+        this.submitButton.classList.add('added-to-cart')
       } else if (cartQty > 0) {
         this.submitButton.querySelector('.added-to-cart').classList.add('hidden')
         this.submitButton.querySelector('.cart-label-default').classList.remove('hidden')
         this.submitButton.querySelector('.cart-label-default').innerText = window.variantStrings.updateCart;
+        this.submitButton.classList.remove('added-to-cart')
       } else {
         this.submitButton.querySelector('.added-to-cart').classList.add('hidden')
         this.submitButton.querySelector('.cart-label-default').classList.remove('hidden')
         this.submitButton.querySelector('.cart-label-default').innerText = window.variantStrings.addToCart;
+        this.submitButton.classList.remove('added-to-cart')
       }
     }
   }

--- a/assets/product-info.js
+++ b/assets/product-info.js
@@ -60,7 +60,6 @@ if (!customElements.get('product-info')) {
 
     fetchQuantityRules() {
       if (!this.currentVariant || !this.currentVariant.value) return;
-      // this.querySelector('.quantity .loading-overlay').classList.remove('hidden');
       fetch(`${this.dataset.url}?variant=${this.currentVariant.value}&section_id=${this.dataset.section}`).then((response) => {
         return response.text()
       })
@@ -72,9 +71,6 @@ if (!customElements.get('product-info')) {
       .catch(e => {
         console.error(e);
       })
-      .finally(() => {
-        // this.querySelector('.quantity .loading-overlay').classList.add('hidden');
-      });
     }
 
     updateQuantityRules(sectionId, html) {

--- a/assets/section-main-product.css
+++ b/assets/section-main-product.css
@@ -473,6 +473,18 @@ a.product__text {
   max-width: 44rem;
 }
 
+.product-form__submit.button--primary.added-to-cart {
+ opacity: 0.75;
+}
+
+.product-form__submit.button--secondary.added-to-cart {
+  color: rgba(var(--color-button-text), 0.6)
+}
+
+.product-form__submit.button--secondary.added-to-cart:after {
+  --border-opacity: 0.1;
+}
+
 .cart-label .icon-checkmark {
   width: 1.3rem;
   margin-left: 0.5rem;

--- a/assets/section-main-product.css
+++ b/assets/section-main-product.css
@@ -473,6 +473,11 @@ a.product__text {
   max-width: 44rem;
 }
 
+.cart-label .icon-checkmark {
+  width: 1.3rem;
+  margin-left: 0.5rem;
+}
+
 .product--no-media .product__info-container > modal-opener {
   display: block;
   text-align: center;

--- a/layout/theme.liquid
+++ b/layout/theme.liquid
@@ -278,6 +278,7 @@
       window.variantStrings = {
         addToCart: `{{ 'products.product.add_to_cart' | t }}`,
         updateCart: `{{ 'products.product.update_cart' | t }}`,
+        addedToCart: `{{ 'products.product.added_to_cart' | t: quantity: '[quantity]' }}`,
         soldOut: `{{ 'products.product.sold_out' | t }}`,
         unavailable: `{{ 'products.product.unavailable' | t }}`,
         unavailable_with_option: `{{ 'products.product.value_unavailable' | t: option_value: '[value]' }}`,

--- a/layout/theme.liquid
+++ b/layout/theme.liquid
@@ -277,6 +277,7 @@
 
       window.variantStrings = {
         addToCart: `{{ 'products.product.add_to_cart' | t }}`,
+        updateCart: `{{ 'products.product.update_cart' | t }}`,
         soldOut: `{{ 'products.product.sold_out' | t }}`,
         unavailable: `{{ 'products.product.unavailable' | t }}`,
         unavailable_with_option: `{{ 'products.product.value_unavailable' | t: option_value: '[value]' }}`,

--- a/locales/en.default.json
+++ b/locales/en.default.json
@@ -108,6 +108,7 @@
     "product": {
       "add_to_cart": "Add to cart",
       "update_cart": "Update cart",
+      "added_to_cart": "Added to cart",
       "choose_options": "Choose options",
       "choose_product_options": "Choose options for {{ product_name }}",
       "description": "Description",

--- a/locales/en.default.json
+++ b/locales/en.default.json
@@ -107,6 +107,7 @@
   "products": {
     "product": {
       "add_to_cart": "Add to cart",
+      "update_cart": "Update cart",
       "choose_options": "Choose options",
       "choose_product_options": "Choose options for {{ product_name }}",
       "description": "Description",

--- a/locales/en.default.json
+++ b/locales/en.default.json
@@ -108,7 +108,7 @@
     "product": {
       "add_to_cart": "Add to cart",
       "update_cart": "Update cart",
-      "added_to_cart": "Added to cart",
+      "added_to_cart": "{{ quantity }} in cart",
       "choose_options": "Choose options",
       "choose_product_options": "Choose options for {{ product_name }}",
       "description": "Description",

--- a/sections/featured-product.liquid
+++ b/sections/featured-product.liquid
@@ -196,32 +196,16 @@
                 >
                   {% comment %} TODO: enable theme-check once `item_count_for_variant` is accepted as valid filter {% endcomment %}
                   {% # theme-check-disable %}
-                  {%- assign cart_qty = cart
-                    | item_count_for_variant: product.selected_or_first_available_variant.id
+                  {%- liquid 
+                    assign cart_qty = cart | item_count_for_variant: product.selected_or_first_available_variant.id
+                    assign input_value = product.selected_or_first_available_variant.quantity_rule.min
+                    if cart_qty > 0
+                      assign input_value = cart_qty
+                    endif
                   -%}
                   {% # theme-check-enable %}
                   <label class="quantity__label form__label" for="Quantity-{{ section.id }}">
                     {{ 'products.product.quantity.label' | t }}
-                    <span class="quantity__rules-cart no-js-hidden{% if cart_qty == 0 %} hidden{% endif %}">
-                      <span class="loading-overlay hidden">
-                        <span class="loading-overlay__spinner">
-                          <svg
-                            aria-hidden="true"
-                            focusable="false"
-                            class="spinner"
-                            viewBox="0 0 66 66"
-                            xmlns="http://www.w3.org/2000/svg"
-                          >
-                            <circle class="path" fill="none" stroke-width="6" cx="33" cy="33" r="30"></circle>
-                          </svg>
-                        </span>
-                      </span>
-                      <span
-                        >(
-                        {{- 'products.product.quantity.in_cart_html' | t: quantity: cart_qty -}}
-                        )</span
-                      >
-                    </span>
                   </label>
                   <quantity-input class="quantity">
                     <button class="quantity__button no-js-hidden" name="minus" type="button">
@@ -243,7 +227,7 @@
                         max="{{ product.selected_or_first_available_variant.quantity_rule.max }}"
                       {% endif %}
                       step="{{ product.selected_or_first_available_variant.quantity_rule.increment }}"
-                      value="{{ product.selected_or_first_available_variant.quantity_rule.min }}"
+                      value="{{ input_value }}"
                       form="{{ product_form_id }}"
                     >
                     <button class="quantity__button no-js-hidden" name="plus" type="button">

--- a/sections/featured-product.liquid
+++ b/sections/featured-product.liquid
@@ -286,7 +286,10 @@
               {%- when 'variant_picker' -%}
                 {% render 'product-variant-picker', product: product, block: block, product_form_id: product_form_id, update_url: false %}
               {%- when 'buy_buttons' -%}
-                {%- render 'buy-buttons', block: block, product: product, product_form_id: product_form_id, section_id: section.id -%}
+                {% # theme-check-disable %}
+                {%- assign cart_qty = cart | item_count_for_variant: product.selected_or_first_available_variant.id -%}
+                {% # theme-check-enable %}
+                {%- render 'buy-buttons', block: block, product: product, product_form_id: product_form_id, section_id: section.id, cart_qty: cart_qty -%}
               {%- when 'custom_liquid' -%}
                 {{ block.settings.custom_liquid }}
               {%- when 'rating' -%}

--- a/sections/featured-product.liquid
+++ b/sections/featured-product.liquid
@@ -35,6 +35,10 @@
   endif
 -%}
 
+{% # theme-check-disable %}
+{%- assign cart_qty = cart | item_count_for_variant: product.selected_or_first_available_variant.id -%}
+{% # theme-check-enable %}
+
 {% comment %} TODO: assign `product.selected_or_first_available_variant` to variable and replace usage to reduce verbosity {% endcomment %}
 
 {%- assign first_3d_model = product.media | where: 'media_type', 'model' | first -%}
@@ -195,15 +199,12 @@
                   {{ block.shopify_attributes }}
                 >
                   {% comment %} TODO: enable theme-check once `item_count_for_variant` is accepted as valid filter {% endcomment %}
-                  {% # theme-check-disable %}
                   {%- liquid 
-                    assign cart_qty = cart | item_count_for_variant: product.selected_or_first_available_variant.id
                     assign input_value = product.selected_or_first_available_variant.quantity_rule.min
                     if cart_qty > 0
                       assign input_value = cart_qty
                     endif
                   -%}
-                  {% # theme-check-enable %}
                   <label class="quantity__label form__label" for="Quantity-{{ section.id }}">
                     {{ 'products.product.quantity.label' | t }}
                   </label>
@@ -270,9 +271,6 @@
               {%- when 'variant_picker' -%}
                 {% render 'product-variant-picker', product: product, block: block, product_form_id: product_form_id, update_url: false %}
               {%- when 'buy_buttons' -%}
-                {% # theme-check-disable %}
-                {%- assign cart_qty = cart | item_count_for_variant: product.selected_or_first_available_variant.id -%}
-                {% # theme-check-enable %}
                 {%- render 'buy-buttons', block: block, product: product, product_form_id: product_form_id, section_id: section.id, cart_qty: cart_qty -%}
               {%- when 'custom_liquid' -%}
                 {{ block.settings.custom_liquid }}

--- a/sections/main-product.liquid
+++ b/sections/main-product.liquid
@@ -205,26 +205,16 @@
               >
                 {% comment %} TODO: enable theme-check once `item_count_for_variant` is accepted as valid filter {% endcomment %}
                 {% # theme-check-disable %}
-                {%- assign cart_qty = cart | item_count_for_variant: product.selected_or_first_available_variant.id -%}
+                {%- liquid 
+                  assign cart_qty = cart | item_count_for_variant: product.selected_or_first_available_variant.id
+                  assign input_value = product.selected_or_first_available_variant.quantity_rule.min
+                  if cart_qty > 0
+                    assign input_value = cart_qty
+                  endif
+                -%}
                 {% # theme-check-enable %}
                 <label class="quantity__label form__label" for="Quantity-{{ section.id }}">
                   {{ 'products.product.quantity.label' | t }}
-                  <span class="quantity__rules-cart no-js-hidden{% if cart_qty == 0 %} hidden{% endif %}">
-                    <span class="loading-overlay hidden">
-                      <span class="loading-overlay__spinner">
-                        <svg
-                          aria-hidden="true"
-                          focusable="false"
-                          class="spinner"
-                          viewBox="0 0 66 66"
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <circle class="path" fill="none" stroke-width="6" cx="33" cy="33" r="30"></circle>
-                        </svg>
-                      </span>
-                    </span>
-                    <span>({{- 'products.product.quantity.in_cart_html' | t: quantity: cart_qty -}})</span>
-                  </span>
                 </label>
                 <quantity-input class="quantity">
                   <button class="quantity__button no-js-hidden" name="minus" type="button">
@@ -246,7 +236,7 @@
                       max="{{ product.selected_or_first_available_variant.quantity_rule.max }}"
                     {% endif %}
                     step="{{ product.selected_or_first_available_variant.quantity_rule.increment }}"
-                    value="{{ product.selected_or_first_available_variant.quantity_rule.min }}"
+                    value="{{ input_value }}"
                     form="{{ product_form_id }}"
                   />
                   <button class="quantity__button no-js-hidden" name="plus" type="button">

--- a/sections/main-product.liquid
+++ b/sections/main-product.liquid
@@ -311,7 +311,11 @@
             {%- when 'variant_picker' -%}
               {% render 'product-variant-picker', product: product, block: block, product_form_id: product_form_id %}
             {%- when 'buy_buttons' -%}
-              {%- render 'buy-buttons', block: block, product: product, product_form_id: product_form_id, section_id: section.id, show_pickup_availability: true -%}
+              {% # theme-check-disable %}
+              {%- assign cart_qty = cart | item_count_for_variant: product.selected_or_first_available_variant.id -%}
+              {% # theme-check-enable %}
+              {%- render 'buy-buttons', block: block, product: product, product_form_id: product_form_id, section_id: section.id, show_pickup_availability: true, cart_qty: cart_qty
+              -%}
             {%- when 'rating' -%}
               {%- if product.metafields.reviews.rating.value != blank -%}
                 {% liquid

--- a/sections/main-product.liquid
+++ b/sections/main-product.liquid
@@ -55,6 +55,9 @@
   {%- endif -%}
 
   {% assign variant_images = product.images | where: 'attached_to_variant?', true | map: 'src' %}
+  {% # theme-check-disable %}
+  {%- assign cart_qty = cart | item_count_for_variant: product.selected_or_first_available_variant.id -%}
+  {% # theme-check-enable %}
 
   <div class="product product--{{ section.settings.media_size }} product--{{ section.settings.media_position }} product--{{ section.settings.gallery_layout }} product--mobile-{{ section.settings.mobile_thumbnails }} grid grid--1-col {% if product.media.size > 0 %}grid--2-col-tablet{% else %}product--no-media{% endif %}">
     <div class="grid__item product__media-wrapper{% if section.settings.media_position == 'right' %} medium-hide large-up-hide{% endif %}">
@@ -206,7 +209,6 @@
                 {% comment %} TODO: enable theme-check once `item_count_for_variant` is accepted as valid filter {% endcomment %}
                 {% # theme-check-disable %}
                 {%- liquid 
-                  assign cart_qty = cart | item_count_for_variant: product.selected_or_first_available_variant.id
                   assign input_value = product.selected_or_first_available_variant.quantity_rule.min
                   if cart_qty > 0
                     assign input_value = cart_qty
@@ -301,9 +303,6 @@
             {%- when 'variant_picker' -%}
               {% render 'product-variant-picker', product: product, block: block, product_form_id: product_form_id %}
             {%- when 'buy_buttons' -%}
-              {% # theme-check-disable %}
-              {%- assign cart_qty = cart | item_count_for_variant: product.selected_or_first_available_variant.id -%}
-              {% # theme-check-enable %}
               {%- render 'buy-buttons', block: block, product: product, product_form_id: product_form_id, section_id: section.id, show_pickup_availability: true, cart_qty: cart_qty
               -%}
             {%- when 'rating' -%}

--- a/snippets/buy-buttons.liquid
+++ b/snippets/buy-buttons.liquid
@@ -6,11 +6,12 @@
   - product_form_id: {String} product form id.
   - section_id: {String} id of section to which this snippet belongs.
   - show_pickup_availability:: {Boolean} for the pickup availability. If true the pickup availability is rendered, false - not rendered (optional).
+  - cart_qty:: {String} for the qty items in cart (optional).
 
   Usage:
   {% render 'buy-buttons', block: block, product: product, product_form_id: product_form_id, show_pickup_availability: true %}
 {% endcomment %}
-<div {{ block.shopify_attributes }}>
+<div id="Buy-Buttons-{{ section.id }}" {{ block.shopify_attributes }}>
   {%- if product != blank -%}
     <product-form class="product-form">
       <div class="product-form__error-message-wrapper" role="alert" hidden>
@@ -56,6 +57,7 @@
             id = "ProductSubmitButton-{{ section_id }}"
             type="submit"
             name="add"
+            data-cartqty="{{ cart_qty }}"
             class="product-form__submit button button--full-width {% if block.settings.show_dynamic_checkout %}button--secondary{% else %}button--primary{% endif %}"
             {% if product.selected_or_first_available_variant.available == false or quantity_rule_soldout %}
               disabled
@@ -64,6 +66,8 @@
             <span>
               {%- if product.selected_or_first_available_variant.available == false or quantity_rule_soldout -%}
                 {{ 'products.product.sold_out' | t }}
+              {%- elsif cart_qty > 0 -%}
+                Update cart
               {%- else -%}
                 {{ 'products.product.add_to_cart' | t }}
               {%- endif -%}

--- a/snippets/buy-buttons.liquid
+++ b/snippets/buy-buttons.liquid
@@ -63,7 +63,6 @@
               disabled
             {% endif %}
           >
-            <span class="hidden added-to-cart">Added to cart {%- render 'icon-checkmark' -%}</span>
             <span class="cart-label" data-addcart="{{ 'products.product.add_to_cart' | t }}" data-updatecart="{{ 'products.product.update_cart' | t }}">
               {%- if product.selected_or_first_available_variant.available == false or quantity_rule_soldout -%}
                 {{ 'products.product.sold_out' | t }}
@@ -84,6 +83,9 @@
                 <circle class="path" fill="none" stroke-width="6" cx="33" cy="33" r="30"></circle>
               </svg>
             </div>
+            <span class="added-to-cart hidden">
+              Added to cart {%- render 'icon-checkmark' -%}
+            </span>
           </button>
           {%- if block.settings.show_dynamic_checkout -%}
             {{ form | payment_button }}

--- a/snippets/buy-buttons.liquid
+++ b/snippets/buy-buttons.liquid
@@ -57,20 +57,24 @@
             id="ProductSubmitButton-{{ section_id }}"
             type="submit"
             name="add"
-            data-cartqty="{{ cart_qty }}"
             class="product-form__submit button button--full-width {% if block.settings.show_dynamic_checkout %}button--secondary{% else %}button--primary{% endif %}"
             {% if product.selected_or_first_available_variant.available == false or quantity_rule_soldout %}
               disabled
             {% endif %}
           >
-            <span class="cart-label" data-addcart="{{ 'products.product.add_to_cart' | t }}" data-updatecart="{{ 'products.product.update_cart' | t }}">
-              {%- if product.selected_or_first_available_variant.available == false or quantity_rule_soldout -%}
-                {{ 'products.product.sold_out' | t }}
-              {%- elsif cart_qty > 0 -%}
-                {{ 'products.product.update_cart' | t }}
-              {%- else -%}
-                {{ 'products.product.add_to_cart' | t }}
-              {%- endif -%}
+            <span class="cart-label">
+              <span class="cart-label-default">
+                {%- if product.selected_or_first_available_variant.available == false or quantity_rule_soldout -%}
+                  {{ 'products.product.sold_out' | t }}
+                {%- elsif cart_qty > 0 -%}
+                  {{ 'products.product.update_cart' | t }}
+                {%- else -%}
+                  {{ 'products.product.add_to_cart' | t }}
+                {%- endif -%}
+              </span>
+              <span class="added-to-cart hidden">
+                {{ 'products.product.added_to_cart' | t }} {%- render 'icon-checkmark' -%}
+              </span>
             </span>
             <div class="loading-overlay__spinner hidden">
               <svg
@@ -83,9 +87,6 @@
                 <circle class="path" fill="none" stroke-width="6" cx="33" cy="33" r="30"></circle>
               </svg>
             </div>
-            <span class="added-to-cart hidden">
-              Added to cart {%- render 'icon-checkmark' -%}
-            </span>
           </button>
           {%- if block.settings.show_dynamic_checkout -%}
             {{ form | payment_button }}

--- a/snippets/buy-buttons.liquid
+++ b/snippets/buy-buttons.liquid
@@ -73,7 +73,7 @@
                 {%- endif -%}
               </span>
               <span class="added-to-cart hidden">
-                {{ 'products.product.added_to_cart' | t }} {%- render 'icon-checkmark' -%}
+                <span class="added-to-cart-text">{{ 'products.product.added_to_cart' | t: quantity: cart_qty }}</span>{%- render 'icon-checkmark' -%}
               </span>
             </span>
             <div class="loading-overlay__spinner hidden">

--- a/snippets/buy-buttons.liquid
+++ b/snippets/buy-buttons.liquid
@@ -54,7 +54,7 @@
             endif
           -%}
           <button
-            id = "ProductSubmitButton-{{ section_id }}"
+            id="ProductSubmitButton-{{ section_id }}"
             type="submit"
             name="add"
             data-cartqty="{{ cart_qty }}"
@@ -63,7 +63,8 @@
               disabled
             {% endif %}
           >
-            <span>
+            <span class="hidden added-to-cart">Added to cart {%- render 'icon-checkmark' -%}</span>
+            <span class="cart-label" data-addcart="{{ 'products.product.add_to_cart' | t }}" data-updatecart="{{ 'products.product.update_cart' | t }}">
               {%- if product.selected_or_first_available_variant.available == false or quantity_rule_soldout -%}
                 {{ 'products.product.sold_out' | t }}
               {%- elsif cart_qty > 0 -%}

--- a/snippets/buy-buttons.liquid
+++ b/snippets/buy-buttons.liquid
@@ -67,7 +67,7 @@
               {%- if product.selected_or_first_available_variant.available == false or quantity_rule_soldout -%}
                 {{ 'products.product.sold_out' | t }}
               {%- elsif cart_qty > 0 -%}
-                Update cart
+                {{ 'products.product.update_cart' | t }}
               {%- else -%}
                 {{ 'products.product.add_to_cart' | t }}
               {%- endif -%}


### PR DESCRIPTION
### PR Summary: 

This PR updates the behaviour where you see the ATC button (PDP, modals with quick buy enabled or featured product). Originally you saw the amount of items in cart right beside the label. Now you will
- [see that is removed](https://screenshot.click/15-57-xktqk-uany0.png)
-  the **add to cart** button gets updated to **update cart** once there are items in cart  (that is not the same amount)
-  the amount in the _qty input_ shows the amount in cart if there are items in cart
-  The **add to cart** button gets changed to **added to cart** when the amount of items in the qty picker and in cart are the same for that variant (and clicking on it opens cart)

Quick video: https://screenshot.click/21-09-b0jxt-yrfvv.mp4

### Why are these changes introduced?
There is an opportunity to better communicate the qty in cart to the buyer

### What approach did you take?
- In `product-form.js`, I am subscribing to the variant change and add to cart, so I can update the API to call the `add to cart API` or `update cart API`, in addition to passing the variant that is changing (needed for the update cart)
-  In `product-info` I am updating the new qty input value to be the qty in cart if there is more than 0 items in cart of that variant. I am also adding logic to ensure the `Add to cart` gets updated to `Update cart` and vice versa. And also including the logic for when the items in cart matches the input amount
- In the liquid files I am removing the label with amount of items in cart beside the quantity label and updating the buy buttons
- In the `cartnotification.js` I am passing the variant ID, if the type of API call is of update (not available in the response when the API call is not add)
- Creating a qty change publish in the qty input element and subscribing to it in the product-form where when it changes, we update the cart API to be of update or add. And also subscribing to it in the product info so we can update the button text accordingly
- The text for `Add to cart` and `Update cart` depends on items in cart and can be defined in liquid. But the text for `Added to cart` is determined by a comparison of the items in cart with the qty input amount (that changes as the user clicks on +/-). Therefore, it is not possible to just re-render the page and display the new content for `Added to cart`, we need to do some JS logic. Therefore the content is saved in a hidden span that can be accessed in JS https://github.com/Shopify/dawn/pull/2306/files#diff-8f1c61683d7292591d2a180ee5be8b3ec83b16f25b94d04b12dbc0b6784b9cb0R66

### Visual impact on existing themes
The buttons will now have a logic that will show "Add to cart" , "Added to cart" or "Update cart" and the label `(1 in cart)` besides `Quantity` is now removed and now lives in the qty input itself


### Testing steps/scenarios
<!-- List all the testing tasks that applies to your fix to help peers review your work. -->
- [ ] Test with no JS
- [ ] Test with cart notification and cart drawer
- [ ] Test in the PDP
- [ ] Test in the feat prod
- [ ] Test in feat collection with quick add enabled
- [ ] Test with qty rules (Test product Bo Ivy black)

### Demo links
<!-- Please include a link to a demo store that includes preconfigured sections and settings to allow reviewers to easily test the features you are working on. -->

- [Store](https://os2-demo.myshopify.com/?_ab=0&_fd=0&_sc=1&key=426fb1f420e906418fa2448926c74e347c9832a999315511ee1be9880525803a&preview_theme_id=139396415510)
- [Editor](https://os2-demo.myshopify.com/admin/themes/139396415510/editor)

### Checklist
- [ ] Added PR summary for [release notes](https://themes.shopify.com/themes/dawn/styles/default#ReleaseNotes)
- [ ] Requested review from UX (Only for changes that are affecting the experience or perceivable visual details)
- [ ] Created a ticket for the [help.shopify.com](https://help.shopify.com) documentation team about updates to theme settings. (Internal-only task)
- [ ] Followed [theme code principles](https://github.com/Shopify/dawn/blob/main/.github/CONTRIBUTING.md#theme-code-principles)
- [ ] Linted with [Theme Check](https://github.com/Shopify/theme-check)
- [ ] Tested on [mobile](https://shopify.dev/themes/store/requirements#mobile-browser-requirements)
- [ ] Tested on [multiple browsers](https://shopify.dev/themes/store/requirements#desktop-browser-requirements)
- [ ] Tested for [accessibility](https://shopify.dev/themes/best-practices/accessibility)
