### PR TITLE
add zoom on hover and show spinner when image loading

### DIFF
--- a/assets/magnify.js
+++ b/assets/magnify.js
@@ -25,7 +25,7 @@ function prepareOverlay(container, image) {
 }
 
 function toggleLoadingSpinner(image) {
-  const loadingSpinner = document.getElementById(`loading-spinner-${image.dataset.mediaId}`);
+  const loadingSpinner = image.parentElement.parentElement.querySelector(`.loading-overlay__spinner`);
   loadingSpinner.classList.toggle('hidden');
 }
 

--- a/assets/magnify.js
+++ b/assets/magnify.js
@@ -1,12 +1,33 @@
 // create a container and set the full-size image as its background
 function createOverlay(image) {
+  const overlayImage = document.createElement('img');
+  overlayImage.setAttribute('src', `${image.src}`);
   overlay = document.createElement('div');
-  overlay.setAttribute('class', 'image-magnify-full-size');
-  overlay.setAttribute('aria-hidden', 'true');
-  overlay.style.backgroundImage = `url('${image.src}')`;
-  image.parentElement.insertBefore(overlay, image);
+  prepareOverlay(overlay, overlayImage);
+
+  image.style.opacity = '50%';
+  toggleLoadingSpinner(image);
+
+  overlayImage.onload = () => {
+    toggleLoadingSpinner(image);
+    image.parentElement.insertBefore(overlay, image);
+    image.style.opacity = '100%';
+  }
+
   return overlay;
 };
+
+function prepareOverlay(container, image) {
+  container.setAttribute('class', 'image-magnify-full-size');
+  container.setAttribute('aria-hidden', 'true');
+  container.style.backgroundImage = `url('${image.src}')`;
+  container.style.backgroundColor = 'var(--gradient-background)';
+}
+
+function toggleLoadingSpinner(image) {
+  const loadingSpinner = document.getElementById(`loading-spinner-${image.dataset.mediaId}`);
+  loadingSpinner.classList.toggle('hidden');
+}
 
 function moveWithHover(image, event, zoomRatio) {
   // calculate mouse position
@@ -14,8 +35,8 @@ function moveWithHover(image, event, zoomRatio) {
   const container = event.target.getBoundingClientRect();
   const xPosition = event.clientX - container.left;
   const yPosition = event.clientY - container.top;
-  const xPercent = `${xPosition / (overlay.clientWidth / 100)}%`;
-  const yPercent = `${yPosition / ((overlay.clientWidth * ratio) / 100)}%`;
+  const xPercent = `${xPosition / (image.clientWidth / 100)}%`;
+  const yPercent = `${yPosition / ((image.clientWidth * ratio) / 100)}%`;
 
   // determine what to show in the frame
   overlay.style.backgroundPosition = `${xPercent} ${yPercent}`;

--- a/assets/section-main-product.css
+++ b/assets/section-main-product.css
@@ -1167,6 +1167,22 @@ a.product__text {
   display: none;
 }
 
+.product__modal-opener > .loading-overlay__spinner {
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  position: absolute;
+  display: flex;
+  align-items: center;
+  height: 48px;
+  width: 48px;
+}
+
+.product__modal-opener .path {
+  stroke: rgb(var(--color-base-accent-1));
+  opacity: 0.75;
+}
+
 @media (hover: hover) {
   .product__media-zoom-hover,
   .product__media-icon--hover {
@@ -1450,6 +1466,12 @@ a.product__text {
 .product-media-container .product__modal-opener {
   display: block;
   position: relative;
+}
+
+.product__modal-opener {
+  display: flex;
+  justify-content: center;
+  align-items: center;
 }
 
 @media screen and (min-width: 750px) {

--- a/assets/section-main-product.css
+++ b/assets/section-main-product.css
@@ -1468,12 +1468,6 @@ a.product__text {
   position: relative;
 }
 
-.product__modal-opener {
-  display: flex;
-  justify-content: center;
-  align-items: center;
-}
-
 @media screen and (min-width: 750px) {
   .product-media-container .product__modal-opener:not(.product__modal-opener--image) {
     display: none;

--- a/sections/featured-product.liquid
+++ b/sections/featured-product.liquid
@@ -1425,12 +1425,17 @@
           "label": "t:sections.main-product.settings.image_zoom.options__1.label"
         },
         {
+          "value": "hover",
+          "label": "t:sections.main-product.settings.image_zoom.options__2.label"
+        },
+        {
           "value": "none",
           "label": "t:sections.main-product.settings.image_zoom.options__3.label"
         }
       ],
       "default": "lightbox",
-      "label": "t:sections.main-product.settings.image_zoom.label"
+      "label": "t:sections.main-product.settings.image_zoom.label",
+      "info": "t:sections.main-product.settings.image_zoom.info"
     },
     {
       "type": "checkbox",

--- a/sections/main-product.liquid
+++ b/sections/main-product.liquid
@@ -1999,12 +1999,17 @@
           "label": "t:sections.main-product.settings.image_zoom.options__1.label"
         },
         {
+          "value": "hover",
+          "label": "t:sections.main-product.settings.image_zoom.options__2.label"
+        },
+        {
           "value": "none",
           "label": "t:sections.main-product.settings.image_zoom.options__3.label"
         }
       ],
       "default": "lightbox",
-      "label": "t:sections.main-product.settings.image_zoom.label"
+      "label": "t:sections.main-product.settings.image_zoom.label",
+      "info": "t:sections.main-product.settings.image_zoom.info"
     },
     {
       "type": "select",

--- a/snippets/product-thumbnail.liquid
+++ b/snippets/product-thumbnail.liquid
@@ -90,11 +90,23 @@
         endcase
       -%}
     </span>
+    <div class="loading-overlay__spinner hidden" id="loading-spinner-{{ media.id }}">
+      <svg
+        aria-hidden="true"
+        focusable="false"
+        class="spinner"
+        viewBox="0 0 66 66"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <circle class="path" fill="none" stroke-width="6" cx="33" cy="33" r="30"></circle>
+      </svg>
+    </div>
     <div class="product__media media media--transparent">
       {{ media.preview_image | image_url: width: 1946 | image_tag:
         class: image_class,
         loading: lazy,
         sizes: sizes,
+        data-media-id: media.id,
         widths: '246, 493, 600, 713, 823, 990, 1100, 1206, 1346, 1426, 1646, 1946'
       }}
     </div>

--- a/snippets/product-thumbnail.liquid
+++ b/snippets/product-thumbnail.liquid
@@ -98,7 +98,7 @@
         viewBox="0 0 66 66"
         xmlns="http://www.w3.org/2000/svg"
       >
-        <circle class="path" fill="none" stroke-width="6" cx="33" cy="33" r="30"></circle>
+        <circle class="path" fill="none" stroke-width="4" cx="33" cy="33" r="30"></circle>
       </svg>
     </div>
     <div class="product__media media media--transparent">

--- a/snippets/product-thumbnail.liquid
+++ b/snippets/product-thumbnail.liquid
@@ -90,7 +90,7 @@
         endcase
       -%}
     </span>
-    <div class="loading-overlay__spinner hidden" id="loading-spinner-{{ media.id }}">
+    <div class="loading-overlay__spinner hidden">
       <svg
         aria-hidden="true"
         focusable="false"
@@ -106,7 +106,6 @@
         class: image_class,
         loading: lazy,
         sizes: sizes,
-        data-media-id: media.id,
         widths: '246, 493, 600, 713, 823, 990, 1100, 1206, 1346, 1426, 1646, 1946'
       }}
     </div>


### PR DESCRIPTION
### PR Summary: 

Fixes an issue with transparent product images when the "Click and hover" image zoom option is activated.

### Why are these changes introduced?

Fixes #2301 

Just like the original image, the magnified overlay currently uses a transparent background. This causes the thumbnail in the background to become visible, which looks buggy. To fix the issue, I applied a solid background to all images, matching the background colour chosen in Theme settings.

The PR also adds a loading spinner to each thumbnail. When a larger image is loading, the thumbnail opacity changes to 50% and the loading spinner is displayed. Once the image is loaded, this disappears and the thumbnail opacity goes back to 100%.

### What approach did you take?
- re-add "Click and Hover" option to main product/featured product "Image zoom" settings
- re-add info regarding Click and Hover behaviour on mobile
- change the overlay's `backgroundColor` to `var(--gradient-background)`
- reuse existing loading spinner from "Add to Cart" button and add it to product thumbnail
- change thumbnail opacity to 50% and display loading spinner while image is loading
- change thumbnail opacity back to 100% and remove loading spinner once image is loaded

### Decision log
| # | Decision | Alternatives | Rationale | Downsides |
|---|---|---|---|---|
| 1 |  Get loading spinner based on the image's parent elements | Add a `data-media-id` to the spinner and use that to query  |  There are several situations where we might have duplicate IDs and these conflicts can break the functionality of the spinner. See @LucasLacerdaUX's [comment](https://github.com/Shopify/dawn/pull/2314#discussion_r1115334455)  |  Grabbing the spinner inside the image's `.parentElement.parentElement` is not very elegant. It's not immediately obvious why we're doing it this way  |

### Visual impact on existing themes
Merchants who upgrade to a new theme version with this change will get a new "Click and hover" option under their "Image zoom" settings.

### Testing steps/scenarios
<!-- List all the testing tasks that applies to your fix to help peers review your work. -->
- [ ] Navigate to the [theme editor](https://os2-demo.myshopify.com/admin/themes/139398873110/editor)
- [ ] In your Theme settings, go to Colours and change "Background 1" to a new colour
- [ ] Pick a product with lots high-res images (like `Art Deco - Cyclamen`, `Bo Ivy - Brown`, or `Pleated Heel Boot`) and navigate to its product page
- [ ] Under "Image zoom", select "Click and hover" and hit Save
- [ ] Click all images to zoom in. Verify that the thumbnail transparency changes to 50% and the loading spinner is showing while the image is loading. Use the "Slow 3G" throttling option in your DevTools Network tab if you need to simulate a slow connection
- [ ] Navigate to the `Transparent background PNG` product page and click the thumbnail to zoom in. Verify that the thumbnail is not showing behind the zoomed-in image, and that the background matches the colour chosen in Theme settings.

### Demo links
_Transparent image_

https://user-images.githubusercontent.com/22390758/220571509-2fd53aae-9971-49ec-9029-21b09d1d3507.mp4



_Regular image with spinner_

https://user-images.githubusercontent.com/22390758/220571563-2629993c-0a46-41b1-a0a2-3b660ac5e9c6.mp4

- [Store](https://os2-demo.myshopify.com/?preview_theme_id=139398873110)
- [Editor](https://os2-demo.myshopify.com/admin/themes/139398873110/editor)

### Checklist
- [x] Added PR summary for [release notes](https://themes.shopify.com/themes/dawn/styles/default#ReleaseNotes)
- [x] Requested review from UX (Only for changes that are affecting the experience or perceivable visual details)
- [ ] Created a ticket for the [help.shopify.com](https://help.shopify.com) documentation team about updates to theme settings. (Internal-only task)
- [x] Followed [theme code principles](https://github.com/Shopify/dawn/blob/main/.github/CONTRIBUTING.md#theme-code-principles)
- [x] Linted with [Theme Check](https://github.com/Shopify/theme-check)
- [x] Tested on [mobile](https://shopify.dev/themes/store/requirements#mobile-browser-requirements)
- [x] Tested on [multiple browsers](https://shopify.dev/themes/store/requirements#desktop-browser-requirements)
- [ ] Tested for [accessibility](https://shopify.dev/themes/best-practices/accessibility)
