### PR TITLE
Duplicated scrollbar in drawer menu

### DIFF
--- a/assets/component-menu-drawer.css
+++ b/assets/component-menu-drawer.css
@@ -93,7 +93,6 @@ details[open].menu-opening > .menu-drawer__submenu {
   display: grid;
   grid-template-rows: 1fr auto;
   align-content: space-between;
-  overflow-y: auto;
   height: 100%;
 }
 

--- a/assets/component-menu-drawer.css
+++ b/assets/component-menu-drawer.css
@@ -93,6 +93,7 @@ details[open].menu-opening > .menu-drawer__submenu {
   display: grid;
   grid-template-rows: 1fr auto;
   align-content: space-between;
+  overflow-y: auto;
   height: 100%;
 }
 
@@ -216,6 +217,7 @@ details[open].menu-opening > .menu-drawer__submenu {
 .menu-drawer__utility-links {
   padding: 2rem;
   background-color: rgba(var(--color-foreground), 0.03);
+  position: relative;
 }
 
 .menu-drawer__account {


### PR DESCRIPTION
### PR Summary: 

This PR is to fix duplicated scrollbar in drawer menu.


### Why are these changes introduced?

Fixes #2398 .

### What approach did you take?
I see there might be different approaches to fix the issue, however the most simple one for me is to add `position: relative` to `.menu-drawer__navigation-container`. I couldn't find a case it would affect anything.
### Other considerations

### Decision log

| # | Decision | Alternatives | Rationale | Downsides |
|---|---|---|---|---|
| 1 |   |   |   |   |


### Visual impact on existing themes
<!-- How will this visually affect merchants who upgrade to a new theme version with this change? -->


### Testing steps/scenarios
- [ ] Open drawer on desktop or mobile and zoom in 200-250% and make sure there is only one scrolling bar
- [ ] Make sure the drawer and language/currency forms work correct.

### Demo links

- [Editor](https://os2-demo.myshopify.com/admin/themes/139527258134/editor)

### Checklist
- [ ] Added PR summary for [release notes](https://themes.shopify.com/themes/dawn/styles/default#ReleaseNotes)
- [ ] Requested review from UX (Only for changes that are affecting the experience or perceivable visual details)
- [ ] Created a ticket for the [help.shopify.com](https://help.shopify.com) documentation team about updates to theme settings. (Internal-only task)
- [ ] Followed [theme code principles](https://github.com/Shopify/dawn/blob/main/.github/CONTRIBUTING.md#theme-code-principles)
- [ ] Linted with [Theme Check](https://github.com/Shopify/theme-check)
- [ ] Tested on [mobile](https://shopify.dev/themes/store/requirements#mobile-browser-requirements)
- [ ] Tested on [multiple browsers](https://shopify.dev/themes/store/requirements#desktop-browser-requirements)
- [ ] Tested for [accessibility](https://shopify.dev/themes/best-practices/accessibility)
