### PR TITLE
[Header] fix shadow on locale selector in the menu drawer

### DIFF
--- a/assets/component-localization-form.css
+++ b/assets/component-localization-form.css
@@ -206,7 +206,8 @@ noscript .localization-selector.link {
   text-decoration: underline;
 }
 
-.header__localization .localization-form__select.link:after {
+.header__localization .localization-form__select.link:after,
+.header__localization .localization-form__select.link:before {
   box-shadow: none;
 }
 


### PR DESCRIPTION
Fixes an issue discovered while testing our theme for the release. Specifically Crave. 

A shadow is still shown on the locale selectors when it shouldn't: 
![](https://screenshot.click/23-45-8fheg-vrfu8.png)