### PR TITLE
Enable "per-PR" async PR mode

### DIFF
--- a/translation.yml
+++ b/translation.yml
@@ -1,6 +1,7 @@
 source_language: en
 target_languages: [bg-BG, cs, da, de, el, es, fi, fr, hr-HR, hu, id, it, ja, ko, lt-LT, nb, nl, pl, pt-BR, pt-PT, ro-RO, ru, sk-SK, sl-SI, sv, th, tr, vi, zh-CN, zh-TW]
 non_blocking_languages: []
+async_pr_mode: per_pr
 components:
   - name: buyer
     audience: buyer


### PR DESCRIPTION
### PR Summary: 
This changes the async translations workflow to a new "per-PR" mode, which means async translations will now come back grouped by the PR number that originally requested them.


### Why are these changes introduced?
This makes it easier to manage those translations and allows the requester to be in the full loop of the process.


### What approach did you take?
Changed the translation.yml config file to add the new setting.



### Checklist
- [ ] Added PR summary for [release notes](https://themes.shopify.com/themes/dawn/styles/default#ReleaseNotes)
- [ ] Requested review from UX (Only for changes that are affecting the experience or perceivable visual details)
- [ ] Created a ticket for the [help.shopify.com](https://help.shopify.com) documentation team about updates to theme settings. (Internal-only task)
- [ ] Followed [theme code principles](https://github.com/Shopify/dawn/blob/main/.github/CONTRIBUTING.md#theme-code-principles)
- [ ] Linted with [Theme Check](https://github.com/Shopify/theme-check)
- [ ] Tested on [mobile](https://shopify.dev/themes/store/requirements#mobile-browser-requirements)
- [ ] Tested on [multiple browsers](https://shopify.dev/themes/store/requirements#desktop-browser-requirements)
- [ ] Tested for [accessibility](https://shopify.dev/themes/best-practices/accessibility)
