### PR TITLE
Tax include or tax exclude on main product

### DIFF
--- a/locales/en.default.json
+++ b/locales/en.default.json
@@ -165,6 +165,7 @@
       "xr_button": "View in your space",
       "xr_button_label": "View in your space, loads item in augmented reality window",
       "include_taxes": "Tax included.",
+      "exclude_taxes": "Tax excluded.",
       "shipping_policy_html": "<a href=\"{{ link }}\">Shipping</a> calculated at checkout."
     },
     "modal": {

--- a/sections/main-product.liquid
+++ b/sections/main-product.liquid
@@ -99,8 +99,10 @@
               </div>
               {%- if cart.taxes_included or shop.shipping_policy.body != blank -%}
                 <div class="product__tax caption rte">
-                  {%- if cart.taxes_included -%}
+                  {%- if product.selected_or_first_available_variant.taxable == true -%}
                     {{ 'products.product.include_taxes' | t }}
+                  {% else %}
+                    {{ 'products.product.exclude_taxes' | t }}
                   {%- endif -%}
                   {%- if shop.shipping_policy.body != blank -%}
                     {{ 'products.product.shipping_policy_html' | t: link: shop.shipping_policy.url }}


### PR DESCRIPTION
### PR Summary: 

Main product page changed to have product/variant display tax status as either includes or excludes tax

### Why are these changes introduced?

Previously the product displayed only one tax status type (included) dependant on store setting.

### What approach did you take?

Added if/else statement for product/variant to determine tax type

### Other considerations

### Decision log

| # | Decision | Alternatives | Rationale | Downsides |
|---|---|---|---|---|
| 1 |   |   |   |   |


### Visual impact on existing themes
Tax included or excluded will be displayed correctly


### Testing steps/scenarios
<!-- List all the testing tasks that applies to your fix to help peers review your work. -->
- [ ] Step 1

### Demo links
N/A

### Checklist
- [ ] Added PR summary for [release notes](https://themes.shopify.com/themes/dawn/styles/default#ReleaseNotes)
- [ ] Requested review from UX (Only for changes that are affecting the experience or perceivable visual details)
- [ ] Created a ticket for the [help.shopify.com](https://help.shopify.com) documentation team about updates to theme settings. (Internal-only task)
- [ ] Followed [theme code principles](https://github.com/Shopify/dawn/blob/main/.github/CONTRIBUTING.md#theme-code-principles)
- [ ] Linted with [Theme Check](https://github.com/Shopify/theme-check)
- [ ] Tested on [mobile](https://shopify.dev/themes/store/requirements#mobile-browser-requirements)
- [ ] Tested on [multiple browsers](https://shopify.dev/themes/store/requirements#desktop-browser-requirements)
- [ ] Tested for [accessibility](https://shopify.dev/themes/best-practices/accessibility)
