### PR TITLE
[Video] Add fade in on scroll animation

### DIFF
--- a/sections/video.liquid
+++ b/sections/video.liquid
@@ -46,7 +46,7 @@
       {% endif %}
     >
       {%- unless section.settings.heading == blank -%}
-        <div class="title-wrapper title-wrapper--no-top-margin">
+        <div class="title-wrapper title-wrapper--no-top-margin{% if settings.animations_reveal_on_scroll %} scroll-trigger animate--slide-in{% endif %}">
           <h2 class="title inline-richtext {{ section.settings.heading_size }}">{{ section.settings.heading }}</h2>
         </div>
       {%- endunless -%}
@@ -84,7 +84,7 @@
       </div>
     </noscript>
     <deferred-media
-      class="video-section__media deferred-media no-js-hidden gradient global-media-settings{% if section.settings.full_width %} global-media-settings--full-width{% endif %}{% if fix_ratio %} media-fit-cover{% endif %}"
+      class="video-section__media deferred-media no-js-hidden gradient global-media-settings{% if section.settings.full_width %} global-media-settings--full-width{% endif %}{% if fix_ratio %} media-fit-cover{% endif %}{% if settings.animations_reveal_on_scroll %} scroll-trigger animate--slide-in{% endif %}"
       data-media-id="{{ video_id }}"
       {% if poster != null %}
         style="--ratio-percent: {{ 1 | divided_by: poster.aspect_ratio | times: 100 }}%;"


### PR DESCRIPTION
### PR Summary: 



### Why are these changes introduced?

Closes #2423

### What approach did you take?

Replicated animations from [the original prototype](https://github.com/Shopify/dawn/pull/2141)

### Visual impact on existing themes

Will animate Multicolumn section on scroll, when Reveal sections on scroll is enabled. 


https://user-images.githubusercontent.com/1202812/230156884-f25d93bd-1c6e-417d-b0d9-841a2a0fc1ef.mp4



### Testing steps/scenarios

- Enable Reveal sections on scroll under Animations in [Theme settings](https://os2-demo.myshopify.com/admin/themes/139536564246/editor?context=theme)
- On the home page, add a Video section and verify that it fades in on scroll
- Verify that each column cascades in
- Update the section's settings and verify that everything still works as expected

### Demo links

- [Store](https://os2-demo.myshopify.com/?preview_theme_id=139659378710)
- [Editor](https://os2-demo.myshopify.com/admin/themes/139659378710/editor)

### Checklist
- [x] Added PR summary for [release notes](https://themes.shopify.com/themes/dawn/styles/default#ReleaseNotes)
- [x] Requested review from UX (Only for changes that are affecting the experience or perceivable visual details)
- [ ] Created a ticket for the [help.shopify.com](https://help.shopify.com) documentation team about updates to theme settings. (Internal-only task)
- [x] Followed [theme code principles](https://github.com/Shopify/dawn/blob/main/.github/CONTRIBUTING.md#theme-code-principles)
- [x] Linted with [Theme Check](https://github.com/Shopify/theme-check)
- [x] Tested on [mobile](https://shopify.dev/themes/store/requirements#mobile-browser-requirements)
- [x] Tested on [multiple browsers](https://shopify.dev/themes/store/requirements#desktop-browser-requirements)
- [x] Tested for [accessibility](https://shopify.dev/themes/best-practices/accessibility)
