### PR TITLE
Prettier and vscode settings tweaks

### DIFF
--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,4 +1,12 @@
 {
   "printWidth": 120,
-  "singleQuote": true
+  "singleQuote": true,
+  "overrides": [
+    {
+      "files": "*.liquid",
+      "options": {
+        "singleQuote": false
+      }
+    }
+  ]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,12 @@
 {
-  "editor.formatOnSave": true
+  "editor.formatOnSave": false,
+  "[javascript]": {
+    "editor.formatOnSave": true
+  },
+  "[css]": {
+    "editor.formatOnSave": true
+  },
+  "[liquid]": {
+    "editor.formatOnSave": true
+  }
 }


### PR DESCRIPTION
### Why are these changes introduced?

Follow up to https://github.com/Shopify/dawn/pull/2323

Defining `singleQuote: true` could override the intended default for liquid files. Also, as is, ALL file types may be auto formatted on save, which can have unintended effects ([example](https://screenshot.click/07-35-30lja-qbwjx.mp4)).

### What approach did you take?

- Added an override for `*.liquid` files to our prettierrc
- Changed our editor settings to be more prescriptive with formatOnSave. I still think it's worth keeping it enabled for css, js, and liquid files to ensure consistency in the codebase. I was originally going to add a `.prettierignore` to deal with this, but I think I like this approach more anyway. Still an option though if we'd rather.

### Testing steps/scenarios

- Using the updated prettierrc, attempt to save changes to a liquid file.
- Ensure no quotes in liquid markup are changed from double to single (e.g `<div class='my-class'>`)
- Ensure all other liquid formatting still occurs on save.
- Ensure css and js formatting still occurs and double quotes are still converted to single quotes in those file types.
- Ensure saving .json or .md files don't format on save.

Note: You may have to restart vscode for the prettier update to take effect.

### Checklist
- [ ] Added PR summary for [release notes](https://themes.shopify.com/themes/dawn/styles/default#ReleaseNotes)
- [ ] Requested review from UX (Only for changes that are affecting the experience or perceivable visual details)
- [ ] Created a ticket for the [help.shopify.com](https://help.shopify.com) documentation team about updates to theme settings. (Internal-only task)
- [ ] Followed [theme code principles](https://github.com/Shopify/dawn/blob/main/.github/CONTRIBUTING.md#theme-code-principles)
- [ ] Linted with [Theme Check](https://github.com/Shopify/theme-check)
- [ ] Tested on [mobile](https://shopify.dev/themes/store/requirements#mobile-browser-requirements)
- [ ] Tested on [multiple browsers](https://shopify.dev/themes/store/requirements#desktop-browser-requirements)
- [ ] Tested for [accessibility](https://shopify.dev/themes/best-practices/accessibility)
