### PR TITLE
Add unique ids to all header menu items

### DIFF
--- a/snippets/header-drawer.liquid
+++ b/snippets/header-drawer.liquid
@@ -25,7 +25,10 @@
                 <li>
                   {%- if link.links != blank -%}
                     <details id="Details-menu-drawer-menu-item-{{ forloop.index }}">
-                      <summary class="menu-drawer__menu-item list-menu__item link link--text focus-inset{% if link.child_active %} menu-drawer__menu-item--active{% endif %}">
+                      <summary
+                        id="HeaderMenu-{{ link.handle }}"
+                        class="menu-drawer__menu-item list-menu__item link link--text focus-inset{% if link.child_active %} menu-drawer__menu-item--active{% endif %}"
+                      >
                         {{ link.title | escape }}
                         {% render 'icon-arrow' %}
                         {% render 'icon-caret' %}
@@ -45,6 +48,7 @@
                               <li>
                                 {%- if childlink.links == blank -%}
                                   <a
+                                    id="HeaderMenu-{{ link.handle }}-{{ childlink.handle }}"
                                     href="{{ childlink.url }}"
                                     class="menu-drawer__menu-item link link--text list-menu__item focus-inset{% if childlink.current %} menu-drawer__menu-item--active{% endif %}"
                                     {% if childlink.current %}
@@ -55,7 +59,10 @@
                                   </a>
                                 {%- else -%}
                                   <details id="Details-menu-drawer-submenu-{{ forloop.index }}">
-                                    <summary class="menu-drawer__menu-item link link--text list-menu__item focus-inset">
+                                    <summary
+                                      id="HeaderMenu-{{ link.handle }}-{{ childlink.handle }}"
+                                      class="menu-drawer__menu-item link link--text list-menu__item focus-inset"
+                                    >
                                       {{ childlink.title | escape }}
                                       {% render 'icon-arrow' %}
                                       {% render 'icon-caret' %}
@@ -71,10 +78,15 @@
                                         {% render 'icon-arrow' %}
                                         {{ childlink.title | escape }}
                                       </button>
-                                      <ul class="menu-drawer__menu list-menu" role="list" tabindex="-1">
+                                      <ul
+                                        class="menu-drawer__menu list-menu"
+                                        role="list"
+                                        tabindex="-1"
+                                      >
                                         {%- for grandchildlink in childlink.links -%}
                                           <li>
                                             <a
+                                              id="HeaderMenu-{{ link.handle }}-{{ childlink.handle }}-{{ grandchildlink.handle }}"
                                               href="{{ grandchildlink.url }}"
                                               class="menu-drawer__menu-item link link--text list-menu__item focus-inset{% if grandchildlink.current %} menu-drawer__menu-item--active{% endif %}"
                                               {% if grandchildlink.current %}
@@ -97,6 +109,7 @@
                     </details>
                   {%- else -%}
                     <a
+                      id="HeaderMenu-{{ link.handle }}"
                       href="{{ link.url }}"
                       class="menu-drawer__menu-item list-menu__item link link--text focus-inset{% if link.current %} menu-drawer__menu-item--active{% endif %}"
                       {% if link.current %}

--- a/snippets/header-drawer.liquid
+++ b/snippets/header-drawer.liquid
@@ -26,7 +26,7 @@
                   {%- if link.links != blank -%}
                     <details id="Details-menu-drawer-menu-item-{{ forloop.index }}">
                       <summary
-                        id="HeaderMenu-{{ link.handle }}"
+                        id="HeaderDrawer-{{ link.handle }}"
                         class="menu-drawer__menu-item list-menu__item link link--text focus-inset{% if link.child_active %} menu-drawer__menu-item--active{% endif %}"
                       >
                         {{ link.title | escape }}
@@ -48,7 +48,7 @@
                               <li>
                                 {%- if childlink.links == blank -%}
                                   <a
-                                    id="HeaderMenu-{{ link.handle }}-{{ childlink.handle }}"
+                                    id="HeaderDrawer-{{ link.handle }}-{{ childlink.handle }}"
                                     href="{{ childlink.url }}"
                                     class="menu-drawer__menu-item link link--text list-menu__item focus-inset{% if childlink.current %} menu-drawer__menu-item--active{% endif %}"
                                     {% if childlink.current %}
@@ -58,9 +58,9 @@
                                     {{ childlink.title | escape }}
                                   </a>
                                 {%- else -%}
-                                  <details id="Details-menu-drawer-submenu-{{ forloop.index }}">
+                                  <details id="Details-menu-drawer-{{ link.handle }}-{{ childlink.handle }}">
                                     <summary
-                                      id="HeaderMenu-{{ link.handle }}-{{ childlink.handle }}"
+                                      id="HeaderDrawer-{{ link.handle }}-{{ childlink.handle }}"
                                       class="menu-drawer__menu-item link link--text list-menu__item focus-inset"
                                     >
                                       {{ childlink.title | escape }}
@@ -86,7 +86,7 @@
                                         {%- for grandchildlink in childlink.links -%}
                                           <li>
                                             <a
-                                              id="HeaderMenu-{{ link.handle }}-{{ childlink.handle }}-{{ grandchildlink.handle }}"
+                                              id="HeaderDrawer-{{ link.handle }}-{{ childlink.handle }}-{{ grandchildlink.handle }}"
                                               href="{{ grandchildlink.url }}"
                                               class="menu-drawer__menu-item link link--text list-menu__item focus-inset{% if grandchildlink.current %} menu-drawer__menu-item--active{% endif %}"
                                               {% if grandchildlink.current %}
@@ -109,7 +109,7 @@
                     </details>
                   {%- else -%}
                     <a
-                      id="HeaderMenu-{{ link.handle }}"
+                      id="HeaderDrawer-{{ link.handle }}"
                       href="{{ link.url }}"
                       class="menu-drawer__menu-item list-menu__item link link--text focus-inset{% if link.current %} menu-drawer__menu-item--active{% endif %}"
                       {% if link.current %}

--- a/snippets/header-dropdown-menu.liquid
+++ b/snippets/header-dropdown-menu.liquid
@@ -45,7 +45,7 @@
                         {{ childlink.title | escape }}
                       </a>
                     {%- else -%}
-                      <details id="Details-HeaderSubMenu-{{ forloop.index }}">
+                      <details id="Details-HeaderSubMenu-{{ link.handle }}-{{ childlink.handle }}">
                         <summary
                           id="HeaderMenu-{{ link.handle }}-{{ childlink.handle }}"
                           class="header__menu-item link link--text list-menu__item focus-inset caption-large"
@@ -54,7 +54,7 @@
                           {% render 'icon-caret' %}
                         </summary>
                         <ul
-                          id="HeaderMenu-SubMenuList-{{ forloop.index }}"
+                          id="HeaderMenu-SubMenuList-{{ link.handle }}-{{ childlink.handle }}-{{ grandchildlink.handle }}"
                           class="header__submenu list-menu motion-reduce"
                         >
                           {%- for grandchildlink in childlink.links -%}

--- a/snippets/header-dropdown-menu.liquid
+++ b/snippets/header-dropdown-menu.liquid
@@ -12,7 +12,10 @@
         {%- if link.links != blank -%}
           <header-menu>
             <details id="Details-HeaderMenu-{{ forloop.index }}">
-              <summary class="header__menu-item list-menu__item link focus-inset">
+              <summary
+                id="HeaderMenu-{{ link.handle }}"
+                class="header__menu-item list-menu__item link focus-inset"
+              >
                 <span
                   {%- if link.child_active %}
                     class="header__active-menu-item"
@@ -32,6 +35,7 @@
                   <li>
                     {%- if childlink.links == blank -%}
                       <a
+                        id="HeaderMenu-{{ link.handle }}-{{ childlink.handle }}"
                         href="{{ childlink.url }}"
                         class="header__menu-item list-menu__item link link--text focus-inset caption-large{% if childlink.current %} list-menu__item--active{% endif %}"
                         {% if childlink.current %}
@@ -42,7 +46,10 @@
                       </a>
                     {%- else -%}
                       <details id="Details-HeaderSubMenu-{{ forloop.index }}">
-                        <summary class="header__menu-item link link--text list-menu__item focus-inset caption-large">
+                        <summary
+                          id="HeaderMenu-{{ link.handle }}-{{ childlink.handle }}"
+                          class="header__menu-item link link--text list-menu__item focus-inset caption-large"
+                        >
                           <span>{{ childlink.title | escape }}</span>
                           {% render 'icon-caret' %}
                         </summary>
@@ -53,6 +60,7 @@
                           {%- for grandchildlink in childlink.links -%}
                             <li>
                               <a
+                                id="HeaderMenu-{{ link.handle }}-{{ childlink.handle }}-{{ grandchildlink.handle }}"
                                 href="{{ grandchildlink.url }}"
                                 class="header__menu-item list-menu__item link link--text focus-inset caption-large{% if grandchildlink.current %} list-menu__item--active{% endif %}"
                                 {% if grandchildlink.current %}
@@ -73,6 +81,7 @@
           </header-menu>
         {%- else -%}
           <a
+            id="HeaderMenu-{{ link.handle }}"
             href="{{ link.url }}"
             class="header__menu-item list-menu__item link link--text focus-inset"
             {% if link.current %}

--- a/snippets/header-mega-menu.liquid
+++ b/snippets/header-mega-menu.liquid
@@ -12,7 +12,10 @@
         {%- if link.links != blank -%}
           <header-menu>
             <details id="Details-HeaderMenu-{{ forloop.index }}" class="mega-menu">
-              <summary class="header__menu-item list-menu__item link focus-inset">
+              <summary
+                id="HeaderMenu-{{ link.handle }}"
+                class="header__menu-item list-menu__item link focus-inset"
+              >
                 <span
                   {%- if link.child_active %}
                     class="header__active-menu-item"
@@ -34,6 +37,7 @@
                   {%- for childlink in link.links -%}
                     <li>
                       <a
+                        id="HeaderMenu-{{ link.handle }}-{{ childlink.handle }}"
                         href="{{ childlink.url }}"
                         class="mega-menu__link mega-menu__link--level-2 link{% if childlink.current %} mega-menu__link--active{% endif %}"
                         {% if childlink.current %}
@@ -47,6 +51,7 @@
                           {%- for grandchildlink in childlink.links -%}
                             <li>
                               <a
+                                id="HeaderMenu-{{ link.handle }}-{{ childlink.handle }}-{{ grandchildlink.handle }}"
                                 href="{{ grandchildlink.url }}"
                                 class="mega-menu__link link{% if grandchildlink.current %} mega-menu__link--active{% endif %}"
                                 {% if grandchildlink.current %}
@@ -67,6 +72,7 @@
           </header-menu>
         {%- else -%}
           <a
+            id="HeaderMenu-{{ link.handle }}"
             href="{{ link.url }}"
             class="header__menu-item list-menu__item link link--text focus-inset"
             {% if link.current %}


### PR DESCRIPTION
### PR Summary: 

Added unique ids for header navigation links for easier styling via Custom CSS.

### Why are these changes introduced?

Fixes #2419 
Fixes #2336 

Gives all header menu items, in all levels, unique ids to allow easier targeting with CSS selectors when using the Header section Custom CSS setting.

### What approach did you take?

I considered two approaches, one primarily using classes and one using explicit ids. The idea with classnames would be to give each ul/list-menu element a class representing it's level and likely cleaning up/consolidating the classes used for the menu items themselves (li, a, and summary). But even with clearer classes I did not find it exceptionally easy to target _only_ the specific item you want in any moderately complex menu structure. 

I could see there being other benefits to adding additional classes for us (which we can add as needed), but for the purpose of improving custom css targeting of menu items, using ids seems like the better approach. 

### Other considerations

### Decision log

| # | Decision | Alternatives | Rationale | Downsides |
|---|---|---|---|---|
| 1 | Use ids on the link elements | - Use classes<br>- Use classes and ids<br>- Use ids on ul or li item | - Results in the most minimal selector | - No real advantage for us or developer ergonomics |
| 2 | Include ancestor link handles in the id string (e.g `#HeaderMenu-Apparel-Shoes-Louise`) | - Use only current link's handle and add additional liquid logic to ensure uniqueness (e.g `#HeaderMenu-Louise`)<br>- Use only current link's handle and the menu level to minimize risk of duplicates | - Duplicates are not possible unless the same menu has 2 links that are actually duplicates for some reason | - Level 2 and 3 links will likely have very long ids |


### Visual impact on existing themes
No visual changes should be noticeable.

### Testing steps/scenarios
Ensure ids display for every menu item and there are no duplicates, checking the following..
- All menu types Dropdown, megamenu, drawer
- All 3 levels of menus
- Menu items with and with child links

You should be able to target and style any menu item on any level via the header's custom css

<img src="https://screenshot.click/10-15-zdxq2-ztrio.png" width="300" />

### Demo links

- [Editor](https://os2-demo.myshopify.com/admin/themes/139685298198/editor)

### Checklist
- [ ] Added PR summary for [release notes](https://themes.shopify.com/themes/dawn/styles/default#ReleaseNotes)
- [ ] Requested review from UX (Only for changes that are affecting the experience or perceivable visual details)
- [ ] Created a ticket for the [help.shopify.com](https://help.shopify.com) documentation team about updates to theme settings. (Internal-only task)
- [ ] Followed [theme code principles](https://github.com/Shopify/dawn/blob/main/.github/CONTRIBUTING.md#theme-code-principles)
- [ ] Linted with [Theme Check](https://github.com/Shopify/theme-check)
- [ ] Tested on [mobile](https://shopify.dev/themes/store/requirements#mobile-browser-requirements)
- [ ] Tested on [multiple browsers](https://shopify.dev/themes/store/requirements#desktop-browser-requirements)
- [ ] Tested for [accessibility](https://shopify.dev/themes/best-practices/accessibility)
