### PR TITLE
Animate the page section

### DIFF
--- a/sections/page.liquid
+++ b/sections/page.liquid
@@ -16,14 +16,14 @@
 
 <div class="color-{{ section.settings.color_scheme }} gradient">
   <div class="page-width page-width--narrow section-{{ section.id }}-padding">
-    <h2 class="page-title {{ section.settings.heading_size }}">
+    <h2 class="page-title {{ section.settings.heading_size }}{% if settings.animations_reveal_on_scroll %} scroll-trigger animate--slide-in{% endif %}">
       {%- if section.settings.page.title != blank -%}
         {{ section.settings.page.title | escape }}
       {%- else -%}
         {{ 'sections.page.title' | t }}
       {%- endif -%}
     </h2>
-    <div class="rte">
+    <div class="rte{% if settings.animations_reveal_on_scroll %} scroll-trigger animate--slide-in{% endif %}">
       {%- if section.settings.page.content != blank -%}
         {{ section.settings.page.content }}
       {%- else -%}


### PR DESCRIPTION
### PR Summary: 

Adds scroll animation to the Page section. 

### Why are these changes introduced?

Fixes #2510

### Visual impact on existing themes

Will animate the Page section when Reveal sections on scroll is enabled.

https://user-images.githubusercontent.com/1202812/231172531-ca48d799-5dff-4445-bfa1-644e7672d3c0.mp4



### Testing steps/scenarios

1. Visit the demo store
2. Add a "Page" section.
3. Activate Animate on Scroll from within Theme Settings > Motion
4. Observe that the page title and page content animate in for the Page section.

### Demo links

- [Store](https://os2-demo.myshopify.com/?preview_theme_id=139689951254)
- [Editor](https://os2-demo.myshopify.com/admin/themes/139689951254/editor)

### Checklist
- [x] Added PR summary for [release notes](https://themes.shopify.com/themes/dawn/styles/default#ReleaseNotes)
- [x] Requested review from UX (Only for changes that are affecting the experience or perceivable visual details)
- [ ] Created a ticket for the [help.shopify.com](https://help.shopify.com) documentation team about updates to theme settings. (Internal-only task)
- [x] Followed [theme code principles](https://github.com/Shopify/dawn/blob/main/.github/CONTRIBUTING.md#theme-code-principles)
- [x] Linted with [Theme Check](https://github.com/Shopify/theme-check)
- [x] Tested on [mobile](https://shopify.dev/themes/store/requirements#mobile-browser-requirements)
- [x] Tested on [multiple browsers](https://shopify.dev/themes/store/requirements#desktop-browser-requirements)
- [x] Tested for [accessibility](https://shopify.dev/themes/best-practices/accessibility)
