### PR TITLE
Animate the multirow section

### DIFF
--- a/sections/multirow.liquid
+++ b/sections/multirow.liquid
@@ -46,7 +46,7 @@
   <div class="multirow__inner page-width">
     {%- for block in section.blocks -%}
       <div
-        class="image-with-text isolate{{ borders_class }}{{ corners_class }}{{ padding_class }}"
+        class="image-with-text isolate{{ borders_class }}{{ corners_class }}{{ padding_class }}{% if settings.animations_reveal_on_scroll %} scroll-trigger animate--slide-in{% endif %}"
         {{ block.shopify_attributes }}
       >
         <div class="image-with-text__grid grid grid--gapless grid--1-col grid--{% if section.settings.desktop_image_width == 'medium' %}2-col-tablet{% else %}3-col-tablet{% endif %}{% if section.settings.image_layout contains 'alternate' %}{% cycle odd_class, even_class %}{% else %}{{ odd_class }}{% endif %}">


### PR DESCRIPTION
### PR Summary: 

Adds fade in on scroll animation to the Multirow section.

### Why are these changes introduced?

Closes #2508.

### What approach did you take?

Replicated animations from the original mockups in https://github.com/Shopify/dawn/pull/2141

### Visual impact on existing themes

Will animate Multirow sections on scroll, when "Reveal sections on scroll" is enabled.

https://user-images.githubusercontent.com/1202812/232047746-be674079-31f4-4c6b-831a-77a1069dca13.mp4

### Testing steps/scenarios

- Ensure "Reveal sections on scroll" is checked within Theme Settings > Animations.
- Add a Multirow section
- Add/remove blocks and adjust settings. Ensure things continue to animate in smoothly.

### Demo links
<!-- Please include a link to a demo store that includes preconfigured sections and settings to allow reviewers to easily test the features you are working on. -->

- [Store](https://os2-demo.myshopify.com/?preview_theme_id=139708727318)
- [Editor](https://os2-demo.myshopify.com/admin/themes/139708727318/editor)

### Checklist
- [x] Added PR summary for [release notes](https://themes.shopify.com/themes/dawn/styles/default#ReleaseNotes)
- [x] Requested review from UX (Only for changes that are affecting the experience or perceivable visual details)
- [ ] Created a ticket for the [help.shopify.com](https://help.shopify.com) documentation team about updates to theme settings. (Internal-only task)
- [x] Followed [theme code principles](https://github.com/Shopify/dawn/blob/main/.github/CONTRIBUTING.md#theme-code-principles)
- [x] Linted with [Theme Check](https://github.com/Shopify/theme-check)
- [x] Tested on [mobile](https://shopify.dev/themes/store/requirements#mobile-browser-requirements)
- [x] Tested on [multiple browsers](https://shopify.dev/themes/store/requirements#desktop-browser-requirements)
- [x] Tested for [accessibility](https://shopify.dev/themes/best-practices/accessibility)
