### PR TITLE
Turn scroll animations on by default

### DIFF
--- a/config/settings_schema.json
+++ b/config/settings_schema.json
@@ -219,7 +219,7 @@
         "type": "checkbox",
         "id": "animations_reveal_on_scroll",
         "label": "t:settings_schema.animations.settings.animations_reveal_on_scroll.label",
-        "default": false
+        "default": true
       }
     ]
   },


### PR DESCRIPTION
### PR Summary: 

Turns on scroll animations by default. 

### Why are these changes introduced?

Our working plan is to have subtle scroll animations on by default. We should have `main` reflect this, so we can more accurately test and evaluate this decision leading up to release. 

### Demo links
<!-- Please include a link to a demo store that includes preconfigured sections and settings to allow reviewers to easily test the features you are working on. -->

- [Store](https://os2-demo.myshopify.com/?preview_theme_id=139708825622)
- [Editor](https://os2-demo.myshopify.com/admin/themes/139708825622/editor)

### Checklist
- [x] Added PR summary for [release notes](https://themes.shopify.com/themes/dawn/styles/default#ReleaseNotes)
- [x] Requested review from UX (Only for changes that are affecting the experience or perceivable visual details)
- [ ] Created a ticket for the [help.shopify.com](https://help.shopify.com) documentation team about updates to theme settings. (Internal-only task)
- [x] Followed [theme code principles](https://github.com/Shopify/dawn/blob/main/.github/CONTRIBUTING.md#theme-code-principles)
- [x] Linted with [Theme Check](https://github.com/Shopify/theme-check)
- [x] Tested on [mobile](https://shopify.dev/themes/store/requirements#mobile-browser-requirements)
- [x] Tested on [multiple browsers](https://shopify.dev/themes/store/requirements#desktop-browser-requirements)
- [ x] Tested for [accessibility](https://shopify.dev/themes/best-practices/accessibility)
