### PR TITLE
Set animation property sustainably

### DIFF
--- a/assets/animations.js
+++ b/assets/animations.js
@@ -8,7 +8,7 @@ function onIntersection(elements, observer) {
       if (elementTarget.classList.contains(SCROLL_ANIMATION_OFFSCREEN_CLASSNAME)) {
         elementTarget.classList.remove(SCROLL_ANIMATION_OFFSCREEN_CLASSNAME);
         if (elementTarget.hasAttribute('data-cascade'))
-          elementTarget.setAttribute('style', `--animation-order: ${index};`);
+          elementTarget.style.setProperty('--animation-order', index);
       }
       observer.unobserve(elementTarget);
     } else {


### PR DESCRIPTION
### PR Summary: 

Sets the `--animation-order` property sustainably.

### Why are these changes introduced?

This intersector currently overwrites the entire `style` attribute, which will remove all existing properties.