### PR TITLE
Modify info string for gift card recipient checkbox

### DIFF
--- a/locales/cs.schema.json
+++ b/locales/cs.schema.json
@@ -1667,7 +1667,7 @@
             },
             "show_gift_card_recipient": {
               "label": "Zobrazit formulář s informacemi o příjemci u produktů dárkových karet",
-              "info": "Produkty dárkových karet je možné volitelně posílat přímo příslušnému příjemci společně s osobní zprávou. [Zjistit více](https://help.shopify.com/manual/online-store/themes/customizing-themes/add-gift-card-recipient-fields)"
+              "info": "Dárkové karty je možné volitelně v naplánované datum posílat přímo příslušnému příjemci společně s osobní zprávou. [Zjistit více](https://help.shopify.com/manual/online-store/themes/customizing-themes/add-gift-card-recipient-fields)"
             }
           }
         },

--- a/locales/da.schema.json
+++ b/locales/da.schema.json
@@ -1667,7 +1667,7 @@
             },
             "show_gift_card_recipient": {
               "label": "Vis formular til modtageroplysninger for gavekortprodukter",
-              "info": "Gavekortprodukter kan sendes direkte til modtageren sammen med en personlig besked. [Få mere at vide](https://help.shopify.com/manual/online-store/themes/customizing-themes/add-gift-card-recipient-fields)"
+              "info": "Gavekortprodukter kan sendes direkte til modtageren på en planlagt dato sammen med en personlig besked. [Få mere at vide](https://help.shopify.com/manual/online-store/themes/customizing-themes/add-gift-card-recipient-fields)"
             }
           }
         },

--- a/locales/de.schema.json
+++ b/locales/de.schema.json
@@ -1666,7 +1666,7 @@
             },
             "show_gift_card_recipient": {
               "label": "Formular für Empfängerinformationen für Geschenkgutscheinprodukte anzeigen",
-              "info": "Geschenkgutscheinprodukte können optional mit einer persönlichen Nachricht an einen Empfänger gesendet werden. [Mehr Informationen](https://help.shopify.com/manual/online-store/themes/customizing-themes/add-gift-card-recipient-fields)"
+              "info": "Geschenkkartenprodukte können optional mit einer persönlichen Nachricht an einem bestimmten Datum direkt an einen Empfänger gesendet werden.[Mehr erfahren](https://help.shopify.com/manual/online-store/themes/customizing-themes/add-gift-card-recipient-fields)"
             }
           }
         },

--- a/locales/en.default.schema.json
+++ b/locales/en.default.schema.json
@@ -2008,7 +2008,7 @@
             },
             "show_gift_card_recipient": {
               "label": "Show recipient information form for gift card products",
-              "info": "Gift card products can optionally be sent direct to a recipient along with a personal message. [Learn more](https://help.shopify.com/manual/online-store/themes/customizing-themes/add-gift-card-recipient-fields)"
+              "info": "Gift card products can optionally be sent direct to a recipient on a scheduled date along with a personal message. [Learn more](https://help.shopify.com/manual/online-store/themes/customizing-themes/add-gift-card-recipient-fields)"
             }
           }
         },

--- a/locales/es.schema.json
+++ b/locales/es.schema.json
@@ -1667,7 +1667,7 @@
             },
             "show_gift_card_recipient": {
               "label": "Mostrar el formulario de información de la persona destinataria para las tarjetas de regalo",
-              "info": "Opcionalmente, las tarjetas de regalo se pueden enviar directamente a una persona destinataria junto con un mensaje personal. [Más información](https://help.shopify.com/manual/online-store/themes/customizing-themes/add-gift-card-recipient-fields)"
+              "info": "Opcionalmente, las tarjetas de regalo se pueden enviar directamente a una persona destinataria en la fecha programada junto con un mensaje personal. [Más información](https://help.shopify.com/manual/online-store/themes/customizing-themes/add-gift-card-recipient-fields)"
             }
           }
         },

--- a/locales/fi.schema.json
+++ b/locales/fi.schema.json
@@ -1666,7 +1666,7 @@
             },
             "show_gift_card_recipient": {
               "label": "Näytä lahjakorttituotteiden vastaanottajien tietolomake",
-              "info": "Lahjakorttituotteet voidaan valinnaisesti lähettää suoraan vastaanottajalle siten, että niissä on mukana henkilökohtainen viesti. [Lisätietoja](https://help.shopify.com/manual/online-store/themes/customizing-themes/add-gift-card-recipient-fields)"
+              "info": "Lahjakorttituotteet voidaan valinnaisesti lähettää suoraan vastaanottajalle ennalta määrättynä päivänä siten, että niissä on mukana henkilökohtainen viesti. [Lisätietoja](https://help.shopify.com/manual/online-store/themes/customizing-themes/add-gift-card-recipient-fields)"
             }
           }
         },

--- a/locales/fr.schema.json
+++ b/locales/fr.schema.json
@@ -1666,7 +1666,7 @@
             },
             "show_gift_card_recipient": {
               "label": "Afficher le formulaire d’information sur le destinataire pour les cartes‑cadeaux en tant que produit",
-              "info": "Les cartes‑cadeaux en tant que produits peuvent être envoyées directement au destinataire, accompagnées d’un message personnel. [En savoir plus](https://help.shopify.com/manual/online-store/themes/customizing-themes/add-gift-card-recipient-fields)"
+              "info": "Les cartes‑cadeaux en tant que produits peuvent être envoyées directement au destinataire à une date programmée, accompagnées d’un message personnel. [En savoir plus](https://help.shopify.com/manual/online-store/themes/customizing-themes/add-gift-card-recipient-fields)"
             }
           }
         },

--- a/locales/it.schema.json
+++ b/locales/it.schema.json
@@ -1667,7 +1667,7 @@
             },
             "show_gift_card_recipient": {
               "label": "Mostra il modulo informazioni del destinatario per i buoni regalo",
-              "info": "I buoni regalo possono essere inviati direttamente al destinatario con un messaggio personale. [Maggiori informazioni](https://help.shopify.com/manual/online-store/themes/customizing-themes/add-gift-card-recipient-fields)"
+              "info": "I buoni regalo possono essere inviati direttamente al destinatario in una data stabilita e con un messaggio personale. [Maggiori informazioni](https://help.shopify.com/manual/online-store/themes/customizing-themes/add-gift-card-recipient-fields)"
             }
           }
         },

--- a/locales/ja.schema.json
+++ b/locales/ja.schema.json
@@ -1657,7 +1657,7 @@
             },
             "show_gift_card_recipient": {
               "label": "ギフトカード商品の受取人情報フォームを表示する",
-              "info": "ギフトカード商品は、オプションで、個人的なメッセージとともに受取人に直接送信できます。[詳しくはこちら](https://help.shopify.com/manual/online-store/themes/customizing-themes/add-gift-card-recipient-fields)"
+              "info": "ギフトカード商品は、オプションで、個人的なメッセージとともに、設定した日時に受取人に直接送信できます。[詳しくはこちら](https://help.shopify.com/manual/online-store/themes/customizing-themes/add-gift-card-recipient-fields)"
             }
           },
           "name": "購入ボタン"

--- a/locales/ko.schema.json
+++ b/locales/ko.schema.json
@@ -1657,7 +1657,7 @@
             },
             "show_gift_card_recipient": {
               "label": "기프트 카드 제품의 수취인 정보 양식 표시",
-              "info": "기프트 카드 제품을 개인 메시지와 함께 선택적으로 수신자에게 직접 전송할 수 있습니다. [자세히 알아보기](https://help.shopify.com/manual/online-store/themes/customizing-themes/add-gift-card-recipient-fields)"
+              "info": "기프트 카드 제품을 개인 메시지와 함께 예약된 날짜에 선택적으로 수신자에게 직접 전송할 수 있습니다. [자세히 알아보기](https://help.shopify.com/manual/online-store/themes/customizing-themes/add-gift-card-recipient-fields)"
             }
           },
           "name": "구매 버튼"

--- a/locales/nb.schema.json
+++ b/locales/nb.schema.json
@@ -1666,7 +1666,7 @@
             },
             "show_gift_card_recipient": {
               "label": "Vis mottakerinformasjonsskjema for produktgavekort",
-              "info": "Produktgavekort kan alternativt sendes direkte til en mottaker sammen med en personlig melding. [Finn ut mer](https://help.shopify.com/manual/online-store/themes/customizing-themes/add-gift-card-recipient-fields)"
+              "info": "Produktgavekort kan alternativt sendes direkte til en mottaker på en planlagt dato, sammen med en personlig melding. [Finn ut mer](https://help.shopify.com/manual/online-store/themes/customizing-themes/add-gift-card-recipient-fields)"
             }
           }
         },

--- a/locales/nl.schema.json
+++ b/locales/nl.schema.json
@@ -1667,7 +1667,7 @@
             },
             "show_gift_card_recipient": {
               "label": "Formulier voor gegevens van ontvanger weergeven voor cadeaubonnen",
-              "info": "Klanten kunnen cadeaubonnen rechtstreeks naar de ontvanger laten sturen met een persoonlijk bericht. [Meer informatie](https://help.shopify.com/manual/online-store/themes/customizing-themes/add-gift-card-recipient-fields)"
+              "info": "Klanten kunnen cadeaubonnen rechtstreeks naar de ontvanger laten sturen op een geplande datum met een persoonlijk bericht. [Meer informatie](https://help.shopify.com/manual/online-store/themes/customizing-themes/add-gift-card-recipient-fields)"
             }
           }
         },

--- a/locales/pl.schema.json
+++ b/locales/pl.schema.json
@@ -1667,7 +1667,7 @@
             },
             "show_gift_card_recipient": {
               "label": "Pokaż formularz danych odbiorcy dla produktów typu karta prezentowa",
-              "info": "Produkty w postaci kart prezentowych mogą być wysyłane bezpośrednio do odbiorcy wraz z osobistą wiadomością. [Dowiedz się więcej](https://help.shopify.com/manual/online-store/themes/customizing-themes/add-gift-card-recipient-fields)"
+              "info": "Produkty w postaci kart prezentowych mogą być wysyłane bezpośrednio do odbiorcy w zaplanowanym terminie wraz z osobistą wiadomością. [Dowiedz się więcej](https://help.shopify.com/manual/online-store/themes/customizing-themes/add-gift-card-recipient-fields)"
             }
           }
         },

--- a/locales/pt-BR.schema.json
+++ b/locales/pt-BR.schema.json
@@ -1666,7 +1666,7 @@
             },
             "show_gift_card_recipient": {
               "label": "Mostrar formulário de informações do destinatário para produtos \"cartão-presente\"",
-              "info": "Existe a opção de enviar produtos \"cartão-presente\" direto a um destinatário com uma mensagem pessoal. [Saiba mais](https://help.shopify.com/manual/online-store/themes/customizing-themes/add-gift-card-recipient-fields)"
+              "info": "Existe a opção de enviar produtos \"cartão-presente\" direto a um destinatário com uma mensagem pessoal em uma data programada. [Saiba mais](https://help.shopify.com/manual/online-store/themes/customizing-themes/add-gift-card-recipient-fields)"
             }
           }
         },

--- a/locales/pt-PT.schema.json
+++ b/locales/pt-PT.schema.json
@@ -1657,7 +1657,7 @@
             },
             "show_gift_card_recipient": {
               "label": "Apresentar o formulário de informações do destinatário para produtos de cartões de oferta",
-              "info": "Os produtos de cartões de oferta podem ser opcionalmente enviados a um destinatário com uma mensagem pessoal. [Saber mais](https://help.shopify.com/manual/online-store/themes/customizing-themes/add-gift-card-recipient-fields)"
+              "info": "Os produtos de cartões de oferta podem, opcionalmente, ser enviados a um destinatário numa data agendada com uma mensagem pessoal. [Saber mais](https://help.shopify.com/manual/online-store/themes/customizing-themes/add-gift-card-recipient-fields)"
             }
           },
           "name": "Botão de compra"

--- a/locales/th.schema.json
+++ b/locales/th.schema.json
@@ -1657,7 +1657,7 @@
             },
             "show_gift_card_recipient": {
               "label": "แสดงแบบฟอร์มข้อมูลผู้รับสำหรับผลิตภัณฑ์บัตรของขวัญ",
-              "info": "คุณสามารถเลือกส่งผลิตภัณฑ์บัตรของขวัญตรงถึงผู้รับพร้อมข้อความของตนเองได้ [ดูข้อมูลเพิ่มเติม](https://help.shopify.com/manual/online-store/themes/customizing-themes/add-gift-card-recipient-fields)"
+              "info": "สามารถเลือกส่งผลิตภัณฑ์บัตรของขวัญตรงถึงผู้รับพร้อมข้อความของตนเองวันที่กำหนดเวลาไว้ได้ [ดูข้อมูลเพิ่มเติม](https://help.shopify.com/manual/online-store/themes/customizing-themes/add-gift-card-recipient-fields)"
             }
           },
           "name": "ปุ่มซื้อ"

--- a/locales/tr.schema.json
+++ b/locales/tr.schema.json
@@ -1666,7 +1666,7 @@
             },
             "show_gift_card_recipient": {
               "label": "Hediye kartı ürünleri için alıcı bilgi formunu göster",
-              "info": "Hediye kartı ürünleri, isteğe bağlı olarak kişisel bir mesajla birlikte doğrudan bir alıcıya gönderilebilir. [Daha fazla bilgi edinin](https://help.shopify.com/manual/online-store/themes/customizing-themes/add-gift-card-recipient-fields)"
+              "info": "Hediye kartı ürünleri isteğe bağlı olarak kişisel bir mesajla birlikte, planlanan bir tarihte doğrudan bir alıcıya gönderilebilir. [Daha fazla bilgi edinin](https://help.shopify.com/manual/online-store/themes/customizing-themes/add-gift-card-recipient-fields)"
             }
           }
         },

--- a/locales/vi.schema.json
+++ b/locales/vi.schema.json
@@ -1667,7 +1667,7 @@
             },
             "show_gift_card_recipient": {
               "label": "Hiển thị biểu mẫu thông tin người nhận cho sản phẩm thẻ quà tặng",
-              "info": "Có thể tùy ý gửi các sản phẩm thẻ quà tặng trực tiếp cho người nhận kèm tin nhắn cá nhân. [Tìm hiểu thêm](https://help.shopify.com/manual/online-store/themes/customizing-themes/add-gift-card-recipient-fields)"
+              "info": "Có thể tùy ý gửi các sản phẩm thẻ quà tặng trực tiếp cho người nhận vào ngày đã lên lịch kèm tin nhắn cá nhân. [Tìm hiểu thêm](https://help.shopify.com/manual/online-store/themes/customizing-themes/add-gift-card-recipient-fields)"
             }
           }
         },

--- a/locales/zh-CN.schema.json
+++ b/locales/zh-CN.schema.json
@@ -1657,7 +1657,7 @@
             },
             "show_gift_card_recipient": {
               "label": "显示礼品卡产品的收件人信息表单",
-              "info": "客户可以选择直接将礼品卡产品发送给收件人并附加私人消息。[了解详细信息](https://help.shopify.com/manual/online-store/themes/customizing-themes/add-gift-card-recipient-fields)"
+              "info": "礼品卡产品可以选择在预定的日期直接寄给收件人，并附上个人信息。[了解更多信息](https://help.shopify.com/manual/online-store/themes/customizing-themes/add-gift-card-recipient-fields)"
             }
           },
           "name": "Buy Button"

--- a/locales/zh-TW.schema.json
+++ b/locales/zh-TW.schema.json
@@ -1657,7 +1657,7 @@
             },
             "show_gift_card_recipient": {
               "label": "顯示禮品卡商品的收件人資訊表單",
-              "info": "可選擇將禮品卡商品與個人化訊息直接傳送給收件人。[瞭解詳情](https://help.shopify.com/manual/online-store/themes/customizing-themes/add-gift-card-recipient-fields)"
+              "info": "可選擇定期將禮品卡商品與個人化訊息傳送給收件人。[瞭解詳情](https://help.shopify.com/manual/online-store/themes/customizing-themes/add-gift-card-recipient-fields)"
             }
           },
           "name": "購買按鈕"


### PR DESCRIPTION
### PR Summary: 

Closes https://github.com/Shopify/core-issues/issues/54765

This PR changes an informational string in the theme editor that is found beside the gift card recipient form enable/disable checkbox.

Existing string:
![image](https://user-images.githubusercontent.com/9780459/235186241-48f3bf9a-403d-4809-8e11-e6f59eb88d96.png)

### Why are these changes introduced?

We are releasing scheduling functionality in the recipient form with the next theme release, so we want to acknowledge that in the string.

### Checklist
- [ ] Added PR summary for [release notes](https://themes.shopify.com/themes/dawn/styles/default#ReleaseNotes)
- [ ] Requested review from UX (Only for changes that are affecting the experience or perceivable visual details)
- [ ] Created a ticket for the [help.shopify.com](https://help.shopify.com) documentation team about updates to theme settings. (Internal-only task)
- [ ] Followed [theme code principles](https://github.com/Shopify/dawn/blob/main/.github/CONTRIBUTING.md#theme-code-principles)
- [ ] Linted with [Theme Check](https://github.com/Shopify/theme-check)
- [ ] Tested on [mobile](https://shopify.dev/themes/store/requirements#mobile-browser-requirements)
- [ ] Tested on [multiple browsers](https://shopify.dev/themes/store/requirements#desktop-browser-requirements)
- [ ] Tested for [accessibility](https://shopify.dev/themes/best-practices/accessibility)
