### PR TITLE
Add body grid areas

### DIFF
--- a/assets/base.css
+++ b/assets/base.css
@@ -99,7 +99,7 @@ html.no-js .no-js-hidden {
   padding: 0 1.5rem;
 }
 
-body:has(.section-header .drawer-menu) .announcement-bar-section slideshow-component {
+body:has(.section-header .drawer-menu) .section-announcement-bar slideshow-component {
   max-width: 100%;
 }
 
@@ -2163,11 +2163,11 @@ product-info .loading-overlay:not(.hidden) ~ *,
 }
 
 @media screen and (min-width: 990px) {
-  body:has(.section-header .header:not(.drawer-menu)) .announcement-bar-section .announcement-bar .slider-button--next {
+  body:has(.section-header .header:not(.drawer-menu)) .section-announcement-bar .announcement-bar .slider-button--next {
     margin-right: -1.8rem;
   }
 
-  body:has(.section-header .header:not(.drawer-menu)) .announcement-bar-section .announcement-bar .slider-button--prev {
+  body:has(.section-header .header:not(.drawer-menu)) .section-announcement-bar .announcement-bar .slider-button--prev {
     margin-left: -1.8rem;
   }
 

--- a/layout/theme.liquid
+++ b/layout/theme.liquid
@@ -219,7 +219,12 @@
 
       body {
         display: grid;
-        grid-template-rows: auto auto 1fr auto;
+        grid-template-areas:
+          "announcement-bar"
+          "header"
+          "content-for-layout"
+          "footer";
+        grid-template-rows: auto auto minmax(0, 1fr) auto;
         grid-template-columns: 100%;
         min-height: 100%;
         margin: 0;
@@ -229,6 +234,19 @@
         font-family: var(--font-body-family);
         font-style: var(--font-body-style);
         font-weight: var(--font-body-weight);
+      }
+
+      .section-anouncement-bar {
+        grid-area: anouncement-bar;
+      }
+      .section-header {
+        grid-area: header;
+      }
+      .content-for-layout {
+        grid-area: content-for-layout;
+      }
+      .section-footer {
+        grid-area: footer;
       }
 
       @media screen and (min-width: 750px) {

--- a/sections/announcement-bar.liquid
+++ b/sections/announcement-bar.liquid
@@ -96,7 +96,7 @@
 {
   "name": "t:sections.announcement-bar.name",
   "max_blocks": 12,
-  "class": "announcement-bar-section",
+  "class": "section-announcement-bar",
   "settings": [
     {
       "type": "color_scheme",

--- a/sections/footer.liquid
+++ b/sections/footer.liquid
@@ -382,6 +382,7 @@
 {% schema %}
 {
   "name": "t:sections.footer.name",
+  "class": "section-footer",
   "blocks": [
     {
       "type": "@app"


### PR DESCRIPTION
### PR Summary: 

Add `grid-template-areas` to the body element and assign them to each main body section.

### Why are these changes introduced?

The current layout breaks when adding or removing children from the main body element. This happens when, for example, disabling the announcement bar or even the entire header/footer groups.

### Other considerations

I also made the section class names more consistent.

### Demo links
- [Store](https://cfx-theme-playground.myshopify.com/?preview_theme_id=131988750510) password **fleomo**

### Checklist
- [x] Added PR summary for [release notes](https://themes.shopify.com/themes/dawn/styles/default#ReleaseNotes)
- [ ] Requested review from UX (Only for changes that are affecting the experience or perceivable visual details)
- [x] Followed [theme code principles](https://github.com/Shopify/dawn/blob/main/.github/CONTRIBUTING.md#theme-code-principles)
- [x] Linted with [Theme Check](https://github.com/Shopify/theme-check)
- [x] Tested on [mobile](https://shopify.dev/themes/store/requirements#mobile-browser-requirements)
- [x] Tested on [multiple browsers](https://shopify.dev/themes/store/requirements#desktop-browser-requirements)
- [ ] Tested for [accessibility](https://shopify.dev/themes/best-practices/accessibility)
