### PR TITLE
Gift cards/enable recipient form by default

### DIFF
--- a/locales/en.default.schema.json
+++ b/locales/en.default.schema.json
@@ -1960,8 +1960,8 @@
               "info": "Using the payment methods available on your store, customers see their preferred option, like PayPal or Apple Pay. [Learn more](https://help.shopify.com/manual/using-themes/change-the-layout/dynamic-checkout)"
             },
             "show_gift_card_recipient": {
-              "label": "Show recipient information form for gift card products",
-              "info": "Gift card products can optionally be sent direct to a recipient on a scheduled date along with a personal message. [Learn more](https://help.shopify.com/manual/online-store/themes/customizing-themes/add-gift-card-recipient-fields)"
+              "label": "Show recipient information form for gift cards",
+              "info": "Allows buyers to send gift cards on a scheduled date along with a personal message. [Learn more](https://help.shopify.com/manual/online-store/themes/customizing-themes/add-gift-card-recipient-fields)"
             }
           }
         },

--- a/sections/main-product.liquid
+++ b/sections/main-product.liquid
@@ -733,7 +733,7 @@
         {
           "type": "checkbox",
           "id": "show_gift_card_recipient",
-          "default": false,
+          "default": true,
           "label": "t:sections.main-product.blocks.buy_buttons.settings.show_gift_card_recipient.label",
           "info": "t:sections.main-product.blocks.buy_buttons.settings.show_gift_card_recipient.info"
         }


### PR DESCRIPTION
### PR Summary: 

Enables gift card recipient form by default and update the copy for the block settings recipient checkbox.

### Why are these changes introduced?

Fixes https://github.com/Shopify/core-issues/issues/53098
Fixes https://github.com/Shopify/core-issues/issues/54878

### Visual impact on existing themes

Before
<img width="200" alt="Screenshot 2023-05-09 at 16 02 00" src="https://github.com/Shopify/dawn/assets/13537657/a12b4a93-8516-41e6-967d-a6295e27680c">

After
<img width="200" alt="Screenshot 2023-05-09 at 16 01 21" src="https://github.com/Shopify/dawn/assets/13537657/1df6428f-7d69-4e32-b7e9-3333938cd8d6">

### Checklist
- [ ] Added PR summary for [release notes](https://themes.shopify.com/themes/dawn/styles/default#ReleaseNotes)
- [ ] Requested review from UX (Only for changes that are affecting the experience or perceivable visual details)
- [ ] Created a ticket for the [help.shopify.com](https://help.shopify.com) documentation team about updates to theme settings. (Internal-only task)
- [ ] Followed [theme code principles](https://github.com/Shopify/dawn/blob/main/.github/CONTRIBUTING.md#theme-code-principles)
- [ ] Linted with [Theme Check](https://github.com/Shopify/theme-check)
- [ ] Tested on [mobile](https://shopify.dev/themes/store/requirements#mobile-browser-requirements)
- [ ] Tested on [multiple browsers](https://shopify.dev/themes/store/requirements#desktop-browser-requirements)
- [ ] Tested for [accessibility](https://shopify.dev/themes/best-practices/accessibility)
