### PR TITLE
Made mobile drawer full width by default-header

### DIFF
--- a/assets/component-menu-drawer.css
+++ b/assets/component-menu-drawer.css
@@ -73,7 +73,6 @@ details[open].menu-opening > .menu-drawer__submenu {
 
   .no-js .menu-drawer {
     height: auto;
-
   }
 }
 


### PR DESCRIPTION
### PR Summary: 
Mobile drawer is full width by default


### Why are these changes introduced?

Fixes #2563 

### What approach did you take?
I changed the width of the menu-drawer to be 100% by default. 


### Visual impact on existing themes
<!-- How will this visually affect merchants who upgrade to a new theme version with this change? -->
Not Applicable


### Testing steps/scenarios
<!-- List all the testing tasks that applies to your fix to help peers review your work. -->
- [ ] Test drawer menu in mobile setting
- [ ] Test drawer menu in desktop setting
- [ ] Test drawer menu in full screen setting
- [ ] Apply color scheme to menu to ensure nothing is broken.

### Demo links
<!-- Please include a link to a demo store that includes preconfigured sections and settings to allow reviewers to easily test the features you are working on. -->
- [Editor](https://os2-demo.myshopify.com/admin/themes/139930009622/editor?section=sections--17248160907286__header)

### Checklist
- [x] Added PR summary for [release notes](https://themes.shopify.com/themes/dawn/styles/default#ReleaseNotes)
- [x] Requested review from UX (Only for changes that are affecting the experience or perceivable visual details)
- [ ] Created a ticket for the [help.shopify.com](https://help.shopify.com) documentation team about updates to theme settings. (Internal-only task)
- [x] Followed [theme code principles](https://github.com/Shopify/dawn/blob/main/.github/CONTRIBUTING.md#theme-code-principles)
- [x] Linted with [Theme Check](https://github.com/Shopify/theme-check)
- [x] Tested on [mobile](https://shopify.dev/themes/store/requirements#mobile-browser-requirements)
- [x] Tested on [multiple browsers](https://shopify.dev/themes/store/requirements#desktop-browser-requirements)
- [ ] Tested for [accessibility](https://shopify.dev/themes/best-practices/accessibility)
