### PR TITLE
[Footer] Remove Global Media settings inheritance from images

### DIFF
--- a/assets/section-footer.css
+++ b/assets/section-footer.css
@@ -402,9 +402,7 @@
 }
 
 .footer-block__image-wrapper {
-  box-shadow: var(--media-shadow-horizontal-offset) var(--media-shadow-vertical-offset) var(--media-shadow-blur-radius)
-    rgba(var(--color-shadow), var(--media-shadow-opacity));
-  margin-bottom: max(calc(2rem + var(--media-shadow-vertical-offset) * var(--media-shadow-visible)), 2rem);
+  margin-bottom: 2rem;
   overflow: hidden !important;
 }
 

--- a/sections/footer.liquid
+++ b/sections/footer.liquid
@@ -110,7 +110,7 @@
                           | divided_by: settings.brand_image.aspect_ratio
                         -%}
                         <div
-                          class="footer-block__image-wrapper global-media-settings"
+                          class="footer-block__image-wrapper"
                           style="max-width: min(100%, {{ settings.brand_image_width }}px);"
                         >
                           {{
@@ -139,7 +139,7 @@
                       {%- if block.settings.image != blank -%}
                         {%- assign image_size_2x = block.settings.image_width | times: 2 | at_most: 5760 -%}
                         <div
-                          class="footer-block__image-wrapper global-media-settings"
+                          class="footer-block__image-wrapper"
                           style="max-width: min(100%, {{ block.settings.image_width }}px);"
                         >
                           <img


### PR DESCRIPTION
### PR Summary: 
Reverts a decision made in #2112 which applied Global Media Settings to images in the Footer.

### Why are these changes introduced?
They were causing layout issues in some themes, essentially preventing merchants from using a logo / transparent background image.

### What approach did you take?
- Kept the wrapper class, removed the `global-media-settings` and the `box-shadow` styles.
- 
### Visual impact on existing themes
This should revert the look on image blocks back to what it was before `8.0.0`.
Any images using media settings in the footer will no longer inherit these styles.

### Testing steps/scenarios
- [ ] Update global media settings to use shadows, borders, etc.
- [ ] Add Image block to the footer. It should NOT inherit global media styles. 
  - [ ] Change the image size and confirm that it's applied to the image.
- [ ] Add a Brand Information image to the footer. It should NOT inherit global media styles. 
  - [ ] Change the image size and confirm that it's applied to the image.

### Demo links

- [Store](https://os2-demo.myshopify.com/?preview_theme_id=139936661526)
- [Editor](https://os2-demo.myshopify.com/admin/themes/139936661526/editor)