### PR TITLE
Send timezone offset as string instead of integer

### DIFF
--- a/assets/recipient-form.js
+++ b/assets/recipient-form.js
@@ -1,164 +1,162 @@
 if (!customElements.get('recipient-form')) {
-  customElements.define('recipient-form', class RecipientForm extends HTMLElement {
-    constructor() {
-      super();
-      this.checkboxInput = this.querySelector(`#Recipient-checkbox-${ this.dataset.sectionId }`);
-      this.checkboxInput.disabled = false;
-      this.hiddenControlField = this.querySelector(`#Recipient-control-${ this.dataset.sectionId }`);
-      this.hiddenControlField.disabled = true;
-      this.emailInput = this.querySelector(`#Recipient-email-${ this.dataset.sectionId }`);
-      this.nameInput = this.querySelector(`#Recipient-name-${ this.dataset.sectionId }`);
-      this.messageInput = this.querySelector(`#Recipient-message-${ this.dataset.sectionId }`);
-      this.sendonInput = this.querySelector(`#Recipient-send-on-${ this.dataset.sectionId }`);
-      this.offsetProperty = this.querySelector(`#Recipient-timezone-offset-${ this.dataset.sectionId }`);
-      if (this.offsetProperty) this.offsetProperty.value = new Date().getTimezoneOffset();
+  customElements.define(
+    'recipient-form',
+    class RecipientForm extends HTMLElement {
+      constructor() {
+        super();
+        this.checkboxInput = this.querySelector(`#Recipient-checkbox-${this.dataset.sectionId}`);
+        this.checkboxInput.disabled = false;
+        this.hiddenControlField = this.querySelector(`#Recipient-control-${this.dataset.sectionId}`);
+        this.hiddenControlField.disabled = true;
+        this.emailInput = this.querySelector(`#Recipient-email-${this.dataset.sectionId}`);
+        this.nameInput = this.querySelector(`#Recipient-name-${this.dataset.sectionId}`);
+        this.messageInput = this.querySelector(`#Recipient-message-${this.dataset.sectionId}`);
+        this.sendonInput = this.querySelector(`#Recipient-send-on-${this.dataset.sectionId}`);
+        this.offsetProperty = this.querySelector(`#Recipient-timezone-offset-${this.dataset.sectionId}`);
+        if (this.offsetProperty) this.offsetProperty.value = new Date().getTimezoneOffset().toString();
 
-      this.errorMessageWrapper = this.querySelector('.product-form__recipient-error-message-wrapper');
-      this.errorMessageList = this.errorMessageWrapper?.querySelector('ul');
-      this.errorMessage = this.errorMessageWrapper?.querySelector('.error-message');
-      this.defaultErrorHeader = this.errorMessage?.innerText;
-      this.currentProductVariantId = this.dataset.productVariantId;
-      this.addEventListener('change', this.onChange.bind(this));
-      this.onChange();
-    }
-
-    cartUpdateUnsubscriber = undefined;
-    variantChangeUnsubscriber = undefined;
-    cartErrorUnsubscriber = undefined;
-
-    connectedCallback() {
-      this.cartUpdateUnsubscriber = subscribe(PUB_SUB_EVENTS.cartUpdate, (event) => {
-        if (event.source === 'product-form' && event.productVariantId.toString() === this.currentProductVariantId) {
-          this.resetRecipientForm();
-        }
-      });
-
-      this.variantChangeUnsubscriber = subscribe(PUB_SUB_EVENTS.variantChange, (event) => {
-        if (event.data.sectionId === this.dataset.sectionId) {
-          this.currentProductVariantId = event.data.variant.id.toString();
-        }
-      });
-
-      this.cartUpdateUnsubscriber = subscribe(PUB_SUB_EVENTS.cartError, (event) => {
-        if (event.source === 'product-form' && event.productVariantId.toString() === this.currentProductVariantId) {
-          this.displayErrorMessage(event.message, event.errors);
-        }
-      });
-    }
-
-    disconnectedCallback() {
-      if (this.cartUpdateUnsubscriber) {
-        this.cartUpdateUnsubscriber();
+        this.errorMessageWrapper = this.querySelector('.product-form__recipient-error-message-wrapper');
+        this.errorMessageList = this.errorMessageWrapper?.querySelector('ul');
+        this.errorMessage = this.errorMessageWrapper?.querySelector('.error-message');
+        this.defaultErrorHeader = this.errorMessage?.innerText;
+        this.currentProductVariantId = this.dataset.productVariantId;
+        this.addEventListener('change', this.onChange.bind(this));
+        this.onChange();
       }
 
-      if (this.variantChangeUnsubscriber) {
-        this.variantChangeUnsubscriber();
-      }
+      cartUpdateUnsubscriber = undefined;
+      variantChangeUnsubscriber = undefined;
+      cartErrorUnsubscriber = undefined;
 
-      if (this.cartErrorUnsubscriber) {
-        this.cartErrorUnsubscriber();
-      }
-    }
-
-    onChange() {
-      if (this.checkboxInput.checked) {
-        this.enableInputFields();
-      } else {
-        this.clearInputFields();
-        this.disableInputFields();
-        this.clearErrorMessage();
-      }
-    }
-
-    inputFields() {
-      return [
-        this.emailInput,
-        this.nameInput,
-        this.messageInput,
-        this.sendonInput
-      ];
-    }
-
-    disableableFields() {
-      return [...this.inputFields(), this.offsetProperty];
-    }
-
-    clearInputFields() {
-      this.inputFields().forEach((field) => field.value = '');
-    }
-
-    enableInputFields() {
-      this.disableableFields().forEach((field) => field.disabled = false);
-    }
-
-    disableInputFields() {
-      this.disableableFields().forEach((field) => field.disabled = true);
-    }
-
-    displayErrorMessage(title, body) {
-      this.clearErrorMessage();
-      this.errorMessageWrapper.hidden = false;
-      if (typeof body === 'object') {
-        this.errorMessage.innerText = this.defaultErrorHeader;
-        return Object.entries(body).forEach(([key, value]) => {
-          const errorMessageId = `RecipientForm-${ key }-error-${ this.dataset.sectionId }`
-          const fieldSelector = `#Recipient-${ key }-${ this.dataset.sectionId }`;
-          const message = `${value.join(', ')}`;
-          const errorMessageElement = this.querySelector(`#${errorMessageId}`);
-          const errorTextElement = errorMessageElement?.querySelector('.error-message')
-          if (!errorTextElement) return;
-
-          if (this.errorMessageList) {
-            this.errorMessageList.appendChild(this.createErrorListItem(fieldSelector, message));
+      connectedCallback() {
+        this.cartUpdateUnsubscriber = subscribe(PUB_SUB_EVENTS.cartUpdate, (event) => {
+          if (event.source === 'product-form' && event.productVariantId.toString() === this.currentProductVariantId) {
+            this.resetRecipientForm();
           }
+        });
 
-          errorTextElement.innerText = `${message}.`;
-          errorMessageElement.classList.remove('hidden');
+        this.variantChangeUnsubscriber = subscribe(PUB_SUB_EVENTS.variantChange, (event) => {
+          if (event.data.sectionId === this.dataset.sectionId) {
+            this.currentProductVariantId = event.data.variant.id.toString();
+          }
+        });
 
-          const inputElement = this[`${key}Input`];
-          if (!inputElement) return;
-
-          inputElement.setAttribute('aria-invalid', true);
-          inputElement.setAttribute('aria-describedby', errorMessageId);
+        this.cartUpdateUnsubscriber = subscribe(PUB_SUB_EVENTS.cartError, (event) => {
+          if (event.source === 'product-form' && event.productVariantId.toString() === this.currentProductVariantId) {
+            this.displayErrorMessage(event.message, event.errors);
+          }
         });
       }
 
-      this.errorMessage.innerText = body;
-    }
+      disconnectedCallback() {
+        if (this.cartUpdateUnsubscriber) {
+          this.cartUpdateUnsubscriber();
+        }
 
-    createErrorListItem(target, message) {
-      const li = document.createElement('li');
-      const a = document.createElement('a');
-      a.setAttribute('href', target);
-      a.innerText = message;
-      li.appendChild(a);
-      li.className = "error-message";
-      return li;
-    }
+        if (this.variantChangeUnsubscriber) {
+          this.variantChangeUnsubscriber();
+        }
 
-    clearErrorMessage() {
-      this.errorMessageWrapper.hidden = true;
+        if (this.cartErrorUnsubscriber) {
+          this.cartErrorUnsubscriber();
+        }
+      }
 
-      if (this.errorMessageList) this.errorMessageList.innerHTML = '';
+      onChange() {
+        if (this.checkboxInput.checked) {
+          this.enableInputFields();
+        } else {
+          this.clearInputFields();
+          this.disableInputFields();
+          this.clearErrorMessage();
+        }
+      }
 
-      this.querySelectorAll('.recipient-fields .form__message').forEach(field => {
-        field.classList.add('hidden');
-        const textField = field.querySelector('.error-message');
-        if (textField) textField.innerText = '';
-      });
+      inputFields() {
+        return [this.emailInput, this.nameInput, this.messageInput, this.sendonInput];
+      }
 
-      [this.emailInput, this.messageInput, this.nameInput, this.sendonInput].forEach(inputElement => {
-        inputElement.setAttribute('aria-invalid', false);
-        inputElement.removeAttribute('aria-describedby');
-      });
-    }
+      disableableFields() {
+        return [...this.inputFields(), this.offsetProperty];
+      }
 
-    resetRecipientForm() {
-      if (this.checkboxInput.checked) {
-        this.checkboxInput.checked = false;
-        this.clearInputFields();
+      clearInputFields() {
+        this.inputFields().forEach((field) => (field.value = ''));
+      }
+
+      enableInputFields() {
+        this.disableableFields().forEach((field) => (field.disabled = false));
+      }
+
+      disableInputFields() {
+        this.disableableFields().forEach((field) => (field.disabled = true));
+      }
+
+      displayErrorMessage(title, body) {
         this.clearErrorMessage();
+        this.errorMessageWrapper.hidden = false;
+        if (typeof body === 'object') {
+          this.errorMessage.innerText = this.defaultErrorHeader;
+          return Object.entries(body).forEach(([key, value]) => {
+            const errorMessageId = `RecipientForm-${key}-error-${this.dataset.sectionId}`;
+            const fieldSelector = `#Recipient-${key}-${this.dataset.sectionId}`;
+            const message = `${value.join(', ')}`;
+            const errorMessageElement = this.querySelector(`#${errorMessageId}`);
+            const errorTextElement = errorMessageElement?.querySelector('.error-message');
+            if (!errorTextElement) return;
+
+            if (this.errorMessageList) {
+              this.errorMessageList.appendChild(this.createErrorListItem(fieldSelector, message));
+            }
+
+            errorTextElement.innerText = `${message}.`;
+            errorMessageElement.classList.remove('hidden');
+
+            const inputElement = this[`${key}Input`];
+            if (!inputElement) return;
+
+            inputElement.setAttribute('aria-invalid', true);
+            inputElement.setAttribute('aria-describedby', errorMessageId);
+          });
+        }
+
+        this.errorMessage.innerText = body;
+      }
+
+      createErrorListItem(target, message) {
+        const li = document.createElement('li');
+        const a = document.createElement('a');
+        a.setAttribute('href', target);
+        a.innerText = message;
+        li.appendChild(a);
+        li.className = 'error-message';
+        return li;
+      }
+
+      clearErrorMessage() {
+        this.errorMessageWrapper.hidden = true;
+
+        if (this.errorMessageList) this.errorMessageList.innerHTML = '';
+
+        this.querySelectorAll('.recipient-fields .form__message').forEach((field) => {
+          field.classList.add('hidden');
+          const textField = field.querySelector('.error-message');
+          if (textField) textField.innerText = '';
+        });
+
+        [this.emailInput, this.messageInput, this.nameInput, this.sendonInput].forEach((inputElement) => {
+          inputElement.setAttribute('aria-invalid', false);
+          inputElement.removeAttribute('aria-describedby');
+        });
+      }
+
+      resetRecipientForm() {
+        if (this.checkboxInput.checked) {
+          this.checkboxInput.checked = false;
+          this.clearInputFields();
+          this.clearErrorMessage();
+        }
       }
     }
-  });
+  );
 }


### PR DESCRIPTION
### PR Summary: 

This fixes an issue when sending timezone offset as negative integer. This change ensures the offset is sent as string which avoid the cart add issue for gift cards with recipient.

### Why are these changes introduced?

The cart serialization of line item properties with negative integer does not work. Using a string instead works. 

The latest version of recipient form sends a new line item property __shopify_offset which can be a negative number (based on the customer timezone). When its negative, request to add gift card to the cart will fail (cart serialization code doesnt accept negative number)

### What approach did you take?

Casting.

### Visual impact on existing themes

Hide whitespace when checking the files changed

No visual impact.

### Checklist
- [ ] Added PR summary for [release notes](https://themes.shopify.com/themes/dawn/styles/default#ReleaseNotes)
- [ ] Requested review from UX (Only for changes that are affecting the experience or perceivable visual details)
- [ ] Created a ticket for the [help.shopify.com](https://help.shopify.com) documentation team about updates to theme settings. (Internal-only task)
- [ ] Followed [theme code principles](https://github.com/Shopify/dawn/blob/main/.github/CONTRIBUTING.md#theme-code-principles)
- [ ] Linted with [Theme Check](https://github.com/Shopify/theme-check)
- [ ] Tested on [mobile](https://shopify.dev/themes/store/requirements#mobile-browser-requirements)
- [ ] Tested on [multiple browsers](https://shopify.dev/themes/store/requirements#desktop-browser-requirements)
- [ ] Tested for [accessibility](https://shopify.dev/themes/best-practices/accessibility)
