### PR TITLE
Gradient fix for transparent background medias and cards

### DIFF
--- a/assets/base.css
+++ b/assets/base.css
@@ -3179,6 +3179,12 @@ details-disclosure > details {
     transform: translateY(0);
   }
 
+  .scroll-trigger .gradient.media.color-background-1,
+  .scroll-trigger:is(.gradient, .deferred-media),
+  .scroll-trigger .collapsible-content__media.gradient {
+    background: transparent;
+  }
+
   @keyframes slideIn {
     from {
       transform: translateY(2rem);

--- a/assets/base.css
+++ b/assets/base.css
@@ -3184,11 +3184,6 @@ details-disclosure > details {
     transform: translateY(0);
   }
 
-  .scroll-trigger:where(.gradient.deferred-media),
-  .scroll-trigger .collapsible-content__media.gradient {
-    background: transparent;
-  }
-
   @keyframes slideIn {
     from {
       transform: translateY(2rem);

--- a/assets/base.css
+++ b/assets/base.css
@@ -2824,6 +2824,11 @@ details-disclosure > details {
   background-attachment: fixed;
 }
 
+.card.gradient {
+  /* Create a new stacking context to apply the gradient to the card specifically */
+  transform: translate(0);
+}
+
 @media screen and (forced-colors: active) {
   .icon {
     color: CanvasText;

--- a/assets/base.css
+++ b/assets/base.css
@@ -2824,7 +2824,7 @@ details-disclosure > details {
   background-attachment: fixed;
 }
 
-.card.gradient {
+.card-wrapper {
   /* Create a new stacking context to apply the gradient to the card specifically */
   transform: translate(0);
 }
@@ -3184,8 +3184,7 @@ details-disclosure > details {
     transform: translateY(0);
   }
 
-  .scroll-trigger .gradient.media.color-background-1,
-  .scroll-trigger:is(.gradient, .deferred-media),
+  .scroll-trigger:where(.gradient.deferred-media),
   .scroll-trigger .collapsible-content__media.gradient {
     background: transparent;
   }

--- a/assets/base.css
+++ b/assets/base.css
@@ -2826,7 +2826,7 @@ details-disclosure > details {
 
 .card-wrapper {
   /* Create a new stacking context to apply the gradient to the card specifically */
-  transform: translate(0);
+  /* transform: translate(0); */
 }
 
 @media screen and (forced-colors: active) {

--- a/assets/base.css
+++ b/assets/base.css
@@ -2824,11 +2824,6 @@ details-disclosure > details {
   background-attachment: fixed;
 }
 
-.card-wrapper {
-  /* Create a new stacking context to apply the gradient to the card specifically */
-  /* transform: translate(0); */
-}
-
 @media screen and (forced-colors: active) {
   .icon {
     color: CanvasText;

--- a/assets/collage.css
+++ b/assets/collage.css
@@ -118,8 +118,8 @@
   padding: var(--image-padding);
 }
 
+/* Needed for gradient continuity with or without animation, background-attachment: local scopes the gradient to its container which happens automatically when a transform is applied (animation on scroll) */
 .collage-card.gradient {
-  /* Needed for gradient continuity with or without animation */
   background-attachment: local;
 }
 

--- a/assets/collage.css
+++ b/assets/collage.css
@@ -111,12 +111,15 @@
 }
 
 .collage-card {
-  background: rgb(var(--color-background));
   height: 100%;
   position: relative;
   border-radius: var(--border-radius);
   border: var(--border-width) solid rgba(var(--color-foreground), var(--border-opacity));
   padding: var(--image-padding);
+}
+
+.collage-card.gradient {
+  background-attachment: local;
 }
 
 .collage-card:after {

--- a/assets/collage.css
+++ b/assets/collage.css
@@ -120,7 +120,7 @@
 
 /* Needed for gradient continuity with or without animation, background-attachment: local scopes the gradient to its container which happens automatically when a transform is applied (animation on scroll) */
 .collage-card.gradient {
-  background-attachment: local;
+  transform: perspective(0);
 }
 
 .collage-card:after {

--- a/assets/collage.css
+++ b/assets/collage.css
@@ -119,6 +119,7 @@
 }
 
 .collage-card.gradient {
+  /* Needed for gradient continuity with or without animation */
   background-attachment: local;
 }
 

--- a/assets/collapsible-content.css
+++ b/assets/collapsible-content.css
@@ -16,6 +16,7 @@
 }
 
 .collapsible-content__media {
+  /* Needed for gradient continuity with or without animation */
   background: transparent;
 }
 
@@ -86,6 +87,7 @@
 .collapsible-row-layout .accordion {
   border: var(--text-boxes-border-width) solid rgba(var(--color-foreground), var(--text-boxes-border-opacity));
   margin-bottom: 1.5rem;
+  /* Needed for gradient continuity with or without animation */
   background-attachment: local;
 }
 

--- a/assets/collapsible-content.css
+++ b/assets/collapsible-content.css
@@ -15,7 +15,7 @@
   }
 }
 
-.scroll-trigger .collapsible-content__media.gradient {
+.collapsible-content__media {
   background: transparent;
 }
 
@@ -86,6 +86,7 @@
 .collapsible-row-layout .accordion {
   border: var(--text-boxes-border-width) solid rgba(var(--color-foreground), var(--text-boxes-border-opacity));
   margin-bottom: 1.5rem;
+  background-attachment: local;
 }
 
 .collapsible-row-layout .accordion summary,

--- a/assets/collapsible-content.css
+++ b/assets/collapsible-content.css
@@ -87,8 +87,8 @@
 .collapsible-row-layout .accordion {
   border: var(--text-boxes-border-width) solid rgba(var(--color-foreground), var(--text-boxes-border-opacity));
   margin-bottom: 1.5rem;
-  /* Needed for gradient continuity with or without animation, background-attachment: local scopes the gradient to its container which happens automatically when a transform is applied (animation on scroll) */
-  background-attachment: local;
+  /* Needed for gradient continuity with or without animation, the transform scopes the gradient to its container which happens already when animation are turned on */
+  transform: perspective(0);
 }
 
 .collapsible-row-layout .accordion summary,

--- a/assets/collapsible-content.css
+++ b/assets/collapsible-content.css
@@ -15,8 +15,8 @@
   }
 }
 
+/* Needed for gradient continuity with or without animation so that transparent PNG images come up as we would expect */
 .collapsible-content__media {
-  /* Needed for gradient continuity with or without animation */
   background: transparent;
 }
 
@@ -87,7 +87,7 @@
 .collapsible-row-layout .accordion {
   border: var(--text-boxes-border-width) solid rgba(var(--color-foreground), var(--text-boxes-border-opacity));
   margin-bottom: 1.5rem;
-  /* Needed for gradient continuity with or without animation */
+  /* Needed for gradient continuity with or without animation, background-attachment: local scopes the gradient to its container which happens automatically when a transform is applied (animation on scroll) */
   background-attachment: local;
 }
 

--- a/assets/collapsible-content.css
+++ b/assets/collapsible-content.css
@@ -15,6 +15,10 @@
   }
 }
 
+.scroll-trigger .collapsible-content__media.gradient {
+  background: transparent;
+}
+
 .collapsible-content__media--small {
   height: 19.4rem;
 }

--- a/assets/component-card.css
+++ b/assets/component-card.css
@@ -52,7 +52,6 @@
 .card--standard .card__inner:after {
   content: '';
   position: absolute;
-  z-index: -1;
   width: calc(var(--border-width) * 2 + 100%);
   height: calc(var(--border-width) * 2 + 100%);
   top: calc(var(--border-width) * -1);

--- a/assets/component-card.css
+++ b/assets/component-card.css
@@ -64,6 +64,7 @@
 
 .card--card.gradient,
 .card__inner.gradient {
+  /* Needed for gradient continuity with or without animation */
   background-attachment: local;
 }
 

--- a/assets/component-card.css
+++ b/assets/component-card.css
@@ -62,7 +62,8 @@
     rgba(var(--color-shadow), var(--shadow-opacity));
 }
 
-.card--card.gradient {
+.card--card.gradient,
+.card__inner.gradient {
   background-attachment: local;
 }
 

--- a/assets/component-card.css
+++ b/assets/component-card.css
@@ -62,14 +62,14 @@
     rgba(var(--color-shadow), var(--shadow-opacity));
 }
 
+/* Needed for gradient continuity with or without animation, background-attachment: local scopes the gradient to its container which happens automatically when a transform is applied (animation on scroll) */
 .card--card.gradient,
 .card__inner.gradient {
-  /* Needed for gradient continuity with or without animation */
   background-attachment: local;
 }
 
+/* Needed for gradient continuity with or without animation so that transparent PNG images come up as we would expect */
 .card__inner.color-background-1 {
-  /* Needed for gradient continuity with or without animation */
   background: transparent;
 }
 

--- a/assets/component-card.css
+++ b/assets/component-card.css
@@ -68,6 +68,11 @@
   background-attachment: local;
 }
 
+.card__inner.color-background-1 {
+  /* Needed for gradient continuity with or without animation */
+  background: transparent;
+}
+
 .card .card__inner .card__media {
   overflow: hidden;
   /* Fix for Safari border bug on hover */

--- a/assets/component-card.css
+++ b/assets/component-card.css
@@ -62,10 +62,10 @@
     rgba(var(--color-shadow), var(--shadow-opacity));
 }
 
-/* Needed for gradient continuity with or without animation, background-attachment: local scopes the gradient to its container which happens automatically when a transform is applied (animation on scroll) */
+/* Needed for gradient continuity with or without animation, the transform scopes the gradient to its container which happens already when animation are turned on */
 .card--card.gradient,
 .card__inner.gradient {
-  background-attachment: local;
+  transform: perspective(0);
 }
 
 /* Needed for gradient continuity with or without animation so that transparent PNG images come up as we would expect */

--- a/assets/component-card.css
+++ b/assets/component-card.css
@@ -52,6 +52,7 @@
 .card--standard .card__inner:after {
   content: '';
   position: absolute;
+  z-index: -1;
   width: calc(var(--border-width) * 2 + 100%);
   height: calc(var(--border-width) * 2 + 100%);
   top: calc(var(--border-width) * -1);
@@ -59,6 +60,10 @@
   border-radius: var(--border-radius);
   box-shadow: var(--shadow-horizontal-offset) var(--shadow-vertical-offset) var(--shadow-blur-radius)
     rgba(var(--color-shadow), var(--shadow-opacity));
+}
+
+.card--card.gradient {
+  background-attachment: local;
 }
 
 .card .card__inner .card__media {

--- a/assets/component-image-with-text.css
+++ b/assets/component-image-with-text.css
@@ -51,8 +51,6 @@
 .image-with-text__media--placeholder:after {
   content: '';
   position: absolute;
-  width: 100%;
-  height: 100%;
   background: rgba(var(--color-foreground), 0.04);
 }
 
@@ -297,6 +295,14 @@
 
 .image-with-text:not(.collapse-corners, .image-with-text--overlap) .image-with-text__media-item {
   z-index: 2;
+}
+
+.image-with-text:not(.image-with-text--overlap) .color-background-1 {
+  background: transparent;
+}
+
+.image-with-text .gradient:not(.color-background-1) {
+  background-attachment: local;
 }
 
 .image-with-text__content {

--- a/assets/component-image-with-text.css
+++ b/assets/component-image-with-text.css
@@ -297,7 +297,8 @@
   z-index: 2;
 }
 
-.image-with-text:not(.image-with-text--overlap) .color-background-1 {
+.image-with-text:not(.image-with-text--overlap) .color-background-1,
+.image-with-text.image-with-text--overlap .image-with-text__media.color-background-1 {
   background: transparent;
 }
 

--- a/assets/component-image-with-text.css
+++ b/assets/component-image-with-text.css
@@ -303,10 +303,9 @@
   background: transparent;
 }
 
-/* Needed for gradient continuity with or without animation, background-attachment: local scopes the gradient to its container which happens automatically when a transform is applied (animation on scroll) */
-.image-with-text .gradient:not(.color-background-1),
-.image-with-text.image-with-text--overlap .gradient {
-  background-attachment: local;
+/* Needed for gradient continuity with or without animation, the transform scopes the gradient to its container which happens already when animation are turned on */
+.image-with-text .gradient {
+  transform: perspective(0);
 }
 
 .image-with-text__content {

--- a/assets/component-image-with-text.css
+++ b/assets/component-image-with-text.css
@@ -299,11 +299,13 @@
 
 .image-with-text:not(.image-with-text--overlap) .color-background-1,
 .image-with-text.image-with-text--overlap .image-with-text__media.color-background-1 {
+  /* Needed for gradient continuity with or without animation */
   background: transparent;
 }
 
 .image-with-text .gradient:not(.color-background-1),
 .image-with-text.image-with-text--overlap .gradient {
+  /* Needed for gradient continuity with or without animation */
   background-attachment: local;
 }
 

--- a/assets/component-image-with-text.css
+++ b/assets/component-image-with-text.css
@@ -301,7 +301,8 @@
   background: transparent;
 }
 
-.image-with-text .gradient:not(.color-background-1) {
+.image-with-text .gradient:not(.color-background-1),
+.image-with-text.image-with-text--overlap .gradient {
   background-attachment: local;
 }
 

--- a/assets/component-image-with-text.css
+++ b/assets/component-image-with-text.css
@@ -297,15 +297,15 @@
   z-index: 2;
 }
 
+/* Needed for gradient continuity with or without animation so that transparent PNG images come up as we would expect */
 .image-with-text:not(.image-with-text--overlap) .color-background-1,
 .image-with-text.image-with-text--overlap .image-with-text__media.color-background-1 {
-  /* Needed for gradient continuity with or without animation */
   background: transparent;
 }
 
+/* Needed for gradient continuity with or without animation, background-attachment: local scopes the gradient to its container which happens automatically when a transform is applied (animation on scroll) */
 .image-with-text .gradient:not(.color-background-1),
 .image-with-text.image-with-text--overlap .gradient {
-  /* Needed for gradient continuity with or without animation */
   background-attachment: local;
 }
 

--- a/assets/section-image-banner.css
+++ b/assets/section-image-banner.css
@@ -8,8 +8,8 @@
   text-align: center;
 }
 
+/* Needed for gradient continuity with or without animation, background-attachment: local scopes the gradient to its container which happens automatically when a transform is applied (animation on scroll) */
 .banner__box.gradient {
-  /* Needed for gradient continuity with or without animation */
   background-attachment: local;
 }
 

--- a/assets/section-image-banner.css
+++ b/assets/section-image-banner.css
@@ -9,6 +9,7 @@
 }
 
 .banner__box.gradient {
+  /* Needed for gradient continuity with or without animation */
   background-attachment: local;
 }
 

--- a/assets/section-image-banner.css
+++ b/assets/section-image-banner.css
@@ -8,6 +8,10 @@
   text-align: center;
 }
 
+.banner__box.gradient {
+  background-attachment: local;
+}
+
 @media only screen and (max-width: 749px) {
   .banner--content-align-mobile-right .banner__box {
     text-align: right;

--- a/assets/section-image-banner.css
+++ b/assets/section-image-banner.css
@@ -320,8 +320,9 @@
     order: 2;
   }
 
-  .banner:not(.banner--mobile-bottom) .field__input {
-    background-color: transparent;
+  .banner:not(.banner--mobile-bottom) .field__input,
+  .banner--mobile-bottom:not(.banner--stacked) .banner__box {
+    background: transparent;
   }
 }
 

--- a/assets/section-image-banner.css
+++ b/assets/section-image-banner.css
@@ -8,9 +8,9 @@
   text-align: center;
 }
 
-/* Needed for gradient continuity with or without animation, background-attachment: local scopes the gradient to its container which happens automatically when a transform is applied (animation on scroll) */
+/* Needed for gradient continuity with or without animation, the transform scopes the gradient to its container which happens already when animation are turned on */
 .banner__box.gradient {
-  background-attachment: local;
+  transform: perspective(0);
 }
 
 @media only screen and (max-width: 749px) {

--- a/assets/section-image-banner.css
+++ b/assets/section-image-banner.css
@@ -322,7 +322,7 @@
   }
 
   .banner:not(.banner--mobile-bottom) .field__input,
-  .banner--mobile-bottom:not(.banner--stacked) .banner__box {
+  .banner--mobile-bottom:not(.banner--stacked) .banner__box.color-background-1 {
     background: transparent;
   }
 }

--- a/assets/video-section.css
+++ b/assets/video-section.css
@@ -4,8 +4,8 @@
   padding-bottom: calc(var(--ratio-percent) - var(--media-border-width));
 }
 
+/* Needed for gradient continuity with or without animation so that transparent PNG images come up as we would expect */
 .scroll-trigger:where(.gradient.video-section__media) {
-  /* Needed for gradient continuity with or without animation */
   background: transparent;
 }
 

--- a/assets/video-section.css
+++ b/assets/video-section.css
@@ -4,6 +4,10 @@
   padding-bottom: calc(var(--ratio-percent) - var(--media-border-width));
 }
 
+.scroll-trigger:where(.gradient.video-section__media) {
+  background: transparent;
+}
+
 .video-section__media.global-media-settings--full-width {
   padding-bottom: var(--ratio-percent);
 }

--- a/assets/video-section.css
+++ b/assets/video-section.css
@@ -5,6 +5,7 @@
 }
 
 .scroll-trigger:where(.gradient.video-section__media) {
+  /* Needed for gradient continuity with or without animation */
   background: transparent;
 }
 

--- a/sections/collage.liquid
+++ b/sections/collage.liquid
@@ -35,7 +35,7 @@
         >
           {%- case block.type -%}
             {%- when 'image' -%}
-              <div class="collage-card {% if section.settings.card_styles == 'none' %}global-media-settings{% else %}card-wrapper {{ section.settings.card_styles }} color-{{ settings.card_color_scheme }}{% endif %}">
+              <div class="collage-card {% if section.settings.card_styles == 'none' %}global-media-settings{% else %}card-wrapper {{ section.settings.card_styles }} color-{{ settings.card_color_scheme }} gradient{% endif %}">
                 <div
                   class="media media--transparent ratio"
                   {% if block.settings.image != blank %}
@@ -105,7 +105,7 @@
                 wrapper_class: section.settings.card_styles
               %}
             {%- when 'video' -%}
-              <div class="collage-card {% if section.settings.card_styles == 'none' %}global-media-settings{% else %}{{ section.settings.card_styles }} color-{{ settings.card_color_scheme }}{% endif %}">
+              <div class="collage-card {% if section.settings.card_styles == 'none' %}global-media-settings{% else %}{{ section.settings.card_styles }} color-{{ settings.card_color_scheme }} gradient{% endif %}">
                 <noscript>
                   <a
                     href="{{ block.settings.video_url }}"


### PR DESCRIPTION
### PR Summary: 

<!-- Please include a short description (using non-technical terms, 1-2 sentences) about the changes you are introducing, what problem is being fixed and/or describe the benefit to merchants. This content will be used in our release notes for Dawn on [themes.shopify.com](https://themes.shopify.com/themes/dawn/styles/default#ReleaseNotes). -->
The issue that we're dealing with here is how gradients behave when animation is turned ON vs when it's OFF. 

The animation is creating a new stacking context on elements receiving the `animate--slide-in` due to a `transform` being applied. 
It means the gradient, which was matching the gradient applied on the general background is now based on the element size itself in which it is. 

Here we're matching some of those new styles due to animation when no animation is applied so we have some consistency. It's a visual change!

[Here is more context](https://screenshot.click/18-25-8toxq-fasqn.gif).
[And a little gif comparison](https://screenshot.click/18-25-8toxq-fasqn.gif)

### Why are these changes introduced?

Fixes #2640

### What approach did you take?

Because the issue introduced via the animations isn't something we have a fix for at the moment. We're wanting to still keep some consistency between the looks and therefor change how the gradient was applied in certain scenarios. 

### Other considerations

### Decision log

| # | Decision | Alternatives | Rationale | Downsides |
|---|---|---|---|---|
| 1 | A decision taken was to, for the time being, apply the same behaviour when animations are off. Instead of trying to fix some of the behaviours/changes when animations are on.   |   |   |   |

Here are some comparison with before and after. What it looked like without animation before and how it looks with the fixes in this PR:

#### Product cards: 

<details>
<summary>Same color schemes, No gradient</summary>

**Current:**
<img width="2856" alt="19-28-4r5qd-oxfiz" src="https://github.com/Shopify/dawn/assets/28613840/3a867183-883f-4ca2-ac3f-1ccf5e3ae9ae">

---
**With fix:**
<img width="2469" alt="19-29-kzd51-x0gs7" src="https://github.com/Shopify/dawn/assets/28613840/d39a8b6c-5169-4383-abd5-4c0ce3fd5599">
</details>

<details>
<summary>Same color schemes, scheme 1 gradient</summary>

**Current:**
<img width="2846" alt="19-26-utuha-pkoac" src="https://github.com/Shopify/dawn/assets/28613840/10154f38-346b-4cee-89c7-2c9b10820c7e">

---
**With fix:**
<img width="2340" alt="19-27-mwkcv-z8lky" src="https://github.com/Shopify/dawn/assets/28613840/6c6a91e7-3a94-43c6-90d9-ee0a11601afd">

</details>

<details>
<summary>Different color schemes, scheme 1 & 2 gradients</summary>

**Current:**
<img width="2421" alt="19-25-kbo6e-brogn" src="https://github.com/Shopify/dawn/assets/28613840/b251abb8-3b96-4a9f-9077-24fb70543a80">

---
**With fix:**
<img width="2468" alt="19-24-qabwu-usyhv" src="https://github.com/Shopify/dawn/assets/28613840/b825a372-35b0-4b7b-a1d6-7196029285a3">
</details>

#### Image banner (with container):

<details>
<summary>Same color schemes, scheme 1 gradient</summary>

<img width="3526" alt="19-14-1zt5a-a4g0l" src="https://github.com/Shopify/dawn/assets/28613840/987d04a1-eeb0-4b51-b911-884f8bc638d5">
</details>

<details>
<summary>Different color schemes, scheme 1 & 2 gradients</summary>

<img width="3761" alt="19-15-8ugtx-2xgy9" src="https://github.com/Shopify/dawn/assets/28613840/fe74f480-e9a8-4ba8-9652-276ac9bac3ff">
</details>

#### Image with text:

<details>
<summary>Different schemes, scheme 1 & 2 gradients</summary>

**Current:**
<img width="862" alt="iwt-current-diff-schemes-png" src="https://github.com/Shopify/dawn/assets/30790058/660f7f3e-ace1-4c74-9b81-a39123204f8f">

---
**With fix:**
<img width="856" alt="iwt-fix-diff-schemes-png" src="https://github.com/Shopify/dawn/assets/30790058/ebff3e5f-79d3-4f43-962e-f716619e5219">
</details>

<details>
<summary>Same scheme, scheme 1 gradient, with shadows</summary>

**Current:**
<img width="865" alt="iwt-current-same-scheme-both-styles-png" src="https://github.com/Shopify/dawn/assets/30790058/6d52fc29-34a8-47b8-b611-a62e89e8aabb">

---
**With fix:**
<img width="854" alt="iwt-fix-same-scheme-both-styles-png" src="https://github.com/Shopify/dawn/assets/30790058/3301d486-ef32-4acd-9815-bb67c51fd14c">

</details>

<details>
<summary>Different schemes, with overlap</summary>

**Current:**
<img width="859" alt="iwt-current-diff-schemes-overlap-png" src="https://github.com/Shopify/dawn/assets/30790058/7c933152-1156-49cb-bfbf-d61e64b3ff4b">

---
**With fix:**
<img width="847" alt="iwt-fix-diff-schemes-overlap-png" src="https://github.com/Shopify/dawn/assets/30790058/ccae88d6-1d95-4361-9632-d20580b1fa7e">
</details>

<details>
<summary>Same schemes, with overlap</summary>

**Current:**
<img width="848" alt="iwt-current-same-scheme-overlap-png" src="https://github.com/Shopify/dawn/assets/30790058/aa4ce83e-6aee-42fc-9d1a-db88bb6d1492">

---
**With fix:**
<img width="836" alt="iwt-fix-same-scheme-overlap" src="https://github.com/Shopify/dawn/assets/30790058/4f558f4b-1586-461c-b61e-81a4158dba9d">
</details>



#### Multirow:

<details>
<summary>Scheme 1 with transparent image</summary>

<img width="2259" alt="19-17-0vqtw-4a83a" src="https://github.com/Shopify/dawn/assets/28613840/6a4100c6-731b-45fa-8269-e8124505d227">
</details>

<details>
<summary>Scheme 2 with transparent image</summary>

<img width="2187" alt="19-18-28zup-q4vee" src="https://github.com/Shopify/dawn/assets/28613840/9d67023f-d161-4dca-ace2-580216a61887">
</details>

### Visual impact on existing themes
<!-- How will this visually affect merchants who upgrade to a new theme version with this change? -->
Are impacted: 
- cards (products, blog, collections)
- content containers in the image banner and slideshow section
- image banner 
- multirow
- collage (added support for gradient for the image and video block)
- collapsible content (image background so PNGs work as expected)
- video section (image background so PNGs work as expected)


### Testing steps/scenarios
<!-- List all the testing tasks that applies to your fix to help peers review your work. -->
- [ ] Step 1

### Demo links
<!-- Please include a link to a demo store that includes preconfigured sections and settings to allow reviewers to easily test the features you are working on. -->

- [Editor](https://os2-demo.myshopify.com/admin/themes/139964416022/editor)

### Checklist
- [ ] Added PR summary for [release notes](https://themes.shopify.com/themes/dawn/styles/default#ReleaseNotes)
- [ ] Requested review from UX (Only for changes that are affecting the experience or perceivable visual details)
- [ ] Created a ticket for the [help.shopify.com](https://help.shopify.com) documentation team about updates to theme settings. (Internal-only task)
- [ ] Followed [theme code principles](https://github.com/Shopify/dawn/blob/main/.github/CONTRIBUTING.md#theme-code-principles)
- [ ] Linted with [Theme Check](https://github.com/Shopify/theme-check)
- [ ] Tested on [mobile](https://shopify.dev/themes/store/requirements#mobile-browser-requirements)
- [ ] Tested on [multiple browsers](https://shopify.dev/themes/store/requirements#desktop-browser-requirements)
- [ ] Tested for [accessibility](https://shopify.dev/themes/best-practices/accessibility)
