### PR TITLE
Add color scheme group default values

### DIFF
--- a/config/settings_schema.json
+++ b/config/settings_schema.json
@@ -43,7 +43,8 @@
           {
             "type": "color",
             "id": "background",
-            "label": "t:settings_schema.colors.settings.background.label"
+            "label": "t:settings_schema.colors.settings.background.label",
+            "default": "#FFFFFF"
           },
           {
             "type": "color_background",
@@ -54,27 +55,32 @@
           {
             "type": "color",
             "id": "text",
-            "label": "t:settings_schema.colors.settings.text.label"
+            "label": "t:settings_schema.colors.settings.text.label",
+            "default": "#121212"
           },
           {
             "type": "color",
             "id": "button",
-            "label": "t:settings_schema.colors.settings.button_background.label"
+            "label": "t:settings_schema.colors.settings.button_background.label",
+            "default": "#121212"
           },
           {
             "type": "color",
             "id": "button_label",
-            "label": "t:settings_schema.colors.settings.button_label.label"
+            "label": "t:settings_schema.colors.settings.button_label.label",
+            "default": "#FFFFFF"
           },
           {
             "type": "color",
             "id": "secondary_button_label",
-            "label": "t:settings_schema.colors.settings.secondary_button_label.label"
+            "label": "t:settings_schema.colors.settings.secondary_button_label.label",
+            "default": "#121212"
           },
           {
             "type": "color",
             "id": "shadow",
-            "label": "t:settings_schema.colors.settings.shadow.label"
+            "label": "t:settings_schema.colors.settings.shadow.label",
+            "default": "#121212"
           }
         ],
         "role": {


### PR DESCRIPTION
### PR Summary: 

<!-- Please include a short description (using non-technical terms, 1-2 sentences) about the changes you are introducing, what problem is being fixed and/or describe the benefit to merchants. This content will be used in our release notes for Dawn on [themes.shopify.com](https://themes.shopify.com/themes/dawn/styles/default#ReleaseNotes). -->


### Why are these changes introduced?

Adds default values for the color schemes definition. The missing defaults were causing non-ideal results when connecting and subsequently disconnecting brand settings.

https://screenshot.click/18-08-s15kd-ghcyp.mp4


### Testing steps/scenarios
- connect and disconnect a brand color to a color scheme
- verify the resulting fallback color is not transparent
- verify default colors match dawn's background-1 scheme

### Demo links
<!-- Please include a link to a demo store that includes preconfigured sections and settings to allow reviewers to easily test the features you are working on. -->

- [Editor](https://os2-demo.myshopify.com/admin/themes/139970969622/editor)

### Checklist
- [ ] Added PR summary for [release notes](https://themes.shopify.com/themes/dawn/styles/default#ReleaseNotes)
- [ ] Requested review from UX (Only for changes that are affecting the experience or perceivable visual details)
- [ ] Created a ticket for the [help.shopify.com](https://help.shopify.com) documentation team about updates to theme settings. (Internal-only task)
- [ ] Followed [theme code principles](https://github.com/Shopify/dawn/blob/main/.github/CONTRIBUTING.md#theme-code-principles)
- [ ] Linted with [Theme Check](https://github.com/Shopify/theme-check)
- [ ] Tested on [mobile](https://shopify.dev/themes/store/requirements#mobile-browser-requirements)
- [ ] Tested on [multiple browsers](https://shopify.dev/themes/store/requirements#desktop-browser-requirements)
- [ ] Tested for [accessibility](https://shopify.dev/themes/best-practices/accessibility)
