### PR TITLE
Remove forced white text color in Image Banner & Slideshow

### DIFF
--- a/assets/section-image-banner.css
+++ b/assets/section-image-banner.css
@@ -209,9 +209,6 @@
 
   .banner:not(.banner--mobile-bottom):not(.email-signup-banner) .banner__box {
     background: transparent;
-    --color-foreground: 255, 255, 255;
-    --color-button: 255, 255, 255;
-    --color-button-text: 0, 0, 0;
   }
 
   .banner:not(.banner--mobile-bottom) .banner__box {
@@ -220,9 +217,7 @@
     box-shadow: none;
   }
 
-  .banner:not(.banner--mobile-bottom) .button--secondary {
-    --color-button: 255, 255, 255;
-    --color-button-text: 255, 255, 255;
+  .banner--desktop-transparent .button--secondary {
     --alpha-button-background: 0;
   }
 
@@ -335,9 +330,6 @@
 @media screen and (min-width: 750px) {
   .banner--desktop-transparent .banner__box {
     background: transparent;
-    --color-foreground: 255, 255, 255;
-    --color-button: 255, 255, 255;
-    --color-button-text: 0, 0, 0;
     max-width: 89rem;
     border: none;
     border-radius: 0;
@@ -345,8 +337,6 @@
   }
 
   .banner--desktop-transparent .button--secondary {
-    --color-button: 255, 255, 255;
-    --color-button-text: 255, 255, 255;
     --alpha-button-background: 0;
   }
 

--- a/assets/section-image-banner.css
+++ b/assets/section-image-banner.css
@@ -217,7 +217,7 @@
     box-shadow: none;
   }
 
-  .banner--desktop-transparent .button--secondary {
+  .banner .button--secondary {
     --alpha-button-background: 0;
   }
 

--- a/assets/section-image-banner.css
+++ b/assets/section-image-banner.css
@@ -217,7 +217,7 @@
     box-shadow: none;
   }
 
-  .banner .button--secondary {
+  .banner:not(.banner--mobile-bottom) .button--secondary {
     --alpha-button-background: 0;
   }
 

--- a/locales/cs.schema.json
+++ b/locales/cs.schema.json
@@ -2572,9 +2572,6 @@
         "image_overlay_opacity": {
           "label": "Neprůhlednost překryvu obrázku"
         },
-        "color_scheme": {
-          "info": "Zobrazuje se v případě, že se zobrazuje kontejner."
-        },
         "show_text_below": {
           "label": "Na mobilním zařízení zobrazovat obsah pod obrázkem",
           "info": "Nejlepších výsledků dosáhnete použitím obrázku s poměrem stran 16:9. [Zjistit více](https://help.shopify.com/manual/shopify-admin/productivity-tools/image-editor#understanding-image-aspect-ratio)"
@@ -2815,9 +2812,6 @@
             },
             "image_overlay_opacity": {
               "label": "Neprůhlednost překryvu obrázku"
-            },
-            "color_scheme": {
-              "info": "Zobrazuje se v případě, že se zobrazuje kontejner."
             },
             "text_alignment_mobile": {
               "label": "Zarovnání obsahu v mobilním prostředí",

--- a/locales/da.schema.json
+++ b/locales/da.schema.json
@@ -2572,9 +2572,6 @@
         "image_overlay_opacity": {
           "label": "Billedoverlejringens uigennemsigtighed"
         },
-        "color_scheme": {
-          "info": "Synlig, når objektbeholderen vises."
-        },
         "show_text_below": {
           "label": "Vis indhold under billede på mobiltelefon",
           "info": "Brug et billede med et højde-bredde-forhold på 16:9 for at opnå det bedste resultat. [Få mere at vide](https://help.shopify.com/manual/shopify-admin/productivity-tools/image-editor#understanding-image-aspect-ratio)"
@@ -2815,9 +2812,6 @@
             },
             "image_overlay_opacity": {
               "label": "Billedoverlejringens uigennemsigtighed"
-            },
-            "color_scheme": {
-              "info": "Synlig, når containeren vises."
             },
             "text_alignment_mobile": {
               "label": "Justering af indhold på mobil",

--- a/locales/de.schema.json
+++ b/locales/de.schema.json
@@ -2572,9 +2572,6 @@
         "image_overlay_opacity": {
           "label": "Deckkraft der Bildüberlagerung"
         },
-        "color_scheme": {
-          "info": "Sichtbar, wenn Container angezeigt wird."
-        },
         "show_text_below": {
           "label": "Auf Mobilgeräten Inhalt unterhalb der Bilder anzeigen",
           "info": "Verwende Bilder mit einem Seitenverhältnis von 16:9 für optimale Ergebnisse. [Mehr Informationen](https://help.shopify.com/manual/shopify-admin/productivity-tools/image-editor#understanding-image-aspect-ratio)"
@@ -2815,9 +2812,6 @@
             },
             "image_overlay_opacity": {
               "label": "Deckkraft der Bildüberlagerung"
-            },
-            "color_scheme": {
-              "info": "Sichtbar, wenn Container angezeigt wird."
             },
             "text_alignment_mobile": {
               "label": "Mobile Inhaltsausrichtung",

--- a/locales/en.default.schema.json
+++ b/locales/en.default.schema.json
@@ -1186,9 +1186,6 @@
           },
           "label": "Desktop content alignment"
         },
-        "color_scheme": {
-          "info": "Visible when container displayed."
-        },
         "mobile": {
           "content": "Mobile Layout"
         },
@@ -3043,9 +3040,6 @@
             },
             "image_overlay_opacity": {
               "label": "Image overlay opacity"
-            },
-            "color_scheme": {
-              "info": "Visible when container displayed."
             },
             "text_alignment_mobile": {
               "label": "Mobile content alignment",

--- a/locales/es.schema.json
+++ b/locales/es.schema.json
@@ -2572,9 +2572,6 @@
         "image_overlay_opacity": {
           "label": "Opacidad de la sobreposición de imagen"
         },
-        "color_scheme": {
-          "info": "Visible cuando se muestre el contenedor."
-        },
         "show_text_below": {
           "label": "Mostrar el contenido debajo de la imagen en el móvil",
           "info": "Para mejores resultados, utiliza una imagen con una relación de aspecto 16:9. [Más información](https://help.shopify.com/manual/shopify-admin/productivity-tools/image-editor#understanding-image-aspect-ratio)"
@@ -2815,9 +2812,6 @@
             },
             "image_overlay_opacity": {
               "label": "Opacidad de la sobreposición de imagen"
-            },
-            "color_scheme": {
-              "info": "Visible cuando se muestre el contenedor."
             },
             "text_alignment_mobile": {
               "label": "Alineación del contenido en dispositivos móviles",

--- a/locales/fi.schema.json
+++ b/locales/fi.schema.json
@@ -2572,9 +2572,6 @@
         "image_overlay_opacity": {
           "label": "Peittokuvan läpikuultavuus"
         },
-        "color_scheme": {
-          "info": "Näkyvissä, kun säilö on esillä."
-        },
         "show_text_below": {
           "label": "Näytä kuvien alla oleva sisältö mobiililaitteessa",
           "info": "Saat parhaat tulokset käyttämällä kuvaa, jonka kuvasuhde on 16:9. [Lisätietoja](https://help.shopify.com/manual/shopify-admin/productivity-tools/image-editor#understanding-image-aspect-ratio)"
@@ -2815,9 +2812,6 @@
             },
             "image_overlay_opacity": {
               "label": "Peittokuvan läpikuultavuus"
-            },
-            "color_scheme": {
-              "info": "Näkyvillä, kun säilö on esillä."
             },
             "text_alignment_mobile": {
               "label": "Mobiilisisällön tasaus",

--- a/locales/fr.schema.json
+++ b/locales/fr.schema.json
@@ -2572,9 +2572,6 @@
         "image_overlay_opacity": {
           "label": "Opacité de la superposition d'images"
         },
-        "color_scheme": {
-          "info": "Visible lorsque le conteneur est affiché."
-        },
         "show_text_below": {
           "label": "Afficher le contenu sous l'image sur le mobile",
           "info": "Pour optimiser vos résultats, utilisez une image ayant un rapport d'aspect de 16:9. [En savoir plus](https://help.shopify.com/manual/shopify-admin/productivity-tools/image-editor#understanding-image-aspect-ratio)"
@@ -2815,9 +2812,6 @@
             },
             "image_overlay_opacity": {
               "label": "Opacité de la superposition d'images"
-            },
-            "color_scheme": {
-              "info": "Visible lorsque le conteneur est affiché."
             },
             "text_alignment_mobile": {
               "label": "Alignement du contenu sur mobile",

--- a/locales/it.schema.json
+++ b/locales/it.schema.json
@@ -2572,9 +2572,6 @@
         "image_overlay_opacity": {
           "label": "Opacità della sovrapposizione immagine"
         },
-        "color_scheme": {
-          "info": "Visibile quando è visualizzato il contenitore."
-        },
         "show_text_below": {
           "label": "Mostra contenuto sotto le immagini sui dispositivi mobili",
           "info": "Per un risultato ottimale utilizza un'immagine con proporzioni 16:9. [Maggiori informazioni](https://help.shopify.com/manual/shopify-admin/productivity-tools/image-editor#understanding-image-aspect-ratio)"
@@ -2815,9 +2812,6 @@
             },
             "image_overlay_opacity": {
               "label": "Opacità della sovrapposizione immagine"
-            },
-            "color_scheme": {
-              "info": "Visibile quando è visualizzato il contenitore."
             },
             "text_alignment_mobile": {
               "label": "Allineamento contenuto su dispositivi mobili",

--- a/locales/ja.schema.json
+++ b/locales/ja.schema.json
@@ -2572,9 +2572,6 @@
         "image_overlay_opacity": {
           "label": "画像のオーバーレイ不透明率"
         },
-        "color_scheme": {
-          "info": "コンテナが表示されたタイミングで表示されます。"
-        },
         "show_text_below": {
           "label": "モバイルで画像の下にコンテンツを表示",
           "info": "画像のアスペクト比が16:9のものを使用すると最適です。[詳しくはこちら](https://help.shopify.com/manual/shopify-admin/productivity-tools/image-editor#understanding-image-aspect-ratio)"
@@ -2815,9 +2812,6 @@
             },
             "image_overlay_opacity": {
               "label": "画像のオーバーレイ不透明率"
-            },
-            "color_scheme": {
-              "info": "コンテナが表示された時に表示。"
             },
             "text_alignment_mobile": {
               "label": "モバイルのコンテンツ配置",

--- a/locales/ko.schema.json
+++ b/locales/ko.schema.json
@@ -2572,9 +2572,6 @@
         "image_overlay_opacity": {
           "label": "이미지 오버레이 투명도"
         },
-        "color_scheme": {
-          "info": "컨테이너가 표시될 때 볼 수 있습니다."
-        },
         "show_text_below": {
           "label": "모바일에서 이미지 아래에 콘텐츠 표시",
           "info": "최고의 결과를 얻으려면 이미지의 가로 세로 비율을 16:9로 사용하십시오. [자세히 알아보기](https://help.shopify.com/manual/shopify-admin/productivity-tools/image-editor#understanding-image-aspect-ratio)"
@@ -2815,9 +2812,6 @@
             },
             "image_overlay_opacity": {
               "label": "이미지 오버레이 투명도"
-            },
-            "color_scheme": {
-              "info": "컨테이너가 표시될 때 볼 수 있습니다."
             },
             "text_alignment_mobile": {
               "label": "모바일 콘텐츠 정렬",

--- a/locales/nb.schema.json
+++ b/locales/nb.schema.json
@@ -2572,9 +2572,6 @@
         "image_overlay_opacity": {
           "label": "Gjennomsiktighet for bildeoverlegg"
         },
-        "color_scheme": {
-          "info": "Synlig når beholderen vises."
-        },
         "show_text_below": {
           "label": "Vis innhold under bildet på mobil",
           "info": "Bruk et bilde med størrelsesforhold 16:9 for best resultat. [Finn ut mer](https://help.shopify.com/manual/shopify-admin/productivity-tools/image-editor#understanding-image-aspect-ratio)"
@@ -2815,9 +2812,6 @@
             },
             "image_overlay_opacity": {
               "label": "Gjennomsiktighet for bildeoverlegg"
-            },
-            "color_scheme": {
-              "info": "Synlig når beholderen vises."
             },
             "text_alignment_mobile": {
               "label": "Innholdsjustering på mobiltelefon",

--- a/locales/nl.schema.json
+++ b/locales/nl.schema.json
@@ -2572,9 +2572,6 @@
         "image_overlay_opacity": {
           "label": "Dekking van afbeeldingsoverlay"
         },
-        "color_scheme": {
-          "info": "Zichtbaar wanneer de container wordt weergegeven."
-        },
         "show_text_below": {
           "label": "Content op mobiel onder de afbeelding weergeven",
           "info": "Gebruik voor de beste resultaten een afbeelding met een beeldverhouding van 16:9. [Meer informatie](https://help.shopify.com/manual/shopify-admin/productivity-tools/image-editor#understanding-image-aspect-ratio)"
@@ -2815,9 +2812,6 @@
             },
             "image_overlay_opacity": {
               "label": "Dekking van afbeeldingsoverlay"
-            },
-            "color_scheme": {
-              "info": "Zichtbaar wanneer de container wordt weergegeven."
             },
             "text_alignment_mobile": {
               "label": "Uitlijning van content op mobiel",

--- a/locales/pl.schema.json
+++ b/locales/pl.schema.json
@@ -2572,9 +2572,6 @@
         "image_overlay_opacity": {
           "label": "Nieprzezroczystość nakładki obrazu"
         },
-        "color_scheme": {
-          "info": "Widoczne podczas wyświetlania kontenera."
-        },
         "show_text_below": {
           "label": "Pokaż treść pod obrazem na urządzeniu mobilnym",
           "info": "Aby uzyskać najlepsze wyniki, użyj obrazu o współczynniku proporcji 16:9. [Dowiedz się więcej](https://help.shopify.com/manual/shopify-admin/productivity-tools/image-editor#understanding-image-aspect-ratio)"
@@ -2815,9 +2812,6 @@
             },
             "image_overlay_opacity": {
               "label": "Nieprzezroczystość nakładki obrazu"
-            },
-            "color_scheme": {
-              "info": "Widoczne podczas wyświetlania kontenera."
             },
             "text_alignment_mobile": {
               "label": "Wyrównanie treści na urządzeniu mobilnym",

--- a/locales/pt-BR.schema.json
+++ b/locales/pt-BR.schema.json
@@ -2572,9 +2572,6 @@
         "image_overlay_opacity": {
           "label": "Opacidade de sobreposição de imagem"
         },
-        "color_scheme": {
-          "info": "Visível quando o contêiner é exibido."
-        },
         "show_text_below": {
           "label": "Exibir conteúdo abaixo da imagem em dispositivos móveis",
           "info": "Use uma imagem com proporção 16:9 para ter os melhores resultados. [Saiba mais](https://help.shopify.com/manual/shopify-admin/productivity-tools/image-editor#understanding-image-aspect-ratio)"
@@ -2815,9 +2812,6 @@
             },
             "image_overlay_opacity": {
               "label": "Opacidade de sobreposição de imagem"
-            },
-            "color_scheme": {
-              "info": "Visível quando o contêiner é exibido."
             },
             "text_alignment_mobile": {
               "label": "Alinhamento de conteúdo em dispositivos móveis",

--- a/locales/pt-PT.schema.json
+++ b/locales/pt-PT.schema.json
@@ -2572,9 +2572,6 @@
         "image_overlay_opacity": {
           "label": "Opacidade da sobreposição da imagem"
         },
-        "color_scheme": {
-          "info": "Visível quando o recetor é exibido."
-        },
         "show_text_below": {
           "label": "Mostrar conteúdo por baixo da imagem em dispositivos móveis",
           "info": "Para obter os melhores resultados, utilize uma imagem com uma proporção de 16:9. [Saber mais](https://help.shopify.com/manual/shopify-admin/productivity-tools/image-editor#understanding-image-aspect-ratio)"
@@ -2815,9 +2812,6 @@
             },
             "image_overlay_opacity": {
               "label": "Opacidade da sobreposição da imagem"
-            },
-            "color_scheme": {
-              "info": "Visível quando o recetor é exibido."
             },
             "text_alignment_mobile": {
               "label": "Alinhamento do conteúdo em dispositivos móveis",

--- a/locales/sv.schema.json
+++ b/locales/sv.schema.json
@@ -2572,9 +2572,6 @@
         "image_overlay_opacity": {
           "label": "Bildens opacitet för överlagring"
         },
-        "color_scheme": {
-          "info": "Synlig när ruta visas."
-        },
         "show_text_below": {
           "label": "Visa innehåll under bild på mobil",
           "info": "Använd en bild med bildformat 16:9, för bästa resultat. [Mer information](https://help.shopify.com/manual/shopify-admin/productivity-tools/image-editor#understanding-image-aspect-ratio)"
@@ -2815,9 +2812,6 @@
             },
             "image_overlay_opacity": {
               "label": "Bildens opacitet för överlagring"
-            },
-            "color_scheme": {
-              "info": "Synlig när ruta visas."
             },
             "text_alignment_mobile": {
               "label": "Linjering av innehåll på mobil",

--- a/locales/th.schema.json
+++ b/locales/th.schema.json
@@ -2572,9 +2572,6 @@
         "image_overlay_opacity": {
           "label": "ความทึบของการวางซ้อนรูปภาพ"
         },
-        "color_scheme": {
-          "info": "ปรากฏให้เห็นเมื่อแสดงกรอบเนื้อหา"
-        },
         "show_text_below": {
           "label": "แสดงเนื้อหาที่ด้านล่างของรูปภาพบนมือถือ",
           "info": "ใช้รูปภาพที่มีอัตราส่วนภาพ 16:9 เพื่อผลลัพธ์ที่ดีที่สุด [ดูข้อมูลเพิ่มเติม](https://help.shopify.com/manual/shopify-admin/productivity-tools/image-editor#understanding-image-aspect-ratio)"
@@ -2815,9 +2812,6 @@
             },
             "image_overlay_opacity": {
               "label": "ความทึบของการวางซ้อนรูปภาพ"
-            },
-            "color_scheme": {
-              "info": "ปรากฏให้เห็นเมื่อแสดงกรอบเนื้อหา"
             },
             "text_alignment_mobile": {
               "label": "การจัดวางเนื้อหาบนมือถือ",

--- a/locales/tr.schema.json
+++ b/locales/tr.schema.json
@@ -2572,9 +2572,6 @@
         "image_overlay_opacity": {
           "label": "Görsel yer paylaşımı opaklığı"
         },
-        "color_scheme": {
-          "info": "Kapsayıcı gösterildiğinde görünür."
-        },
         "show_text_below": {
           "label": "Mobil cihaz üzerinde görselin altındaki içeriği göster",
           "info": "En iyi sonuçlar için 16:9 en-boy oranına sahip bir görsel kullanın. [Daha fazla bilgi edinin](https://help.shopify.com/manual/shopify-admin/productivity-tools/image-editor#understanding-image-aspect-ratio)"
@@ -2815,9 +2812,6 @@
             },
             "image_overlay_opacity": {
               "label": "Görsel yer paylaşımı opaklığı"
-            },
-            "color_scheme": {
-              "info": "Kapsayıcı gösterildiğinde görünür."
             },
             "text_alignment_mobile": {
               "label": "Mobil içerik hizalaması",

--- a/locales/vi.schema.json
+++ b/locales/vi.schema.json
@@ -2572,9 +2572,6 @@
         "image_overlay_opacity": {
           "label": "Độ chắn sáng của lớp phủ hình ảnh"
         },
-        "color_scheme": {
-          "info": "Có thể nhìn thấy khi vùng chứa hiển thị."
-        },
         "show_text_below": {
           "label": "Hiển thị nội dung dưới hình ảnh trên thiết bị di động",
           "info": "Để có kết quả tốt nhất, hãy sử dụng hình ảnh có tỷ lệ khung hình 16:9. [Tìm hiểu thêm](https://help.shopify.com/manual/shopify-admin/productivity-tools/image-editor#understanding-image-aspect-ratio)"
@@ -2815,9 +2812,6 @@
             },
             "image_overlay_opacity": {
               "label": "Độ chắn sáng của lớp phủ hình ảnh"
-            },
-            "color_scheme": {
-              "info": "Có thể nhìn thấy khi vùng chứa hiển thị."
             },
             "text_alignment_mobile": {
               "label": "Căn chỉnh nội dung trên thiết bị di động",

--- a/locales/zh-CN.schema.json
+++ b/locales/zh-CN.schema.json
@@ -2572,9 +2572,6 @@
         "image_overlay_opacity": {
           "label": "图片叠加不透明度"
         },
-        "color_scheme": {
-          "info": "在显示容器时可见。"
-        },
         "show_text_below": {
           "label": "在移动设备上的图片下方显示内容。",
           "info": "若要获得最佳效果，请使用纵横比为 16:9 的图片。[了解详细信息](https://help.shopify.com/manual/shopify-admin/productivity-tools/image-editor#understanding-image-aspect-ratio)"
@@ -2815,9 +2812,6 @@
             },
             "image_overlay_opacity": {
               "label": "图片叠加不透明度"
-            },
-            "color_scheme": {
-              "info": "在显示容器时可见。"
             },
             "text_alignment_mobile": {
               "label": "移动设备内容对齐方式",

--- a/locales/zh-TW.schema.json
+++ b/locales/zh-TW.schema.json
@@ -2572,9 +2572,6 @@
         "image_overlay_opacity": {
           "label": "圖片疊加層透明度"
         },
-        "color_scheme": {
-          "info": "顯示容器時可見。"
-        },
         "show_text_below": {
           "label": "在行動版圖片下方顯示內容",
           "info": "若想要獲得最佳結果，請使用寬高比為 16:9 的圖片。[瞭解詳情](https://help.shopify.com/manual/shopify-admin/productivity-tools/image-editor#understanding-image-aspect-ratio)"
@@ -2815,9 +2812,6 @@
             },
             "image_overlay_opacity": {
               "label": "圖片疊加層透明度"
-            },
-            "color_scheme": {
-              "info": "顯示容器時可見。"
             },
             "text_alignment_mobile": {
               "label": "行動版內容對齊方式",

--- a/sections/image-banner.liquid
+++ b/sections/image-banner.liquid
@@ -290,7 +290,6 @@
       "type": "color_scheme",
       "id": "color_scheme",
       "label": "t:sections.all.colors.label",
-      "info": "t:sections.image-banner.settings.color_scheme.info",
       "default": "background-1"
     },
     {

--- a/sections/slideshow.liquid
+++ b/sections/slideshow.liquid
@@ -531,7 +531,6 @@
           "type": "color_scheme",
           "id": "color_scheme",
           "label": "t:sections.all.colors.label",
-          "info": "t:sections.slideshow.blocks.slide.settings.color_scheme.info",
           "default": "background-1"
         },
         {

--- a/templates/index.json
+++ b/templates/index.json
@@ -40,7 +40,7 @@
         "desktop_content_position": "bottom-center",
         "show_text_box": false,
         "desktop_content_alignment": "center",
-        "color_scheme": "background-1",
+        "color_scheme": "inverse",
         "mobile_content_alignment": "center",
         "stack_images_on_mobile": false,
         "show_text_below": false


### PR DESCRIPTION
### PR Summary: 

Always allow text and button color customization within the Image banner and Slideshow sections. 
Important: Color scheme may need to be manually changed to  prevent visual change and ensure adequate contrast.

### Why are these changes introduced?

Fixes https://github.com/Shopify/dawn/issues/1391

### What approach did you take?

This PR does a few things: 

1. On Image Banner and Slideshow sections, it removes the forced white color for text and buttons when the content container is hidden. 
2. On Dawn's default homepage template, it changes the Image Banner's default color palette from `background-1` (which uses black text) to `inverse` (which uses white text). 
3. It removes the "Visible when container displayed." that showed underneath the color palette control for Image Banner & Slideshow, since it's no longer relevant. 

For new merchants, this approach maintains the acceptable contrast ratio that existed by default on the top of the homepage template for Dawn (the text and buttons are still white, so there's no perceptable change.)

In other areas, we cannot guarantee an acceptable ratio today anyway: If the background image is light, and/or there's no overlay applied, white text is unreadable. In the past, the merchant was stuck with that being broken. With this new approach, the merchant can fix it by applying a new color scheme. 

<details>
<summary>🎥 Video</summary>


https://github.com/Shopify/dawn/assets/1202812/79643d16-d8f5-483b-8e52-b3673402be12



</details>

### Other considerations

- [ ] This should be fine for new merchants, but if a merchant upgrades to this change automatically, they may lose their previously-white text. Is there anything we can do about that? 
- [ ] We need to double check and ensure that this works right with the starter content in our other themes that use Image Banners too. 

### Visual changes
If selected color scheme doesn't use white text, image banners and slideshows without content containers may have a visual change. Shops will need to manually update their color scheme to account for this.

### Testing steps/scenarios
<!-- List all the testing tasks that applies to your fix to help peers review your work. -->

1. [Visit the demo store](https://os2-demo.myshopify.com/admin/themes/139977031702/editor). 
2. Select the Image Banner at the top of the page. Change the color scheme, and note that the text + button color updates.
3. Edit the color scheme, ensure that the new colors also appear.
4. Repeat with a freshly-inserted Image Banner section and a Slideshow section. 

### Demo links
<!-- Please include a link to a demo store that includes preconfigured sections and settings to allow reviewers to easily test the features you are working on. -->

- [Editor](https://os2-demo.myshopify.com/admin/themes/140005474326/editor)

### Checklist
- [x] Added PR summary for [release notes](https://themes.shopify.com/themes/dawn/styles/default#ReleaseNotes)
- [x] Requested review from UX (Only for changes that are affecting the experience or perceivable visual details)
- [ ] Created a ticket for the [help.shopify.com](https://help.shopify.com) documentation team about updates to theme settings. (Internal-only task)
- [x] Followed [theme code principles](https://github.com/Shopify/dawn/blob/main/.github/CONTRIBUTING.md#theme-code-principles)
- [x] Linted with [Theme Check](https://github.com/Shopify/theme-check)
- [x] Tested on [mobile](https://shopify.dev/themes/store/requirements#mobile-browser-requirements)
- [x] Tested on [multiple browsers](https://shopify.dev/themes/store/requirements#desktop-browser-requirements)
- [x] Tested for [accessibility](https://shopify.dev/themes/best-practices/accessibility)
