### PR TITLE
product_card_style = card now shows placeholder image

### DIFF
--- a/snippets/card-product.liquid
+++ b/snippets/card-product.liquid
@@ -334,16 +334,15 @@
   </div>
 {%- else -%}
   <div class="card-wrapper product-card-wrapper underline-links-hover">
-    <div class="card card--{{ settings.card_style }} card--media 
+    <div class="card card--{{ settings.card_style }}
         {% if extend_height %} card--extend-height{% endif %}
-        {% if settings.card_style == 'card' %} color-{{ settings.card_color_scheme }} gradient{% endif %}
-        {% if horizontal_class %} card--horizontal{% endif %}"
+        {% if settings.card_style == 'card' %} color-{{ settings.card_color_scheme }} gradient{% endif %}"
       style="--ratio-percent: 100%;"
     >
-      <div class="card__inner {% if settings.card_style == 'standard' %}color-{{ settings.card_color_scheme }} gradient{% endif %} ratio"
+      <div class="card__inner{% if settings.card_style == 'standard' %} color-{{ settings.card_color_scheme }} gradient{% endif %} ratio"
         style="--ratio-percent: 100%;"
       >
-        <div class="card__media color-{{ settings.card_color_scheme }} gradient"> 
+        <div class="card__media"> 
             <div class= "media media--transparent">
               {%- if placeholder_image -%}
                 {{ placeholder_image | placeholder_svg_tag: 'placeholder-svg' }}

--- a/snippets/card-product.liquid
+++ b/snippets/card-product.liquid
@@ -35,13 +35,16 @@
     endif
   -%}
   <div class="card-wrapper product-card-wrapper underline-links-hover">
-    <div class="card card--{{ settings.card_style }}
+    <div
+      class="
+        card card--{{ settings.card_style }}
         {% if card_product.featured_media %} card--media{% else %} card--text{% endif %}
         {% if settings.card_style == 'card' %} color-{{ settings.card_color_scheme }} gradient{% endif %}
         {% if image_shape and image_shape != 'default' %} card--shape{% endif %}
         {% if extend_height %} card--extend-height{% endif %}
         {% if card_product.featured_media == nil and settings.card_style == 'card' %} ratio{% endif %}
-        {% if horizontal_class %} card--horizontal{% endif %}"
+        {% if horizontal_class %} card--horizontal{% endif %}
+      "
       style="--ratio-percent: {{ 1 | divided_by: ratio | times: 100 }}%;"
     >
       <div
@@ -334,22 +337,26 @@
   </div>
 {%- else -%}
   <div class="card-wrapper product-card-wrapper underline-links-hover">
-    <div class="card card--{{ settings.card_style }}
+    <div
+      class="
+        card card--{{ settings.card_style }}
         {% if extend_height %} card--extend-height{% endif %}
-        {% if settings.card_style == 'card' %} color-{{ settings.card_color_scheme }} gradient{% endif %}"
+        {% if settings.card_style == 'card' %} color-{{ settings.card_color_scheme }} gradient{% endif %}
+      "
       style="--ratio-percent: 100%;"
     >
-      <div class="card__inner{% if settings.card_style == 'standard' %} color-{{ settings.card_color_scheme }} gradient{% endif %} ratio"
+      <div
+        class="card__inner{% if settings.card_style == 'standard' %} color-{{ settings.card_color_scheme }} gradient{% endif %} ratio"
         style="--ratio-percent: 100%;"
       >
-        <div class="card__media"> 
-            <div class= "media media--transparent">
-              {%- if placeholder_image -%}
-                {{ placeholder_image | placeholder_svg_tag: 'placeholder-svg' }}
-              {%- else -%}
-                {{ 'product-apparel-2' | placeholder_svg_tag: 'placeholder-svg' }}
-              {% endif %}   
-            </div>
+        <div class="card__media">
+          <div class="media media--transparent">
+            {%- if placeholder_image -%}
+              {{ placeholder_image | placeholder_svg_tag: 'placeholder-svg' }}
+            {%- else -%}
+              {{ 'product-apparel-2' | placeholder_svg_tag: 'placeholder-svg' }}
+            {% endif %}
+          </div>
         </div>
       </div>
       <div class="card__content">

--- a/snippets/card-product.liquid
+++ b/snippets/card-product.liquid
@@ -35,17 +35,13 @@
     endif
   -%}
   <div class="card-wrapper product-card-wrapper underline-links-hover">
-    <div
-      class="
-        card
-        card--{{ settings.card_style }}
+    <div class="card card--{{ settings.card_style }}
         {% if card_product.featured_media %} card--media{% else %} card--text{% endif %}
         {% if settings.card_style == 'card' %} color-{{ settings.card_color_scheme }} gradient{% endif %}
         {% if image_shape and image_shape != 'default' %} card--shape{% endif %}
         {% if extend_height %} card--extend-height{% endif %}
         {% if card_product.featured_media == nil and settings.card_style == 'card' %} ratio{% endif %}
-        {% if horizontal_class %} card--horizontal{% endif %}
-      "
+        {% if horizontal_class %} card--horizontal{% endif %}"
       style="--ratio-percent: {{ 1 | divided_by: ratio | times: 100 }}%;"
     >
       <div
@@ -338,28 +334,23 @@
   </div>
 {%- else -%}
   <div class="card-wrapper product-card-wrapper underline-links-hover">
-    <div
-      class="
-        card
-        card--{{ settings.card_style }}
-        card--text
+    <div class="card card--{{ settings.card_style }} card--media 
         {% if extend_height %} card--extend-height{% endif %}
         {% if settings.card_style == 'card' %} color-{{ settings.card_color_scheme }} gradient{% endif %}
-        {% if card_product.featured_media == nil and settings.card_style == 'card' %} ratio{% endif %}
-        {{ horizontal_class }}
-      "
+        {% if horizontal_class %} card--horizontal{% endif %}"
       style="--ratio-percent: 100%;"
     >
-      <div
-        class="card__inner {% if settings.card_style == 'standard' %}color-{{ settings.card_color_scheme }} gradient{% endif %}{% if settings.card_style == 'standard' %} ratio{% endif %}"
+      <div class="card__inner {% if settings.card_style == 'standard' %}color-{{ settings.card_color_scheme }} gradient{% endif %} ratio"
         style="--ratio-percent: 100%;"
       >
-        <div class="card__media">
-          {%- if placeholder_image -%}
-            {{ placeholder_image | placeholder_svg_tag: 'placeholder-svg' }}
-          {%- else -%}
-            {{ 'product-apparel-2' | placeholder_svg_tag: 'placeholder-svg' }}
-          {%- endif -%}
+        <div class="card__media color-{{ settings.card_color_scheme }} gradient"> 
+            <div class= "media media--transparent">
+              {%- if placeholder_image -%}
+                {{ placeholder_image | placeholder_svg_tag: 'placeholder-svg' }}
+              {%- else -%}
+                {{ 'product-apparel-2' | placeholder_svg_tag: 'placeholder-svg' }}
+              {% endif %}   
+            </div>
         </div>
       </div>
       <div class="card__content">


### PR DESCRIPTION
### PR Summary: 
The default feature collection will show placeholder images when product card style = card in the global theme settings.


### Why are these changes introduced?

Fixes #2466 .

### What approach did you take?

1. I removed the ratio from the  `card card--{{ settings.card_style }} card--media` div and placed it in the ` card__inner` div. 
2. I added a div called `media media--transparent` that holds the placeholder_image to apply the same styling as the non-default product card gets.
3. Removed some unnecessary classes in the section that were throwing off the styling of the placeholder product collection


### Other considerations
no other consideration at the moment

### Visual impact on existing themes
Merchants will see an accurate representation of what their featured collection will look like when the default featured collection product_card_style is set to card

### Testing steps/scenarios

- [ ] Test in mobile, tablet, and desktop

Product Card Theme Settings:

- [ ] Test both styles: standard and card
- [ ]  Test the text alignment: left, center and right
- [ ]  Apply the color scheme
- [ ]  Test border styles: thickness, opacity and corner radius.
- [ ]  Test Shadow: opacity, horizontal and vertical offset and blur

### Demo links

- [Editor](https://os2-demo.myshopify.com/admin/themes/140168003606/editor)

### Checklist
- [x] Added PR summary for [release notes](https://themes.shopify.com/themes/dawn/styles/default#ReleaseNotes)
- [x] Requested review from UX (Only for changes that are affecting the experience or perceivable visual details)
- [x] Created a ticket for the [help.shopify.com](https://help.shopify.com) documentation team about updates to theme settings. (Internal-only task)
- [x] Followed [theme code principles](https://github.com/Shopify/dawn/blob/main/.github/CONTRIBUTING.md#theme-code-principles)
- [x] Linted with [Theme Check](https://github.com/Shopify/theme-check)
- [x] Tested on [mobile](https://shopify.dev/themes/store/requirements#mobile-browser-requirements)
- [x] Tested on [multiple browsers](https://shopify.dev/themes/store/requirements#desktop-browser-requirements)
- [x] Tested for [accessibility](https://shopify.dev/themes/best-practices/accessibility)
