### PR TITLE
fixed bug that was causing extra spacing in footer

### DIFF
--- a/sections/footer.liquid
+++ b/sections/footer.liquid
@@ -47,7 +47,7 @@
   -%}
   {%- if section.blocks.size > 0
     or section.settings.newsletter_enable
-    or section.settings.show_social
+    or section.settings.show_social and has_social_icons == true
     or section.settings.enable_follow_on_shop
   -%}
     {%- unless only_empty_brand -%}


### PR DESCRIPTION
### PR Summary: 
Footer will not have extra space when unchecking the "Show email signup" setting in the footer.

### Why are these changes introduced?

Fixes #2691 .

### What approach did you take?
Added `and has_social_icons == true` in the section block to check if social media icons are present.

### Other considerations
N/A


### Visual impact on existing themes
If a merchant chooses to add an email sign up section and remove the default email sign up, there will no longer be a extra space between both section.


### Testing steps/scenarios
<!-- List all the testing tasks that applies to your fix to help peers review your work. -->
- [ ] Add email sign up section above the footer
- [ ] uncheck "Show email signup" setting in the footer 
- [ ] add social media icons
- [ ] uncheck language/ currency selector
- [ ] add color schema

### Demo links
- [Editor](https://os2-demo.myshopify.com/admin/themes/140175015958/editor?section=sections--17294602108950__footer)

### Checklist
- [x] Added PR summary for [release notes](https://themes.shopify.com/themes/dawn/styles/default#ReleaseNotes)
- [x] Requested review from UX (Only for changes that are affecting the experience or perceivable visual details)
- [x] Created a ticket for the [help.shopify.com](https://help.shopify.com) documentation team about updates to theme settings. (Internal-only task)
- [x] Followed [theme code principles](https://github.com/Shopify/dawn/blob/main/.github/CONTRIBUTING.md#theme-code-principles)
- [x] Linted with [Theme Check](https://github.com/Shopify/theme-check)
- [x] Tested on [mobile](https://shopify.dev/themes/store/requirements#mobile-browser-requirements)
- [x] Tested on [multiple browsers](https://shopify.dev/themes/store/requirements#desktop-browser-requirements)
- [x] Tested for [accessibility](https://shopify.dev/themes/best-practices/accessibility)
