### PR TITLE
Update cart unit price to reflect of line item

### DIFF
--- a/sections/main-cart-items.liquid
+++ b/sections/main-cart-items.liquid
@@ -203,15 +203,15 @@
                       {%- if item.variant.available and item.unit_price_measurement -%}
                         <div class="unit-price caption">
                           <span class="visually-hidden">{{ 'products.product.price.unit_price' | t }}</span>
-                          {{ item.variant.unit_price | money }}
+                          {{ item.unit_price | money }}
                           <span aria-hidden="true">/</span>
                           <span class="visually-hidden"
                             >&nbsp;{{ 'accessibility.unit_price_separator' | t }}&nbsp;</span
                           >
-                          {%- if item.variant.unit_price_measurement.reference_value != 1 -%}
-                            {{- item.variant.unit_price_measurement.reference_value -}}
+                          {%- if item.unit_price_measurement.reference_value != 1 -%}
+                            {{- item.unit_price_measurement.reference_value -}}
                           {%- endif -%}
-                          {{ item.variant.unit_price_measurement.reference_unit }}
+                          {{ item.unit_price_measurement.reference_unit }}
                         </div>
                       {%- endif -%}
                     </div>
@@ -326,15 +326,15 @@
                       {%- if item.variant.available and item.unit_price_measurement -%}
                         <div class="unit-price caption">
                           <span class="visually-hidden">{{ 'products.product.price.unit_price' | t }}</span>
-                          {{ item.variant.unit_price | money }}
+                          {{ item.unit_price | money }}
                           <span aria-hidden="true">/</span>
                           <span class="visually-hidden"
                             >&nbsp;{{ 'accessibility.unit_price_separator' | t }}&nbsp;</span
                           >
-                          {%- if item.variant.unit_price_measurement.reference_value != 1 -%}
-                            {{- item.variant.unit_price_measurement.reference_value -}}
+                          {%- if item.unit_price_measurement.reference_value != 1 -%}
+                            {{- item.unit_price_measurement.reference_value -}}
                           {%- endif -%}
-                          {{ item.variant.unit_price_measurement.reference_unit }}
+                          {{ item.unit_price_measurement.reference_unit }}
                         </div>
                       {%- endif -%}
                     </div>

--- a/snippets/cart-drawer.liquid
+++ b/snippets/cart-drawer.liquid
@@ -254,15 +254,15 @@
                             {%- if item.variant.available and item.unit_price_measurement -%}
                               <div class="unit-price caption">
                                 <span class="visually-hidden">{{ 'products.product.price.unit_price' | t }}</span>
-                                {{ item.variant.unit_price | money }}
+                                {{ item.unit_price | money }}
                                 <span aria-hidden="true">/</span>
                                 <span class="visually-hidden"
                                   >&nbsp;{{ 'accessibility.unit_price_separator' | t }}&nbsp;</span
                                 >
-                                {%- if item.variant.unit_price_measurement.reference_value != 1 -%}
-                                  {{- item.variant.unit_price_measurement.reference_value -}}
+                                {%- if item.unit_price_measurement.reference_value != 1 -%}
+                                  {{- item.unit_price_measurement.reference_value -}}
                                 {%- endif -%}
-                                {{ item.variant.unit_price_measurement.reference_unit }}
+                                {{ item.unit_price_measurement.reference_unit }}
                               </div>
                             {%- endif -%}
                           </div>


### PR DESCRIPTION
### PR Summary: 

Original ticket: https://github.com/orgs/Shopify/projects/6397/views/5?pane=issue&itemId=30821952

### Why are these changes introduced?

it makes sense to use the discounted unit price in cart (currently we don't). So we can use `line_item.unit_price` instead of `line_item.variant.unit_price`

UX: The unit price needs to show cost clarity of how much it will cost per unit values - the strike-through price is not important at this line level because we already display it on the total price with discount in a larger font size.

### Demo links
<!-- Please include a link to a demo store that includes preconfigured sections and settings to allow reviewers to easily test the features you are working on. -->

Test cart page and cart drawer

- [Editor](https://os2-demo.myshopify.com/admin/themes/140178685974/editor)

