### PR TITLE
Slim down the height of the announcement bar on desktop

### DIFF
--- a/assets/base.css
+++ b/assets/base.css
@@ -117,7 +117,8 @@ body:has(.section-header .drawer-menu) .announcement-bar-section .page-width {
     padding: 0 5rem;
   }
 
-  .header.page-width {
+  .header.page-width,
+  .utility-bar__grid.page-width {
     padding-left: 3.2rem;
     padding-right: 3.2rem;
   }
@@ -2196,6 +2197,10 @@ product-info .loading-overlay:not(.hidden) ~ *,
   width: 100%;
 }
 
+.announcement-bar .slider-button {
+  height: 3.8rem;
+}
+
 .announcement-bar .slider-button--next {
   margin-right: -1.5rem;
   min-width: 44px;
@@ -2266,6 +2271,7 @@ product-info .loading-overlay:not(.hidden) ~ *,
   padding: 1rem 0;
   margin: 0;
   letter-spacing: 0.1rem;
+  min-height: 3.8rem;
 }
 
 .announcement-bar-slider--fade-in-next .announcement-bar__message,

--- a/assets/base.css
+++ b/assets/base.css
@@ -2197,10 +2197,6 @@ product-info .loading-overlay:not(.hidden) ~ *,
   width: 100%;
 }
 
-.announcement-bar .slider-button {
-  height: 3.8rem;
-}
-
 .announcement-bar .slider-button--next {
   margin-right: -1.5rem;
   min-width: 44px;
@@ -2237,6 +2233,10 @@ product-info .loading-overlay:not(.hidden) ~ *,
 
   .announcement-bar-slider {
     width: 60%;
+  }
+
+  .announcement-bar .slider-button {
+    height: 3.8rem;
   }
 }
 

--- a/assets/component-list-social.css
+++ b/assets/component-list-social.css
@@ -22,6 +22,10 @@
   color: rgb(var(--color-foreground));
 }
 
+.utility-bar .list-social__link {
+  padding: 1rem 1.1rem;
+}
+
 .list-social__link:hover .icon {
   transform: scale(1.07);
 }

--- a/assets/component-localization-form.css
+++ b/assets/component-localization-form.css
@@ -193,12 +193,14 @@ noscript .localization-selector.link {
 /* Header localization */
 .header-localization .localization-form:only-child {
   margin: 0;
+  padding: 0;
 }
 
 .header-localization .disclosure .localization-form__select {
   font-size: 1.4rem;
   letter-spacing: 0.06rem;
   height: auto;
+  min-height: initial;
   background: transparent;
 }
 
@@ -234,11 +236,10 @@ noscript .localization-selector.link {
 
 .header-localization:not(.menu-drawer__localization) {
   align-items: center;
-  min-height: 4.4rem;
 }
 
 .js .header-localization:not(.menu-drawer__localization) .localization-form__select {
-  padding: 0 2.7rem 0 1.2rem;
+  padding: 0.85rem 2.7rem 0.85rem 1.2rem;
   width: max-content;
 }
 


### PR DESCRIPTION
### PR Summary: 

Slims down the height of the announcement bar on desktop.

### Why are these changes introduced?

Addresses some feedback we've received about the general size of the announcements bar. This PR:
 
- Changes the height of the announcements bar from 48px to 38px on desktop. This is roughly the same size it was before. 
- Updates the hit area for all buttons on the announcement bar to be the entire height of the announcement bar. The hit area for all announcement bar buttons on desktop is at least 38px by 38px here. 
- Sets a min-height for the announcement bar message so that the height of the utility bar doesn't fluctuate as you turn on/off settings. 

It also fixes the following small bug: 

- It sets the language and currency picker font sizes to be 13px instead of 14px, to match the rest of the text in the announcement bar + header.  
- It adjusts the width of the announcement bar so that it matches the width of the rest of the header. Currently it was matching the width of the page below, which felt odd. 

The PR does **NOT** make any adjustments to the mobile state of the announcement bar. 

### Visual impact on existing themes
<!-- How will this visually affect merchants who upgrade to a new theme version with this change? -->

Screenshots:

New height: 

Before|After
---|---
<img width="1107" alt="Screenshot 2023-07-10 at 12 43 06 PM" src="https://github.com/Shopify/dawn/assets/1202812/177cdac3-2f89-497e-be2a-130d8acbc79a">|<img width="1106" alt="after-b" src="https://github.com/Shopify/dawn/assets/1202812/8a98faec-ded7-4523-be43-c1194aa03d20">

Note the left/right arrows alignment: 

Before|After
---|---
<img width="799" alt="Screenshot 2023-07-10 at 12 43 20 PM" src="https://github.com/Shopify/dawn/assets/1202812/50da8635-ec46-4f31-886a-7989f75f14f4">|<img width="798" alt="after-a" src="https://github.com/Shopify/dawn/assets/1202812/4bbb4ae4-4eb3-4dc0-a76b-aa5cb5723aad">

### Testing steps/scenarios

- [Editor](https://os2-demo.myshopify.com/admin/themes/140249923606/editor?category=gid%3A%2F%2Fshopify%2FOnlineStoreThemeSettingsCategory%2FSocial%2Bmedia%3Ftheme_id%3D140249923606%26first_setting_id%3Dsocial_facebook_link&section=sections--17309029924886__announcement-bar)

### Checklist
- [x] Added PR summary for [release notes](https://themes.shopify.com/themes/dawn/styles/default#ReleaseNotes)
- [x] Requested review from UX (Only for changes that are affecting the experience or perceivable visual details)
- [ ] Created a ticket for the [help.shopify.com](https://help.shopify.com) documentation team about updates to theme settings. (Internal-only task)
- [x] Followed [theme code principles](https://github.com/Shopify/dawn/blob/main/.github/CONTRIBUTING.md#theme-code-principles)
- [x] Linted with [Theme Check](https://github.com/Shopify/theme-check)
- [x] Tested on [mobile](https://shopify.dev/themes/store/requirements#mobile-browser-requirements)
- [x] Tested on [multiple browsers](https://shopify.dev/themes/store/requirements#desktop-browser-requirements)
- [x] Tested for [accessibility](https://shopify.dev/themes/best-practices/accessibility)
