### PR TITLE
[Announcement Bar] Auto-rotate fixes

### DIFF
--- a/assets/component-slider.css
+++ b/assets/component-slider.css
@@ -38,6 +38,10 @@ slider-component.slider-component-full-width {
   padding-bottom: 0;
 }
 
+.slider__slide[aria-hidden="true"] {
+  visibility: hidden;
+}
+
 @media screen and (max-width: 749px) {
   .slider.slider--mobile {
     position: relative;

--- a/assets/component-slideshow.css
+++ b/assets/component-slideshow.css
@@ -25,10 +25,6 @@ slideshow-component .slideshow.banner {
   visibility: visible;
 }
 
-.slideshow__slide--hidden {
-  visibility: hidden;
-}
-
 @media screen and (max-width: 749px) {
   .slideshow--placeholder.banner--mobile-bottom.banner--adapt_image .slideshow__media,
   .slideshow--placeholder.banner--adapt_image:not(.banner--mobile-bottom) {

--- a/assets/component-slideshow.css
+++ b/assets/component-slideshow.css
@@ -22,6 +22,11 @@ slideshow-component .slideshow.banner {
   position: relative;
   display: flex;
   flex-direction: column;
+  visibility: visible;
+}
+
+.slideshow__slide--hidden {
+  visibility: hidden;
 }
 
 @media screen and (max-width: 749px) {

--- a/assets/global.js
+++ b/assets/global.js
@@ -735,13 +735,9 @@ class SlideshowComponent extends SliderComponent {
     if (this.announcementBarSlider) {
       this.announcementBarArrowButtonWasClicked = false;
 
-      this.desktopLayout = window.matchMedia('(min-width: 750px)');
       this.reducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)');
-
-      [this.reducedMotion, this.desktopLayout].forEach((mediaQuery) => {
-        mediaQuery.addEventListener('change', () => {
-          if (this.slider.getAttribute('data-autoplay') === 'true') this.setAutoPlay();
-        });
+      this.reducedMotion.addEventListener('change', () => {
+        if (this.slider.getAttribute('data-autoplay') === 'true') this.setAutoPlay();
       });
 
       [this.prevButton, this.nextButton].forEach((button) => {
@@ -771,7 +767,7 @@ class SlideshowComponent extends SliderComponent {
       this.autoplayButtonIsSetToPlay = true;
       this.play();
     } else {
-      this.reducedMotion.matches || this.announcementBarArrowButtonWasClicked || !this.desktopLayout.matches
+      this.reducedMotion.matches || this.announcementBarArrowButtonWasClicked
         ? this.pause()
         : this.play();
     }
@@ -839,8 +835,7 @@ class SlideshowComponent extends SliderComponent {
       this.play();
     } else if (
       !this.reducedMotion.matches &&
-      !this.announcementBarArrowButtonWasClicked &&
-      this.desktopLayout.matches
+      !this.announcementBarArrowButtonWasClicked
     ) {
       this.play();
     }
@@ -900,6 +895,7 @@ class SlideshowComponent extends SliderComponent {
             button.removeAttribute('tabindex');
           });
         item.setAttribute('aria-hidden', 'false');
+        item.classList.remove('slideshow__slide--hidden');
         item.removeAttribute('tabindex');
       } else {
         if (linkElements.length)
@@ -907,6 +903,7 @@ class SlideshowComponent extends SliderComponent {
             button.setAttribute('tabindex', '-1');
           });
         item.setAttribute('aria-hidden', 'true');
+        item.classList.add('slideshow__slide--hidden');
         item.setAttribute('tabindex', '-1');
       }
     });

--- a/assets/global.js
+++ b/assets/global.js
@@ -895,7 +895,6 @@ class SlideshowComponent extends SliderComponent {
             button.removeAttribute('tabindex');
           });
         item.setAttribute('aria-hidden', 'false');
-        item.classList.remove('slideshow__slide--hidden');
         item.removeAttribute('tabindex');
       } else {
         if (linkElements.length)
@@ -903,7 +902,6 @@ class SlideshowComponent extends SliderComponent {
             button.setAttribute('tabindex', '-1');
           });
         item.setAttribute('aria-hidden', 'true');
-        item.classList.add('slideshow__slide--hidden');
         item.setAttribute('tabindex', '-1');
       }
     });

--- a/locales/en.default.schema.json
+++ b/locales/en.default.schema.json
@@ -448,7 +448,7 @@
       "name": "Announcement bar",
       "settings": {
         "auto_rotate": {
-          "label": "Auto-rotate on desktop"
+          "label": "Auto-rotate announcements"
         },
         "change_slides_speed": {
           "label": "Change every"


### PR DESCRIPTION
### PR Summary: 

- Rotates by default on mobile, undoing changes in #2580.
- Removes "on desktop" in the settings label, which reverts part of #2787.
- Adds a `visibility: hidden` rule to slides that are hidden, so that they may be hidden from the preview inspector.

### Why are these changes introduced?

- We received feedback that it's unexpected that slides won't rotate on mobile automatically. This was originally done for accessibility reasons, but due to the relatively small footprint of the animation we're turning this animation back on for small screens. `prefers-reduced-motion` will still work for visitors who have that option set. 
- The visibility rule was added to help prevent the outlines of hidden blocks from showing up in power preview. This will require a change in the editor to be fully realized. (cc @clauderic)

### Visual impact on existing themes

On mobile, the announcement bar will auto-rotate if the merchant has set it to do so.

### Testing steps/scenarios

Demo: https://os2-demo.myshopify.com/admin/themes/140250742806/editor

### Checklist
- [x] Added PR summary for [release notes](https://themes.shopify.com/themes/dawn/styles/default#ReleaseNotes)
- [x] Requested review from UX (Only for changes that are affecting the experience or perceivable visual details)
- [ ] Created a ticket for the [help.shopify.com](https://help.shopify.com) documentation team about updates to theme settings. (Internal-only task)
- [x] Followed [theme code principles](https://github.com/Shopify/dawn/blob/main/.github/CONTRIBUTING.md#theme-code-principles)
- [x] Linted with [Theme Check](https://github.com/Shopify/theme-check)
- [x] Tested on [mobile](https://shopify.dev/themes/store/requirements#mobile-browser-requirements)
- [x] Tested on [multiple browsers](https://shopify.dev/themes/store/requirements#desktop-browser-requirements)
- [x] Tested for [accessibility](https://shopify.dev/themes/best-practices/accessibility)
