### PR TITLE
apply image shapes to placeholders in featured collection

### DIFF
--- a/assets/component-card.css
+++ b/assets/component-card.css
@@ -300,7 +300,6 @@
 }
 
 .card--standard:not(.card--horizontal) .placeholder-svg {
-  height: auto;
   width: 100%;
 }
 

--- a/sections/featured-collection.liquid
+++ b/sections/featured-collection.liquid
@@ -109,6 +109,8 @@
               {%- assign placeholder_image = 'product-apparel-' | append: forloop.rindex -%}
               {% render 'card-product',
                 show_vendor: section.settings.show_vendor,
+                media_aspect_ratio: section.settings.image_ratio,
+                image_shape: section.settings.image_shape,
                 placeholder_image: placeholder_image
               %}
             </li>

--- a/snippets/card-product.liquid
+++ b/snippets/card-product.liquid
@@ -325,21 +325,31 @@
     </div>
   </div>
 {%- else -%}
+  {%- liquid
+    assign ratio = 1
+    if media_aspect_ratio == 'portrait'
+      assign ratio = 0.8
+    endif
+  -%}
   <div class="card-wrapper product-card-wrapper underline-links-hover">
     <div
       class="
         card card--{{ settings.card_style }}
         {% if extend_height %} card--extend-height{% endif %}
+        {% if image_shape and image_shape != 'default' %} card--shape{% endif %}
         {% if settings.card_style == 'card' %} color-{{ settings.card_color_scheme }} gradient{% endif %}
       "
-      style="--ratio-percent: 100%;"
+      style="--ratio-percent: {{ 1 | divided_by: ratio | times: 100 }}%;"
     >
       <div
         class="card__inner{% if settings.card_style == 'standard' %} color-{{ settings.card_color_scheme }} gradient{% endif %} ratio"
-        style="--ratio-percent: 100%;"
       >
-        <div class="card__media">
-          <div class="media media--transparent">
+        <div
+          class="card__media {% if image_shape and image_shape != 'default' %} shape--{{ image_shape }} color-{{ settings.card_color_scheme }} gradient{% endif %}"
+        >
+          <div
+            class="media media--transparent"
+          >
             {%- if placeholder_image -%}
               {{ placeholder_image | placeholder_svg_tag: 'placeholder-svg' }}
             {%- else -%}


### PR DESCRIPTION
### PR Summary: 
Placeholders in the featured collection works with image shape and image ratio presets.

### Why are these changes introduced?

Fixes #2687 .

### What approach did you take?
- Added media_aspect_ratio and image_shape parameters to product-card in the placeholder
- Added ratio in the styles
- Added an image-shape class in the placeholder section

### Visual impact on existing themes
Placeholder cards in the featured collection now imitate what a real featured collection would look like.


### Testing steps/scenarios
- [ ]  Remove collection in featured collection to show placeholder cards

Image ratio testing
- [ ] square
- [ ] portrait
- [ ] adapt to image

Image shape
- [ ] default
- [ ] arch 
- [ ] blob
- [ ] chevron left
- [ ] chevron right
- [ ] diamond
- [ ] parallelogram
- [ ] round

Other testing
- [ ] test in mobile, tablet, desktop
- [ ] Apply color schemes and gradient


### Demo links
- [Editor](https://admin.shopify.com/store/os2-demo/themes/140258279446/editor)

### Checklist
- [x] Added PR summary for [release notes](https://themes.shopify.com/themes/dawn/styles/default#ReleaseNotes)
- [x] Requested review from UX (Only for changes that are affecting the experience or perceivable visual details)
- [x] Created a ticket for the [help.shopify.com](https://help.shopify.com) documentation team about updates to theme settings. (Internal-only task)
- [x] Followed [theme code principles](https://github.com/Shopify/dawn/blob/main/.github/CONTRIBUTING.md#theme-code-principles)
- [x] Linted with [Theme Check](https://github.com/Shopify/theme-check)
- [x] Tested on [mobile](https://shopify.dev/themes/store/requirements#mobile-browser-requirements)
- [x] Tested on [multiple browsers](https://shopify.dev/themes/store/requirements#desktop-browser-requirements)
- [x] Tested for [accessibility](https://shopify.dev/themes/best-practices/accessibility)
