### PR TITLE
Fix announcement bar link padding

### DIFF
--- a/assets/base.css
+++ b/assets/base.css
@@ -2248,7 +2248,6 @@ product-info .loading-overlay:not(.hidden) ~ *,
 .announcement-bar__link {
   display: flex;
   width: 100%;
-  padding: 1rem 0;
   text-decoration: none;
   height: 100%;
   justify-content: center;
@@ -2265,10 +2264,6 @@ product-info .loading-overlay:not(.hidden) ~ *,
   margin-left: 0.8rem;
   vertical-align: middle;
   margin-bottom: 0.2rem;
-}
-
-.announcement-bar__link .announcement-bar__message {
-  padding: 0;
 }
 
 .announcement-bar__message {


### PR DESCRIPTION
### PR Summary: 

Fixes announcement bar padding when a link is assigned. 

### Why are these changes introduced?

There's a pretty obvious visual bug when you assign a link to an announcement bar message. This was missed when we tophatted #2807.

Before: 
<img width="1039" alt="Screenshot 2023-07-11 at 11 15 40 AM" src="https://github.com/Shopify/dawn/assets/1202812/50632f10-87ee-4425-a151-f9096aaa82d0">

After: 
<img width="1041" alt="Screenshot 2023-07-11 at 11 22 05 AM" src="https://github.com/Shopify/dawn/assets/1202812/c7c5e821-f752-47b0-94c7-736bb4b48e59">

### Demo links
<!-- Please include a link to a demo store that includes preconfigured sections and settings to allow reviewers to easily test the features you are working on. -->

- [Editor](https://os2-demo.myshopify.com/admin/themes/140259983382/editor)

### Checklist
- [x] Added PR summary for [release notes](https://themes.shopify.com/themes/dawn/styles/default#ReleaseNotes)
- [x] Requested review from UX (Only for changes that are affecting the experience or perceivable visual details)
- [ ] Created a ticket for the [help.shopify.com](https://help.shopify.com) documentation team about updates to theme settings. (Internal-only task)
- [x] Followed [theme code principles](https://github.com/Shopify/dawn/blob/main/.github/CONTRIBUTING.md#theme-code-principles)
- [x] Linted with [Theme Check](https://github.com/Shopify/theme-check)
- [x] Tested on [mobile](https://shopify.dev/themes/store/requirements#mobile-browser-requirements)
- [x] Tested on [multiple browsers](https://shopify.dev/themes/store/requirements#desktop-browser-requirements)
- [x] Tested for [accessibility](https://shopify.dev/themes/best-practices/accessibility)
