### PR TITLE
[Quick order list] Use quantity passed into function instead of re-querying from element

### DIFF
--- a/assets/variant-list.js
+++ b/assets/variant-list.js
@@ -242,8 +242,8 @@ class VariantList extends HTMLElement {
 
         const currentItem = parsedState.items.find((item) => item.variant_id === parseInt(id));
         const updatedValue = currentItem ? currentItem.quantity : undefined;
-        if (updatedValue && updatedValue !== parseInt(quantityElement.value)) {
-          this.updateError(updatedValue, id)
+        if (updatedValue && updatedValue !== quantity) {
+          this.updateError(updatedValue, id);
           hasError = true;
         }
 


### PR DESCRIPTION
### PR Summary: 

### Why are these changes introduced?

Fixes #2820.

### What approach did you take?

After a quantity update in Quick order list, a new quantity element with the updated value is returned by the cart API. We perform a parity check on this value in the `updateQuantity` function. The number we used to perform this parity check was sometimes incorrect if consecutive quantity updates are performed quickly. This lead to false positives and error messages displaying when they shouldn't be.

To fix this, we use the quantity value passed as argument in the `updateQuantity` function, which is more reliable as a source of truth.

### Other considerations

### Decision log

| # | Decision | Alternatives | Rationale | Downsides |
|---|---|---|---|---|
| 1 |   |   |   |   |

### Visual impact on existing themes

### Testing steps/scenarios

- [ ] Use video linked in [issue](https://github.com/Shopify/dawn/issues/2820) as reference
- [ ] Navigate to product page with Quick order list and update quantity (add or subtract) consecutively with ~1s delay

### Demo links
<!-- Please include a link to a demo store that includes preconfigured sections and settings to allow reviewers to easily test the features you are working on. -->

- [Store](https://os2-demo.myshopify.com/?preview_theme_id=140264898582)
- [Editor](https://os2-demo.myshopify.com/admin/themes/140264898582/editor)

### Checklist
- [ ] Added PR summary for [release notes](https://themes.shopify.com/themes/dawn/styles/default#ReleaseNotes)
- [ ] Requested review from UX (Only for changes that are affecting the experience or perceivable visual details)
- [ ] Created a ticket for the [help.shopify.com](https://help.shopify.com) documentation team about updates to theme settings. (Internal-only task)
- [ ] Followed [theme code principles](https://github.com/Shopify/dawn/blob/main/.github/CONTRIBUTING.md#theme-code-principles)
- [ ] Linted with [Theme Check](https://github.com/Shopify/theme-check)
- [ ] Tested on [mobile](https://shopify.dev/themes/store/requirements#mobile-browser-requirements)
- [ ] Tested on [multiple browsers](https://shopify.dev/themes/store/requirements#desktop-browser-requirements)
- [ ] Tested for [accessibility](https://shopify.dev/themes/best-practices/accessibility)
