### PR TITLE
Remove unused event `cartUpdateStarted` for Vol Pricing

### DIFF
--- a/assets/cart.js
+++ b/assets/cart.js
@@ -6,8 +6,6 @@ class CartRemoveButton extends HTMLElement {
       event.preventDefault();
       const cartItems = this.closest('cart-items') || this.closest('cart-drawer-items');
       cartItems.updateQuantity(this.dataset.index, 0);
-
-      publish(PUB_SUB_EVENTS.cartUpdateStarted, { variantId: event.target.parentNode.dataset.variantId });
     });
   }
 }
@@ -169,7 +167,7 @@ class CartItems extends HTMLElement {
           trapFocus(cartDrawerWrapper, document.querySelector('.cart-item__name'));
         }
 
-        publish(PUB_SUB_EVENTS.cartUpdate, { source: 'cart-items', cartData: parsedState, variantId: variantId});
+        publish(PUB_SUB_EVENTS.cartUpdate, { source: 'cart-items', cartData: parsedState, variantId: variantId });
       })
       .catch(() => {
         this.querySelectorAll('.loading-overlay').forEach((overlay) => overlay.classList.add('hidden'));

--- a/assets/price-per-item.js
+++ b/assets/price-per-item.js
@@ -14,7 +14,6 @@ if (!customElements.get('price-per-item')) {
       }
 
       updatePricePerItemUnsubscriber = undefined;
-      cartUpdateStartedUnsubscriber = undefined;
       variantIdChangedUnsubscriber = undefined;
 
       connectedCallback() {
@@ -22,9 +21,6 @@ if (!customElements.get('price-per-item')) {
         this.variantIdChangedUnsubscriber = subscribe(PUB_SUB_EVENTS.variantChange, (event) => {
           this.variantId = event.data.variant.id.toString();
           this.getVolumePricingArray();
-        });
-        this.cartUpdateStartedUnsubscriber = subscribe(PUB_SUB_EVENTS.cartUpdateStarted, (event) => {
-          if (event.variantId !== this.variantId) return;
         });
 
         this.updatePricePerItemUnsubscriber = subscribe(PUB_SUB_EVENTS.cartUpdate, (response) => {
@@ -53,9 +49,6 @@ if (!customElements.get('price-per-item')) {
       disconnectedCallback() {
         if (this.updatePricePerItemUnsubscriber) {
           this.updatePricePerItemUnsubscriber();
-        }
-        if (this.cartUpdateStartedUnsubscriber) {
-          this.cartUpdateStartedUnsubscriber();
         }
         if (this.variantIdChangedUnsubscriber) {
           this.variantIdChangedUnsubscriber();

--- a/assets/product-form.js
+++ b/assets/product-form.js
@@ -41,8 +41,6 @@ if (!customElements.get('product-form')) {
         }
         config.body = formData;
 
-        publish(PUB_SUB_EVENTS.cartUpdateStarted, {variantId: evt.target.querySelector('.product-variant-id').value} );
-
         fetch(`${routes.cart_add_url}`, config)
           .then((response) => response.json())
           .then((response) => {


### PR DESCRIPTION
Remove unused events `cartUpdateStarted` now that we have removed the loader when the price changes depending on the Vol Pricing bracket.

Context: https://github.com/Shopify/dawn/pull/2791#discussion_r1256546787

Editor:https://os2-demo.myshopify.com/admin/themes/140265127958/editor
