### PR TITLE
Use consistent font sizes in the Utility Bar

### DIFF
--- a/assets/base.css
+++ b/assets/base.css
@@ -2230,6 +2230,11 @@ product-info .loading-overlay:not(.hidden) ~ *,
   animation: animateMenuOpen var(--duration-default) ease;
 }
 
+.utility-bar .localization-wrapper .disclosure .localization-form__select,
+.utility-bar .localization-wrapper .disclosure__link {
+  font-size: calc(var(--font-heading-scale) * 1.3rem);
+}
+
 @media screen and (min-width: 990px) {
   body:has(.section-header .header:not(.drawer-menu)) .utility-bar .page-width {
     padding-left: 5rem;


### PR DESCRIPTION
### PR Summary: 

Change the font size of the the language and currency picker to be 13px instead of 14px to match the rest of the text in the announcement bar.

### Why are these changes introduced?

For consistency. Currently, the font size for the language and currency picker is 1px larger than the font size for the announcement bar messages.

I'd meant to take care of this in #2807 (it's even mentioned in the description!), but it slipped out at some point. 

### Screenshots

Before:
<img width="670" alt="Screenshot 2023-07-12 at 7 50 43 AM" src="https://github.com/Shopify/dawn/assets/1202812/abb49bb3-2c6b-4a15-95b9-123ba1e9ba2f">

After:
<img width="670" alt="Screenshot 2023-07-12 at 7 44 10 AM" src="https://github.com/Shopify/dawn/assets/1202812/41fc3384-1b71-4804-b2d3-181dd08c945e">


### Demo links

- [Editor](https://os2-demo.myshopify.com/admin/themes/140267618326/editor)

### Checklist
- [x] Added PR summary for [release notes](https://themes.shopify.com/themes/dawn/styles/default#ReleaseNotes)
- [x] Requested review from UX (Only for changes that are affecting the experience or perceivable visual details)
- [ ] Created a ticket for the [help.shopify.com](https://help.shopify.com) documentation team about updates to theme settings. (Internal-only task)
- [x] Followed [theme code principles](https://github.com/Shopify/dawn/blob/main/.github/CONTRIBUTING.md#theme-code-principles)
- [x] Linted with [Theme Check](https://github.com/Shopify/theme-check)
- [x] Tested on [mobile](https://shopify.dev/themes/store/requirements#mobile-browser-requirements)
- [x] Tested on [multiple browsers](https://shopify.dev/themes/store/requirements#desktop-browser-requirements)
- [x] Tested for [accessibility](https://shopify.dev/themes/best-practices/accessibility)
