### PR TITLE
added country flags to locales

### DIFF
--- a/assets/component-localization-form.css
+++ b/assets/component-localization-form.css
@@ -50,6 +50,11 @@
   padding: 1rem;
 }
 
+.localization-form__country_flag {
+  display: flex;
+  align-items: center;
+} 
+
 .localization-form__currency {
   display: inline-block;
 }

--- a/snippets/country-localization.liquid
+++ b/snippets/country-localization.liquid
@@ -13,10 +13,12 @@
     aria-controls="{{ localPosition }}List"
     aria-describedby="{{ localPosition }}Label"
   >
-    <span>
-      {{- localization.country.currency.iso_code }}
-      {{ localization.country.currency.symbol }} | {{ localization.country.name -}}
-    </span>
+    
+    <span  class="localization-form__country_flag">
+      {{ localization.country | image_url: width: 18 | image_tag }} 
+      <span style="padding-left: 1rem"> {{- localization.country.currency.iso_code }} <span>
+    </span> 
+   
     {% render 'icon-caret' %}
   </button>
   <div class="disclosure__list-wrapper" hidden>
@@ -32,10 +34,10 @@
             data-value="{{ country.iso_code }}"
           >
             <span class="localization-form__currency">
+              {{ country | image_url: width: 18 | image_tag }}
               {{- country.currency.iso_code }}
-              {{ country.currency.symbol }} |</span
-            >
-            {{ country.name }}
+            </span>
+            | {{ country.name }}
           </a>
         </li>
       {%- endfor -%}


### PR DESCRIPTION
### PR Summary: 
Locale selector has country flags in the currency picker.

### Why are these changes introduced?

Fixes #2470 .

### What approach did you take?
Used the global [country liquid object](https://shopify.dev/docs/api/liquid/objects/country) and rendered the country flag image.
Added some styling to get the alignment right

### Other considerations
N/A

### Visual impact on existing themes
Merchants will see country flags instead of currency symbols on the currency selector


### Testing steps/scenarios
<!-- List all the testing tasks that applies to your fix to help peers review your work. -->
- [ ] Add Currency selector in announcement bar
- [ ] Add Currency selector in header
- [ ] Add Currency selector in footer
- [ ] Test in mobile, tablet, desktop

### Demo links
- [Editor](https://admin.shopify.com/store/os2-demo/themes/140312281110/editor)

### Checklist
- [ ] Added PR summary for [release notes](https://themes.shopify.com/themes/dawn/styles/default#ReleaseNotes)
- [ ] Requested review from UX (Only for changes that are affecting the experience or perceivable visual details)
- [ ] Created a ticket for the [help.shopify.com](https://help.shopify.com) documentation team about updates to theme settings. (Internal-only task)
- [ ] Followed [theme code principles](https://github.com/Shopify/dawn/blob/main/.github/CONTRIBUTING.md#theme-code-principles)
- [ ] Linted with [Theme Check](https://github.com/Shopify/theme-check)
- [ ] Tested on [mobile](https://shopify.dev/themes/store/requirements#mobile-browser-requirements)
- [ ] Tested on [multiple browsers](https://shopify.dev/themes/store/requirements#desktop-browser-requirements)
- [ ] Tested for [accessibility](https://shopify.dev/themes/best-practices/accessibility)
