### PR TITLE
Add missing shadow styles to inputs in Quick Order List

### DIFF
--- a/assets/quick-order-list.css
+++ b/assets/quick-order-list.css
@@ -32,6 +32,14 @@ quick-order-list .quantity__button {
   text-align: center;
 }
 
+.variant-item__quantity .quantity:before {
+  z-index: 0;
+}
+
+.variant-item__quantity .quantity__button {
+  z-index: 1;
+}
+
 @media screen and (min-width: 990px) {
   .quick-order-list__total {
     position: sticky;
@@ -47,14 +55,6 @@ quick-order-list .quantity__button {
   .variant__items {
     max-height: 90rem;
     overflow-y: auto;
-  }
-
-  .variant-item__quantity .quantity:before {
-    z-index: 0;
-  }
-
-  .variant-item__quantity .quantity__button {
-    z-index: 1;
   }
 
   .variant-item__quantity-wrapper--no-info,


### PR DESCRIPTION
### PR Summary: 

Add missing Global setting shadow styles to inputs in Quick Order List

Editor: https://admin.shopify.com/store/os2-demo/themes/140318343190/editor

