### PR TITLE
Fix font family for quick order list

### DIFF
--- a/assets/quick-order-list.css
+++ b/assets/quick-order-list.css
@@ -603,6 +603,7 @@ quick-order-list-remove-button {
 .totals__subtotal-value {
   margin-top: 0;
   margin-bottom: 0;
+  color: rgb(var(--color-foreground));
 }
 
 .quick-order-list__total-items p,

--- a/assets/quick-order-list.css
+++ b/assets/quick-order-list.css
@@ -215,6 +215,7 @@ quick-order-list .quantity__button {
 .variant-item__sold-out {
   opacity: 0.7;
   font-size: 1.6rem;
+  color: rgb(var(--color-foreground));
 }
 
 quick-order-list-remove-button {
@@ -598,7 +599,7 @@ quick-order-list-remove-button {
   align-items: center;
 }
 
-.quick-order-list__total-items h3,
+.quick-order-list__total-items span,
 .totals__subtotal-value {
   margin-top: 0;
   margin-bottom: 0;
@@ -658,7 +659,7 @@ quick-order-list-remove-button {
   }
 
   .totals__subtotal-value,
-  .quick-order-list__total-items h3 {
+  .quick-order-list__total-items span {
     margin-right: 1.2rem;
   }
 

--- a/sections/quick-order-list.liquid
+++ b/sections/quick-order-list.liquid
@@ -160,9 +160,9 @@
             </span>
           </div>
           <div class="quick-order-list__total-items">
-            <h3>
+            <span>
               {{ items_in_cart }}
-            </h3>
+            </span>
             <p class="h5">{{ 'sections.quick_order_list.total_items' | t }}</p>
           </div>
           <div class="quick-order-list-total__price">
@@ -172,12 +172,12 @@
               </button>
             </noscript>
             <div class="totals__product-total">
-              <h3 class="totals__subtotal-value">
+              <span class="totals__subtotal-value">
                 {% comment %} TODO: enable theme-check once `line_items_for` is accepted as valid filter {% endcomment %}
                 {% # theme-check-disable %}
                 {{ cart | line_items_for: product | sum: 'original_line_price' | money }}
                 {% # theme-check-enable %}
-              </h3>
+              </span>
               <p class="totals__subtotal h5">{{ 'sections.quick_order_list.product_total' | t }}</p>
             </div>
             <small class="tax-note caption-large rte">

--- a/snippets/quick-order-list-row.liquid
+++ b/snippets/quick-order-list-row.liquid
@@ -212,7 +212,7 @@
             </button>
           {%- endif -%}
           {%- if variant.available == false or quantity_rule_soldout -%}
-            <span class="variant-item__sold-out h4"> {{ 'products.product.sold_out' | t }} </span>
+            <span class="variant-item__sold-out"> {{ 'products.product.sold_out' | t }} </span>
           {%- else -%}
             {% comment %} TODO: Remove theme check {% endcomment %}
             {% # theme-check-disable %}


### PR DESCRIPTION
### PR Summary: 

Fixes font family to folllow body for
- sold out 
- total items
- total price

Fixes #2873.

Editor: https://admin.shopify.com/store/os2-demo/themes/140326141974/editor
