### PR TITLE
Hide vol pricing and qty rules when variant is unavailable

### DIFF
--- a/assets/global.js
+++ b/assets/global.js
@@ -798,7 +798,7 @@ class SlideshowComponent extends SliderComponent {
 
   setSlidePosition(position) {
     if (this.setPositionTimeout) clearTimeout(this.setPositionTimeout);
-    this.setPositionTimeout = setTimeout (() => {
+    this.setPositionTimeout = setTimeout(() => {
       this.slider.scrollTo({
         left: position,
       });
@@ -1110,6 +1110,12 @@ class VariantSelects extends HTMLElement {
         const pricePerItemSource = html.getElementById(`Price-Per-Item-${this.dataset.originalSection ? this.dataset.originalSection : this.dataset.section}`);
 
         const volumePricingDestination = document.getElementById(`Volume-${this.dataset.section}`);
+        const qtyRules = document.getElementById(`Quantity-Rules-${this.dataset.section}`);
+        const volumeNote = document.getElementById(`Volume-Note-${this.dataset.section}`);
+
+        if (volumeNote) volumeNote.classList.remove('visibility-hidden');
+        if (volumePricingDestination) volumePricingDestination.classList.remove('visibility-hidden');
+        if (qtyRules) qtyRules.classList.remove('visibility-hidden');
 
         if (source && destination) destination.innerHTML = source.innerHTML;
         if (inventorySource && inventoryDestination) inventoryDestination.innerHTML = inventorySource.innerHTML;
@@ -1176,6 +1182,9 @@ class VariantSelects extends HTMLElement {
     const inventory = document.getElementById(`Inventory-${this.dataset.section}`);
     const sku = document.getElementById(`Sku-${this.dataset.section}`);
     const pricePerItem = document.getElementById(`Price-Per-Item-${this.dataset.section}`);
+    const volumeNote = document.getElementById(`Volume-Note-${this.dataset.section}`);
+    const volumeTable = document.getElementById(`Volume-${this.dataset.section}`);
+    const qtyRules = document.getElementById(`Quantity-Rules-${this.dataset.section}`);
 
     if (!addButton) return;
     addButtonText.textContent = window.variantStrings.unavailable;
@@ -1183,6 +1192,9 @@ class VariantSelects extends HTMLElement {
     if (inventory) inventory.classList.add('visibility-hidden');
     if (sku) sku.classList.add('visibility-hidden');
     if (pricePerItem) pricePerItem.classList.add('visibility-hidden');
+    if (volumeNote) volumeNote.classList.add('visibility-hidden');
+    if (volumeTable) volumeTable.classList.add('visibility-hidden');
+    if (qtyRules) qtyRules.classList.add('visibility-hidden');
   }
 
   getVariantData() {

--- a/assets/global.js
+++ b/assets/global.js
@@ -1113,15 +1113,15 @@ class VariantSelects extends HTMLElement {
         const qtyRules = document.getElementById(`Quantity-Rules-${this.dataset.section}`);
         const volumeNote = document.getElementById(`Volume-Note-${this.dataset.section}`);
 
-        if (volumeNote) volumeNote.classList.remove('visibility-hidden');
-        if (volumePricingDestination) volumePricingDestination.classList.remove('visibility-hidden');
-        if (qtyRules) qtyRules.classList.remove('visibility-hidden');
+        if (volumeNote) volumeNote.classList.remove('hidden');
+        if (volumePricingDestination) volumePricingDestination.classList.remove('hidden');
+        if (qtyRules) qtyRules.classList.remove('hidden');
 
         if (source && destination) destination.innerHTML = source.innerHTML;
         if (inventorySource && inventoryDestination) inventoryDestination.innerHTML = inventorySource.innerHTML;
         if (skuSource && skuDestination) {
           skuDestination.innerHTML = skuSource.innerHTML;
-          skuDestination.classList.toggle('visibility-hidden', skuSource.classList.contains('visibility-hidden'));
+          skuDestination.classList.toggle('hidden', skuSource.classList.contains('hidden'));
         }
 
         if (volumePricingSource && volumePricingDestination) {
@@ -1130,15 +1130,15 @@ class VariantSelects extends HTMLElement {
 
         if (pricePerItemSource && pricePerItemDestination) {
           pricePerItemDestination.innerHTML = pricePerItemSource.innerHTML;
-          pricePerItemDestination.classList.toggle('visibility-hidden', pricePerItemSource.classList.contains('visibility-hidden'));
+          pricePerItemDestination.classList.toggle('hidden', pricePerItemSource.classList.contains('hidden'));
         }
 
         const price = document.getElementById(`price-${this.dataset.section}`);
 
-        if (price) price.classList.remove('visibility-hidden');
+        if (price) price.classList.remove('hidden');
 
         if (inventoryDestination)
-          inventoryDestination.classList.toggle('visibility-hidden', inventorySource.innerText === '');
+          inventoryDestination.classList.toggle('hidden', inventorySource.innerText === '');
 
         const addButtonUpdated = html.getElementById(`ProductSubmitButton-${sectionId}`);
         this.toggleAddButton(
@@ -1188,13 +1188,13 @@ class VariantSelects extends HTMLElement {
 
     if (!addButton) return;
     addButtonText.textContent = window.variantStrings.unavailable;
-    if (price) price.classList.add('visibility-hidden');
-    if (inventory) inventory.classList.add('visibility-hidden');
-    if (sku) sku.classList.add('visibility-hidden');
-    if (pricePerItem) pricePerItem.classList.add('visibility-hidden');
-    if (volumeNote) volumeNote.classList.add('visibility-hidden');
-    if (volumeTable) volumeTable.classList.add('visibility-hidden');
-    if (qtyRules) qtyRules.classList.add('visibility-hidden');
+    if (price) price.classList.add('hidden');
+    if (inventory) inventory.classList.add('hidden');
+    if (sku) sku.classList.add('hidden');
+    if (pricePerItem) pricePerItem.classList.add('hidden');
+    if (volumeNote) volumeNote.classList.add('hidden');
+    if (volumeTable) volumeTable.classList.add('hidden');
+    if (qtyRules) qtyRules.classList.add('hidden');
   }
 
   getVariantData() {

--- a/assets/quick-order-list.css
+++ b/assets/quick-order-list.css
@@ -603,6 +603,7 @@ quick-order-list-remove-button {
 .totals__subtotal-value {
   margin-top: 0;
   margin-bottom: 0;
+  color: rgb(var(--color-foreground));
 }
 
 .quick-order-list__total-items p,

--- a/assets/quick-order-list.css
+++ b/assets/quick-order-list.css
@@ -215,6 +215,7 @@ quick-order-list .quantity__button {
 .variant-item__sold-out {
   opacity: 0.7;
   font-size: 1.6rem;
+  color: rgb(var(--color-foreground));
 }
 
 quick-order-list-remove-button {
@@ -598,7 +599,7 @@ quick-order-list-remove-button {
   align-items: center;
 }
 
-.quick-order-list__total-items h3,
+.quick-order-list__total-items span,
 .totals__subtotal-value {
   margin-top: 0;
   margin-bottom: 0;
@@ -658,7 +659,7 @@ quick-order-list-remove-button {
   }
 
   .totals__subtotal-value,
-  .quick-order-list__total-items h3 {
+  .quick-order-list__total-items span {
     margin-right: 1.2rem;
   }
 

--- a/sections/featured-product.liquid
+++ b/sections/featured-product.liquid
@@ -177,7 +177,7 @@
                   -%}
                 </div>
                 {%- if product.quantity_price_breaks_configured? -%}
-                  <div class="volume-pricing-note">
+                  <div class="volume-pricing-note" id="Volume-Note-{{ section.id }}">
                     <span>{{ 'products.product.volume_pricing.note' | t }}</span>
                   </div>
                 {%- endif -%}
@@ -361,7 +361,7 @@
                       </price-per-item>
                     {%- endif -%}
                   </div>
-                  <div class="quantity__rules caption no-js-hidden">
+                  <div class="quantity__rules caption no-js-hidden" id="Quantity-Rules-{{ section.id }}">
                     {%- if product.selected_or_first_available_variant.quantity_rule.increment > 1 -%}
                       <span class="divider">
                         {{-

--- a/sections/main-product.liquid
+++ b/sections/main-product.liquid
@@ -106,7 +106,7 @@
                 -%}
               </div>
               {%- if product.quantity_price_breaks_configured? -%}
-                <div class="volume-pricing-note">
+                <div class="volume-pricing-note" id="Volume-Note-{{ section.id }}">
                   <span>{{ 'products.product.volume_pricing.note' | t }}</span>
                 </div>
               {%- endif -%}
@@ -334,7 +334,7 @@
                     </price-per-item>
                   {%- endif -%}
                 </div>
-                <div class="quantity__rules caption no-js-hidden">
+                <div class="quantity__rules caption no-js-hidden" id="Quantity-Rules-{{ section.id }}">
                   {%- if product.selected_or_first_available_variant.quantity_rule.increment > 1 -%}
                     <span class="divider">
                       {{-

--- a/sections/quick-order-list.liquid
+++ b/sections/quick-order-list.liquid
@@ -160,9 +160,9 @@
             </span>
           </div>
           <div class="quick-order-list__total-items">
-            <h3>
+            <span>
               {{ items_in_cart }}
-            </h3>
+            </span>
             <p class="h5">{{ 'sections.quick_order_list.total_items' | t }}</p>
           </div>
           <div class="quick-order-list-total__price">
@@ -172,12 +172,12 @@
               </button>
             </noscript>
             <div class="totals__product-total">
-              <h3 class="totals__subtotal-value">
+              <span class="totals__subtotal-value">
                 {% comment %} TODO: enable theme-check once `line_items_for` is accepted as valid filter {% endcomment %}
                 {% # theme-check-disable %}
                 {{ cart | line_items_for: product | sum: 'original_line_price' | money }}
                 {% # theme-check-enable %}
-              </h3>
+              </span>
               <p class="totals__subtotal h5">{{ 'sections.quick_order_list.product_total' | t }}</p>
             </div>
             <small class="tax-note caption-large rte">

--- a/snippets/quick-order-list-row.liquid
+++ b/snippets/quick-order-list-row.liquid
@@ -212,7 +212,7 @@
             </button>
           {%- endif -%}
           {%- if variant.available == false or quantity_rule_soldout -%}
-            <span class="variant-item__sold-out h4"> {{ 'products.product.sold_out' | t }} </span>
+            <span class="variant-item__sold-out"> {{ 'products.product.sold_out' | t }} </span>
           {%- else -%}
             {% comment %} TODO: Remove theme check {% endcomment %}
             {% # theme-check-disable %}


### PR DESCRIPTION
### PR Summary: 

Ensure qty rules and vol pricing dont show for variants that dont exist.

### Why are these changes introduced?

Fixes #2870 and https://github.com/Shopify/dawn/issues/2932

Test:
- Mobile
- Desktop
- Feat Prod 
- PDP

[Editor](https://admin.shopify.com/store/os2-demo/themes/140326273046/editor)

