### PR TITLE
fixed rating stars not visible due to incorrect variable references

### DIFF
--- a/sections/featured-product.liquid
+++ b/sections/featured-product.liquid
@@ -476,7 +476,7 @@
                 {%- if product.metafields.reviews.rating.value != blank -%}
                   {% liquid
                     assign rating_decimal = 0
-                    assign decimal = product.metafields.reviews.rating.value.rating | modulo: 1
+                    assign decimal = product.metafields.reviews.rating.value | modulo: 1
                     if decimal >= 0.3 and decimal <= 0.7
                       assign rating_decimal = 0.5
                     elsif decimal > 0.7
@@ -486,18 +486,18 @@
                   <div
                     class="rating"
                     role="img"
-                    aria-label="{{ 'accessibility.star_reviews_info' | t: rating_value: product.metafields.reviews.rating.value, rating_max: product.metafields.reviews.rating.value.scale_max }}"
+                    aria-label="{{ 'accessibility.star_reviews_info' | t: rating_value: product.metafields.reviews.rating.value, rating_max: product.metafields.reviews.rating.scale_max }}"
                   >
                     <span
                       aria-hidden="true"
                       class="rating-star"
-                      style="--rating: {{ product.metafields.reviews.rating.value.rating | floor }}; --rating-max: {{ product.metafields.reviews.rating.value.scale_max }}; --rating-decimal: {{ rating_decimal }};"
+                      style="--rating: {{ product.metafields.reviews.rating.value | floor }}; --rating-max: {{ product.metafields.reviews.rating.scale_max }}; --rating-decimal: {{ rating_decimal }};"
                     ></span>
                   </div>
                   <p class="rating-text caption">
                     <span aria-hidden="true">
                       {{- product.metafields.reviews.rating.value }} /
-                      {{ product.metafields.reviews.rating.value.scale_max -}}
+                      {{ product.metafields.reviews.rating.scale_max -}}
                     </span>
                   </p>
                   <p class="rating-count caption">

--- a/sections/main-product.liquid
+++ b/sections/main-product.liquid
@@ -428,7 +428,7 @@
               {%- if product.metafields.reviews.rating.value != blank -%}
                 {% liquid
                   assign rating_decimal = 0
-                  assign decimal = product.metafields.reviews.rating.value.rating | modulo: 1
+                  assign decimal = product.metafields.reviews.rating.value | modulo: 1
                   if decimal >= 0.3 and decimal <= 0.7
                     assign rating_decimal = 0.5
                   elsif decimal > 0.7
@@ -438,18 +438,18 @@
                 <div
                   class="rating"
                   role="img"
-                  aria-label="{{ 'accessibility.star_reviews_info' | t: rating_value: product.metafields.reviews.rating.value, rating_max: product.metafields.reviews.rating.value.scale_max }}"
+                  aria-label="{{ 'accessibility.star_reviews_info' | t: rating_value: product.metafields.reviews.rating.value, rating_max: product.metafields.reviews.rating.scale_max }}"
                 >
                   <span
                     aria-hidden="true"
                     class="rating-star"
-                    style="--rating: {{ product.metafields.reviews.rating.value.rating | floor }}; --rating-max: {{ product.metafields.reviews.rating.value.scale_max }}; --rating-decimal: {{ rating_decimal }};"
+                    style="--rating: {{ product.metafields.reviews.rating.value | floor }}; --rating-max: {{ product.metafields.reviews.rating.scale_max }}; --rating-decimal: {{ rating_decimal }};"
                   ></span>
                 </div>
                 <p class="rating-text caption">
                   <span aria-hidden="true">
                     {{- product.metafields.reviews.rating.value }} /
-                    {{ product.metafields.reviews.rating.value.scale_max -}}
+                    {{ product.metafields.reviews.rating.scale_max -}}
                   </span>
                 </p>
                 <p class="rating-count caption">

--- a/snippets/card-product.liquid
+++ b/snippets/card-product.liquid
@@ -166,7 +166,7 @@
             {%- if show_rating and card_product.metafields.reviews.rating.value != blank -%}
               {% liquid
                 assign rating_decimal = 0
-                assign decimal = card_product.metafields.reviews.rating.value.rating | modulo: 1
+                assign decimal = card_product.metafields.reviews.rating.value | modulo: 1
                 if decimal >= 0.3 and decimal <= 0.7
                   assign rating_decimal = 0.5
                 elsif decimal > 0.7
@@ -176,18 +176,18 @@
               <div
                 class="rating"
                 role="img"
-                aria-label="{{ 'accessibility.star_reviews_info' | t: rating_value: card_product.metafields.reviews.rating.value, rating_max: card_product.metafields.reviews.rating.value.scale_max }}"
+                aria-label="{{ 'accessibility.star_reviews_info' | t: rating_value: card_product.metafields.reviews.rating.value, rating_max: card_product.metafields.reviews.rating.scale_max }}"
               >
                 <span
                   aria-hidden="true"
                   class="rating-star"
-                  style="--rating: {{ card_product.metafields.reviews.rating.value.rating | floor }}; --rating-max: {{ card_product.metafields.reviews.rating.value.scale_max }}; --rating-decimal: {{ rating_decimal }};"
+                  style="--rating: {{ card_product.metafields.reviews.rating.value | floor }}; --rating-max: {{ card_product.metafields.reviews.rating.scale_max }}; --rating-decimal: {{ rating_decimal }};"
                 ></span>
               </div>
               <p class="rating-text caption">
                 <span aria-hidden="true">
                   {{- card_product.metafields.reviews.rating.value }} /
-                  {{ card_product.metafields.reviews.rating.value.scale_max -}}
+                  {{ card_product.metafields.reviews.rating.scale_max -}}
                 </span>
               </p>
               <p class="rating-count caption">


### PR DESCRIPTION
### PR Summary: 

Rating stars not showing up on Product single, collection or featured product section


### Why are these changes introduced?

Fixed variable names here:
```sh
change product.metafields.reviews.rating.value.rating => product.metafields.reviews.rating.value
change card_product.metafields.reviews.rating.value.scale_max => card_product.metafields.reviews.rating.scale_max
```
https://github.com/Shopify/dawn/blob/main/snippets/card-product.liquid#L169-L190
https://github.com/Shopify/dawn/blob/main/sections/main-product.liquid#L431-L452
https://github.com/Shopify/dawn/blob/main/sections/featured-product.liquid#L479-L500
