### PR TITLE
Fix for small screens with large fonts don't fit all content

### DIFF
--- a/assets/quick-order-list.css
+++ b/assets/quick-order-list.css
@@ -184,13 +184,8 @@ quick-order-list .quantity__button {
   margin-top: 0;
   margin-bottom: 0;
   display: flex;
+  flex-wrap: wrap;
   align-items: center;
-}
-
-@media screen and (max-width: 749px) {
-  .variant-item__discounted-prices {
-    display: block;
-  }
 }
 
 .variant-item__discounted-prices dd {

--- a/assets/quick-order-list.css
+++ b/assets/quick-order-list.css
@@ -186,6 +186,12 @@ quick-order-list .quantity__button {
   align-items: center;
 }
 
+@media screen and (max-width: 749px) {
+  .variant-item__discounted-prices {
+    display: block;
+  }
+}
+
 .variant-item__discounted-prices dd {
   margin: 0;
 }


### PR DESCRIPTION
### PR Summary: 

<!-- Please include a short description (using non-technical terms, 1-2 sentences) about the changes you are introducing, what problem is being fixed and/or describe the benefit to merchants. This content will be used in our release notes for Dawn on [themes.shopify.com](https://themes.shopify.com/themes/dawn/styles/default#ReleaseNotes). -->

This PR fixes an issue when the total price of an item on mobile goes out of screen. This happens when an item has `compare_at_price` and large fonts, so in that case there is just not enough room to fit the total price on a small screen. 


### Why are these changes introduced?

Fixes #2931 .

### What approach did you take?

I changed the way we display ~~the old price~~ and the current one. They used to be in one line. Now I place them in two different lines under each other. 

### Visual impact on existing themes
<!-- How will this visually affect merchants who upgrade to a new theme version with this change? -->

The layout of  ~~the old price~~ and the current one has been changed for mobile. 

<details><summary>Before</summary>
<img width="490" alt="258262137-6e672390-fbc3-4dd7-92c4-1c4cf50082cb" src="https://github.com/Shopify/dawn/assets/105315663/2de1522d-635b-4890-b727-2b768889934d">
</details>

<details><summary>After</summary>
<img width="533" alt="258263003-c27329aa-4dc3-42ef-8ce9-4ffc657dc605" src="https://github.com/Shopify/dawn/assets/105315663/a8b7c783-b589-4c48-852d-8d3253883859">
</details>

### Testing steps/scenarios
<!-- List all the testing tasks that applies to your fix to help peers review your work. -->
- [ ] Add the quick order list section to the product page.
- [ ] Go to a product that has compare_at_price (i.e Louise Slide Sandal)
- [ ] In the Quick Order List settings choose Show images.
- [ ] In Global Theme settings set fonts to max
- [ ] in the editor or using the dev tool go to the mobile view.
- [ ] In the quick order list increase the qty of an item that has compare_at_pricer to make the total price be a four-digit number and make sure it fits the screen. 

### Demo links
<!-- Please include a link to a demo store that includes preconfigured sections and settings to allow reviewers to easily test the features you are working on. -->

- [Editor](https://admin.shopify.com/store/os2-demo/themes/140437225494/editor)

### Checklist
- [ ] Added PR summary for [release notes](https://themes.shopify.com/themes/dawn/styles/default#ReleaseNotes)
- [ ] Requested review from UX (Only for changes that are affecting the experience or perceivable visual details)
- [ ] Created a ticket for the [help.shopify.com](https://help.shopify.com) documentation team about updates to theme settings. (Internal-only task)
- [ ] Followed [theme code principles](https://github.com/Shopify/dawn/blob/main/.github/CONTRIBUTING.md#theme-code-principles)
- [ ] Linted with [Theme Check](https://github.com/Shopify/theme-check)
- [ ] Tested on [mobile](https://shopify.dev/themes/store/requirements#mobile-browser-requirements)
- [ ] Tested on [multiple browsers](https://shopify.dev/themes/store/requirements#desktop-browser-requirements)
- [ ] Tested for [accessibility](https://shopify.dev/themes/best-practices/accessibility)
