### PR TITLE
Allow bigger logo

### DIFF
--- a/config/settings_schema.json
+++ b/config/settings_schema.json
@@ -19,7 +19,7 @@
         "type": "range",
         "id": "logo_width",
         "min": 50,
-        "max": 300,
+        "max": 600,
         "step": 10,
         "default": 100,
         "unit": "px",


### PR DESCRIPTION
### PR Summary: 

Allow logo bigger than 300px. For some brands and some logos it makes sense to be bigger.

### Why are these changes introduced?

Fixes the need for merchants to change the schema just to make the logo bigger.

### What approach did you take?

Change the schema.

### Visual impact on existing themes

No change by default.

### Testing steps/scenarios
- [ ] Attempt to make the logo bigger than 300px width.

### Demo links
<!-- Please include a link to a demo store that includes preconfigured sections and settings to allow reviewers to easily test the features you are working on. -->


### Checklist
- [x] Added PR summary for [release notes](https://themes.shopify.com/themes/dawn/styles/default#ReleaseNotes)
- [ ] Requested review from UX (Only for changes that are affecting the experience or perceivable visual details)
- [ ] Created a ticket for the [help.shopify.com](https://help.shopify.com) documentation team about updates to theme settings. (Internal-only task)
- [ ] Followed [theme code principles](https://github.com/Shopify/dawn/blob/main/.github/CONTRIBUTING.md#theme-code-principles)
- [ ] Linted with [Theme Check](https://github.com/Shopify/theme-check)
- [ ] Tested on [mobile](https://shopify.dev/themes/store/requirements#mobile-browser-requirements)
- [ ] Tested on [multiple browsers](https://shopify.dev/themes/store/requirements#desktop-browser-requirements)
- [ ] Tested for [accessibility](https://shopify.dev/themes/best-practices/accessibility)
