### PR TITLE
Change to multiple tags to  'liquid' tag to remove theme check error

### DIFF
--- a/sections/featured-product.liquid
+++ b/sections/featured-product.liquid
@@ -454,8 +454,10 @@
                   {%- endif -%}
                 </div>
               {%- when 'share' -%}
-                {% assign share_url = product.selected_variant.url | default: product.url | prepend: request.origin %}
-                {% render 'share-button', block: block, share_link: share_url %}
+                {% liquid
+                  assign share_url = product.selected_variant.url | default: product.url | prepend: request.origin
+                  render 'share-button', block: block, share_link: share_url 
+                  %}
               {%- when 'variant_picker' -%}
                 {% render 'product-variant-picker',
                   product: product,

--- a/sections/main-product.liquid
+++ b/sections/main-product.liquid
@@ -414,10 +414,9 @@
                 {{- block.settings.text -}}
               </a>
             {%- when 'share' -%}
-              {% assign share_url = product.selected_variant.url | default: product.url | prepend: request.origin %}
-              {% render 'share-button',
-                block: block,
-                share_link: share_url
+              {% liquid
+                assign share_url = product.selected_variant.url | default: product.url | prepend: request.origin 
+                render 'share-button', block: block, share_link: share_url
               %}
 
             {%- when 'variant_picker' -%}


### PR DESCRIPTION
### PR Summary: 

Remove theme check error caused by consecutive tags on 'main-product.liquid' and 'featured-product.liquid'. Included `liquid` tag in to rectify

### Why are these changes introduced?

To Remove theme check errors, and follow recommended practices for liquid.

### What approach did you take?

### Other considerations

### Decision log

### Visual impact on existing themes
No effect on the front-end


### Testing steps/scenarios
- [ ] Step 1 > Try and change different settings for "Share" block for Product section


### Checklist
- [ ] Added PR summary for [release notes](https://themes.shopify.com/themes/dawn/styles/default#ReleaseNotes)
- [ ] Requested review from UX (Only for changes that are affecting the experience or perceivable visual details)
- [ ] Created a ticket for the [help.shopify.com](https://help.shopify.com) documentation team about updates to theme settings. (Internal-only task)
- [ ] Followed [theme code principles](https://github.com/Shopify/dawn/blob/main/.github/CONTRIBUTING.md#theme-code-principles)
- [ ] Linted with [Theme Check](https://github.com/Shopify/theme-check)
- [ ] Tested on [mobile](https://shopify.dev/themes/store/requirements#mobile-browser-requirements)
- [ ] Tested on [multiple browsers](https://shopify.dev/themes/store/requirements#desktop-browser-requirements)
- [ ] Tested for [accessibility](https://shopify.dev/themes/best-practices/accessibility)
