### PR TITLE
Add visual representation for filters

### DIFF
--- a/assets/component-facets.css
+++ b/assets/component-facets.css
@@ -272,9 +272,40 @@
   padding: 0.5rem 2rem;
 }
 
+.facets-layout-grid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  text-align: center;
+  padding: 2rem 2.4rem;
+  gap: 3rem 1rem;
+}
+
+.facets-layout-grid.facets__list--vertical {
+  padding: 1rem 0;
+}
+
 .facets__item {
   display: flex;
   align-items: center;
+}
+
+/* Hover/focus state */
+.facets-layout-list .facets__label:hover .facet-checkbox__text,
+.facets-layout-list input:focus ~ .facet-checkbox__text {
+  text-decoration: underline;
+}
+
+.facets-layout-grid > * {
+  align-items: flex-start;
+}
+
+.facets-layout-grid .visual-display-parent {
+  display: flex;
+  flex-direction: column;
+  gap: 0.8rem;
+  padding: 0;
+  height: 100%;
+  font-size: 1.3rem;
 }
 
 .facets__item label,
@@ -291,6 +322,18 @@
   word-break: break-word;
 }
 
+/* Hover, active, and focus states */
+:is(.facets__label:hover, .facets__label.active, .facets__label:has(:focus-visible)) {
+  color: rgba(var(--color-foreground), 1);
+}
+
+/* Focus states for older browsers */
+@supports not selector(:has(a, b)) {
+  .facets__label:focus-within {
+    color: rgba(var(--color-foreground), 1);
+  }
+}
+
 .facet-checkbox input[type='checkbox'] {
   position: absolute;
   opacity: 1;
@@ -301,6 +344,23 @@
   z-index: -1;
   appearance: none;
   -webkit-appearance: none;
+}
+
+.facets-layout-grid input[type='checkbox'] {
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  width: 100%;
+  height: 100%;
+  opacity: 0;
+}
+
+.facets__visual-display-wrapper {
+  display: flex;
+  justify-content: center;
+  flex-shrink: 0;
 }
 
 .no-js .facet-checkbox input[type='checkbox'] {
@@ -336,8 +396,10 @@
   }
 }
 
-.facet-checkbox--disabled {
-  color: rgba(var(--color-foreground), 0.4);
+.facet-checkbox--disabled,
+.mobile-facets__label--disabled {
+  opacity: 0.4;
+  pointer-events: none;
 }
 
 .facets__price {
@@ -744,13 +806,6 @@ details.menu-opening .mobile-facets__close svg {
 }
 
 .mobile-facets__highlight {
-  opacity: 0;
-  visibility: hidden;
-}
-
-.mobile-facets__checkbox:checked + .mobile-facets__highlight {
-  visibility: visible;
-  opacity: 1;
   position: absolute;
   top: 0px;
   left: 0px;
@@ -758,6 +813,13 @@ details.menu-opening .mobile-facets__close svg {
   bottom: 0px;
   display: block;
   background-color: rgba(var(--color-foreground), 0.04);
+  opacity: 0;
+  visibility: hidden;
+}
+
+.mobile-facets__checkbox:checked + .mobile-facets__highlight {
+  opacity: 1;
+  visibility: visible;
 }
 
 .mobile-facets__summary {
@@ -852,10 +914,6 @@ input.mobile-facets__checkbox {
 .mobile-facets__summary .icon-caret {
   margin-left: auto;
   display: block;
-}
-
-.mobile-facets__label--disabled {
-  opacity: 0.5;
 }
 
 .mobile-facets__footer {

--- a/assets/component-visual-display.css
+++ b/assets/component-visual-display.css
@@ -1,0 +1,89 @@
+.visual-display {
+  --visual-display__size: min(2.4rem, 100%);
+  position: relative;
+  width: var(--visual-display__size);
+  max-width: 100%;
+  border: 0.1rem solid rgba(var(--color-foreground), 0.2);
+  aspect-ratio: 1/1;
+}
+
+.visual-display.empty {
+  border-style: dashed;
+}
+
+.visual-display--presentation-swatch {
+  --visual-display__size: min(2.4rem, 100%);
+
+  border-radius: 100%;
+  overflow: hidden;
+}
+
+.visual-display-parent .visual-display--presentation-swatch {
+  outline-offset: 0.2rem;
+}
+
+/* Hover, active, and focus states */
+:is(
+    .visual-display-parent:hover .visual-display--presentation-swatch,
+    .visual-display-parent.active .visual-display--presentation-swatch,
+    .visual-display-parent:has(:focus-visible) .visual-display--presentation-swatch
+  ) {
+  outline-style: solid;
+}
+
+/* Active state */
+.visual-display-parent.active .visual-display--presentation-swatch {
+  outline-width: 0.1rem;
+  outline-color: rgb(var(--color-foreground), 1);
+}
+
+/* Hover state */
+.visual-display-parent:hover .visual-display--presentation-swatch {
+  outline-width: 0.2rem;
+  outline-color: rgb(var(--color-foreground), 0.4);
+}
+
+/* Focus state */
+.visual-display-parent:has(:focus-visible) .visual-display--presentation-swatch {
+  outline-width: 0.2rem;
+  outline-color: rgb(var(--color-foreground), 0.4);
+  box-shadow: 0 0 0 0.6rem rgb(var(--color-background)), 0 0 0 0.8rem rgba(var(--color-foreground), 0.5),
+    0 0 1.2rem 0.4rem rgba(var(--color-foreground), 0.3);
+}
+
+/* Focus state for older browsers */
+@supports not selector(:has(a, b)) {
+  .visual-display-parent:focus-within .visual-display--presentation-swatch {
+    outline-offset: 0.2rem;
+    outline: 0.2rem solid rgb(var(--color-foreground), 0.4);
+    box-shadow: 0 0 0 0.6rem rgb(var(--color-background)), 0 0 0 0.8rem rgba(var(--color-foreground), 0.5),
+      0 0 1.2rem 0.4rem rgba(var(--color-foreground), 0.3);
+  }
+}
+
+.visual-display-parent.disabled {
+  opacity: 0.4;
+  pointer-events: none;
+}
+
+/* Used to display the disabled dash */
+.visual-display-parent.disabled .visual-display::after {
+  display: block;
+  content: '';
+
+  /* 1.414 is not a magic number, it's the square root of 2, or the length of the diagonal */
+  width: calc(var(--visual-display__size) * 1.414);
+  border-bottom: 0.1rem solid rgb(var(--color-background-contrast));
+  transform: rotate(-45deg);
+  transform-origin: left;
+}
+
+.visual-display .visual-display__child {
+  display: block;
+  height: 100%;
+  width: 100%;
+}
+
+.visual-display--presentation-swatch .visual-display__image {
+  object-fit: cover;
+}

--- a/layout/theme.liquid
+++ b/layout/theme.liquid
@@ -62,7 +62,21 @@
         {% else %}
           --gradient-background: {{ scheme.settings.background }};
         {% endif %}
+
+        {% liquid
+          assign background_color = scheme.settings.background
+          assign background_color_brightness = background_color | color_brightness
+          if background_color_brightness <= 26
+            assign background_color_contrast = background_color | color_lighten: 50
+          elsif background_color_brightness <= 65
+            assign background_color_contrast = background_color | color_lighten: 5
+          else
+            assign background_color_contrast = background_color | color_darken: 25
+          endif
+        %}
+
         --color-foreground: {{ scheme.settings.text.red }},{{ scheme.settings.text.green }},{{ scheme.settings.text.blue }};
+        --color-background-contrast: {{ background_color_contrast.red }},{{ background_color_contrast.green }},{{ background_color_contrast.blue }};
         --color-shadow: {{ scheme.settings.shadow.red }},{{ scheme.settings.shadow.green }},{{ scheme.settings.shadow.blue }};
         --color-button: {{ scheme.settings.button.red }},{{ scheme.settings.button.green }},{{ scheme.settings.button.blue }};
         --color-button-text: {{ scheme.settings.button_label.red }},{{ scheme.settings.button_label.green }},{{ scheme.settings.button_label.blue }};

--- a/snippets/facets.liquid
+++ b/snippets/facets.liquid
@@ -13,6 +13,7 @@
 {% endcomment %}
 
 {{ 'component-show-more.css' | asset_url | stylesheet_tag }}
+{{ 'component-visual-display.css' | asset_url | stylesheet_tag }}
 
 {%- liquid
   assign sort_by = results.sort_by | default: results.default_sort_by
@@ -111,7 +112,20 @@
             <script src="{{ 'show-more.js' | asset_url }}" defer="defer"></script>
             {% comment %} Filters for both horizontal and vertical filter {% endcomment %}
             {%- for filter in results.filters -%}
-              {%- assign total_active_values = total_active_values | plus: filter.active_values.size -%}
+              {% liquid
+                assign total_active_values = total_active_values | plus: filter.active_values.size
+                case filter.presentation
+                  when 'swatch'
+                    assign has_visual_display = true
+                    assign show_more_number = 15
+                    assign visual_layout_class = 'facets-layout-grid facets-layout-grid--' | append: filter.presentation
+                  else
+                    assign has_visual_display = false
+                    assign visual_layout_class = 'facets-layout-list'
+                    assign show_more_number = 10
+                endcase
+              %}
+
               {% case filter.type %}
                 {% when 'boolean', 'list' %}
                   <details
@@ -157,14 +171,21 @@
                       <fieldset class="facets-wrap parent-wrap {% if filter_type == 'vertical' %} facets-wrap-vertical{% endif %}">
                         <legend class="visually-hidden">{{ filter.label | escape }}</legend>
                         <ul
-                          class="{% if filter_type != 'vertical' %} facets__list{% endif %} list-unstyled no-js-hidden"
+                          class="{{ visual_layout_class }}{% if filter_type == 'vertical' %} facets__list--vertical{% else %} facets__list{% endif %} list-unstyled no-js-hidden"
                           role="list"
                         >
                           {%- for value in filter.values -%}
-                            <li class="list-menu__item facets__item{% if forloop.index > 10 and filter_type == 'vertical' %} show-more-item hidden{% endif %}">
+                            {% liquid
+                              assign is_disabled = false
+                              if value.count == 0 and value.active == false
+                                assign is_disabled = true
+                              endif
+                            %}
+
+                            <li class="list-menu__item facets__item{% if forloop.index > show_more_number and filter_type == 'vertical' %} show-more-item hidden{% endif %}">
                               <label
                                 for="Filter-{{ filter.param_name | escape }}-{{ forloop.index }}"
-                                class="facet-checkbox{% if value.count == 0 and value.active == false %} facet-checkbox--disabled{% endif %}"
+                                class="facets__label facet-checkbox{% if is_disabled %} facet-checkbox--disabled disabled{% endif %}{% if has_visual_display %} visual-display-parent visual-display-parent--{{ filter.presentation }}{% endif %}{% if value.active %} active{% endif %}"
                               >
                                 <input
                                   type="checkbox"
@@ -174,38 +195,50 @@
                                   {% if value.active %}
                                     checked
                                   {% endif %}
-                                  {% if value.count == 0 and value.active == false %}
+                                  {% if is_disabled %}
                                     disabled
                                   {% endif %}
                                 >
 
-                                <svg
-                                  width="1.6rem"
-                                  height="1.6rem"
-                                  viewBox="0 0 16 16"
-                                  aria-hidden="true"
-                                  focusable="false"
-                                >
-                                  <rect width="16" height="16" stroke="currentColor" fill="none" stroke-width="1"></rect>
-                                </svg>
+                                {% if has_visual_display %}
+                                  <div class="facets__visual-display-wrapper">
+                                    {% render 'visual-display',
+                                      type: value.display.type,
+                                      value: value.display.value,
+                                      presentation: filter.presentation
+                                    %}
+                                  </div>
+                                {% else %}
+                                  <svg
+                                    width="1.6rem"
+                                    height="1.6rem"
+                                    viewBox="0 0 16 16"
+                                    aria-hidden="true"
+                                    focusable="false"
+                                  >
+                                    <rect width="16" height="16" stroke="currentColor" fill="none" stroke-width="1"></rect>
+                                  </svg>
 
-                                <svg
-                                  aria-hidden="true"
-                                  class="icon icon-checkmark"
-                                  width="1.1rem"
-                                  height="0.7rem"
-                                  viewBox="0 0 11 7"
-                                  fill="none"
-                                  xmlns="http://www.w3.org/2000/svg"
-                                >
-                                  <path d="M1.5 3.5L2.83333 4.75L4.16667 6L9.5 1"
-                                    stroke="currentColor"
-                                    stroke-width="1.75"
-                                    stroke-linecap="round"
-                                    stroke-linejoin="round" />
-                                </svg>
+                                  <svg
+                                    aria-hidden="true"
+                                    class="icon icon-checkmark"
+                                    width="1.1rem"
+                                    height="0.7rem"
+                                    viewBox="0 0 11 7"
+                                    fill="none"
+                                    xmlns="http://www.w3.org/2000/svg"
+                                  >
+                                    <path d="M1.5 3.5L2.83333 4.75L4.16667 6L9.5 1"
+                                      stroke="currentColor"
+                                      stroke-width="1.75"
+                                      stroke-linecap="round"
+                                      stroke-linejoin="round" />
+                                  </svg>
+                                {% endif %}
 
-                                <span aria-hidden="true">{{ value.label | escape }} ({{ value.count }})</span>
+                                <span class="facet-checkbox__text" aria-hidden="true">
+                                  {{- value.label | escape }} ({{ value.count }})</span
+                                >
                                 <span class="visually-hidden">
                                   {{- value.label | escape }} (
                                   {%- if value.count == 1 -%}
@@ -284,7 +317,7 @@
                           {%- endfor -%}
                         </ul>
                       </fieldset>
-                      {%- if filter.values.size > 10 and filter_type == 'vertical' -%}
+                      {%- if filter.values.size > show_more_number and filter_type == 'vertical' -%}
                         <show-more-button>
                           <button
                             class="button-show-more link underlined-link no-js-hidden"
@@ -631,6 +664,17 @@
             <div class="mobile-facets__main has-submenu gradient">
               {%- if enable_filtering -%}
                 {%- for filter in results.filters -%}
+                  {% liquid
+                    case filter.presentation
+                      when 'swatch'
+                        assign has_visual_display = true
+                        assign visual_layout_class = 'facets-layout-grid facets-layout-grid--' | append: filter.presentation
+                      else
+                        assign has_visual_display = false
+                        assign visual_layout_class = 'facets-layout-list'
+                    endcase
+                  %}
+
                   {% case filter.type %}
                     {% when 'boolean', 'list' %}
                       <details
@@ -657,12 +701,19 @@
                             {% render 'icon-arrow' %}
                             {{ filter.label | escape }}
                           </button>
-                          <ul class="mobile-facets__list list-unstyled" role="list">
+                          <ul class="{{ visual_layout_class }} mobile-facets__list list-unstyled" role="list">
                             {%- for value in filter.values -%}
+                              {% liquid
+                                assign is_disabled = false
+                                if value.count == 0 and value.active == false
+                                  assign is_disabled = true
+                                endif
+                              %}
+
                               <li class="mobile-facets__item list-menu__item">
                                 <label
                                   for="Filter-{{ filter.param_name | escape }}-mobile-{{ forloop.index }}"
-                                  class="mobile-facets__label{% if value.count == 0 and value.active == false %} mobile-facets__label--disabled{% endif %}"
+                                  class="facets__label mobile-facets__label{% if is_disabled %} mobile-facets__label--disabled disabled{% endif %}{% if has_visual_display %} visual-display-parent visual-display-parent--{{ filter.presentation }}{% endif %}{% if value.active %} active{% endif %}"
                                 >
                                   <input
                                     class="mobile-facets__checkbox"
@@ -673,36 +724,48 @@
                                     {% if value.active %}
                                       checked
                                     {% endif %}
-                                    {% if value.count == 0 and value.active == false %}
+                                    {% if is_disabled %}
                                       disabled
                                     {% endif %}
                                   >
 
-                                  <span class="mobile-facets__highlight"></span>
+                                  {% if has_visual_display %}
+                                    <div class="facets__visual-display-wrapper">
+                                      {% render 'visual-display',
+                                        type: value.display.type,
+                                        value: value.display.value,
+                                        presentation: filter.presentation
+                                      %}
+                                    </div>
+                                  {% else %}
+                                    <span class="mobile-facets__highlight"></span>
 
-                                  <svg
-                                    width="1.6rem"
-                                    height="1.6rem"
-                                    viewBox="0 0 16 16"
-                                    aria-hidden="true"
-                                    focusable="false"
+                                    <svg
+                                      width="1.6rem"
+                                      height="1.6rem"
+                                      viewBox="0 0 16 16"
+                                      aria-hidden="true"
+                                      focusable="false"
+                                    >
+                                      <rect width="16" height="16" stroke="currentColor" fill="none" stroke-width="1"></rect>
+                                    </svg>
+
+                                    <svg
+                                      aria-hidden="true"
+                                      class="icon icon-checkmark"
+                                      width="1.1rem"
+                                      height="0.7rem"
+                                      viewBox="0 0 11 7"
+                                      fill="none"
+                                      xmlns="http://www.w3.org/2000/svg"
+                                    >
+                                      <path d="M1.5 3.5L2.83333 4.75L4.16667 6L9.5 1" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round" />
+                                    </svg>
+                                  {% endif %}
+
+                                  <span class="facet-checkbox__text" aria-hidden="true">
+                                    {{- value.label | escape }} ({{ value.count }})</span
                                   >
-                                    <rect width="16" height="16" stroke="currentColor" fill="none" stroke-width="1"></rect>
-                                  </svg>
-
-                                  <svg
-                                    aria-hidden="true"
-                                    class="icon icon-checkmark"
-                                    width="1.1rem"
-                                    height="0.7rem"
-                                    viewBox="0 0 11 7"
-                                    fill="none"
-                                    xmlns="http://www.w3.org/2000/svg"
-                                  >
-                                    <path d="M1.5 3.5L2.83333 4.75L4.16667 6L9.5 1" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round" />
-                                  </svg>
-
-                                  <span aria-hidden="true">{{ value.label | escape }} ({{ value.count }})</span>
                                   <span class="visually-hidden">
                                     {{- value.label | escape }} (
                                     {%- if value.count == '1' -%}

--- a/snippets/visual-display.liquid
+++ b/snippets/visual-display.liquid
@@ -1,0 +1,45 @@
+{% comment %}
+  Renders a visual display element, currently just a swatch. If wrapped in "visual-display-parent" and "visual-display-parent--swatch" classes, this will receive hover and focus states.
+
+  Add a class of "active" or "disabled" to the parent element to change the state of the visual display.
+
+  Accepts:
+  - type: {String} Can be "colors" or "image", or nothing to represent an empty state.
+  - value: {Object} Will be an array of color drops, or image drop, depending on the "type"
+  - presentation: {String} Can only be "swatch"
+
+  Usage:
+  {% render 'visual-display', type: value.display.type, value: value.display.value, presentation: filter.presentation %}
+{% endcomment %}
+<div class="visual-display visual-display--presentation-{{ presentation }}{% unless type == "colors" or type == "image" %} empty{% endunless %}">
+  {%- case type -%}
+    {%- when 'colors' -%}
+      {% liquid
+        assign size_limit = value.size | at_most: 4
+        assign rotation = '0deg'
+        if size_limit == 2
+          assign rotation = '45deg'
+        endif
+
+        assign angle_increment = 360 | divided_by: size_limit
+        assign angle = 0
+      %}
+      {%- capture conic_gradient -%}
+        {%- for color in value limit: size_limit -%}
+          {{ color }} {{ angle }}deg{%- assign angle = angle | plus: angle_increment %} {{ angle }}deg{%- unless forloop.last %}, {%- endunless -%}
+        {%- endfor -%}
+      {%- endcapture -%}
+      <div
+        class="visual-display__child"
+        style="background: conic-gradient({{ conic_gradient }}); transform: rotateZ({{ rotation }});"
+      ></div>
+    {%- when 'image' -%}
+      {{
+        value
+        | image_url: width: 300
+        | image_tag: class: 'visual-display__child visual-display__image', alt: value.alt
+      }}
+    {%- else -%}
+      <div class="visual-display__child"></div>
+  {%- endcase -%}
+</div>


### PR DESCRIPTION
### PR Summary: 

<!-- Please include a short description (using non-technical terms, 1-2 sentences) about the changes you are introducing, what problem is being fixed and/or describe the benefit to merchants. This content will be used in our release notes for Dawn on [themes.shopify.com](https://themes.shopify.com/themes/dawn/styles/default#ReleaseNotes). -->
You can now use color swatches and thumbnails for your store's metaobject filters.

### Why are these changes introduced?

This will allow merchants using the Search & Discovery app a way to choose between a swatch or thumbnail visual style for certain filter types (to date: only metafield references to metaobjects).

### What approach did you take?
I followed the [figma design](https://www.figma.com/file/DfFkTjUypdH1oDZSBfByNt/Storefront-Filtering-enhancements?node-id=6842%3A105934&mode=dev), and tried to componentize the visual representation so it can be used outside of the context of filters as well.

When wrapped in a `.visual-display-parent` and either `.visual-display-parent--swatch` or `.visual-display-parent--thumbnail`, hover, active, disabled, and focus states can be applied as well.

### Other considerations
Ensure that this can be reused outside of the context of filters.

It's worth noting that there is a TON of unnecessary duplication between the mobile filters and the non-mobile filters. I added a few classes to each to cut down on the duplication of css rules (`.facets__label`, `.facets-layout-grid`, `.facets-layout-list`, `.facet-checkbox__text` to name a few), but I think that we should take the time to refactor filters from the ground up at a later date to get rid of all/most of the duplication of HTML and CSS.

### Decision log

| # | Decision | Alternatives | Rationale | Downsides |
|---|---|---|---|---|
| 1 | Keep visual representation generic and not only filter-aware | Have less css/code and only allow it to work inside of the context of filters | Other teams or consumers may want to show a visual representation anywhere else in the theme. | The HTML structure and CSS gets a bit bloated with this approach, but allows for better componentization and reusability. |


### Visual impact on existing themes
<!-- How will this visually affect merchants who upgrade to a new theme version with this change? -->
In the image below, I am showing the different possible states. In order:
1. Default
2. Active
3. Hover
4. Focus
5. Disabled
6. Empty

<img width="1206" alt="image" src="https://github.com/Shopify/dawn/assets/1019769/c56cd49c-4113-4a27-b829-28f390f57a8a">



### Testing steps/scenarios
<!-- List all the testing tasks that applies to your fix to help peers review your work. -->
Testing directions are listed [here](https://github.com/Shopify/dawn-private/issues/251).


[Theme upload](https://github.com/Shopify/dawn/files/13047474/Dawn-11.0.0.zip)


### Demo links
<!-- Please include a link to a demo store that includes preconfigured sections and settings to allow reviewers to easily test the features you are working on. -->
- [Editor](https://admin.shopify.com/store/jsonwebdev/themes/157816717334/editor?previewPath=%2Fcollections%2Fall)

### Checklist
- [x] Added PR summary for [release notes](https://themes.shopify.com/themes/dawn/styles/default#ReleaseNotes)
- [x] Requested review from UX (Only for changes that are affecting the experience or perceivable visual details)
- [x] Created a ticket for the [help.shopify.com](https://help.shopify.com) documentation team about updates to theme settings. (Internal-only task)
- [x] Followed [theme code principles](https://github.com/Shopify/dawn/blob/main/.github/CONTRIBUTING.md#theme-code-principles)
- [x] Linted with [Theme Check](https://github.com/Shopify/theme-check)
- [x] Tested on [mobile](https://shopify.dev/themes/store/requirements#mobile-browser-requirements)
- [x] Tested on [multiple browsers](https://shopify.dev/themes/store/requirements#desktop-browser-requirements)
- [x] Tested for [accessibility](https://shopify.dev/themes/best-practices/accessibility)
