### PR TITLE
[Facets] dynamic header

### DIFF
--- a/assets/facets.js
+++ b/assets/facets.js
@@ -165,6 +165,13 @@ class FacetFiltersForm extends HTMLElement {
       targetSummary.outerHTML = sourceSummary.outerHTML;
     }
 
+    const targetHeaderElement = target.querySelector('.facets__header');
+    const sourceHeaderElement = source.querySelector('.facets__header');
+
+    if (sourceHeaderElement && targetHeaderElement) {
+      targetHeaderElement.outerHTML = sourceHeaderElement.outerHTML;
+    }
+
     const targetWrapElement = target.querySelector('.facets-wrap');
     const sourceWrapElement = source.querySelector('.facets-wrap');
 


### PR DESCRIPTION
### PR Summary: 

Following the latest changes to the facets which enabled dynamic updates to the counts, we've introduced a bug where the `x Selected` headers would no longer update for the current active filter on horizontal display mode.

### Why are these changes introduced?

Fixes the regression issue

### What approach did you take?

JS update logic now properly looks for the `facets__header` container and updates the internal text of it when re-rendering the counts.


### Checklist
- [x] Added PR summary for [release notes](https://themes.shopify.com/themes/dawn/styles/default#ReleaseNotes)
- [-] Requested review from UX (Only for changes that are affecting the experience or perceivable visual details)
- [-] Created a ticket for the [help.shopify.com](https://help.shopify.com) documentation team about updates to theme settings. (Internal-only task)
- [x] Followed [theme code principles](https://github.com/Shopify/dawn/blob/main/.github/CONTRIBUTING.md#theme-code-principles)
- [x] Linted with [Theme Check](https://github.com/Shopify/theme-check)
- [x] Tested on [mobile](https://shopify.dev/themes/store/requirements#mobile-browser-requirements)
- [x] Tested on [multiple browsers](https://shopify.dev/themes/store/requirements#desktop-browser-requirements)
- [x] Tested for [accessibility](https://shopify.dev/themes/best-practices/accessibility)
