### PR TITLE
fix(animations.js): Only set `--animation-order` css variable. Fixes #3051

### DIFF
--- a/assets/animations.js
+++ b/assets/animations.js
@@ -11,7 +11,7 @@ function onIntersection(elements, observer) {
       if (elementTarget.classList.contains(SCROLL_ANIMATION_OFFSCREEN_CLASSNAME)) {
         elementTarget.classList.remove(SCROLL_ANIMATION_OFFSCREEN_CLASSNAME);
         if (elementTarget.hasAttribute('data-cascade'))
-          elementTarget.setAttribute('style', `--animation-order: ${index};`);
+          elementTarget.style.setProperty('--animation-order', index);
       }
       observer.unobserve(elementTarget);
     } else {


### PR DESCRIPTION
### PR Summary: 

Only sets `--animation-order` css variable instead of the whole style property.

### Why are these changes introduced?

Currently, the file `animations.js` sets the whole `style` property, removing all other inline styles in the element.
#3051 for more information about the issue.

