### PR TITLE
[VisualDisplay] bump the active outline width

### DIFF
--- a/assets/component-visual-display.css
+++ b/assets/component-visual-display.css
@@ -33,7 +33,7 @@
 
 /* Active state */
 .visual-display-parent.active .visual-display--presentation-swatch {
-  outline-width: 0.1rem;
+  outline-width: 0.2rem;
   outline-color: rgb(var(--color-foreground), 1);
 }
 


### PR DESCRIPTION
### PR Summary: 

Bumping the width of selected swatch outline by 0.1 rem.


### Checklist
- [x] Added PR summary for [release notes](https://themes.shopify.com/themes/dawn/styles/default#ReleaseNotes)
- [x] Requested review from UX (Only for changes that are affecting the experience or perceivable visual details)
- [-] Created a ticket for the [help.shopify.com](https://help.shopify.com) documentation team about updates to theme settings. (Internal-only task)
- [x] Followed [theme code principles](https://github.com/Shopify/dawn/blob/main/.github/CONTRIBUTING.md#theme-code-principles)
- [x] Linted with [Theme Check](https://github.com/Shopify/theme-check)
- [x] Tested on [mobile](https://shopify.dev/themes/store/requirements#mobile-browser-requirements)
- [x] Tested on [multiple browsers](https://shopify.dev/themes/store/requirements#desktop-browser-requirements)
- [x] Tested for [accessibility](https://shopify.dev/themes/best-practices/accessibility)
