### PR TITLE
Enhance Security | Add rel='noopener' and target='_blank' to Social Links

### DIFF
--- a/snippets/social-icons.liquid
+++ b/snippets/social-icons.liquid
@@ -12,7 +12,7 @@
 <ul class="list-unstyled list-social{% if class %} {{ class}}{% endif %}" role="list">
   {%- if settings.social_facebook_link != blank -%}
     <li class="list-social__item">
-      <a href="{{ settings.social_facebook_link }}" class="link list-social__link">
+      <a href="{{ settings.social_facebook_link }}" target="_blank" rel="noopener" class="link list-social__link">
         {%- render 'icon-facebook' -%}
         <span class="visually-hidden">{{ 'general.social.links.facebook' | t }}</span>
       </a>
@@ -20,7 +20,7 @@
   {%- endif -%}
   {%- if settings.social_instagram_link != blank -%}
     <li class="list-social__item">
-      <a href="{{ settings.social_instagram_link }}" class="link list-social__link">
+      <a href="{{ settings.social_instagram_link }}" target="_blank" rel="noopener" class="link list-social__link">
         {%- render 'icon-instagram' -%}
         <span class="visually-hidden">{{ 'general.social.links.instagram' | t }}</span>
       </a>
@@ -28,7 +28,7 @@
   {%- endif -%}
   {%- if settings.social_youtube_link != blank -%}
     <li class="list-social__item">
-      <a href="{{ settings.social_youtube_link }}" class="link list-social__link">
+      <a href="{{ settings.social_youtube_link }}" target="_blank" rel="noopener" class="link list-social__link">
         {%- render 'icon-youtube' -%}
         <span class="visually-hidden">{{ 'general.social.links.youtube' | t }}</span>
       </a>
@@ -36,7 +36,7 @@
   {%- endif -%}
   {%- if settings.social_tiktok_link != blank -%}
     <li class="list-social__item">
-      <a href="{{ settings.social_tiktok_link }}" class="link list-social__link">
+      <a href="{{ settings.social_tiktok_link }}" target="_blank" rel="noopener" class="link list-social__link">
         {%- render 'icon-tiktok' -%}
         <span class="visually-hidden">{{ 'general.social.links.tiktok' | t }}</span>
       </a>
@@ -44,7 +44,7 @@
   {%- endif -%}
   {%- if settings.social_twitter_link != blank -%}
     <li class="list-social__item">
-      <a href="{{ settings.social_twitter_link }}" class="link list-social__link">
+      <a href="{{ settings.social_twitter_link }}" target="_blank" rel="noopener" class="link list-social__link">
         {%- render 'icon-twitter' -%}
         <span class="visually-hidden">{{ 'general.social.links.twitter' | t }}</span>
       </a>
@@ -52,7 +52,7 @@
   {%- endif -%}
   {%- if settings.social_pinterest_link != blank -%}
     <li class="list-social__item">
-      <a href="{{ settings.social_pinterest_link }}" class="link list-social__link">
+      <a href="{{ settings.social_pinterest_link }}" target="_blank" rel="noopener" class="link list-social__link">
         {%- render 'icon-pinterest' -%}
         <span class="visually-hidden">{{ 'general.social.links.pinterest' | t }}</span>
       </a>
@@ -60,7 +60,7 @@
   {%- endif -%}
   {%- if settings.social_snapchat_link != blank -%}
     <li class="list-social__item">
-      <a href="{{ settings.social_snapchat_link }}" class="link list-social__link">
+      <a href="{{ settings.social_snapchat_link }}" target="_blank" rel="noopener" class="link list-social__link">
         {%- render 'icon-snapchat' -%}
         <span class="visually-hidden">{{ 'general.social.links.snapchat' | t }}</span>
       </a>
@@ -68,7 +68,7 @@
   {%- endif -%}
   {%- if settings.social_tumblr_link != blank -%}
     <li class="list-social__item">
-      <a href="{{ settings.social_tumblr_link }}" class="link list-social__link">
+      <a href="{{ settings.social_tumblr_link }}" target="_blank" rel="noopener" class="link list-social__link">
         {%- render 'icon-tumblr' -%}
         <span class="visually-hidden">{{ 'general.social.links.tumblr' | t }}</span>
       </a>
@@ -76,7 +76,7 @@
   {%- endif -%}
   {%- if settings.social_vimeo_link != blank -%}
     <li class="list-social__item">
-      <a href="{{ settings.social_vimeo_link }}" class="link list-social__link">
+      <a href="{{ settings.social_vimeo_link }}" target="_blank" rel="noopener" class="link list-social__link">
         {%- render 'icon-vimeo' -%}
         <span class="visually-hidden">{{ 'general.social.links.vimeo' | t }}</span>
       </a>


### PR DESCRIPTION
### PR Summary: 
Added `rel='noopener'` and `target='_blank'` attributes to social links for enhanced security and to open external links in new tabs for merchant storefronts.


<!-- Please include a short description (using non-technical terms, 1-2 sentences) about the changes you are introducing, what problem is being fixed and/or describe the benefit to merchants. This content will be used in our release notes for Dawn on [themes.shopify.com](https://themes.shopify.com/themes/dawn/styles/default#ReleaseNotes). -->


### Why are these changes introduced?
This change addresses potential security risks related to `target="_blank"` links in social media icons by adding both the `rel='noopener'` and `target='_blank'` attributes. It ensures that these external links open in a new tab without the risk of the new tab having access to the original page's window object.



### What approach did you take?

Identified and updated the HTML elements responsible for social links in the theme to include both `rel='noopener'` and `target='_blank'` attributes.

### Decision log

| # | Decision | Alternatives | Rationale | Downsides |
|---|---|---|---|---|
| 1 |  N/A  | N/A |  Security enhancement  |  None observed  |


### Visual impact on existing themes
<!-- How will this visually affect merchants who upgrade to a new theme version with this change? -->
**This change will not have any visual impact on existing themes**; it solely impacts the HTML attributes of social links, preserving the current visual appearance.