### PR TITLE
Fixed race condition for cart note updates

### DIFF
--- a/assets/cart.js
+++ b/assets/cart.js
@@ -234,7 +234,7 @@ if (!customElements.get('cart-note')) {
         super();
 
         this.addEventListener(
-          'change',
+          'input',
           debounce((event) => {
             const body = JSON.stringify({ note: event.target.value });
             fetch(`${routes.cart_update_url}`, { ...fetchConfig(), ...{ body } });


### PR DESCRIPTION
### PR Summary: 

Sometimes cart note wasn't being carried over to checkout properly.  I believe it was because the `change` event was being fired as a result of them finishing typing by clicking the checkout button itself.  Changed the event to `input` instead so that it updates as they finish typing instead of when they click/tab out of the `textarea` which should mitigate the chance of `update` not being completed before checkout.

This came to my attention from Support.

### Other considerations

To totally eliminate the possibility that the update isn't finished prior to checkout, we'd need to block the checkout button until the `update` finishes.  This seems unnecessary because you'd need to be pretty quick to finish typing and then get over to the button and checkout, but it would be the absolute safest approach.