### PR TITLE
[Quick order form] Add sticky header

### DIFF
--- a/assets/base.css
+++ b/assets/base.css
@@ -2326,7 +2326,7 @@ product-info .loading__spinner:not(.hidden) ~ *,
 
 /* section-header */
 .section-header.shopify-section-group-header-group {
-  z-index: 3;
+  z-index: 4;
 }
 
 .shopify-section-header-sticky {

--- a/assets/quick-order-form.css
+++ b/assets/quick-order-form.css
@@ -288,7 +288,7 @@
   top: 0;
   z-index: 3; /* Prevent volume pricing popover overlap */
   /* background-color: rgb(var(--color-background)); */
-  transition: top .15s ease-out;
+  /* transition: top .15s ease-out; */
 }
 
 .quick-order-form .quick-order-list__table--sticky thead.sticky-active {

--- a/assets/quick-order-form.css
+++ b/assets/quick-order-form.css
@@ -291,8 +291,24 @@
   transition: top .15s ease-out;
 }
 
-.quick-order-form .quick-order-list__table--sticky .variant-item__name {
+.quick-order-form .quick-order-list__table--sticky th.product-title .variant-item__name {
   text-transform: none;
+  font-size: 1.4rem;
+}
+
+@media screen and (max-width: 989px) {
+  .quick-order-form .quick-order-list__table--sticky thead th {
+    display: flex;
+    align-items: center;
+}
+
+  .quick-order-form .quick-order-list__table--sticky th.product-title .variant-item__name {
+    margin-bottom: 0;
+  }
+}
+
+.quick-order-form .quick-order-list__table--sticky th.product-title .variant-item__media {
+  margin-right: 0.8rem;
 }
 
 .quick-order-form .quick-order-list__table--sticky th.product-title .variant-item__media,

--- a/assets/quick-order-form.css
+++ b/assets/quick-order-form.css
@@ -287,8 +287,16 @@
   position: sticky;
   top: 0;
   z-index: 3; /* Prevent volume pricing popover overlap */
-  background-color: rgb(var(--color-background));
+  /* background-color: rgb(var(--color-background)); */
   transition: top .15s ease-out;
+}
+
+.quick-order-form .quick-order-list__table--sticky thead.sticky-active {
+  background-color: rgb(var(--color-background));
+}
+
+.quick-order-form .quick-order-list__table--sticky thead tr {
+  height: 7.2rem;
 }
 
 .quick-order-form .quick-order-list__table--sticky th.product-title .variant-item__name {

--- a/assets/quick-order-form.css
+++ b/assets/quick-order-form.css
@@ -286,7 +286,7 @@
 .quick-order-form .quick-order-list__table--sticky thead {
   position: sticky;
   top: 0;
-  z-index: 3;
+  z-index: 3; /* Prevent volume pricing popover overlap */
   background-color: rgb(var(--color-background));
   transition: top .15s ease-out;
 }

--- a/assets/quick-order-form.css
+++ b/assets/quick-order-form.css
@@ -280,3 +280,31 @@
     padding-top: 1.4rem;
   }
 }
+
+/* Sticky header */
+
+.quick-order-form .quick-order-list__table--sticky thead {
+  position: sticky;
+  top: 0;
+  z-index: 3;
+  background-color: rgb(var(--color-background));
+  transition: top .15s ease-out;
+}
+
+.quick-order-form .quick-order-list__table--sticky .variant-item__name {
+  text-transform: none;
+}
+
+.quick-order-form .quick-order-list__table--sticky th.product-title .variant-item__media,
+.quick-order-form .quick-order-list__table--sticky th.product-title .variant-item__image-container {
+  width: 4rem;
+}
+
+@media screen and (min-width: 990px) {
+  .quick-order-form .quick-order-list__table--sticky .product-title {
+    min-height: calc((var(--inputs-border-width) * 2) + 5rem);
+    padding-top: 1.6rem;
+    padding-bottom: 1.6rem;
+    padding-left: 1rem;
+  }
+}

--- a/assets/quick-order-list.css
+++ b/assets/quick-order-list.css
@@ -36,7 +36,7 @@ quick-order-list .quantity__button {
   .quick-order-list__total {
     position: sticky;
     bottom: 0;
-    z-index: 1;
+    z-index: 2; /* Prevent volume pricing popover overlap */
     background-color: rgb(var(--color-background));
   }
 

--- a/assets/quick-order-list.js
+++ b/assets/quick-order-list.js
@@ -77,6 +77,11 @@ class QuickOrderList extends HTMLElement {
       this.onChange(event);
     }, ON_CHANGE_DEBOUNCE_TIMER);
     this.addEventListener('change', debouncedOnChange.bind(this));
+
+    // Check if sticky header is enabled
+    if (this.isStickyHeaderEnabled()) {
+      this.stickyHeader();
+    }
   }
 
   cartUpdateUnsubscriber = undefined;
@@ -206,6 +211,58 @@ class QuickOrderList extends HTMLElement {
       });
   }
 
+  isAtTop(element) {
+    const mainHeader = document.querySelector('.section-header');
+    const rect = element.getBoundingClientRect();
+    const stickyHeaderHeight = mainHeader.offsetHeight;
+    return rect.top <= stickyHeaderHeight;
+  }
+  
+  replaceHeader(productItemElement) {
+    const productHeader = document.querySelector('.quick-order-form .quick-order-list__table--sticky .product-title');
+    const newHeaderContent = productItemElement.innerHTML;
+    productHeader.innerHTML = newHeaderContent;
+  }
+  
+  restoreHeader() {
+    const productHeader = document.querySelector('.quick-order-form .quick-order-list__table--sticky .product-title');
+    const defaultHeaderContent = productHeader.innerHTML;
+    productHeader.innerHTML = defaultHeaderContent;
+  }
+  
+  adjustStickyHeaderPosition() {
+    const stickyTableHeader = document.querySelector('.quick-order-list__table--sticky thead');
+    const mainHeader = document.querySelector('.section-header');
+    const isHeaderHidden = mainHeader.getBoundingClientRect().top < 0;
+    const mainStickyHeaderType = document.querySelector('sticky-header')?.getAttribute('data-sticky-type') ?? null;
+  
+    if (stickyTableHeader && mainStickyHeaderType) {
+      stickyTableHeader.style.top = (isHeaderHidden || mainStickyHeaderType === 'none') ? '0' : 'var(--header-height)';
+    }
+  }
+  
+  checkProducts() {
+    const productItems = document.querySelectorAll('.quick-order-form .quick-order-list__table--sticky tr.product');
+    const productHeader = document.querySelector('.quick-order-form .quick-order-list__table--sticky .product-title');
+    const defaultHeaderContent = productHeader.innerHTML;
+    const mainHeader = document.querySelector('.section-header');
+  
+    const visibleProducts = Array.from(productItems).filter((element) => this.isAtTop(element, mainHeader));
+    visibleProducts.length > 0 ? this.replaceHeader(visibleProducts[visibleProducts.length - 1], productHeader) : this.restoreHeader(productHeader, defaultHeaderContent);
+    this.adjustStickyHeaderPosition();
+  }
+  
+  stickyHeader() {
+    const activateStickyHeader = () => {
+      this.checkProducts();
+      window.removeEventListener('load', activateStickyHeader);
+    };
+  
+    window.addEventListener('scroll', this.checkProducts.bind(this));
+    window.addEventListener('resize', this.adjustStickyHeaderPosition.bind(this));
+    window.addEventListener('load', activateStickyHeader);
+  }
+
   updateQuantity(id, quantity, name, action) {
     this.toggleLoading(id, true);
 
@@ -284,6 +341,9 @@ class QuickOrderList extends HTMLElement {
         } else {
           this.updateMessage(-parseInt(quantityElement.dataset.cartQuantity))
         }
+
+        // Manually update product details in the sticky header
+        this.checkProducts();
       }).catch((error) => {
         this.querySelectorAll('.loading__spinner').forEach((overlay) => overlay.classList.add('hidden'));
         this.resetQuantityInput(id);
@@ -386,6 +446,10 @@ class QuickOrderList extends HTMLElement {
       quickOrderList.classList.remove('quick-order-list__container--disabled');
       quickOrderListItems.forEach((overlay) => overlay.classList.add('hidden'));
     }
+  }
+
+  isStickyHeaderEnabled() {
+    return document.querySelector('.quick-order-form .quick-order-list__table--sticky') !== null;
   }
 }
 

--- a/assets/quick-order-list.js
+++ b/assets/quick-order-list.js
@@ -223,6 +223,7 @@ class QuickOrderList extends HTMLElement {
 
   replaceHeader(productItemElement) {
     const newHeaderContent = productItemElement.innerHTML;
+    this.productHeader = document.querySelector('.quick-order-form .quick-order-list__table--sticky .product-title');
     this.productHeader.innerHTML = newHeaderContent;
   }
 

--- a/assets/quick-order-list.js
+++ b/assets/quick-order-list.js
@@ -78,12 +78,12 @@ class QuickOrderList extends HTMLElement {
     }, ON_CHANGE_DEBOUNCE_TIMER);
     this.addEventListener('change', debouncedOnChange.bind(this));
 
-    this.productHeader = document.querySelector('.quick-order-form .quick-order-list__table--sticky .product-title');
-    this.defaultProductHeader = this.productHeader.innerHTML;
-    this.mainHeader = document.querySelector('.section-header');
-
-    // Check if sticky header is enabled
     if (this.isStickyHeaderEnabled()) {
+      this.productHeader = document.querySelector('.quick-order-form .quick-order-list__table--sticky .product-title');
+      this.defaultProductHeader = this.productHeader.innerHTML;
+      this.mainHeader = document.querySelector('.section-header');
+  
+      this.initializeMainHeaderObserver();
       this.initializeStickyHeader();
     }
   }
@@ -108,6 +108,10 @@ class QuickOrderList extends HTMLElement {
   disconnectedCallback() {
     if (this.cartUpdateUnsubscriber) {
       this.cartUpdateUnsubscriber();
+    }
+
+    if (this.isStickyHeaderEnabled()) {
+      this.mainHeaderObserver.disconnect();
     }
   }
 
@@ -215,6 +219,18 @@ class QuickOrderList extends HTMLElement {
       });
   }
 
+  initializeMainHeaderObserver() {
+    this.mainHeaderObserver = new MutationObserver((mutations) => {
+      mutations.forEach((mutation) => {
+        if (mutation.type === 'attributes' && mutation.attributeName === 'class') {
+          this.adjustStickyHeaderPosition();
+        }
+      });
+    });
+
+    this.mainHeaderObserver.observe(this.mainHeader, { attributes: true });
+  }
+
   isAtTop(element) {
     const rect = element.getBoundingClientRect();
     const stickyHeaderHeight = this.mainHeader.offsetHeight;
@@ -233,7 +249,7 @@ class QuickOrderList extends HTMLElement {
 
   adjustStickyHeaderPosition() {
     const stickyTableHeader = document.querySelector('.quick-order-list__table--sticky thead');
-    const isHeaderHidden = this.mainHeader.getBoundingClientRect().top < 0;
+    const isHeaderHidden = this.mainHeader.classList.contains('shopify-section-header-hidden');
     const mainStickyHeaderType = document.querySelector('sticky-header')?.getAttribute('data-sticky-type') ?? null;
 
     if (stickyTableHeader && mainStickyHeaderType) {

--- a/assets/quick-order-list.js
+++ b/assets/quick-order-list.js
@@ -136,7 +136,12 @@ class QuickOrderList extends HTMLElement {
       .then((responseText) => {
         const html = new DOMParser().parseFromString(responseText, 'text/html');
         const sourceQty = html.querySelector(`#${this.quickOrderListId}`);
-        this.innerHTML = sourceQty.innerHTML;
+        const updatedTbody = sourceQty.querySelector('tbody');
+        const updatedTotal = sourceQty.querySelector('.quick-order-list__total');
+
+        // Temporary: replace only specific elements
+        this.querySelector('tbody').innerHTML = updatedTbody.innerHTML;
+        this.querySelector('.quick-order-list__total').innerHTML = updatedTotal.innerHTML;
       })
       .catch(e => {
         console.error(e);

--- a/assets/quick-order-list.js
+++ b/assets/quick-order-list.js
@@ -238,8 +238,9 @@ class QuickOrderList extends HTMLElement {
   }
 
   replaceHeader(productItemElement) {
-    const newHeaderContent = productItemElement.innerHTML;
+    const newHeaderContent = productItemElement.querySelector('.product-item__inner').innerHTML;
     this.productHeader = document.querySelector('.quick-order-form .quick-order-list__table--sticky .product-title');
+    if (this.productHeader.innerHTML === newHeaderContent) return;
     this.productHeader.innerHTML = newHeaderContent;
   }
 

--- a/assets/quick-order-list.js
+++ b/assets/quick-order-list.js
@@ -233,8 +233,7 @@ class QuickOrderList extends HTMLElement {
 
   isAtTop(element) {
     const rect = element.getBoundingClientRect();
-    const stickyHeaderHeight = this.mainHeader.offsetHeight;
-    return rect.top <= stickyHeaderHeight;
+    return rect.bottom <= this.productHeader.getBoundingClientRect().bottom;
   }
 
   replaceHeader(productItemElement) {

--- a/assets/quick-order-list.js
+++ b/assets/quick-order-list.js
@@ -245,6 +245,7 @@ class QuickOrderList extends HTMLElement {
   }
 
   restoreHeader() {
+    if (this.productHeader.innerHTML === this.defaultProductHeader) return;
     this.productHeader.innerHTML = this.defaultProductHeader;
   }
 

--- a/assets/quick-order-list.js
+++ b/assets/quick-order-list.js
@@ -78,6 +78,10 @@ class QuickOrderList extends HTMLElement {
     }, ON_CHANGE_DEBOUNCE_TIMER);
     this.addEventListener('change', debouncedOnChange.bind(this));
 
+    this.productHeader = document.querySelector('.quick-order-form .quick-order-list__table--sticky .product-title');
+    this.defaultProductHeader = this.productHeader.innerHTML;
+    this.mainHeader = document.querySelector('.section-header');
+
     // Check if sticky header is enabled
     if (this.isStickyHeaderEnabled()) {
       this.initializeStickyHeader();
@@ -212,52 +216,45 @@ class QuickOrderList extends HTMLElement {
   }
 
   isAtTop(element) {
-    const mainHeader = document.querySelector('.section-header');
     const rect = element.getBoundingClientRect();
-    const stickyHeaderHeight = mainHeader.offsetHeight;
+    const stickyHeaderHeight = this.mainHeader.offsetHeight;
     return rect.top <= stickyHeaderHeight;
   }
-  
+
   replaceHeader(productItemElement) {
-    const productHeader = document.querySelector('.quick-order-form .quick-order-list__table--sticky .product-title');
     const newHeaderContent = productItemElement.innerHTML;
-    productHeader.innerHTML = newHeaderContent;
+    this.productHeader.innerHTML = newHeaderContent;
   }
-  
+
   restoreHeader() {
-    const productHeader = document.querySelector('.quick-order-form .quick-order-list__table--sticky .product-title');
-    const defaultHeaderContent = productHeader.innerHTML;
-    productHeader.innerHTML = defaultHeaderContent;
+    this.productHeader.innerHTML = this.defaultProductHeader;
   }
-  
+
   adjustStickyHeaderPosition() {
     const stickyTableHeader = document.querySelector('.quick-order-list__table--sticky thead');
-    const mainHeader = document.querySelector('.section-header');
-    const isHeaderHidden = mainHeader.getBoundingClientRect().top < 0;
+    const isHeaderHidden = this.mainHeader.getBoundingClientRect().top < 0;
     const mainStickyHeaderType = document.querySelector('sticky-header')?.getAttribute('data-sticky-type') ?? null;
-  
+
     if (stickyTableHeader && mainStickyHeaderType) {
       stickyTableHeader.style.top = (isHeaderHidden || mainStickyHeaderType === 'none') ? '0' : 'var(--header-height)';
     }
   }
-  
+
   checkProducts() {
     const productItems = document.querySelectorAll('.quick-order-form .quick-order-list__table--sticky tr.product');
-    const productHeader = document.querySelector('.quick-order-form .quick-order-list__table--sticky .product-title');
-    const defaultHeaderContent = productHeader.innerHTML;
-    const mainHeader = document.querySelector('.section-header');
-  
-    const visibleProducts = Array.from(productItems).filter((element) => this.isAtTop(element, mainHeader));
-    visibleProducts.length > 0 ? this.replaceHeader(visibleProducts[visibleProducts.length - 1], productHeader) : this.restoreHeader(productHeader, defaultHeaderContent);
+    const visibleProducts = Array.from(productItems).filter((element) => this.isAtTop(element));
+
+    visibleProducts.length > 0 ? this.replaceHeader(visibleProducts[visibleProducts.length - 1]) : this.restoreHeader();
+
     this.adjustStickyHeaderPosition();
   }
-  
+
   initializeStickyHeader() {
     const activateStickyHeader = () => {
       this.checkProducts();
       window.removeEventListener('load', activateStickyHeader);
     };
-  
+
     window.addEventListener('scroll', this.checkProducts.bind(this));
     window.addEventListener('resize', this.adjustStickyHeaderPosition.bind(this));
     window.addEventListener('load', activateStickyHeader);

--- a/assets/quick-order-list.js
+++ b/assets/quick-order-list.js
@@ -246,11 +246,17 @@ class QuickOrderList extends HTMLElement {
     this.productHeader = document.querySelector('.quick-order-form .quick-order-list__table--sticky .product-title');
     if (this.productHeader.innerHTML === newHeaderContent) return;
     this.productHeader.innerHTML = newHeaderContent;
+
+    const theadElement = document.querySelector('.quick-order-list__table--sticky thead');
+    theadElement.classList.add('sticky-active');
   }
 
   restoreHeader() {
     if (this.productHeader.innerHTML === this.defaultProductHeader) return;
     this.productHeader.innerHTML = this.defaultProductHeader;
+
+    const theadElement = document.querySelector('.quick-order-list__table--sticky thead');
+    theadElement.classList.remove('sticky-active');
   }
 
   adjustStickyHeaderPosition() {

--- a/assets/quick-order-list.js
+++ b/assets/quick-order-list.js
@@ -358,7 +358,7 @@ class QuickOrderList extends HTMLElement {
         }
 
         // Manually update product details in the sticky header
-        this.checkProducts();
+        this.isStickyHeaderEnabled() && this.checkProducts();
       }).catch((error) => {
         this.querySelectorAll('.loading__spinner').forEach((overlay) => overlay.classList.add('hidden'));
         this.resetQuantityInput(id);

--- a/assets/quick-order-list.js
+++ b/assets/quick-order-list.js
@@ -80,7 +80,7 @@ class QuickOrderList extends HTMLElement {
 
     // Check if sticky header is enabled
     if (this.isStickyHeaderEnabled()) {
-      this.stickyHeader();
+      this.initializeStickyHeader();
     }
   }
 
@@ -252,7 +252,7 @@ class QuickOrderList extends HTMLElement {
     this.adjustStickyHeaderPosition();
   }
   
-  stickyHeader() {
+  initializeStickyHeader() {
     const activateStickyHeader = () => {
       this.checkProducts();
       window.removeEventListener('load', activateStickyHeader);

--- a/locales/cs.schema.json
+++ b/locales/cs.schema.json
@@ -3327,6 +3327,9 @@
     "quick-order-form": {
       "name": "Formulář rychlé objednávky",
       "settings": {
+        "enable_sticky_header": {
+          "label": "Zobrazit plovoucí záhlaví"
+        },
         "show_variant_image": {
           "label": "Zobrazit obrázky varianty"
         },

--- a/locales/da.schema.json
+++ b/locales/da.schema.json
@@ -3327,6 +3327,9 @@
     "quick-order-form": {
       "name": "Hurtig ordreformular",
       "settings": {
+        "enable_sticky_header": {
+          "label": "Aktivér fastgjort sidehoved"
+        },
         "show_variant_image": {
           "label": "Vis variantbilleder"
         },

--- a/locales/de.schema.json
+++ b/locales/de.schema.json
@@ -3327,6 +3327,9 @@
     "quick-order-form": {
       "name": "Schnelles Bestellformular",
       "settings": {
+        "enable_sticky_header": {
+          "label": "Fixierten Header aktivieren"
+        },
         "show_variant_image": {
           "label": "Variantenbilder anzeigen"
         },

--- a/locales/en.default.schema.json
+++ b/locales/en.default.schema.json
@@ -2745,6 +2745,9 @@
     "quick-order-form": {
       "name": "Quick order form",
       "settings": {
+        "enable_sticky_header": {
+          "label": "Enable sticky header"
+        },
         "show_variant_image": {
           "label": "Show variant images"
         },

--- a/locales/es.schema.json
+++ b/locales/es.schema.json
@@ -3327,6 +3327,9 @@
     "quick-order-form": {
       "name": "Formulario de pedidos rápidos",
       "settings": {
+        "enable_sticky_header": {
+          "label": "Activar encabezado fijo"
+        },
         "show_variant_image": {
           "label": "Mostrar imágenes de variantes"
         },

--- a/locales/fi.schema.json
+++ b/locales/fi.schema.json
@@ -3327,6 +3327,9 @@
     "quick-order-form": {
       "name": "Pikatilauslomake",
       "settings": {
+        "enable_sticky_header": {
+          "label": "Ota paikallaan pysyvä ylätunniste käyttöön"
+        },
         "show_variant_image": {
           "label": "Näytä versiokuvat"
         },

--- a/locales/fr.schema.json
+++ b/locales/fr.schema.json
@@ -3327,6 +3327,9 @@
     "quick-order-form": {
       "name": "Formulaire de commande rapide",
       "settings": {
+        "enable_sticky_header": {
+          "label": "Activer l'en-tête collé"
+        },
         "show_variant_image": {
           "label": "Afficher les images de variante"
         },

--- a/locales/it.schema.json
+++ b/locales/it.schema.json
@@ -3327,6 +3327,9 @@
     "quick-order-form": {
       "name": "Modulo ordine rapido",
       "settings": {
+        "enable_sticky_header": {
+          "label": "Abilita header fisso"
+        },
         "show_variant_image": {
           "label": "Mostra immagini varianti"
         },

--- a/locales/ja.schema.json
+++ b/locales/ja.schema.json
@@ -3327,6 +3327,9 @@
     "quick-order-form": {
       "name": "迅速な注文フォーム",
       "settings": {
+        "enable_sticky_header": {
+          "label": "常時表示のヘッダーを有効にする"
+        },
         "show_variant_image": {
           "label": "バリエーション画像を表示"
         },

--- a/locales/ko.schema.json
+++ b/locales/ko.schema.json
@@ -3327,6 +3327,9 @@
     "quick-order-form": {
       "name": "빠른 주문 양식",
       "settings": {
+        "enable_sticky_header": {
+          "label": "고정 머리글 사용"
+        },
         "show_variant_image": {
           "label": "이형 상품 이미지 표시"
         },

--- a/locales/nb.schema.json
+++ b/locales/nb.schema.json
@@ -3327,6 +3327,9 @@
     "quick-order-form": {
       "name": "Hurtigordreskjema",
       "settings": {
+        "enable_sticky_header": {
+          "label": "Aktiver festet overskrift"
+        },
         "show_variant_image": {
           "label": "Vis variantbilder"
         },

--- a/locales/nl.schema.json
+++ b/locales/nl.schema.json
@@ -3327,6 +3327,9 @@
     "quick-order-form": {
       "name": "Snel bestelformulier",
       "settings": {
+        "enable_sticky_header": {
+          "label": "Sticky header inschakelen"
+        },
         "show_variant_image": {
           "label": "Afbeeldingen van varianten weergeven"
         },

--- a/locales/pl.schema.json
+++ b/locales/pl.schema.json
@@ -3327,6 +3327,9 @@
     "quick-order-form": {
       "name": "Formularz szybkiego zamówienia",
       "settings": {
+        "enable_sticky_header": {
+          "label": "Włącz przypięty nagłówek"
+        },
         "show_variant_image": {
           "label": "Pokaż obrazy wariantu"
         },

--- a/locales/pt-BR.schema.json
+++ b/locales/pt-BR.schema.json
@@ -3327,6 +3327,9 @@
     "quick-order-form": {
       "name": "Formulário de pedido rápido",
       "settings": {
+        "enable_sticky_header": {
+          "label": "Habilitar cabeçalho fixo"
+        },
         "show_variant_image": {
           "label": "Exibir imagens de variantes"
         },

--- a/locales/pt-PT.schema.json
+++ b/locales/pt-PT.schema.json
@@ -3327,6 +3327,9 @@
     "quick-order-form": {
       "name": "Formulário de encomendas rápidas",
       "settings": {
+        "enable_sticky_header": {
+          "label": "Ativar cabeçalho fixo"
+        },
         "show_variant_image": {
           "label": "Mostrar imagens da variante"
         },

--- a/locales/sv.schema.json
+++ b/locales/sv.schema.json
@@ -3327,6 +3327,9 @@
     "quick-order-form": {
       "name": "Snabborderformulär",
       "settings": {
+        "enable_sticky_header": {
+          "label": "Aktivera fast rubrik"
+        },
         "show_variant_image": {
           "label": "Visa variantbilder"
         },

--- a/locales/th.schema.json
+++ b/locales/th.schema.json
@@ -3327,6 +3327,9 @@
     "quick-order-form": {
       "name": "แบบฟอร์มคำสั่งซื้อแบบด่วน",
       "settings": {
+        "enable_sticky_header": {
+          "label": "เปิดใช้งานส่วนหัวแบบยึดตำแหน่ง"
+        },
         "show_variant_image": {
           "label": "แสดงรูปภาพตัวเลือกสินค้า"
         },

--- a/locales/tr.schema.json
+++ b/locales/tr.schema.json
@@ -3327,6 +3327,9 @@
     "quick-order-form": {
       "name": "Hızlı sipariş formu",
       "settings": {
+        "enable_sticky_header": {
+          "label": "Yapışkanlı üstbilgiyi etkinleştir"
+        },
         "show_variant_image": {
           "label": "Varyasyon görsellerini göster"
         },

--- a/locales/vi.schema.json
+++ b/locales/vi.schema.json
@@ -3327,6 +3327,9 @@
     "quick-order-form": {
       "name": "Biểu mẫu đặt hàng nhanh",
       "settings": {
+        "enable_sticky_header": {
+          "label": "Bật đầu trang dính"
+        },
         "show_variant_image": {
           "label": "Hiển thị hình ảnh mẫu mã"
         },

--- a/locales/zh-CN.schema.json
+++ b/locales/zh-CN.schema.json
@@ -3327,6 +3327,9 @@
     "quick-order-form": {
       "name": "快速订单表单",
       "settings": {
+        "enable_sticky_header": {
+          "label": "启用粘性标头"
+        },
         "show_variant_image": {
           "label": "显示多属性图片"
         },

--- a/locales/zh-TW.schema.json
+++ b/locales/zh-TW.schema.json
@@ -3327,6 +3327,9 @@
     "quick-order-form": {
       "name": "快速訂單表單",
       "settings": {
+        "enable_sticky_header": {
+          "label": "啟用固定式頁首"
+        },
         "show_variant_image": {
           "label": "顯示子類圖片"
         },

--- a/sections/quick-order-form.liquid
+++ b/sections/quick-order-form.liquid
@@ -74,13 +74,16 @@
     >
       <div class="quick-order-list__container" id="main-variant-items-{{ section.id }}">
         <div class="js-contents">
-          <table class="quick-order-list__table">
+          <table class="quick-order-list__table{% if section.settings.enable_sticky_header %} quick-order-list__table--sticky{% endif %}">
             <caption class="visually-hidden">
               {{ 'sections.cart.title' | t }}
             </caption>
             <thead>
               <tr>
-                <th class="caption-with-letter-spacing" scope="col">
+                <th
+                  class="caption-with-letter-spacing product-title"
+                  scope="col"
+                >
                   {{ 'sections.quick_order_list.product' | t }}
                 </th>
                 <th class="large-up-hide right caption-with-letter-spacing" scope="col">
@@ -105,19 +108,22 @@
             </thead>
 
             <tbody>
-              {%-
-                render 'quick-order-product-row',
-                item: collections['shop-all'].products.first,
-                image: collections['shop-all']products.first.featured_media,
-              -%}
-              {%- for variant in collections['shop-all'].products.first.variants -%}
-                {%-
-                  render 'quick-order-list-row',
-                  item: variant,
-                  image: variant.image,
-                  sku: variant.sku,
-                  variant: variant,
-                -%}
+              {% comment %} Temporary: show first 5 products {% endcomment %}
+              {%- for i in (0..4) -%}
+                {%- assign product = collections['shop-all'].products[i] -%}
+                {%- assign image = product.featured_media -%}
+
+                {%- render 'quick-order-product-row', item: product, image: image -%}
+
+                {%- for variant in product.variants -%}
+                  {%-
+                    render 'quick-order-list-row',
+                    item: variant,
+                    image: variant.image,
+                    sku: variant.sku,
+                    variant: variant,
+                  -%}
+                {%- endfor -%}
               {%- endfor -%}
             </tbody>
           </table>
@@ -233,6 +239,12 @@
     "templates": ["article", "blog", "index", "list-collections", "page"]
   },
   "settings": [
+    {
+      "type": "checkbox",
+      "id": "enable_sticky_header",
+      "default": false,
+      "label": "t:sections.quick-order-form.settings.enable_sticky_header.label"
+    },
     {
       "type": "checkbox",
       "id": "show_image",

--- a/sections/quick-order-form.liquid
+++ b/sections/quick-order-form.liquid
@@ -108,8 +108,8 @@
             </thead>
 
             <tbody>
-              {% comment %} Temporary: show first 5 products {% endcomment %}
-              {%- for i in (0..4) -%}
+              {% comment %} Temporary: show first 10 products {% endcomment %}
+              {%- for i in (0..9) -%}
                 {%- assign product = collections['shop-all'].products[i] -%}
                 {%- assign image = product.featured_media -%}
 

--- a/sections/quick-order-form.liquid
+++ b/sections/quick-order-form.liquid
@@ -109,12 +109,12 @@
 
             <tbody>
               {% comment %} Temporary: show first 10 products {% endcomment %}
-              {%- for i in (0..9) -%}
-                {%- assign product = collections['shop-all'].products[i] -%}
-                {%- assign image = product.featured_media -%}
-
-                {%- render 'quick-order-product-row', item: product, image: image -%}
-
+              {%- for product in collections['shop-all'].products limit: 10 -%}
+                {%-
+                  render 'quick-order-product-row',
+                  item: product,
+                  image: product.featured_media,
+                -%}
                 {%- for variant in product.variants -%}
                   {%-
                     render 'quick-order-list-row',


### PR DESCRIPTION
## PR Summary

This PR adds a sticky header option to the quick order form.

## Why are these changes introduced?

Fixes https://github.com/Shopify/dawn/issues/3032 / [Figma](https://www.figma.com/file/CruV4wCdMmlovbE3GEs6WZ/Quick-order-form?type=design&node-id=2139-280441&mode=design&t=fhK0zrm2PziDP9Qh-0)

The sticky header will be active on both desktop and mobile.

This quick order form sticky header should adjust accordingly with the different [main sticky header](https://screenshot.click/29-58-xmplq-1hsyn-23-x3b78.png) settings in the header section (`None`, `On scroll-up` _default_, `Always`, and `Always, reduce logo size`).

## Other considerations

### Translations

To save time, I manually added all translations for the "Enable sticky header" section setting so we don't have to request them. I got the translations from: 8aac1e58075de6dcfc9582ca08d7347e5a7d28d2 when the main header section only had one setting: `enable_sticky_header`, before the 4 above settings were added. I marked translations as async.

### Important notes ⚠️ 👀

The main focus for this PR is to add the sticky header functionality to the quick order form so that each and every product ([screenshot](https://screenshot.click/29-04-tmit2-cakbc-23-keghs.png)) 'sticks' as you scroll down and up on the quick order form.

### Header z-index adjustment

Since we're introducing an additional sticky header feature to the quick order form, it should play nicely with the existing, main sticky header. I increased the `z-index` of `shopify-section-group-header-group` to `4`. This correctly addresses the volume pricing popover issue we previously encountered ([screenshot](https://screenshot.click/05-44-ilntp-xituw-23-og0at.png)), along with the issue where when you reach the bottom of the form and scroll back up ([noted by Melissa](https://github.com/Shopify/dawn/pull/3132#issuecomment-1835374510)).

## Testing steps/scenarios

Since the team is still ironing out implementation decisions, I currently have it set up to display the first 10 products from the `shop-all` collection.

Make sure [Enable sticky header](https://screenshot.click/29-18-er6cw-t910e-23-30kie.png) is enabled.

- [ ] Ensure the product title, product image, and product link are updated to the next product when it's at the top of the viewport
- [ ] Test all 4 main sticky header settings ([screenshot](https://screenshot.click/29-58-xmplq-1hsyn-23-x3b78.png))
- [ ] Test with and without `Show variant images`
- [ ] Test with and without `Show SKUs`
- [ ] Ensure the volume pricing popover displays correctly
- [ ] Update the quantities of variants to ensure the sticky header remains
- [ ] Test desktop and mobile

### Demo links

- [Editor](https://admin.shopify.com/store/os2-demo/themes/162608939030/editor)

### Notes

This was built from the exploration work done here:

- https://github.com/Shopify/dawn/pull/3065