### PR TITLE
[VariantPicker] Unify variant selects and radios under new component

### DIFF
--- a/assets/product-info.js
+++ b/assets/product-info.js
@@ -6,7 +6,7 @@ if (!customElements.get('product-info')) {
         super();
         this.input = this.querySelector('.quantity__input');
         this.currentVariant = this.querySelector('.product-variant-id');
-        this.variantSelects = this.querySelector('variant-radios');
+        this.variantSelects = this.querySelector('variant-picker');
         this.submitButton = this.querySelector('[type="submit"]');
       }
 

--- a/assets/quick-add.js
+++ b/assets/quick-add.js
@@ -67,7 +67,7 @@ if (!customElements.get('quick-add-modal')) {
       }
 
       preventVariantURLSwitching() {
-        const variantPicker = this.modalContent.querySelector('variant-radios,variant-selects');
+        const variantPicker = this.modalContent.querySelector('variant-picker');
         if (!variantPicker) return;
 
         variantPicker.setAttribute('data-update-url', 'false');
@@ -87,7 +87,7 @@ if (!customElements.get('quick-add-modal')) {
       preventDuplicatedIDs() {
         const sectionId = this.productElement.dataset.section;
         this.productElement.innerHTML = this.productElement.innerHTML.replaceAll(sectionId, `quickadd-${sectionId}`);
-        this.productElement.querySelectorAll('variant-selects, variant-radios, product-info').forEach((element) => {
+        this.productElement.querySelectorAll('variant-picker, product-info').forEach((element) => {
           element.dataset.originalSection = sectionId;
         });
       }

--- a/assets/section-main-product.css
+++ b/assets/section-main-product.css
@@ -168,8 +168,7 @@
   border: none;
 }
 
-variant-radios,
-variant-selects {
+variant-picker {
   display: block;
 }
 

--- a/sections/featured-product.liquid
+++ b/sections/featured-product.liquid
@@ -672,13 +672,11 @@
     if (!isIE()) return;
     const hiddenInput = document.querySelector('#{{ product_form_id }} input[name="id"]');
     const noScriptInputWrapper = document.createElement('div');
-    const variantSwitcher =
-      document.querySelector('variant-radios[data-section="{{ section.id }}"]') ||
-      document.querySelector('variant-selects[data-section="{{ section.id }}"]');
+    const variantPicker = document.querySelector('variant-picker[data-section="{{ section.id }}"]');
     noScriptInputWrapper.innerHTML = document.querySelector(
       '.product-form__noscript-wrapper-{{ section.id }}'
     ).textContent;
-    variantSwitcher.outerHTML = noScriptInputWrapper.outerHTML;
+    variantPicker.outerHTML = noScriptInputWrapper.outerHTML;
 
     document.querySelector('#Variants-{{ section.id }}').addEventListener('change', function (event) {
       hiddenInput.value = event.currentTarget.value;

--- a/sections/main-product.liquid
+++ b/sections/main-product.liquid
@@ -601,13 +601,12 @@
       if (!isIE()) return;
       const hiddenInput = document.querySelector('#{{ product_form_id }} input[name="id"]');
       const noScriptInputWrapper = document.createElement('div');
-      const variantSwitcher =
-        document.querySelector('variant-radios[data-section="{{ section.id }}"]') ||
-        document.querySelector('variant-selects[data-section="{{ section.id }}"]');
+      const variantPicker =
+        document.querySelector('variant-picker[data-section="{{ section.id }}"]');
       noScriptInputWrapper.innerHTML = document.querySelector(
         '.product-form__noscript-wrapper-{{ section.id }}'
       ).textContent;
-      variantSwitcher.outerHTML = noScriptInputWrapper.outerHTML;
+      variantPicker.outerHTML = noScriptInputWrapper.outerHTML;
 
       document.querySelector('#Variants-{{ section.id }}').addEventListener('change', function (event) {
         hiddenInput.value = event.currentTarget.value;

--- a/snippets/product-variant-picker.liquid
+++ b/snippets/product-variant-picker.liquid
@@ -10,39 +10,24 @@
   {% render 'product-variant-picker', product: product, block: block, product_form_id: product_form_id %}
 {% endcomment %}
 {%- unless product.has_only_default_variant -%}
-  {%- if block.settings.picker_type == 'button' -%}
-    <variant-radios
-      id="variant-radios-{{ section.id }}"
-      class="no-js-hidden"
-      data-section="{{ section.id }}"
-      data-url="{{ product.url }}"
-      {% if update_url == false %}
-        data-update-url="false"
-      {% endif %}
-      {{ block.shopify_attributes }}
-    >
-      {%- for option in product.options_with_values -%}
+  <variant-picker
+    id="variant-picker-{{ section.id }}"
+    class="no-js-hidden"
+    type="{{ block.settings.picker_type }}"
+    data-section="{{ section.id }}"
+    data-url="{{ product.url }}"
+    {% if update_url == false %}
+      data-update-url="false"
+    {% endif %}
+    {{ block.shopify_attributes }}
+  >
+    {%- for option in product.options_with_values -%}
+      {%- if block.settings.picker_type == 'button' -%}
         <fieldset class="js product-form__input">
           <legend class="form__label">{{ option.name }}</legend>
           {% render 'product-variant-options', product: product, option: option, block: block %}
         </fieldset>
-      {%- endfor -%}
-      <script type="application/json">
-        {{ product.variants | json }}
-      </script>
-    </variant-radios>
-  {%- else -%}
-    <variant-selects
-      id="variant-selects-{{ section.id }}"
-      class="no-js-hidden"
-      data-section="{{ section.id }}"
-      data-url="{{ product.url }}"
-      {% if update_url == false %}
-        data-update-url="false"
-      {% endif %}
-      {{ block.shopify_attributes }}
-    >
-      {%- for option in product.options_with_values -%}
+      {%- else -%}
         <div class="product-form__input product-form__input--dropdown">
           <label class="form__label" for="Option-{{ section.id }}-{{ forloop.index0 }}">
             {{ option.name }}
@@ -59,13 +44,12 @@
             {% render 'icon-caret' %}
           </div>
         </div>
-      {%- endfor -%}
-
-      <script type="application/json">
-        {{ product.variants | json }}
-      </script>
-    </variant-selects>
-  {%- endif -%}
+      {%- endif -%}
+    {%- endfor -%}
+    <script type="application/json">
+      {{ product.variants | json }}
+    </script>
+  </variant-picker>
 {%- endunless -%}
 
 <noscript class="product-form__noscript-wrapper-{{ section.id }}">


### PR DESCRIPTION
### PR Summary: 

Unify `<variant-selects>` and `<variant-radios>` custom elements as a `<variant-picker>` custom element. 

### Why are these changes introduced?

### What approach did you take?


<!--
### Other considerations

 ### Decision log

| # | Decision | Alternatives | Rationale | Downsides |
|---|---|---|---|---|
| 1 |   |   |   |   |
-->

### Visual impact on existing themes
<!-- How will this visually affect merchants who upgrade to a new theme version with this change? -->
None

### Testing steps/scenarios
<!-- List all the testing tasks that applies to your fix to help peers review your work. -->
- [ ] Ensure selecting different combination of varaints works as expected
- [ ] Not available variants should be selectable and UI updated correspondingly
- [ ] Variant picker should work in both main product and feature product sections

### Demo links
<!-- Please include a link to a demo store that includes preconfigured sections and settings to allow reviewers to easily test the features you are working on. -->


### Checklist
- [x] Added PR summary for [release notes](https://themes.shopify.com/themes/dawn/styles/default#ReleaseNotes)
- [ ] Requested review from UX (Only for changes that are affecting the experience or perceivable visual details)
- [ ] Created a ticket for the [help.shopify.com](https://help.shopify.com) documentation team about updates to theme settings. (Internal-only task)
- [ ] Followed [theme code principles](https://github.com/Shopify/dawn/blob/main/.github/CONTRIBUTING.md#theme-code-principles)
- [x] Linted with [Theme Check](https://github.com/Shopify/theme-check)
- [ ] Tested on [mobile](https://shopify.dev/themes/store/requirements#mobile-browser-requirements)
- [ ] Tested on [multiple browsers](https://shopify.dev/themes/store/requirements#desktop-browser-requirements)
- [ ] Tested for [accessibility](https://shopify.dev/themes/best-practices/accessibility)
