### PR TITLE
Prevent potential nested sliders from initializing together

### DIFF
--- a/assets/global.js
+++ b/assets/global.js
@@ -613,7 +613,7 @@ customElements.define('deferred-media', DeferredMedia);
 class SliderComponent extends HTMLElement {
   constructor() {
     super();
-    tthis.sliderId = this.querySelectorAll('[id^="Slider-"]')[0].id.split('-')[1];
+    this.sliderId = this.querySelectorAll('[id^="Slider-"]')[0].id.split('-')[1];
     this.slider = this.querySelector(`[id^="Slider-${this.sliderId}"]`);
     this.sliderItems = this.querySelectorAll(`[id^="Slide-${this.sliderId}"]`);
     this.enableSliderLooping = false;

--- a/assets/global.js
+++ b/assets/global.js
@@ -613,8 +613,9 @@ customElements.define('deferred-media', DeferredMedia);
 class SliderComponent extends HTMLElement {
   constructor() {
     super();
-    this.slider = this.querySelector('[id^="Slider-"]');
-    this.sliderItems = this.querySelectorAll('[id^="Slide-"]');
+    tthis.sliderId = this.querySelectorAll('[id^="Slider-"]')[0].id.split('-')[1];
+    this.slider = this.querySelector(`[id^="Slider-${this.sliderId}"]`);
+    this.sliderItems = this.querySelectorAll(`[id^="Slide-${this.sliderId}"]`);
     this.enableSliderLooping = false;
     this.currentPageElement = this.querySelector('.slider-counter--current');
     this.pageTotalElement = this.querySelector('.slider-counter--total');


### PR DESCRIPTION
### PR Summary: 

In the potential case a developer would like to nest a slider, this prevents the sliders from initializing together and breaking things.


### Why are these changes introduced?

I added a slider onto my product cards, when present with a featured collection slider things broke. More specifically the `initPages()` function was taking in slides it shouldn't be.

### What approach did you take?

The SliderComponent slider and sliderElements now have an id to match instead of matching all nested ids that begin with `Slider-`

### Other considerations

### Decision log

| # | Decision | Alternatives | Rationale | Downsides |
|---|---|---|---|---|
| 1 |   |   |   |   |


### Visual impact on existing themes

This will not impact existing themes, it only serves as a fail safe for a potential use case.

### Testing steps/scenarios

- [ ] Create a slideshow banner and ensure it works
- [ ] Create a nested slider component within a slide on a slider component and ensure it works

### Checklist
- [x] Added PR summary for [release notes](https://themes.shopify.com/themes/dawn/styles/default#ReleaseNotes)
- [ ] Requested review from UX (Only for changes that are affecting the experience or perceivable visual details)
- [ ] Created a ticket for the [help.shopify.com](https://help.shopify.com) documentation team about updates to theme settings. (Internal-only task)
- [x] Followed [theme code principles](https://github.com/Shopify/dawn/blob/main/.github/CONTRIBUTING.md#theme-code-principles)
- [x] Linted with [Theme Check](https://github.com/Shopify/theme-check)
- [x] Tested on [mobile](https://shopify.dev/themes/store/requirements#mobile-browser-requirements)
- [x] Tested on [multiple browsers](https://shopify.dev/themes/store/requirements#desktop-browser-requirements)
- [x] Tested for [accessibility](https://shopify.dev/themes/best-practices/accessibility)
