### PR TITLE
simplify variant picker disabled option detection logic

### DIFF
--- a/snippets/product-variant-options.liquid
+++ b/snippets/product-variant-options.liquid
@@ -15,11 +15,6 @@
   %}
 {% endcomment %}
 {%- liquid
-  assign variants_available_arr = product.variants | map: 'available'
-  assign variants_option1_arr = product.variants | map: 'option1'
-  assign variants_option2_arr = product.variants | map: 'option2'
-  assign variants_option3_arr = product.variants | map: 'option3'
-
   assign product_form_id = 'product-form-' | append: section.id
 -%}
 
@@ -27,18 +22,18 @@
   {%- liquid
     assign option_disabled = true
 
-    for option1_name in variants_option1_arr
+    for variant in product.variants
       case option.position
         when 1
-          if variants_option1_arr[forloop.index0] == value and variants_available_arr[forloop.index0]
+          if variant.option1 == value and variant.available
             assign option_disabled = false
           endif
         when 2
-          if option1_name == product.selected_or_first_available_variant.option1 and variants_option2_arr[forloop.index0] == value and variants_available_arr[forloop.index0]
+          if variant.option1 == product.selected_or_first_available_variant.option1 and variant.option2 == value and variant.available
             assign option_disabled = false
           endif
         when 3
-          if option1_name == product.selected_or_first_available_variant.option1 and variants_option2_arr[forloop.index0] == product.selected_or_first_available_variant.option2 and variants_option3_arr[forloop.index0] == value and variants_available_arr[forloop.index0]
+          if variant.option1 == product.selected_or_first_available_variant.option1 and variant.option2 == product.selected_or_first_available_variant.option2 and variant.option3 == value and variant.available
             assign option_disabled = false
           endif
       endcase


### PR DESCRIPTION
### PR Summary: 

Introducing a more simplified version to decide whether an option is available or not in a given product.

### Why are these changes introduced?

The original version is complicated, very verbose with a lot of unnecessary variables and 3 map operations that all make the logic behind deciding whether the option is disabled or not hard to figure out.
New version is straight to the point and clearer on the variables used, while also technically faster with less operations.

### What approach did you take?

Same approach as before, it's just simplified without the need to allocate new variables and distract the focus of the developers.

### Visual impact on existing themes

None, this is a purely backend improvement.

### Testing steps/scenarios
- [ ] Test on product with no options.
- [ ] Test on product with 1 option
- [ ] Test on product with 2 options
- [ ] Test on product with 3 options

### Checklist
- [ ] Added PR summary for [release notes](https://themes.shopify.com/themes/dawn/styles/default#ReleaseNotes)
- [ ] Followed [theme code principles](https://github.com/Shopify/dawn/blob/main/.github/CONTRIBUTING.md#theme-code-principles)
- [ ] Linted with [Theme Check](https://github.com/Shopify/theme-check)
- [ ] Tested on [mobile](https://shopify.dev/themes/store/requirements#mobile-browser-requirements)
- [ ] Tested on [multiple browsers](https://shopify.dev/themes/store/requirements#desktop-browser-requirements)
- [ ] Tested for [accessibility](https://shopify.dev/themes/best-practices/accessibility)
