### PR TITLE
Bring back lighthouse-ci-action on v1 for automatic updates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Lighthouse
-        uses: shopify/lighthouse-ci-action@v1.1.1
+        uses: shopify/lighthouse-ci-action@v1
         with:
           store: ${{ secrets.SHOP_STORE_OS2 }}
           password: ${{ secrets.SHOP_PASSWORD_OS2 }}


### PR DESCRIPTION
This will make sure new releases are automatically used.

Better for forks as well.

### PR Summary:

Remove the pinned version of lighthouse-ci-action.


### Why are these changes introduced?

- Pinned versions means that it doesn't get updates, `v1` is rereleased on updates and therefore fixed are automatically deployed to users.
- `lighthouse-ci-action` was broken recently because of a ruby 2 EOL problem. We fixed the problem in `v1.2.0`.

### Testing steps/scenarios

See CI

### Checklist

Not applicable
