### PR TITLE
Focus search on country selector open and fix iOS bug

### DIFF
--- a/assets/localization-form.js
+++ b/assets/localization-form.js
@@ -117,7 +117,7 @@ if (!customElements.get('localization-form')) {
         if (!document.body.classList.contains('overflow-hidden-tablet')) {
           document.body.classList.add('overflow-hidden-mobile');
         }
-        if (this.mql.matches) {
+        if (this.elements.search && this.mql.matches) {
           this.elements.search.focus();
         }
         document.querySelector('.menu-drawer').classList.add('country-selector-open');

--- a/assets/localization-form.js
+++ b/assets/localization-form.js
@@ -4,6 +4,7 @@ if (!customElements.get('localization-form')) {
     class LocalizationForm extends HTMLElement {
       constructor() {
         super();
+        this.mql = window.matchMedia('(min-width: 750px)');
         this.elements = {
           input: this.querySelector('input[name="locale_code"], input[name="country_code"]'),
           button: this.querySelector('button.localization-form__select'),
@@ -115,6 +116,9 @@ if (!customElements.get('localization-form')) {
         );
         if (!document.body.classList.contains('overflow-hidden-tablet')) {
           document.body.classList.add('overflow-hidden-mobile');
+        }
+        if (this.mql.matches) {
+          this.elements.search.focus();
         }
         document.querySelector('.menu-drawer').classList.add('country-selector-open');
       }

--- a/assets/section-image-banner.css
+++ b/assets/section-image-banner.css
@@ -2,6 +2,8 @@
   display: flex;
   position: relative;
   flex-direction: column;
+  z-index: auto;
+  isolation: isolate;
 }
 
 .banner__box {


### PR DESCRIPTION
### PR Summary: 

Follow up to https://github.com/Shopify/dawn/pull/3175

Sets focus to search field when country selector is open on desktop screens only and adds stacking context to banner

### Why are these changes introduced?

In order to match the behaviour of the predictive search of focusing the field when opened.

The stacking context is added because on Webkit/iOS browsers there's a bug (maybe feature? it looks similar to [this](https://bugs.webkit.org/show_bug.cgi?id=153852) which seems to be resolved) that when the keyboard is open overflow: hidden on document.body doesn't work. Since the banner in Dawn didn't belong to a stacking context, you would get this bug:

https://github.com/Shopify/dawn/assets/54807699/9c36fa79-0a38-4096-b96f-f917209a3dde

By adding a z-index this is the result:

https://github.com/Shopify/dawn/assets/54807699/68f2c810-39af-425a-a3f5-c18522d357c2

### Demo links

- [Store](https://hamidehs-store.myshopify.com/)
- [Editor](https://admin.shopify.com/store/hamidehs-store/themes/162662645782?key=assets%2Flocalization-form.js)