### PR TITLE
Prevent sticky header from hiding when localization selector is open

### DIFF
--- a/assets/component-localization-form.css
+++ b/assets/component-localization-form.css
@@ -257,6 +257,7 @@ noscript .localization-selector.link {
     height: 100%;
     background-color: rgba(var(--color-foreground), 0.5);
     z-index: 3;
+    animation: animateLocalization var(--duration-default) ease;
   }
 
   .disclosure__list-wrapper.country-selector {

--- a/assets/localization-form.js
+++ b/assets/localization-form.js
@@ -5,6 +5,7 @@ if (!customElements.get('localization-form')) {
       constructor() {
         super();
         this.mql = window.matchMedia('(min-width: 750px)');
+        this.header = document.querySelector('.header-wrapper');
         this.elements = {
           input: this.querySelector('input[name="locale_code"], input[name="country_code"]'),
           button: this.querySelector('button.localization-form__select'),
@@ -47,6 +48,7 @@ if (!customElements.get('localization-form')) {
         }
         document.body.classList.remove('overflow-hidden-mobile');
         document.querySelector('.menu-drawer').classList.remove('country-selector-open');
+        this.header.preventHide = false;
       }
 
       onContainerKeyDown(event) {
@@ -119,6 +121,9 @@ if (!customElements.get('localization-form')) {
         }
         if (this.elements.search && this.mql.matches) {
           this.elements.search.focus();
+        }
+        if (this.hasAttribute('data-prevent-hide')) {
+          this.header.preventHide = true;
         }
         document.querySelector('.menu-drawer').classList.add('country-selector-open');
       }

--- a/sections/header.liquid
+++ b/sections/header.liquid
@@ -255,7 +255,7 @@
             {%- endform -%}
           </noscript>
 
-          <localization-form class="small-hide medium-hide no-js-hidden">
+          <localization-form class="small-hide medium-hide no-js-hidden" data-prevent-hide>
             {%- form 'localization', id: 'HeaderCountryForm', class: 'localization-form' -%}
               <div>
                 <h2 class="visually-hidden" id="HeaderCountryLabel">{{ 'localization.country_label' | t }}</h2>
@@ -283,7 +283,7 @@
             {%- endform -%}
           </noscript>
 
-          <localization-form class="small-hide medium-hide no-js-hidden">
+          <localization-form class="small-hide medium-hide no-js-hidden" data-prevent-hide>
             {%- form 'localization', id: 'HeaderLanguageForm', class: 'localization-form' -%}
               <div>
                 <h2 class="visually-hidden" id="HeaderLanguageLabel">{{ 'localization.language_label' | t }}</h2>


### PR DESCRIPTION
### PR Summary: 

We've received feedback that the localization selectors (country and language selectors) do not behave the same way as other disclosures in the sticky header. Specifically, when scrolling, the selector cuts off and and the sticky header becomes hidden.

https://github.com/Shopify/dawn/assets/54807699/e650b9cc-e703-4bfb-b697-059a7398f255

### What approach did you take?

Since we only want to prevent the header from hiding when the selector in the header (not in the footer or announcement bar) is open, I added a data attribute `data-prevent-hide` to the `localization-form` that indicates it's in the header and thus prevent it from hiding.

### Demo links

- [Store](https://hamidehs-store.myshopify.com/)
- [Editor](https://admin.shopify.com/store/hamidehs-store/themes/162662645782?key=sections%2Fheader.liquid)

The header scroll behaviour when the country or language selector is open should be exactly the same when a menu item is open.
