### PR TITLE
Update inline quantity error styles for quick order list

### DIFF
--- a/assets/quick-order-list.css
+++ b/assets/quick-order-list.css
@@ -331,16 +331,18 @@ quick-order-list-remove-button:hover .icon-remove {
 }
 
 .variant-item__error-text {
-  font-size: 1.2rem;
-  line-height: calc(1 + 0.2 / var(--font-body-scale));
+  font-size: 1.3rem;
+  line-height: 1.4;
+  letter-spacing: 0.04rem;
   order: 1;
 }
 
 .variant-item__error-text+svg {
   flex-shrink: 0;
-  width: 1.2rem;
-  margin-right: 0.5rem;
-  margin-top: 0.1rem;
+  width: 1.5rem;
+  height: 1.5rem;
+  margin-right: 0.7rem;
+  margin-top: 0.25rem;
 }
 
 .variant-item__error-text:empty+svg {


### PR DESCRIPTION
### PR Summary: 

Updates the inline error text and icon to match its appearance in our cart instances. 

### Why are these changes introduced?

Followup to #3150. We missed changing this instance of inline error text the first time around. Thanks @melissaperreault for [noticing](https://github.com/Shopify/dawn/pull/3150#issuecomment-1894293754)! 

### Visual impact on existing themes

Before: 
<img width="1085" alt="Screenshot 2024-01-17 at 8 16 33 AM" src="https://github.com/Shopify/dawn/assets/1202812/f1d87594-ab46-4909-9748-414929c856ec">

After: 
<img width="1090" alt="Screenshot 2024-01-17 at 8 15 19 AM" src="https://github.com/Shopify/dawn/assets/1202812/6ff0299c-0eed-4684-8616-19baf141f207">

### Testing steps/scenarios
1. Visit a PDP template on [the demo store](https://os2-demo.myshopify.com/admin/themes/162762948630/editor).
2. Add a Quick Order List" Section.
3. Ensure the selected product preview has tracked inventory, and that "Continue selling when out of stock" is not checked.
4. Attempt to add more than the available inventory to your cart using the Quick Order List quantity picker.

### Demo links

- [Editor](https://os2-demo.myshopify.com/admin/themes/162762948630/editor)

### Checklist
- [x] Added PR summary for [release notes](https://themes.shopify.com/themes/dawn/styles/default#ReleaseNotes)
- [x] Requested review from UX (Only for changes that are affecting the experience or perceivable visual details)
- [ ] Created a ticket for the [help.shopify.com](https://help.shopify.com) documentation team about updates to theme settings. (Internal-only task)
- [x] Followed [theme code principles](https://github.com/Shopify/dawn/blob/main/.github/CONTRIBUTING.md#theme-code-principles)
- [x] Linted with [Theme Check](https://github.com/Shopify/theme-check)
- [x] Tested on [mobile](https://shopify.dev/themes/store/requirements#mobile-browser-requirements)
- [x] Tested on [multiple browsers](https://shopify.dev/themes/store/requirements#desktop-browser-requirements)
- [x] Tested for [accessibility](https://shopify.dev/themes/best-practices/accessibility)
