### PR TITLE
Fix translation path

### DIFF
--- a/sections/related-products.liquid
+++ b/sections/related-products.liquid
@@ -111,7 +111,7 @@
       "type": "color_scheme",
       "id": "color_scheme",
       "label": "t:sections.all.colors.label",
-      "info": "t:sections.image-banner.settings.color_scheme.info",
+      "info": "t:sections.all.colors.has_cards_info",
       "default": "scheme-1"
     },
     {


### PR DESCRIPTION
A translation path was changed when it shouldn't have. Reverting it back to the right thing. 