### PR TITLE
Change product variant swatches' border color

### DIFF
--- a/assets/component-swatch.css
+++ b/assets/component-swatch.css
@@ -9,7 +9,7 @@
   background: var(--swatch--background);
   background-size: cover;
   background-origin: border-box;
-  border: 0.1rem solid rgba(var(--color-foreground), 0.2);
+  border: 0.1rem solid rgba(var(--color-foreground), 0.45);
   border-radius: var(--swatch--border-radius);
 }
 


### PR DESCRIPTION
### PR Summary: 

<!-- Please include a short description (using non-technical terms, 1-2 sentences) about the changes you are introducing, what problem is being fixed and/or describe the benefit to merchants. This content will be used in our release notes for Dawn on [themes.shopify.com](https://themes.shopify.com/themes/dawn/styles/default#ReleaseNotes). -->
Change the border color reference to foreground to improve contrast and mobile width.


### Why are these changes introduced?

### Problem
- [Color contrast](https://screenshot.click/17-01-ou1f2-exv1v.png) issues on dark website

#### Solution 
Use common styling across similar components and avoid using hard coded colors:

_**Current implementation**_
- PDP Variant swatches`0.1rem solid rgba(var(--color-background-contrast),.5);`
      - Background contrast color = 128,128,128 = Grey

- [Filter color swatches](https://screenshot.click/17-34-263u8-wnav0.png) we have the border color set to `0.1rem solid rgba(var(--color-foreground),.2);`

_**Change suggestion**_
- `0.1rem solid rgba(var(--color-foreground),.45);`
Foreground reference ensures the foreground will at least contrast with the background merchants will set if swatch and store background colors are too close. 45% opacity is the opacity that met good contrast ratio with basic black and white associations. ([See reference](https://screenshot.click/17-33-2ij6i-v3lyo.png))

| Color | Before | After |
|--------|--------|--------|
| Dark on dark | ![](https://screenshot.click/17-02-6dn30-um6zb.png) | ![](https://screenshot.click/17-30-l6ypx-b4muh.png) |
| Light on light | ![](https://screenshot.click/17-53-amkfy-ly51n.png) | ![](https://screenshot.click/17-27-n9vbd-bpsqb.png) |
| Other colorful example | ![](https://screenshot.click/17-58-5zo25-xsc7i.png) | ![](https://screenshot.click/17-32-rupfu-vksmp.png) |


### Other considerations

To investigate styling for other states like disabled, focus, etc.

### Decision log

1. Make the opacity at 20%, but this resulted in poor contrast ratio ([less than 1.7](https://screenshot.click/17-33-2ij6i-v3lyo.png)) for generic colors like black or white.

| Color | Before | After | Contrast ratio |
|--------|--------|--------|--------|
| Dark on dark | ![](https://screenshot.click/17-02-6dn30-um6zb.png) | ![](https://screenshot.click/17-01-eelyy-es6fo.png) | Poor ratio | 
| Light on light | ![](https://screenshot.click/17-53-amkfy-ly51n.png) | ![](https://screenshot.click/17-53-3hkjh-280eu.png) | Poor ratio |
| Other colorful example | ![](https://screenshot.click/17-58-5zo25-xsc7i.png) | ![](https://screenshot.click/17-58-y6rpc-ygudv.png) | Poor ratio |

### Testing steps/scenarios
<!-- List all the testing tasks that applies to your fix to help peers review your work. -->
- [ ] Step 1



### Checklist
- [ ] Added PR summary for [release notes](https://themes.shopify.com/themes/dawn/styles/default#ReleaseNotes)
- [ ] Requested review from UX (Only for changes that are affecting the experience or perceivable visual details)
- [ ] Created a ticket for the [help.shopify.com](https://help.shopify.com) documentation team about updates to theme settings. (Internal-only task)
- [ ] Followed [theme code principles](https://github.com/Shopify/dawn/blob/main/.github/CONTRIBUTING.md#theme-code-principles)
- [ ] Linted with [Theme Check](https://github.com/Shopify/theme-check)
- [ ] Tested on [mobile](https://shopify.dev/themes/store/requirements#mobile-browser-requirements)
- [ ] Tested on [multiple browsers](https://shopify.dev/themes/store/requirements#desktop-browser-requirements)
- [ ] Tested for [accessibility](https://shopify.dev/themes/best-practices/accessibility)
