### PR TITLE
Update cart API usage

### DIFF
--- a/sections/main-cart-items.liquid
+++ b/sections/main-cart-items.liquid
@@ -79,7 +79,7 @@
 
               <tbody>
                 {%- for item in cart.items -%}
-                  <tr class="cart-item" id="CartItem-{{ item.index | plus: 1 }}">
+                  <tr class="cart-item" id="CartItem-{{ item.key | handle }}">
                     <td class="cart-item__media">
                       {% if item.image %}
                         {% comment %} Leave empty space due to a:empty CSS display: none rule {% endcomment %}
@@ -262,8 +262,9 @@
                                 step="{{ item.variant.quantity_rule.increment }}"
                                 {% # theme-check-enable %}
                                 aria-label="{{ 'products.product.quantity.input_label' | t: product: item.product.title | escape }}"
-                                id="Quantity-{{ item.index | plus: 1 }}"
-                                data-index="{{ item.index | plus: 1 }}"
+                                id="Quantity-{{ item.key | handle }}"
+                                data-handleized-key="{{ item.key | handle }}"
+                                data-key="{{ item.key }}"
                               >
                               <button class="quantity__button no-js-hidden" name="plus" type="button">
                                 <span class="visually-hidden">
@@ -274,8 +275,9 @@
                             </quantity-input>
                           </div>
                           <cart-remove-button
-                            id="Remove-{{ item.index | plus: 1 }}"
-                            data-index="{{ item.index | plus: 1 }}"
+                            id="Remove-{{ item.key | handle }}"
+                            data-handleized-key="{{ item.key | handle }}"
+                            data-key="{{ item.key }}"
                           >
                             <a
                               href="{{ item.url_to_remove }}"
@@ -369,7 +371,7 @@
                             {%- endif -%}
                           </div>
                         {%- endif -%}
-                        <div class="cart-item__error" id="Line-item-error-{{ item.index | plus: 1 }}" role="alert">
+                        <div class="cart-item__error" id="Line-item-error-{{ item.key | handle }}" role="alert">
                           <small class="cart-item__error-text"></small>
                           <svg
                             aria-hidden="true"

--- a/snippets/cart-drawer.liquid
+++ b/snippets/cart-drawer.liquid
@@ -114,7 +114,7 @@
 
                   <tbody role="rowgroup">
                     {%- for item in cart.items -%}
-                      <tr id="CartDrawer-Item-{{ item.index | plus: 1 }}" class="cart-item" role="row">
+                      <tr id="CartDrawer-Item-{{ item.key | handle }}" class="cart-item" role="row">
                         <td class="cart-item__media" role="cell" headers="CartDrawer-ColumnProductImage">
                           {% if item.image %}
                             {% comment %} Leave empty space due to a:empty CSS display: none rule {% endcomment %}
@@ -303,8 +303,9 @@
                                     step="{{ item.variant.quantity_rule.increment }}"
                                     {% # theme-check-enable %}
                                     aria-label="{{ 'products.product.quantity.input_label' | t: product: item.product.title | escape }}"
-                                    id="Drawer-quantity-{{ item.index | plus: 1 }}"
-                                    data-index="{{ item.index | plus: 1 }}"
+                                    id="Drawer-quantity-{{ item.key | handle }}"
+                                    data-handleized-key="{{ item.key | handle }}"
+                                    data-key="{{ item.key }}"
                                   >
                                   <button class="quantity__button no-js-hidden" name="plus" type="button">
                                     <span class="visually-hidden">
@@ -319,8 +320,9 @@
                                 </quantity-input>
                               </div>
                               <cart-remove-button
-                                id="CartDrawer-Remove-{{ item.index | plus: 1 }}"
-                                data-index="{{ item.index | plus: 1 }}"
+                                id="CartDrawer-Remove-{{ item.key | handle }}"
+                                data-handleized-key="{{ item.key | handle }}"
+                                data-key="{{ item.key }}"
                               >
                                 <button
                                   type="button"
@@ -414,7 +416,7 @@
                               </div>
                             {%- endif -%}
                             <div
-                              id="CartDrawer-LineItemError-{{ item.index | plus: 1 }}"
+                              id="CartDrawer-LineItemError-{{ item.key | handle }}"
                               class="cart-item__error"
                               role="alert"
                             >


### PR DESCRIPTION
### PR Summary: 

This PR addresses #3207 and changes the usage of line to key.

### Why are these changes introduced?

There are several reasons why I am doing those changes.

#### Changing of the endpoint

As I explained in #3207, the usage of `/cart/change` with JSON payload is undocumented. The only reference is the `/cart/change.js` endpoint (https://shopify.dev/docs/api/ajax). I remember having spotted some inconsistencies between the .js and non .js endpoint in the past, although this might have been changed. In all cases, using a behavior not documented anywhere is unpredictable, can lead to confusion, and makes our life harder when we want to compare it with Dawn behavior to confirm if an issue is coming from the platform or the theme.

If Shopify decides to reject this PR, then the documentation of the Ajax API should be updated first to indicate that .js and non .js endpoints are exactly equivalent (which is why I never used them on our themes).

#### Using key instead of line

Shopify is using the `url_to_remove` Liquid variable for the non-JS mode (https://github.com/Shopify/dawn/blob/main/sections/main-cart-items.liquid#L281). This Liquid feature generates a URL using the line item key (rather than the line position), so this PR unifies it to ensure that the key is used everywhere.

One main advantage of the line key over the line ID is that it no longer depends on the order of line items in the cart. One of the reasons we switched to `key` on our themes a long time ago is merchants install apps or write custom code that dynamically adds items to the cart without necessarily refreshing the drawer/cart page. Doing so shifts the indexes (as the newly added product in Ajax becomes first) and can cause the incorrect items to be updated/removed. Using the `key` instead ensures that the code is entirely independent of the order and makes the theme more robust when interacting with the cart.

The other reason (the main one, actually) is that in the last few months, the Ajax API in Shopify has been **extremely unreliable**. A high number of regressions and bugs for super basic features has been introduced, such as the impossibility of removing a bundle product from the cart, the impossibility of removing a product that has been split with automatic discounts, and yesterday I found another issue where Shopify generates _different line item keys_ when the user changes pages, even though the cart content has not changed. Those issues were mainly only reproducible using the `key` (but not for the simpler line position that Dawn is using currently).

As all our themes at Maestrooo use the line item `key` to interact with the cart API (which is, by the way, a documented feature in the Ajax API that we should be able to rely on), we end up in a complex situation where it seems that Shopify simply does not properly test the Cart Ajax API when new features are released, simply because Dawn is not using it.
Unfortunately, when a merchant reaches Shopify support to report such problems, the debugging process of Shopify support is as basic as "it works on Dawn, so the theme is faulty; reach your theme developer"... And then we have to struggle sometimes for weeks to try to escalate the issue and have Shopify recognizing the issue is indeed on their end.

Considering how critical the cart Ajax API is, I am hoping that updating Dawn to also use the key approach (which is by itself superior and more flexible than the line position) will force Shopify to better test, identify, and fix the cart Ajax API sooner, and stop hiding themselves behind the very frustrating support position that "it works on Dawn, so it's not our responsibility." Ultimately, the merchants always suffer the most from those situations.

### Checklist
- [ ] Added PR summary for [release notes](https://themes.shopify.com/themes/dawn/styles/default#ReleaseNotes)
- [ ] Requested review from UX (Only for changes that are affecting the experience or perceivable visual details)
- [ ] Created a ticket for the [help.shopify.com](https://help.shopify.com) documentation team about updates to theme settings. (Internal-only task)
- [x] Followed [theme code principles](https://github.com/Shopify/dawn/blob/main/.github/CONTRIBUTING.md#theme-code-principles)
- [x] Linted with [Theme Check](https://github.com/Shopify/theme-check)
- [x] Tested on [mobile](https://shopify.dev/themes/store/requirements#mobile-browser-requirements)
- [x] Tested on [multiple browsers](https://shopify.dev/themes/store/requirements#desktop-browser-requirements)
- [x] Tested for [accessibility](https://shopify.dev/themes/best-practices/accessibility)
