### PR TITLE
add override for mobile devices to show smaller swatches

### DIFF
--- a/assets/component-swatch-input.css
+++ b/assets/component-swatch-input.css
@@ -10,6 +10,12 @@
   forced-color-adjust: none;
 }
 
+@media screen and (max-width: 750px) {
+  .swatch-input__input + .swatch-input__label {
+  --swatch-input--size: 3.6rem;
+}
+}
+
 .swatch-input__input + .swatch-input__label.swatch-input__label--square {
   --swatch-input--border-radius: 0.2rem;
 }

--- a/assets/component-swatch-input.css
+++ b/assets/component-swatch-input.css
@@ -1,4 +1,5 @@
 /* swatch-input lives in its own file for reusability of the swatch in other areas than the product form context */
+
 .swatch-input__input + .swatch-input__label {
   --swatch-input--size: 4.4rem;
   --swatch-input--border-radius: 50%;
@@ -6,14 +7,19 @@
   display: inline-block;
   border-radius: var(--swatch-input--border-radius);
   cursor: pointer;
-  outline-offset: 0.2rem;
+  outline-offset: -0.2rem;
   forced-color-adjust: none;
 }
 
-@media screen and (max-width: 750px) {
   .swatch-input__input + .swatch-input__label {
   --swatch-input--size: 3.6rem;
-}
+  font-size: var(--swatch-input--size);
+  width: 44px;
+  height: 44px;
+  display: flex;
+  justify-content: center;
+  align-items: center
+
 }
 
 .swatch-input__input + .swatch-input__label.swatch-input__label--square {


### PR DESCRIPTION
### PR Summary: 
Really small PR to make the swatches a bit smaller on mobile. This will optimize the way they look/feel when selecting variants. 


### Why are these changes introduced?
We got feedback that the swatches were too large on mobile at 4.4rem - so we reduced them to 3.6rem

### What approach did you take?
A media class in CSS

### Visual impact on existing themes
Before:
![Screenshot 2024-01-24 at 1 30 53 PM](https://github.com/Shopify/dawn/assets/97565111/0ffc4e52-767c-4118-bc02-a3605f58c694)

After: 
![Screenshot 2024-01-24 at 1 31 05 PM](https://github.com/Shopify/dawn/assets/97565111/6b61988c-e8cf-48ce-a83d-86b235e13525)

### Testing steps/scenarios
<!-- List all the testing tasks that applies to your fix to help peers review your work. -->
- [ ] Step 1 check out these changes on my [test shop pdp](https://content-apparel-example.myshopify.com/products/short-sleeve-t-shirt)

### Demo links
<!-- Please include a link to a demo store that includes preconfigured sections and settings to allow reviewers to easily test the features you are working on. -->

- [Store](https://content-apparel-example.myshopify.com/products/short-sleeve-t-shirt)


### Checklist
- [x] Added PR summary for [release notes](https://themes.shopify.com/themes/dawn/styles/default#ReleaseNotes)
- [x] Requested review from UX (Only for changes that are affecting the experience or perceivable visual details)
- [x] Created a ticket for the [help.shopify.com](https://help.shopify.com) documentation team about updates to theme settings. (Internal-only task)
- [x] Followed [theme code principles](https://github.com/Shopify/dawn/blob/main/.github/CONTRIBUTING.md#theme-code-principles)
- [x] Linted with [Theme Check](https://github.com/Shopify/theme-check)
- [x] Tested on [mobile](https://shopify.dev/themes/store/requirements#mobile-browser-requirements)
- [x] Tested on [multiple browsers](https://shopify.dev/themes/store/requirements#desktop-browser-requirements)
- [x] Tested for [accessibility](https://shopify.dev/themes/best-practices/accessibility)
