### PR TITLE
Simplify `product-media-gallery` snippet and consumers

### DIFF
--- a/assets/global.js
+++ b/assets/global.js
@@ -972,7 +972,6 @@ class VariantSelects extends HTMLElement {
       this.toggleAddButton(true, '', true);
       this.setUnavailable();
     } else {
-      this.updateMedia();
       this.updateURL();
       this.updateVariantInput();
       this.renderProductInfo();
@@ -1024,21 +1023,6 @@ class VariantSelects extends HTMLElement {
       const selectedSwatchValue = this.querySelector(`[data-selected-swatch-value="${name}"]`);
       if (selectedSwatchValue) selectedSwatchValue.innerHTML = value;
     }
-  }
-
-  updateMedia() {
-    if (!this.currentVariant) return;
-    if (!this.currentVariant.featured_media) return;
-
-    const mediaGalleries = document.querySelectorAll(`[id^="MediaGallery-${this.dataset.section}"]`);
-    mediaGalleries.forEach((mediaGallery) =>
-      mediaGallery.setActiveMedia(`${this.dataset.section}-${this.currentVariant.featured_media.id}`, true)
-    );
-
-    const modalContent = document.querySelector(`#ProductModal-${this.dataset.section} .product-media-modal__content`);
-    if (!modalContent) return;
-    const newMediaModal = modalContent.querySelector(`[data-media-id="${this.currentVariant.featured_media.id}"]`);
-    modalContent.prepend(newMediaModal);
   }
 
   updateURL() {
@@ -1144,6 +1128,20 @@ class VariantSelects extends HTMLElement {
         const volumePricingSource = html.getElementById(
           `Volume-${this.dataset.originalSection ? this.dataset.originalSection : this.dataset.section}`
         );
+
+        // update media gallery
+        const mediaGallerySource = document.querySelector(`[id^="MediaGallery-${this.dataset.section}"]`);
+        const mediaGalleryDestination = html.querySelector(`[id^="MediaGallery-${this.dataset.section}"]`);
+        if (mediaGallerySource && mediaGalleryDestination) {
+          mediaGallerySource.innerHTML = mediaGalleryDestination.innerHTML;
+        }
+
+        // update media modal
+        const modalContent = document.querySelector(`#ProductModal-${this.dataset.section} .product-media-modal__content`);
+        if (modalContent) {
+          const newMediaModal = modalContent.querySelector(`[data-media-id="${this.currentVariant.featured_media.id}"]`);
+          modalContent.prepend(newMediaModal);
+        }
 
         const pricePerItemDestination = document.getElementById(`Price-Per-Item-${this.dataset.section}`);
         const pricePerItemSource = html.getElementById(`Price-Per-Item-${this.dataset.originalSection ? this.dataset.originalSection : this.dataset.section}`);

--- a/assets/global.js
+++ b/assets/global.js
@@ -1098,6 +1098,65 @@ class VariantSelects extends HTMLElement {
     if (productForm) productForm.handleErrorMessage();
   }
 
+
+  updateMedia(html) {
+    const mediaGallerySource = document.querySelector(`[id^="MediaGallery-${this.dataset.section}"] ul`);
+    const mediaGalleryDestination = html.querySelector(`[id^="MediaGallery-${this.dataset.section}"] ul`);
+
+    const refreshSourceData = () => {
+      const mediaGallerySourceItems = Array.from(mediaGallerySource.querySelectorAll('li[data-media-id]'));
+      const sourceSet = new Set(mediaGallerySourceItems.map(item => item.dataset.mediaId));
+      const sourceMap = new Map(mediaGallerySourceItems.map((item, index) => [item.dataset.mediaId, {item, index}]));
+      return [mediaGallerySourceItems, sourceSet, sourceMap];
+    };
+
+    if (mediaGallerySource && mediaGalleryDestination) {
+      let [mediaGallerySourceItems, sourceSet, sourceMap] = refreshSourceData();
+      const mediaGalleryDestinationItems = Array.from(mediaGalleryDestination.querySelectorAll('li[data-media-id]'));
+      const destinationSet = new Set(mediaGalleryDestinationItems.map(({dataset}) => dataset.mediaId));
+      let shouldRefresh = false;
+
+      // add items from new data not present in DOM
+      for (let i = mediaGalleryDestinationItems.length - 1; i >= 0; i--) {
+        if (!sourceSet.has(mediaGalleryDestinationItems[i].dataset.mediaId)) {
+          mediaGallerySource.prepend(mediaGalleryDestinationItems[i]);
+          shouldRefresh = true;
+        }
+      }
+
+      // remove items from DOM not present in new data
+      for (let i = 0; i < mediaGallerySourceItems.length; i++) {
+        if (!destinationSet.has(mediaGallerySourceItems[i].dataset.mediaId)) {
+          mediaGallerySourceItems[i].remove();
+          shouldRefresh = true;
+        }
+      }
+
+      // refresh
+      if (shouldRefresh) [mediaGallerySourceItems, sourceSet, sourceMap] = refreshSourceData();
+
+      // if media galleries don't match, sort to match new data order
+      mediaGalleryDestinationItems.forEach((destinationItem, destinationIndex) => {
+        const sourceData = sourceMap.get(destinationItem.dataset.mediaId);
+
+        if (sourceData && sourceData.index !== destinationIndex) {
+          mediaGallerySource.insertBefore(sourceData.item, mediaGallerySource.querySelector(`li:nth-of-type(${destinationIndex + 1})`));
+
+          // refresh source now that it has been modified
+          [mediaGallerySourceItems, sourceSet, sourceMap] = refreshSourceData();
+        }
+      });
+    }
+
+    document.querySelector(`[id^="MediaGallery-${this.dataset.section}"]`).setActiveMedia(`${this.dataset.section}-${this.currentVariant.featured_media.id}`, false);
+
+    // update media modal
+    const modalContent = document.querySelector(`#ProductModal-${this.dataset.section} .product-media-modal__content`);
+    if (modalContent && this.currentVariant.featured_media) {
+      modalContent.prepend(modalContent.querySelector(`[data-media-id="${this.currentVariant.featured_media.id}"]`));
+    }
+  }
+
   renderProductInfo() {
     const requestedVariantId = this.currentVariant.id;
     const sectionId = this.dataset.originalSection ? this.dataset.originalSection : this.dataset.section;
@@ -1129,19 +1188,7 @@ class VariantSelects extends HTMLElement {
           `Volume-${this.dataset.originalSection ? this.dataset.originalSection : this.dataset.section}`
         );
 
-        // update media gallery
-        const mediaGallerySource = document.querySelector(`[id^="MediaGallery-${this.dataset.section}"]`);
-        const mediaGalleryDestination = html.querySelector(`[id^="MediaGallery-${this.dataset.section}"]`);
-        if (mediaGallerySource && mediaGalleryDestination) {
-          mediaGallerySource.innerHTML = mediaGalleryDestination.innerHTML;
-        }
-
-        // update media modal
-        const modalContent = document.querySelector(`#ProductModal-${this.dataset.section} .product-media-modal__content`);
-        if (modalContent) {
-          const newMediaModal = modalContent.querySelector(`[data-media-id="${this.currentVariant.featured_media.id}"]`);
-          modalContent.prepend(newMediaModal);
-        }
+        this.updateMedia(html);
 
         const pricePerItemDestination = document.getElementById(`Price-Per-Item-${this.dataset.section}`);
         const pricePerItemSource = html.getElementById(`Price-Per-Item-${this.dataset.originalSection ? this.dataset.originalSection : this.dataset.section}`);

--- a/assets/global.js
+++ b/assets/global.js
@@ -1148,13 +1148,12 @@ class VariantSelects extends HTMLElement {
       });
     }
 
-    document.querySelector(`[id^="MediaGallery-${this.dataset.section}"]`).setActiveMedia(`${this.dataset.section}-${this.currentVariant.featured_media.id}`, false);
+    document.querySelector(`[id^="MediaGallery-${this.dataset.section}"]`).setActiveMedia(`${this.dataset.section}-${this.currentVariant.featured_media?.id}`);
 
     // update media modal
     const modalContent = document.querySelector(`#ProductModal-${this.dataset.section} .product-media-modal__content`);
-    if (modalContent && this.currentVariant.featured_media) {
-      modalContent.prepend(modalContent.querySelector(`[data-media-id="${this.currentVariant.featured_media.id}"]`));
-    }
+    const newModalContent = html.querySelector(`product-modal`);
+    if (modalContent && newModalContent) modalContent.innerHTML = newModalContent.innerHTML;
   }
 
   renderProductInfo() {

--- a/assets/media-gallery.js
+++ b/assets/media-gallery.js
@@ -35,15 +35,6 @@ if (!customElements.get('media-gallery')) {
         });
         activeMedia.classList.add('is-active');
 
-        // if (prepend) {
-        //   activeMedia.parentElement.prepend(activeMedia);
-        //   if (this.elements.thumbnails) {
-        //     const activeThumbnail = this.elements.thumbnails.querySelector(`[data-target="${mediaId}"]`);
-        //     activeThumbnail.parentElement.prepend(activeThumbnail);
-        //   }
-        //   if (this.elements.viewer.slider) this.elements.viewer.resetPages();
-        // }
-
         this.preventStickyHeader();
         window.setTimeout(() => {
           if (!this.mql.matches || this.elements.thumbnails) {

--- a/assets/media-gallery.js
+++ b/assets/media-gallery.js
@@ -16,7 +16,7 @@ if (!customElements.get('media-gallery')) {
         this.elements.thumbnails.querySelectorAll('[data-target]').forEach((mediaToSwitch) => {
           mediaToSwitch
             .querySelector('button')
-            .addEventListener('click', this.setActiveMedia.bind(this, mediaToSwitch.dataset.target, false));
+            .addEventListener('click', this.setActiveMedia.bind(this, mediaToSwitch.dataset.target));
         });
         if (this.dataset.desktopLayout.includes('thumbnail') && this.mql.matches) this.removeListSemantic();
       }
@@ -28,21 +28,21 @@ if (!customElements.get('media-gallery')) {
         this.setActiveThumbnail(thumbnail);
       }
 
-      setActiveMedia(mediaId, prepend) {
-        const activeMedia = this.elements.viewer.querySelector(`[data-media-id="${mediaId}"]`);
+      setActiveMedia(mediaId) {
+        const activeMedia = this.elements.viewer.querySelector(`[data-media-id="${mediaId}"],[data-media-id]`);
         this.elements.viewer.querySelectorAll('[data-media-id]').forEach((element) => {
           element.classList.remove('is-active');
         });
         activeMedia.classList.add('is-active');
 
-        if (prepend) {
-          activeMedia.parentElement.prepend(activeMedia);
-          if (this.elements.thumbnails) {
-            const activeThumbnail = this.elements.thumbnails.querySelector(`[data-target="${mediaId}"]`);
-            activeThumbnail.parentElement.prepend(activeThumbnail);
-          }
-          if (this.elements.viewer.slider) this.elements.viewer.resetPages();
-        }
+        // if (prepend) {
+        //   activeMedia.parentElement.prepend(activeMedia);
+        //   if (this.elements.thumbnails) {
+        //     const activeThumbnail = this.elements.thumbnails.querySelector(`[data-target="${mediaId}"]`);
+        //     activeThumbnail.parentElement.prepend(activeThumbnail);
+        //   }
+        //   if (this.elements.viewer.slider) this.elements.viewer.resetPages();
+        // }
 
         this.preventStickyHeader();
         window.setTimeout(() => {

--- a/assets/media-gallery.js
+++ b/assets/media-gallery.js
@@ -29,11 +29,16 @@ if (!customElements.get('media-gallery')) {
       }
 
       setActiveMedia(mediaId) {
-        const activeMedia = this.elements.viewer.querySelector(`[data-media-id="${mediaId}"],[data-media-id]`);
+        const activeMedia =
+          this.elements.viewer.querySelector(`[data-media-id="${mediaId}"]`) ||
+          this.elements.viewer.querySelector('[data-media-id]');
+        if (!activeMedia) {
+          return;
+        }
         this.elements.viewer.querySelectorAll('[data-media-id]').forEach((element) => {
           element.classList.remove('is-active');
         });
-        activeMedia.classList.add('is-active');
+        activeMedia?.classList?.add('is-active');
 
         this.preventStickyHeader();
         window.setTimeout(() => {

--- a/assets/section-featured-product.css
+++ b/assets/section-featured-product.css
@@ -11,11 +11,6 @@
 
 .featured-product .product__media-item {
   padding-left: 0;
-  width: 100%;
-}
-
-.featured-product .product__media-item:not(:first-child) {
-  display: none;
 }
 
 .featured-product .placeholder-svg {
@@ -52,6 +47,10 @@
 
   .background-secondary .featured-product {
     padding: 5rem;
+  }
+
+  .product--right .product__media-wrapper {
+    order: 2;
   }
 }
 

--- a/assets/section-main-product.css
+++ b/assets/section-main-product.css
@@ -50,6 +50,10 @@
   .product__media-container .slider-buttons {
     display: none;
   }
+
+  .product--right .product__media-wrapper {
+    order: 2;
+  }
 }
 
 @media screen and (min-width: 990px) {

--- a/assets/section-main-product.css
+++ b/assets/section-main-product.css
@@ -435,14 +435,6 @@ a.product__text {
   }
 }
 
-.product__media-item.product__media-item--variant {
-  display: none;
-}
-
-.product__media-item--variant:first-child {
-  display: block;
-}
-
 @media screen and (min-width: 750px) and (max-width: 989px) {
   .product__media-list .product__media-item:first-child {
     padding-left: 0;

--- a/sections/featured-product.liquid
+++ b/sections/featured-product.liquid
@@ -31,14 +31,6 @@
 
 {%- liquid
   assign product = section.settings.product
-
-  if section.settings.media_size == 'large'
-    assign media_width = 0.65
-  elsif section.settings.media_size == 'medium'
-    assign media_width = 0.55
-  elsif section.settings.media_size == 'small'
-    assign media_width = 0.45
-  endif
 -%}
 
 {% comment %} TODO: assign `product.selected_or_first_available_variant` to variable and replace usage to reduce verbosity {% endcomment %}

--- a/sections/featured-product.liquid
+++ b/sections/featured-product.liquid
@@ -62,86 +62,24 @@
   >
 {%- endif -%}
 
+{% assign variant_images = product.images | where: 'attached_to_variant?', true | map: 'src' %}
+
 <section class="color-{{ section.settings.color_scheme }} {% if section.settings.secondary_background %}background-secondary{% else %}gradient{% endif %}">
   <div class="page-width section-{{ section.id }}-padding{% if section.settings.secondary_background %} isolate{% endif %}">
     <div class="featured-product product product--{{ section.settings.media_size }} grid grid--1-col gradient color-{{ section.settings.color_scheme }} product--{{ section.settings.media_position }}{% if section.settings.secondary_background == false %} isolate{% endif %} {% if product.media.size > 0 or section.settings.product == blank %}grid--2-col-tablet{% else %}product--no-media{% endif %}">
-      <div class="grid__item product__media-wrapper{% if section.settings.media_position == 'right' %} medium-hide large-up-hide{% endif %}">
-        <media-gallery
-          id="MediaGallery-{{ section.id }}"
-          role="region"
-          aria-label="{{ 'products.product.media.gallery_viewer' | t }}"
-          data-desktop-layout="stacked"
-        >
-          <div
-            id="GalleryViewer-{{ section.id }}"
-            class="product__media-list{% if settings.animations_reveal_on_scroll %} scroll-trigger animate--fade-in{% endif %}"
-          >
-            {%- if section.settings.product != blank -%}
-              {%- if product.selected_or_first_available_variant.featured_media != null -%}
-                {%- assign media = product.selected_or_first_available_variant.featured_media -%}
-                <div class="product__media-item" data-media-id="{{ section.id }}-{{ media.id }}">
-                  {% render 'product-thumbnail',
-                    media: media,
-                    position: 'featured',
-                    loop: section.settings.enable_video_looping,
-                    modal_id: section.id,
-                    xr_button: false,
-                    media_width: media_width,
-                    media_fit: section.settings.media_fit,
-                    constrain_to_viewport: section.settings.constrain_to_viewport
-                  %}
-                </div>
-              {%- endif -%}
-              {%- liquid
-                assign media_to_render = product.featured_media.id
-                for variant in product.variants
-                  assign media_to_render = media_to_render | append: variant.featured_media.id | append: ' '
-                endfor
-              -%}
-              {%- for media in product.media -%}
-                {%- if media_to_render contains media.id
-                  and media.id != product.selected_or_first_available_variant.featured_media.id
-                -%}
-                  <div class="product__media-item" data-media-id="{{ section.id }}-{{ media.id }}">
-                    {% render 'product-thumbnail',
-                      media: media,
-                      position: forloop.index,
-                      loop: section.settings.enable_video_looping,
-                      modal_id: section.id,
-                      xr_button: false,
-                      media_width: media_width,
-                      media_fit: section.settings.media_fit,
-                      constrain_to_viewport: section.settings.constrain_to_viewport
-                    %}
-                  </div>
-                {%- endif -%}
-              {%- endfor -%}
-            {%- else -%}
-              <div class="product__media-item">
-                <div
-                  class="product-media-container global-media-settings gradient{% if section.settings.constrain_to_viewport %} constrain-height{% endif %}"
-                  style="--ratio: 1.0; --preview-ratio: 1.0;"
-                >
-                  {{ 'product-apparel-1' | placeholder_svg_tag: 'placeholder-svg' }}
-                </div>
-              </div>
-            {%- endif -%}
-          </div>
-          {%- if first_3d_model -%}
-            <button
-              class="button button--full-width product__xr-button"
-              type="button"
-              aria-label="{{ 'products.product.xr_button_label' | t }}"
-              data-shopify-xr
-              data-shopify-model3d-id="{{ first_3d_model.id }}"
-              data-shopify-title="{{ product.title | escape }}"
-              data-shopify-xr-hidden
+      <div class="grid__item product__media-wrapper">
+        {%- if section.settings.product != blank -%}
+          {% render 'product-media-gallery', product: product, variant_images: variant_images, limit: 1 %}
+        {%- else -%}
+          <div class="product__media-item">
+            <div
+              class="product-media-container global-media-settings gradient{% if section.settings.constrain_to_viewport %} constrain-height{% endif %}"
+              style="--ratio: 1.0; --preview-ratio: 1.0;"
             >
-              {% render 'icon-3d-model' %}
-              {{ 'products.product.xr_button' | t }}
-            </button>
-          {%- endif -%}
-        </media-gallery>
+              {{ 'product-apparel-1' | placeholder_svg_tag: 'placeholder-svg' }}
+            </div>
+          </div>
+        {%- endif -%}
       </div>
       <div class="product__info-wrapper grid__item{% if settings.animations_reveal_on_scroll %} scroll-trigger animate--slide-in{% endif %}">
         <product-info
@@ -499,82 +437,8 @@
           </a>
         </product-info>
       </div>
-      {%- if section.settings.media_position == 'right' -%}
-        <div class="grid__item product__media-wrapper small-hide">
-          {%- if section.settings.product != blank -%}
-            <media-gallery
-              id="MediaGallery-{{ section.id }}-right"
-              role="region"
-              aria-label="{{ 'products.product.media.gallery_viewer' | t }}"
-              data-desktop-layout="stacked"
-            >
-              <div
-                id="GalleryViewer-{{ section.id }}-right"
-                class="product__media-list{% if settings.animations_reveal_on_scroll %} scroll-trigger animate--fade-in{% endif %}"
-              >
-                {%- if product.selected_or_first_available_variant.featured_media != null -%}
-                  {%- assign media = product.selected_or_first_available_variant.featured_media -%}
-                  <div class="product__media-item" data-media-id="{{ section.id }}-{{ media.id }}">
-                    {% render 'product-thumbnail',
-                      media: media,
-                      position: 'featured',
-                      loop: section.settings.enable_video_looping,
-                      modal_id: section.id,
-                      xr_button: false,
-                      media_width: media_width,
-                      media_fit: section.settings.media_fit,
-                      constrain_to_viewport: section.settings.constrain_to_viewport
-                    %}
-                  </div>
-                {%- endif -%}
-                {%- for media in product.media -%}
-                  {%- if media_to_render contains media.id
-                    and media.id != product.selected_or_first_available_variant.featured_media.id
-                  -%}
-                    <div class="product__media-item" data-media-id="{{ section.id }}-{{ media.id }}">
-                      {% render 'product-thumbnail',
-                        media: media,
-                        position: forloop.index,
-                        loop: section.settings.enable_video_looping,
-                        modal_id: section.id,
-                        xr_button: false,
-                        media_width: media_width,
-                        media_fit: section.settings.media_fit,
-                        constrain_to_viewport: section.settings.constrain_to_viewport
-                      %}
-                    </div>
-                  {%- endif -%}
-                {%- endfor -%}
-              </div>
-              {%- if first_3d_model -%}
-                <button
-                  class="button button--full-width product__xr-button"
-                  type="button"
-                  aria-label="{{ 'products.product.xr_button_label' | t }}"
-                  data-shopify-xr
-                  data-shopify-model3d-id="{{ first_3d_model.id }}"
-                  data-shopify-title="{{ product.title | escape }}"
-                  data-shopify-xr-hidden
-                >
-                  {% render 'icon-3d-model' %}
-                  {{ 'products.product.xr_button' | t }}
-                </button>
-              {%- endif -%}
-            </media-gallery>
-          {%- else -%}
-            <div class="product__media-item">
-              <div
-                class="product-media-container global-media-settings gradient{% if section.settings.constrain_to_viewport %} constrain-height{% endif %}"
-                style="--ratio: 1.0; --preview-ratio: 1.0;"
-              >
-                {{ 'product-apparel-1' | placeholder_svg_tag: 'placeholder-svg' }}
-              </div>
-            </div>
-          {%- endif -%}
-        </div>
-      {%- endif -%}
     </div>
-    {% render 'product-media-modal', product: product, variant_images: media_to_render %}
+    {% render 'product-media-modal', product: product, variant_images: variant_images %}
   </div>
 </section>
 

--- a/sections/main-product.liquid
+++ b/sections/main-product.liquid
@@ -68,7 +68,7 @@
   {% assign variant_images = product.images | where: 'attached_to_variant?', true | map: 'src' %}
   <div class="page-width">
     <div class="product product--{{ section.settings.media_size }} product--{{ section.settings.media_position }} product--{{ section.settings.gallery_layout }} product--mobile-{{ section.settings.mobile_thumbnails }} grid grid--1-col {% if product.media.size > 0 %}grid--2-col-tablet{% else %}product--no-media{% endif %}">
-      <div class="grid__item product__media-wrapper{% if section.settings.media_position == 'right' %} medium-hide large-up-hide{% endif %}">
+      <div class="grid__item product__media-wrapper">
         {% render 'product-media-gallery', variant_images: variant_images %}
       </div>
       <div class="product__info-wrapper grid__item{% if settings.page_width > 1400 and section.settings.media_size == "small" %} product__info-wrapper--extra-padding{% endif %}{% if settings.animations_reveal_on_scroll %} scroll-trigger animate--slide-in{% endif %}">
@@ -643,12 +643,6 @@
           </a>
         </product-info>
       </div>
-      {%- if section.settings.media_position == 'right' -%}
-        {% comment %} Duplicate gallery to display after product content on tablet/desktop breakpoint {% endcomment %}
-        <div class="grid__item product__media-wrapper small-hide">
-          {% render 'product-media-gallery', variant_images: variant_images, is_duplicate: true %}
-        </div>
-      {%- endif -%}
     </div>
 
     {% render 'product-media-modal', variant_images: variant_images %}

--- a/snippets/product-media-gallery.liquid
+++ b/snippets/product-media-gallery.liquid
@@ -5,14 +5,18 @@
   Accepts:
   - product: {Object} Product liquid object
   - variant_images: {Array} Product images associated with a variant
-  - is_duplicate: {Boolean} Prevents rendering uneeded elements and duplicate ids for subsequent instances
+  - limit: {Number} (optional) When passed, limits the number of media items to render
 
   Usage:
-  {% render 'product-media-gallery', is_duplicate: true %}
+  {% render 'product-media-gallery' %}
 {% endcomment %}
 
 {%- liquid
   if section.settings.hide_variants and variant_images.size == product.media.size
+    assign single_media_visible = true
+  endif
+
+  if limit == 1
     assign single_media_visible = true
   endif
 
@@ -36,15 +40,10 @@
   elsif section.settings.media_size == 'small'
     assign media_width = 0.45
   endif
-
-  assign id_append = ''
-  if is_duplicate
-    assign id_append = '-duplicate'
-  endif
 -%}
 
 <media-gallery
-  id="MediaGallery-{{ section.id }}{{ id_append }}"
+  id="MediaGallery-{{ section.id }}"
   role="region"
   {% if section.settings.enable_sticky_info %}
     class="product__column-sticky"
@@ -53,22 +52,20 @@
   data-desktop-layout="{{ section.settings.gallery_layout }}"
 >
   <div id="GalleryStatus-{{ section.id }}" class="visually-hidden" role="status"></div>
-  <slider-component id="GalleryViewer-{{ section.id }}{{ id_append }}" class="slider-mobile-gutter">
-    {%- unless is_duplicate -%}
-      <a class="skip-to-content-link button visually-hidden quick-add-hidden" href="#ProductInfo-{{ section.id }}">
-        {{ 'accessibility.skip_to_product_info' | t }}
-      </a>
-    {%- endunless -%}
+  <slider-component id="GalleryViewer-{{ section.id }}" class="slider-mobile-gutter">
+    <a class="skip-to-content-link button visually-hidden quick-add-hidden" href="#ProductInfo-{{ section.id }}">
+      {{ 'accessibility.skip_to_product_info' | t }}
+    </a>
     <ul
-      id="Slider-Gallery-{{ section.id }}{{ id_append }}"
+      id="Slider-Gallery-{{ section.id }}"
       class="product__media-list contains-media grid grid--peek list-unstyled slider slider--mobile"
       role="list"
     >
-      {%- if product.selected_or_first_available_variant.featured_media != null -%}
+      {%- if product.selected_or_first_available_variant.featured_media != nil -%}
         {%- assign featured_media = product.selected_or_first_available_variant.featured_media -%}
         <li
-          id="Slide-{{ section.id }}-{{ featured_media.id }}{{ id_append }}"
-          class="product__media-item grid__item slider__slide is-active{% if single_media_visible %} product__media-item--single{% endif %}{% if featured_media.media_type != 'image' %} product__media-item--full{% endif %}{% if section.settings.hide_variants and variant_images contains featured_media.src %} product__media-item--variant{% endif %}{% if settings.animations_reveal_on_scroll %} scroll-trigger animate--fade-in{% endif %}"
+          id="Slide-{{ section.id }}-{{ featured_media.id }}"
+          class="product__media-item grid__item slider__slide is-active{% if single_media_visible %} product__media-item--single{% endif %}{% if featured_media.media_type != 'image' %} product__media-item--full{% endif %}{% if settings.animations_reveal_on_scroll %} scroll-trigger animate--fade-in{% endif %}"
           data-media-id="{{ section.id }}-{{ featured_media.id }}"
         >
           {%- assign media_position = 1 -%}
@@ -89,10 +86,14 @@
         </li>
       {%- endif -%}
       {%- for media in product.media -%}
+        {% if media_position >= limit or media_position >= 1 and section.settings.hide_variants and variant_images contains media.src %}
+          {% continue %}
+        {% endif %}
+
         {%- unless media.id == product.selected_or_first_available_variant.featured_media.id -%}
           <li
-            id="Slide-{{ section.id }}-{{ media.id }}{{ id_append }}"
-            class="product__media-item grid__item slider__slide{% if single_media_visible %} product__media-item--single{% endif %}{% if product.selected_or_first_available_variant.featured_media == null and forloop.index == 1 %} is-active{% endif %}{% if media.media_type != 'image' %} product__media-item--full{% endif %}{% if section.settings.hide_variants and variant_images contains media.src %} product__media-item--variant{% endif %}{% if settings.animations_reveal_on_scroll %} scroll-trigger animate--fade-in{% endif %}"
+            id="Slide-{{ section.id }}-{{ media.id }}"
+            class="product__media-item grid__item slider__slide{% if single_media_visible %} product__media-item--single{% endif %}{% if product.selected_or_first_available_variant.featured_media == nil and forloop.index == 1 %} is-active{% endif %}{% if media.media_type != 'image' %} product__media-item--full{% endif %}{% if settings.animations_reveal_on_scroll %} scroll-trigger animate--fade-in{% endif %}"
             data-media-id="{{ section.id }}-{{ media.id }}"
           >
             {%- liquid
@@ -120,32 +121,30 @@
         {%- endunless -%}
       {%- endfor -%}
     </ul>
-    {%- unless is_duplicate -%}
-      <div class="slider-buttons quick-add-hidden{% if hide_mobile_slider %} small-hide{% endif %}">
-        <button
-          type="button"
-          class="slider-button slider-button--prev"
-          name="previous"
-          aria-label="{{ 'general.slider.previous_slide' | t }}"
-        >
-          {% render 'icon-caret' %}
-        </button>
-        <div class="slider-counter caption">
-          <span class="slider-counter--current">1</span>
-          <span aria-hidden="true"> / </span>
-          <span class="visually-hidden">{{ 'general.slider.of' | t }}</span>
-          <span class="slider-counter--total">{{ media_count }}</span>
-        </div>
-        <button
-          type="button"
-          class="slider-button slider-button--next"
-          name="next"
-          aria-label="{{ 'general.slider.next_slide' | t }}"
-        >
-          {% render 'icon-caret' %}
-        </button>
+    <div class="slider-buttons quick-add-hidden{% if hide_mobile_slider %} small-hide{% endif %}">
+      <button
+        type="button"
+        class="slider-button slider-button--prev"
+        name="previous"
+        aria-label="{{ 'general.slider.previous_slide' | t }}"
+      >
+        {% render 'icon-caret' %}
+      </button>
+      <div class="slider-counter caption">
+        <span class="slider-counter--current">1</span>
+        <span aria-hidden="true"> / </span>
+        <span class="visually-hidden">{{ 'general.slider.of' | t }}</span>
+        <span class="slider-counter--total">{{ media_count }}</span>
       </div>
-    {%- endunless -%}
+      <button
+        type="button"
+        class="slider-button slider-button--next"
+        name="next"
+        aria-label="{{ 'general.slider.next_slide' | t }}"
+      >
+        {% render 'icon-caret' %}
+      </button>
+    </div>
   </slider-component>
   {%- if first_3d_model -%}
     <button
@@ -161,12 +160,19 @@
       {{ 'products.product.xr_button' | t }}
     </button>
   {%- endif -%}
-  {%- if media_count > 1
+  {%- liquid
+    assign is_not_limited_to_single_item = false
+    if limit == nil or limit > 1
+      assign is_not_limited_to_single_item = true
+    endif
+  -%}
+  {%- if is_not_limited_to_single_item
+    and media_count > 1
     and section.settings.gallery_layout contains 'thumbnail'
     or section.settings.mobile_thumbnails == 'show'
   -%}
     <slider-component
-      id="GalleryThumbnails-{{ section.id }}{{ id_append }}"
+      id="GalleryThumbnails-{{ section.id }}"
       class="thumbnail-slider slider-mobile-gutter quick-add-hidden{% unless section.settings.gallery_layout contains 'thumbnail' %} medium-hide large-up-hide{% endunless %}{% if section.settings.mobile_thumbnails != 'show' %} small-hide{% endif %}{% if media_count <= 3 %} thumbnail-slider--no-slide{% endif %}"
     >
       <button
@@ -180,7 +186,7 @@
         {% render 'icon-caret' %}
       </button>
       <ul
-        id="Slider-Thumbnails-{{ section.id }}{{ id_append }}"
+        id="Slider-Thumbnails-{{ section.id }}"
         class="thumbnail-list list-unstyled slider slider--mobile{% if section.settings.gallery_layout == 'thumbnail_slider' %} slider--tablet-up{% endif %}"
       >
         {%- capture sizes -%}
@@ -190,7 +196,7 @@
           calc((100vw - 8rem) / 3)
         {%- endcapture -%}
 
-        {%- if featured_media != null -%}
+        {%- if featured_media != nil -%}
           {%- liquid
             capture media_index
               if featured_media.media_type == 'model'
@@ -204,19 +210,19 @@
             assign media_index = media_index | plus: 1
           -%}
           <li
-            id="Slide-Thumbnails-{{ section.id }}-0{{ id_append }}"
+            id="Slide-Thumbnails-{{ section.id }}-0"
             class="thumbnail-list__item slider__slide{% if section.settings.hide_variants and variant_images contains featured_media.src %} thumbnail-list_item--variant{% endif %}"
             data-target="{{ section.id }}-{{ featured_media.id }}"
             data-media-position="{{ media_index }}"
           >
             {%- capture thumbnail_id -%}
-              Thumbnail-{{ section.id }}-0{{ id_append }}
+              Thumbnail-{{ section.id }}-0
             {%- endcapture -%}
             <button
               class="thumbnail global-media-settings global-media-settings--no-shadow"
               aria-label="{%- if featured_media.media_type == 'image' -%}{{ 'products.product.media.load_image' | t: index: media_index }}{%- elsif featured_media.media_type == 'model' -%}{{ 'products.product.media.load_model' | t: index: media_index }}{%- elsif featured_media.media_type == 'video' or featured_media.media_type == 'external_video' -%}{{ 'products.product.media.load_video' | t: index: media_index }}{%- endif -%}"
               aria-current="true"
-              aria-controls="GalleryViewer-{{ section.id }}{{ id_append }}"
+              aria-controls="GalleryViewer-{{ section.id }}"
               aria-describedby="{{ thumbnail_id }}"
             >
               {{
@@ -248,7 +254,7 @@
               assign media_index = media_index | plus: 1
             -%}
             <li
-              id="Slide-Thumbnails-{{ section.id }}-{{ forloop.index }}{{ id_append }}"
+              id="Slide-Thumbnails-{{ section.id }}-{{ forloop.index }}"
               class="thumbnail-list__item slider__slide{% if section.settings.hide_variants and variant_images contains media.src %} thumbnail-list_item--variant{% endif %}"
               data-target="{{ section.id }}-{{ media.id }}"
               data-media-position="{{ media_index }}"
@@ -263,18 +269,18 @@
                 </span>
               {%- endif -%}
               {%- capture thumbnail_id -%}
-                Thumbnail-{{ section.id }}-{{ forloop.index }}{{ id_append }}
+                Thumbnail-{{ section.id }}-{{ forloop.index }}
               {%- endcapture -%}
               <button
                 class="thumbnail global-media-settings global-media-settings--no-shadow"
                 aria-label="{%- if media.media_type == 'image' -%}{{ 'products.product.media.load_image' | t: index: media_index }}{%- elsif media.media_type == 'model' -%}{{ 'products.product.media.load_model' | t: index: media_index }}{%- elsif media.media_type == 'video' or media.media_type == 'external_video' -%}{{ 'products.product.media.load_video' | t: index: media_index }}{%- endif -%}"
                 {% if media == product.selected_or_first_available_variant.featured_media
-                  or product.selected_or_first_available_variant.featured_media == null
+                  or product.selected_or_first_available_variant.featured_media == nil
                   and forloop.index == 1
                 %}
                   aria-current="true"
                 {% endif %}
-                aria-controls="GalleryViewer-{{ section.id }}{{ id_append }}"
+                aria-controls="GalleryViewer-{{ section.id }}"
                 aria-describedby="{{ thumbnail_id }}"
               >
                 {{


### PR DESCRIPTION
### PR Summary: 

This PR is a fairly minor refactor to product images that simplifies the code and significantly improves liquid render performance with minimal impact to the existing UX.

### Why are these changes introduced?

**Iterating over `product.variants` can be bad for perf**
The primary motivation for this change was to eliminate an iteration over `product.variants` in `featured-products.liquid`. While building [Combined Listings](https://shopify.dev/docs/themes/product-merchandising/variants/combined-listings), we found that this iteration becomes a perf bottleneck as the variant count increases, and we should eliminate as many instances of it as possible.

**Media gallery was being rendered twice by main and featured product**
Additionally, I found that when the merchant setting positioned the image gallery to the right, we were rendering the media gallery twice, in both `main-product` and `featured-product`. Since this snippet iterates over all of a product's media, this may cause poor theme perf if a product contains many images.

**Main and Featured product rendered more images than it displayed**
To facilitate swapping between highlighted images, [main](https://github.com/Shopify/dawn/blob/767f62f5b5641be1182c1400e2f21fd5a52c6464/assets/section-main-product.css#L449-L455) and [featured](https://github.com/Shopify/dawn/blob/c77ebf5e86756831e1bc85cc24881ea8ae9eca98/assets/section-featured-product.css#L17-L19) product render thumbnails as hidden and then use JS to swap them into view if their associated variant is selected.  With many images, this can cause theme perf issues and it's likely that many of the hidden images will never be displayed.

**Featured product didn't use the product-media-gallery widget**
Introduced [in this PR,](https://github.com/Shopify/dawn/pull/1934) the featured-product section rendered the product media gallery in nearly the same way as main-product. This can increase drift and maintenance headaches.

### What approach did you take?

(1) Updated the product-media-gallery widget to have a `limit` prop so that it supported the featured-product use case, which enabled eliminating iterating over `product.variants`.

(2) Removed the duplicate render of product-media-gallery and position with a CSS `order`. This also enabled me to simplify `product-media-gallery` because it contained logic to handle the case where it was rendered twice by a section (which doesn't happen anymore).

(3) Removed hidden thumbnail rendering for main and featured product, and instead update images using the response from the section rendering api. This is probably the most controversial part of the change since it takes sync behavior and makes it async. There is also some UX impact (see below).

### Impact of these changes

> **tl;dr** 15-65% improved load times for featured product alone, 10-69% improved load times when featured product and main product are rendered together.

The perf impact was pretty substantial. I set up 5 experiments with 20 overall test cases with an increasing number of variants and images. For each experiment, I ran a control (current dawn theme) vs a test (dawn theme with my changes), two test cases each--one for a page with just featured-product and one with featured-product+main-product together on a page. The merchant setting `hide other variants' media after selecting a variant` was checked. In storefront with caches disabled, I then measured render times using a Shopify-internal tracing tool once for each test case, by loading the storefront page with all caches disabled. Reach out to me via internal slack if you want more info on process. Results below:

> ⚠️ **Note** -- these numbers should be taken with a gigantic grain of salt and only be used as a rough indicator of performance since there is only 1 run per test case. Ideally I'd like to run a much higher number of tests and have something more statistically significant.

**page with just featured product**
| \# variant images | control - total time | test - total time | % reduction |
| ----------------- | -------------------- | ----------------- | ----------- |
| 3                 | 145.88               | 122.97            | \-15.70     |
| 10                | 277.65               | 222.88            | \-19.73     |
| 50                | 404.63               | 263.35            | \-34.92     |
| 100               | 493.41               | 211.42            | \-57.15     |
| 250               | 1180                 | 417.38            | \-64.63     |

**page with main and featured product rendered together**
| \# variant images | control - total time | test - total time | % reduction |
| ----------- | -------------------- | ----------------- | ----------- |
| 3           | 150.25               | 134.01            | \-10.81     |
| 10          | 340                  | 194.55            | \-42.78     |
| 50          | 532.99               | 266.61            | \-49.98     |
| 100         | 958.43               | 304.77            | \-68.20     |
| 250         | 2010                 | 621.55            | \-69.08     |

### Visual impact on existing themes

1) The image gallery is now rendered AFTER the section rendering api response, instead of being rendered hidden in the dom and revealed. This doesn't have a very noticeable impact with a [low number of images (new code on left)](https://screenshot.click/28-59-km7e9-etrrq.mp4) but is a bit more noticeable if the [product has a lot of images (new code on the left)](https://screenshot.click/28-53-dgcdg-hz5uq.mp4)
2) The theme used to always show the last selected variant featured media, even after switching to a different variant. [You can see an example in this demo where the `black` variant has no featured image](https://screenshot.click/28-02-szdvr-ae03b.mp4). After my changes, we only ever show the featured image associated with the current variant, meaning that you will never end up in a scenario where the `white cat` is shown when `black cat` is selected: [demo](https://screenshot.click/28-03-pvoow-547sj.mp4). (tbh I see this as more of a bug fix than a regression)

### Testing steps/scenarios

- [Test PDP](https://hack-week-test-one.myshopify.com/products/test-product) / pw: test
- [Control PDP](https://hack-week-control-one.myshopify.com/products/control-product) / pw: test

<!-- List all the testing tasks that applies to your fix to help peers review your work. -->
- [ ] Images are displayed the same for both main and featured product between test and control
- [ ] Image carousel shows the same images for both main and featured product between test and control
- [ ] Changing selected option values changes the featured image

### Checklist
- [x] Added PR summary for [release notes](https://themes.shopify.com/themes/dawn/styles/default#ReleaseNotes)
- [x] Requested review from UX (Only for changes that are affecting the experience or perceivable visual details)
- [ ] Created a ticket for the [help.shopify.com](https://help.shopify.com) documentation team about updates to theme settings. (Internal-only task)
- [x] Followed [theme code principles](https://github.com/Shopify/dawn/blob/main/.github/CONTRIBUTING.md#theme-code-principles)
- [x] Linted with [Theme Check](https://github.com/Shopify/theme-check)
- [x] Tested on [mobile](https://shopify.dev/themes/store/requirements#mobile-browser-requirements)
- [x] Tested on [multiple browsers](https://shopify.dev/themes/store/requirements#desktop-browser-requirements)
- [x] Tested for [accessibility](https://shopify.dev/themes/best-practices/accessibility)
