### PR TITLE
Condense country selector width when there are no currencies

### DIFF
--- a/assets/component-localization-form.css
+++ b/assets/component-localization-form.css
@@ -173,9 +173,12 @@ noscript .localization-selector.link {
 }
 
 .country-selector__list {
-  width: 25.5rem;
   padding-bottom: 0.95rem;
   padding-top: 0;
+}
+
+.country-selector__list--with-multiple-currencies {
+  width: 25.5rem;
 }
 
 .country-selector__close-button {

--- a/snippets/country-localization.liquid
+++ b/snippets/country-localization.liquid
@@ -18,6 +18,11 @@
   if localization.available_countries.size > 9 and popular_countries.size > 1
     assign show_popular_countries = true
   endif
+
+  assign show_currencies = false
+  if currencies.size > 1
+    assign show_currencies = true
+  endif
 %}
 
 <div class="disclosure">
@@ -83,7 +88,7 @@
     </div>
     <div id="sr-country-search-results" class="visually-hidden" aria-live="polite"></div>
     <div
-      class="disclosure__list country-selector__list"
+      class="disclosure__list country-selector__list{% if show_currencies %} country-selector__list--with-multiple-currencies{% endif %}"
       id="{{ localPosition }}-country-results"
     >
       {% if show_popular_countries %}
@@ -111,7 +116,7 @@
                   {%- render 'icon-checkmark' -%}
                 </span>
                 <span class="country">{{- country.name }}</span>
-                <span class="localization-form__currency motion-reduce {% if currencies.size < 2 %}hidden{% endif %}">
+                <span class="localization-form__currency motion-reduce{% unless show_currencies %} hidden{% endunless %}">
                   {{ country.currency.iso_code }}
                   {{ country.currency.symbol -}}
                 </span>
@@ -140,7 +145,7 @@
                 {%- render 'icon-checkmark' -%}
               </span>
               <span class="country">{{- country.name }}</span>
-              <span class="localization-form__currency motion-reduce{% if currencies.size < 2 %} hidden{% endif %}">
+              <span class="localization-form__currency motion-reduce{% unless show_currencies %} hidden{% endunless %}">
                 {{ country.currency.iso_code }}
                 {{ country.currency.symbol -}}
               </span>


### PR DESCRIPTION
### PR Summary: 

In the country selector, when the merchant's shop only sells in 1 currency we don't display that currency. That results in an unnecessarily wide selector. This PR sets the width of the selector to 25.5rem only when currencies are visible (i.e. > 1 currency on the store)

Shop w/ only 1 currency
<img width="315" alt="Screenshot 2024-02-08 at 4 27 50 PM" src="https://github.com/Shopify/dawn/assets/54807699/8059c88d-8f79-435d-80a2-4a9e6a5cc0de">

Shop w/ 1+ currencies
<img width="315" alt="Screenshot 2024-02-08 at 4 30 57 PM" src="https://github.com/Shopify/dawn/assets/54807699/fee8444b-34c8-4128-a203-886417d67af7">

Note that with the search box (> 9 countries), the width of the selector is still 25.5rem

<img width="307" alt="Screenshot 2024-02-08 at 4 43 52 PM" src="https://github.com/Shopify/dawn/assets/54807699/4c6c3f81-ad43-4fa5-9a9b-e3fd8ac4c906">

### Demo links
<!-- Please include a link to a demo store that includes preconfigured sections and settings to allow reviewers to easily test the features you are working on. -->

- [Store](https://hamidehs-store.myshopify.com/)
- [Editor](https://admin.shopify.com/store/hamidehs-store/themes/162839986198?key=assets%2Fcomponent-localization-form.css)

TO enable more than 1 currency, in the admin go into [market preferences](https://admin.shopify.com/store/hamidehs-store/settings/markets/preferences) and turn on local currencies for any of the markets. 

<img width="714" alt="Screenshot 2024-02-08 at 4 39 43 PM" src="https://github.com/Shopify/dawn/assets/54807699/743fd018-707f-45cc-9fc5-a452cf35f8f4">

### Checklist
- [x] Tested on [mobile](https://shopify.dev/themes/store/requirements#mobile-browser-requirements)
- [x] Tested on [multiple browsers](https://shopify.dev/themes/store/requirements#desktop-browser-requirements)
- [x] Tested for [accessibility](https://shopify.dev/themes/best-practices/accessibility)
