### PR TITLE
Touch up scroll into view PDP

### DIFF
--- a/assets/media-gallery.js
+++ b/assets/media-gallery.js
@@ -49,17 +49,11 @@ if (!customElements.get('media-gallery')) {
           if (this.elements.thumbnails) {
             activeMedia.parentElement.scrollTo({ left: activeMedia.offsetLeft });
           }
-          if (
-            !this.elements.thumbnails ||
-            this.dataset.desktopLayout === 'stacked' ||
-            this.dataset.desktopLayout === 'columns'
-          ) {
-            const activeMediaRect = activeMedia.getBoundingClientRect();
-            // Don't scroll if the image is already in view
-            if (activeMediaRect.top > -0.5) return;
-            const top = activeMediaRect.top + window.scrollY;
-            window.scrollTo({ top: top, behavior: 'smooth' });
-          }
+          const activeMediaRect = activeMedia.getBoundingClientRect();
+          // Don't scroll if the image is already in view
+          if (activeMediaRect.top > -0.5) return;
+          const top = activeMediaRect.top + window.scrollY;
+          window.scrollTo({ top: top, behavior: 'smooth' });
         });
         this.playActiveMedia(activeMedia);
 


### PR DESCRIPTION
Follow up fixes for the scroll into view behaviour on the product page. 

I was running into issues, specifically on mobile. The image wasn't scrolling into view and when I enabled mobile thumbnails everything was wonky. 

[Editor link](https://admin.shopify.com/store/os2-demo/themes/162912600086/editor)