### PR TITLE
Remove sticky header on cart drawer to avoid overlap of content

### DIFF
--- a/assets/component-cart-drawer.css
+++ b/assets/component-cart-drawer.css
@@ -182,10 +182,6 @@ cart-drawer {
 .cart-drawer thead {
   display: inline-table;
   width: 100%;
-  position: sticky;
-  top: 0;
-  z-index: 2;
-  background-color: rgb(var(--color-background));
 }
 
 cart-drawer-items {


### PR DESCRIPTION
When you add many items to the cart drawer, it will be scrollable. When you do there is an overlap in v13 of the content and table head. 
I was re adding the background color it use to have but that didn't support gradient. So on publisher [it looked off](https://screenshot.click/14-33-9snth-kbgv1.png). 
When adding support for the gradient, it's not blending in with the drawer because the fixed attachment is based on the viewport and not the element it's in. 

So in the end we're removing the sticky position of the table header to resolve the original overlap issue. 