### PR TITLE
Fixed wrong css code in component-predictive-search.css

### DIFF
--- a/assets/component-predictive-search.css
+++ b/assets/component-predictive-search.css
@@ -221,5 +221,4 @@ predictive-search[loading] .predictive-search__results-groups-wrapper ~ .predict
 .predictive-search__image {
   grid-area: product-image;
   object-fit: contain;
-  font-family: 'object-fit: contain';
 }


### PR DESCRIPTION
### PR Summary: 
Removed wrong extra code

### Visual impact on existing themes
No visual impact even though the css code was wrong it wouldn't have any effect on theme appeareance as css doesn't throw errors.

###Link to issue
https://github.com/Shopify/dawn/issues/3284