### PR TITLE
[Product medias] Scroll left mobile fix

### DIFF
--- a/assets/media-gallery.js
+++ b/assets/media-gallery.js
@@ -46,7 +46,7 @@ if (!customElements.get('media-gallery')) {
 
         this.preventStickyHeader();
         window.setTimeout(() => {
-          if (this.elements.thumbnails) {
+          if (!this.mql.matches || this.elements.thumbnails) {
             activeMedia.parentElement.scrollTo({ left: activeMedia.offsetLeft });
           }
           const activeMediaRect = activeMedia.getBoundingClientRect();


### PR DESCRIPTION
We added a fix for some scrolling issues on the PDP. Though one behaviour slipped through the cracks. 

On mobile, if you go through the product medias in the slider, then click on a variant that has an image associated with it, it wouldn't scroll back to the left. 

Because scrollIntoView was not running since the media is seen as within the viewport. And the if statement we had was to only scroll left when thumbnails are enabled. 

Though now we're also running this scroll left on mobile by default. 

I tried for a product that only has variant images and therefore no slider because the variant images are set to be hidden and it worked well. No errors coming up in the consoles. Desktop is still working as expected as well from what I could tell. 

[Editor](https://admin.shopify.com/store/os2-demo/themes/162929836054/editor). 