### PR TITLE
[Quick Order List] Disable volume-price popover on mouse hover and focus

### DIFF
--- a/assets/quantity-popover.css
+++ b/assets/quantity-popover.css
@@ -142,10 +142,6 @@ quantity-popover .quantity__rules span:first-of-type {
   }
 }
 
-quantity-popover:has(.quantity__input:focus-visible) .quantity-popover__info {
-  display: block;
-}
-
 quantity-popover .quantity {
   background: rgb(var(--color-background));
 }

--- a/assets/quantity-popover.css
+++ b/assets/quantity-popover.css
@@ -114,12 +114,12 @@ quantity-popover .quantity__rules span:first-of-type {
   padding: 0.5rem 0.5rem 0.5rem 0;
 }
 
-.quantity-popover-container:not(.quantity-popover-container--hover) {
+.quantity-popover-container:not(.quantity-popover-container--focus) {
   align-items: center;
 }
 
 @media screen and (min-width: 990px) {
-  .quantity-popover-container--hover:hover {
+  .quantity-popover-container--focus {
     background-color: rgba(var(--color-foreground), 0.03);
     border-radius: var(--inputs-radius-outset);
   }

--- a/assets/quantity-popover.js
+++ b/assets/quantity-popover.js
@@ -60,12 +60,16 @@ if (!customElements.get('quantity-popover')) {
 
       closePopover(event) {
         event.preventDefault();
+        const isChild = this.variantInfo.contains(event.relatedTarget);
         const button = this.infoButtonDesktop && this.mql.matches ? this.infoButtonDesktop : this.infoButtonMobile;
-        button.setAttribute('aria-expanded', 'false');
-        this.variantInfo.classList.remove('quantity-popover-container--focus');
-        button.classList.remove('quantity-popover__info-button--open');
-        this.popoverInfo.setAttribute('hidden', '');
-        this.eventClickHappened = false;
+
+        if (!isChild || !event.relatedTarget) {
+          button.setAttribute('aria-expanded', 'false');
+          this.variantInfo.classList.remove('quantity-popover-container--focus');
+          button.classList.remove('quantity-popover__info-button--open');
+          this.popoverInfo.setAttribute('hidden', '');
+          this.eventClickHappened = false;
+        }
       }
     }
   );

--- a/assets/quantity-popover.js
+++ b/assets/quantity-popover.js
@@ -11,6 +11,8 @@ if (!customElements.get('quantity-popover')) {
         this.popoverInfo = this.querySelector('.quantity-popover__info');
         this.closeButton = this.querySelector('.button-close');
         this.variantInfo = this.querySelector('.quantity-popover-container');
+        this.isVariantSoldout = this.querySelector('.quantity-popover-container .variant-item__sold-out');
+        this.eventClickHappened = false;
 
         if (this.closeButton) {
           this.closeButton.addEventListener('click', this.closePopover.bind(this));
@@ -29,12 +31,23 @@ if (!customElements.get('quantity-popover')) {
 
       togglePopover(event) {
         event.preventDefault();
+        if (event.type === 'click' && this.eventClickHappened) {
+          this.closePopover(event);
+          return;
+        }
+
+        if (event.type === 'click') {
+          this.eventClickHappened = true;
+        }
+
         const button = this.infoButtonDesktop && this.mql.matches ? this.infoButtonDesktop : this.infoButtonMobile;
         const isExpanded = button.getAttribute('aria-expanded') === 'true';
 
         button.setAttribute('aria-expanded', !isExpanded);
 
         this.popoverInfo.toggleAttribute('hidden');
+
+        this.isVariantSoldout ?? this.variantInfo.classList.add('quantity-popover-container--focus');
 
         const isOpen = button.getAttribute('aria-expanded') === 'true';
 
@@ -49,8 +62,10 @@ if (!customElements.get('quantity-popover')) {
         event.preventDefault();
         const button = this.infoButtonDesktop && this.mql.matches ? this.infoButtonDesktop : this.infoButtonMobile;
         button.setAttribute('aria-expanded', 'false');
+        this.variantInfo.classList.remove('quantity-popover-container--focus');
         button.classList.remove('quantity-popover__info-button--open');
         this.popoverInfo.setAttribute('hidden', '');
+        this.eventClickHappened = false;
       }
     }
   );

--- a/assets/quantity-popover.js
+++ b/assets/quantity-popover.js
@@ -11,14 +11,9 @@ if (!customElements.get('quantity-popover')) {
         this.popoverInfo = this.querySelector('.quantity-popover__info');
         this.closeButton = this.querySelector('.button-close');
         this.variantInfo = this.querySelector('.quantity-popover-container');
-        this.eventMouseEnterHappened = false;
 
         if (this.closeButton) {
           this.closeButton.addEventListener('click', this.closePopover.bind(this));
-        }
-
-        if (this.popoverInfo && this.infoButtonDesktop && this.mql.matches) {
-          this.popoverInfo.addEventListener('mouseenter', this.closePopover.bind(this));
         }
 
         if (this.infoButtonDesktop) {
@@ -30,21 +25,10 @@ if (!customElements.get('quantity-popover')) {
           this.infoButtonMobile.addEventListener('click', this.togglePopover.bind(this));
           this.infoButtonMobile.addEventListener('focusout', this.closePopover.bind(this));
         }
-
-        if (this.infoButtonDesktop && this.mqlTablet.matches) {
-          this.variantInfo.addEventListener('mouseenter', this.togglePopover.bind(this));
-          this.variantInfo.addEventListener('mouseleave', this.closePopover.bind(this));
-        }
       }
 
       togglePopover(event) {
         event.preventDefault();
-        if (event.type === 'mouseenter') {
-          this.eventMouseEnterHappened = true;
-        }
-
-        if (event.type === 'click' && this.eventMouseEnterHappened) return;
-
         const button = this.infoButtonDesktop && this.mql.matches ? this.infoButtonDesktop : this.infoButtonMobile;
         const isExpanded = button.getAttribute('aria-expanded') === 'true';
 
@@ -63,17 +47,10 @@ if (!customElements.get('quantity-popover')) {
 
       closePopover(event) {
         event.preventDefault();
-        const isChild = this.variantInfo.contains(event.relatedTarget);
-
         const button = this.infoButtonDesktop && this.mql.matches ? this.infoButtonDesktop : this.infoButtonMobile;
-
-        if (!event.relatedTarget || !isChild) {
-          button.setAttribute('aria-expanded', 'false');
-          button.classList.remove('quantity-popover__info-button--open');
-          this.popoverInfo.setAttribute('hidden', '');
-        }
-
-        this.eventMouseEnterHappened = false;
+        button.setAttribute('aria-expanded', 'false');
+        button.classList.remove('quantity-popover__info-button--open');
+        this.popoverInfo.setAttribute('hidden', '');
       }
     }
   );

--- a/sections/main-cart-items.liquid
+++ b/sections/main-cart-items.liquid
@@ -230,7 +230,7 @@
                           <label class="visually-hidden" for="Quantity-{{ item.index | plus: 1 }}">
                             {{ 'products.product.quantity.label' | t }}
                           </label>
-                          <div class="quantity-popover-container{% if has_qty_rules or has_vol_pricing %} quantity-popover-container--hover{% endif %}">
+                          <div class="quantity-popover-container">
                             {%- if has_qty_rules or has_vol_pricing -%}
                               <button
                                 type="button"

--- a/snippets/cart-drawer.liquid
+++ b/snippets/cart-drawer.liquid
@@ -276,7 +276,7 @@
                         >
                           <quantity-popover>
                             <div class="cart-item__quantity-wrapper quantity-popover-wrapper">
-                              <div class="quantity-popover-container{% if has_qty_rules or has_vol_pricing %} quantity-popover-container--hover{% endif %}">
+                              <div class="quantity-popover-container">
                                 <quantity-input class="quantity cart-quantity">
                                   <button class="quantity__button no-js-hidden" name="minus" type="button">
                                     <span class="visually-hidden">

--- a/snippets/quick-order-list-row.liquid
+++ b/snippets/quick-order-list-row.liquid
@@ -201,7 +201,7 @@
         <label class="visually-hidden" for="Quantity-{{ variant.id }}">
           {{ 'products.product.quantity.label' | t }}
         </label>
-        <div class="quantity-popover-container{% if is_available and has_popover %} quantity-popover-container--hover{% endif %}{% if cart_qty == 0 %} quantity-popover-container--empty{% endif %}">
+        <div class="quantity-popover-container{% if cart_qty == 0 %} quantity-popover-container--empty{% endif %}">
           {%- if has_qty_rules or has_vol_pricing -%}
             <button
               type="button"


### PR DESCRIPTION
### PR Summary: 

This PR removes volume-price popover on mouse hover and focus the input element. 

### Why are these changes introduced?

Fixes #0.

### What approach did you take?

### Other considerations

### Decision log

| # | Decision | Alternatives | Rationale | Downsides |
|---|---|---|---|---|
| 1 |   |   |   |   |


### Visual impact on existing themes
<!-- How will this visually affect merchants who upgrade to a new theme version with this change? -->


### Testing steps/scenarios
<!-- List all the testing tasks that applies to your fix to help peers review your work. -->
- [ ] Step 1

### Demo links
<!-- Please include a link to a demo store that includes preconfigured sections and settings to allow reviewers to easily test the features you are working on. -->

- [Editor](https://admin.shopify.com/store/os2-demo/themes/162931179542/editor)

### Checklist
- [ ] Added PR summary for [release notes](https://themes.shopify.com/themes/dawn/styles/default#ReleaseNotes)
- [ ] Requested review from UX (Only for changes that are affecting the experience or perceivable visual details)
- [ ] Created a ticket for the [help.shopify.com](https://help.shopify.com) documentation team about updates to theme settings. (Internal-only task)
- [ ] Followed [theme code principles](https://github.com/Shopify/dawn/blob/main/.github/CONTRIBUTING.md#theme-code-principles)
- [ ] Linted with [Theme Check](https://github.com/Shopify/theme-check)
- [ ] Tested on [mobile](https://shopify.dev/themes/store/requirements#mobile-browser-requirements)
- [ ] Tested on [multiple browsers](https://shopify.dev/themes/store/requirements#desktop-browser-requirements)
- [ ] Tested for [accessibility](https://shopify.dev/themes/best-practices/accessibility)
