### PR TITLE
Add product puppeteer class and simplify component update behavior

### DIFF
--- a/assets/base.css
+++ b/assets/base.css
@@ -1989,7 +1989,7 @@ input[type='checkbox'] {
   position: relative;
 }
 
-product-info .loading__spinner:not(.hidden) ~ *,
+.product__info-container .loading__spinner:not(.hidden) ~ *,
 .quantity__rules-cart .loading__spinner:not(.hidden) ~ * {
   visibility: hidden;
 }

--- a/assets/constants.js
+++ b/assets/constants.js
@@ -3,6 +3,7 @@ const ON_CHANGE_DEBOUNCE_TIMER = 300;
 const PUB_SUB_EVENTS = {
   cartUpdate: 'cart-update',
   quantityUpdate: 'quantity-update',
+  variantChangeStart: 'variant-change-start',
   variantChange: 'variant-change',
   cartError: 'cart-error',
   sectionRefreshed: 'section-refreshed',

--- a/assets/pickup-availability.js
+++ b/assets/pickup-availability.js
@@ -36,8 +36,17 @@ if (!customElements.get('pickup-availability')) {
           });
       }
 
-      onClickRefreshList(evt) {
+      onClickRefreshList() {
         this.fetchAvailability(this.dataset.variantId);
+      }
+
+      update(variant) {
+        if (variant?.available) {
+          this.fetchAvailability(variant.id);
+        } else {
+          this.removeAttribute('available');
+          this.innerHTML = '';
+        }
       }
 
       renderError() {

--- a/assets/product-form.js
+++ b/assets/product-form.js
@@ -6,10 +6,11 @@ if (!customElements.get('product-form')) {
         super();
 
         this.form = this.querySelector('form');
-        this.form.querySelector('[name=id]').disabled = false;
+        this.variantIdInput.disabled = false;
         this.form.addEventListener('submit', this.onSubmitHandler.bind(this));
         this.cart = document.querySelector('cart-notification') || document.querySelector('cart-drawer');
         this.submitButton = this.querySelector('[type="submit"]');
+        this.submitButtonText = this.submitButton.querySelector('span');
 
         if (document.querySelector('cart-drawer')) this.submitButton.setAttribute('aria-haspopup', 'dialog');
 
@@ -56,7 +57,7 @@ if (!customElements.get('product-form')) {
               const soldOutMessage = this.submitButton.querySelector('.sold-out-message');
               if (!soldOutMessage) return;
               this.submitButton.setAttribute('aria-disabled', true);
-              this.submitButton.querySelector('span').classList.add('hidden');
+              this.submitButtonText.classList.add('hidden');
               soldOutMessage.classList.remove('hidden');
               this.error = true;
               return;
@@ -112,6 +113,20 @@ if (!customElements.get('product-form')) {
         if (errorMessage) {
           this.errorMessage.textContent = errorMessage;
         }
+      }
+
+      toggleSubmitButton(disable = true, text) {
+        if (disable) {
+          this.submitButton.setAttribute('disabled', 'disabled');
+          if (text) this.submitButtonText.textContent = text;
+        } else {
+          this.submitButton.removeAttribute('disabled');
+          this.submitButtonText.textContent = window.variantStrings.addToCart;
+        }
+      }
+
+      get variantIdInput() {
+        return this.form.querySelector('[name=id]');
       }
     }
   );

--- a/assets/product-info.js
+++ b/assets/product-info.js
@@ -2,85 +2,339 @@ if (!customElements.get('product-info')) {
   customElements.define(
     'product-info',
     class ProductInfo extends HTMLElement {
+      quantityInput = undefined;
+      quantityForm = undefined;
+      onVariantChangeUnsubscriber = undefined;
+      cartUpdateUnsubscriber = undefined;
+      swapProductUtility = undefined;
+      abortController = undefined;
+
       constructor() {
         super();
-        this.input = this.querySelector('.quantity__input');
-        this.currentVariant = this.querySelector('.product-variant-id');
-        this.submitButton = this.querySelector('[type="submit"]');
+
+        this.quantityInput = this.querySelector('.quantity__input');
       }
 
-      cartUpdateUnsubscriber = undefined;
-      variantChangeUnsubscriber = undefined;
-
       connectedCallback() {
-        if (!this.input) return;
+        this.initializeProductSwapUtility();
+
+        this.onVariantChangeUnsubscriber = subscribe(
+          PUB_SUB_EVENTS.variantChangeStart,
+          this.handleOptionValueChange.bind(this)
+        );
+
+        this.initQuantityHandlers();
+        this.dispatchEvent(new CustomEvent('product-info:loaded', { bubbles: true }));
+      }
+
+      addPreProcessCallback(callback) {
+        this.swapProductUtility.addPreProcessCallback(callback);
+      }
+
+      initQuantityHandlers() {
+        if (!this.quantityInput) return;
+
         this.quantityForm = this.querySelector('.product-form__quantity');
         if (!this.quantityForm) return;
+
         this.setQuantityBoundries();
         if (!this.dataset.originalSection) {
           this.cartUpdateUnsubscriber = subscribe(PUB_SUB_EVENTS.cartUpdate, this.fetchQuantityRules.bind(this));
         }
-        this.variantChangeUnsubscriber = subscribe(PUB_SUB_EVENTS.variantChange, (event) => {
-          const sectionId = this.dataset.originalSection ? this.dataset.originalSection : this.dataset.section;
-          if (event.data.sectionId !== sectionId) return;
-          this.updateQuantityRules(event.data.sectionId, event.data.html);
-          this.setQuantityBoundries();
-        });
       }
 
       disconnectedCallback() {
-        if (this.cartUpdateUnsubscriber) {
-          this.cartUpdateUnsubscriber();
+        this.onVariantChangeUnsubscriber();
+        this.cartUpdateUnsubscriber?.();
+      }
+
+      initializeProductSwapUtility() {
+        this.swapProductUtility = new HTMLUpdateUtility();
+        this.swapProductUtility.addPreProcessCallback((html) =>
+          html.querySelectorAll('.scroll-trigger').forEach((element) => element.classList.add('scroll-trigger--cancel'))
+        );
+        this.swapProductUtility.addPostProcessCallback((newNode) => {
+          window?.Shopify?.PaymentButton?.init();
+          window?.ProductModel?.loadShopifyXR();
+          publish(PUB_SUB_EVENTS.sectionRefreshed, {
+            data: {
+              sectionId: this.sectionId,
+              resource: {
+                type: SECTION_REFRESH_RESOURCE_TYPE.product,
+                id: newNode.dataset.productId,
+              },
+            },
+          });
+        });
+      }
+
+      handleOptionValueChange({ data: { event, target, variant } }) {
+        if (!this.contains(event.target)) return;
+
+        const targetUrl = target.dataset.productUrl || this.dataset.url;
+
+        const productForm = this.productForm;
+        productForm?.toggleSubmitButton(true);
+        productForm?.handleErrorMessage();
+
+        let callback = () => {};
+        let productUrl = this.getProductInfoUrl(targetUrl, variant?.id);
+        if (this.dataset.url !== targetUrl) {
+          this.updateURL(targetUrl, variant?.id);
+          this.updateShareUrl(targetUrl, variant?.id);
+          callback = this.handleSwapProduct();
+          productUrl = this.getProductInfoUrl(targetUrl, variant?.id, true);
+        } else if (!variant) {
+          this.setUnavailable();
+          callback = (html) => {
+            this.pickupAvailability?.update(variant);
+            this.updateOptionValues(html);
+          };
+        } else {
+          this.updateURL(targetUrl, variant.id);
+          this.updateShareUrl(targetUrl, variant.id);
+          this.updateVariantInputs(variant.id);
+          callback = this.handleUpdateProductInfo(variant);
         }
-        if (this.variantChangeUnsubscriber) {
-          this.variantChangeUnsubscriber();
+
+        this.renderProductInfo(productUrl, target.id, callback);
+      }
+
+      handleSwapProduct() {
+        return (html) => {
+          this.productModal?.remove();
+
+          // If we are in an embedded context (quick add, featured product, etc), only swap product info.
+          // Otherwise, refresh the entire page content and sibling sections.
+          if (this.dataset.updateUrl === 'false') {
+            this.swapProductUtility.viewTransition(this, html.querySelector('product-info'));
+          } else {
+            this.swapProductUtility.viewTransition(document.querySelector('main'), html.querySelector('main'));
+          }
+        };
+      }
+
+      renderProductInfo(productUrl, targetId, callback) {
+        this.abortController?.abort();
+        this.abortController = new AbortController();
+
+        fetch(productUrl, { signal: this.abortController.signal })
+          .then((response) => response.text())
+          .then((responseText) => {
+            const html = new DOMParser().parseFromString(responseText, 'text/html');
+            callback(html);
+          })
+          .then(() => {
+            // set focus to last clicked option value
+            document.querySelector(`#${targetId}`)?.focus();
+          });
+      }
+
+      getProductInfoUrl(url, variantId, shouldFetchFullPage = false) {
+        const params = [];
+
+        !shouldFetchFullPage && params.push(`section_id=${this.sectionId}`);
+
+        if (variantId) {
+          params.push(`variant=${variantId}`);
+        } else {
+          const optionValues = this.variantSelectors.selectedOptionValues;
+          if (optionValues.length) {
+            params.push(`option_values=${optionValues.join(',')}`);
+          }
+        }
+
+        return `${url}?${params.join('&')}`;
+      }
+
+      updateOptionValues(html) {
+        const variantSelects = html.querySelector('variant-selects');
+        if (variantSelects) this.variantSelectors.innerHTML = variantSelects.innerHTML;
+      }
+
+      handleUpdateProductInfo(variant) {
+        return (html) => {
+          this.pickupAvailability?.update(variant);
+          this.updateMedia(html, variant?.featured_media?.id);
+          this.updateOptionValues(html);
+
+          const updateSourceFromDestination = (id, shouldHide = (source) => false) => {
+            const source = html.getElementById(`${id}-${this.sectionId}`);
+            const destination = this.querySelector(`#${id}-${this.dataset.section}`);
+            if (source && destination) {
+              destination.innerHTML = source.innerHTML;
+              destination.classList.toggle('hidden', shouldHide(source));
+            }
+          };
+
+          updateSourceFromDestination('price');
+          updateSourceFromDestination('Sku', ({ classList }) => classList.contains('hidden'));
+          updateSourceFromDestination('Inventory', ({ innerText }) => innerText === '');
+          updateSourceFromDestination('Volume');
+          updateSourceFromDestination('Price-Per-Item', ({ classList }) => classList.contains('hidden'));
+
+          this.updateQuantityRules(this.sectionId, html);
+          this.querySelector(`#Quantity-Rules-${this.dataset.section}`)?.classList.remove('hidden');
+          this.querySelector(`#Volume-Note-${this.dataset.section}`)?.classList.remove('hidden');
+
+          this.productForm?.toggleSubmitButton(
+            html.getElementById(`ProductSubmitButton-${this.sectionId}`)?.hasAttribute('disabled') ?? true,
+            window.variantStrings.soldOut
+          );
+
+          publish(PUB_SUB_EVENTS.variantChange, {
+            data: {
+              sectionId: this.sectionId,
+              html,
+              variant,
+            },
+          });
+        };
+      }
+
+      updateVariantInputs(variantId) {
+        this.querySelectorAll(
+          `#product-form-${this.dataset.section}, #product-form-installment-${this.dataset.section}`
+        ).forEach((productForm) => {
+          const input = productForm.querySelector('input[name="id"]');
+          input.value = variantId;
+          input.dispatchEvent(new Event('change', { bubbles: true }));
+        });
+      }
+
+      updateURL(url, variantId) {
+        if (this.dataset.updateUrl === 'false') return;
+        window.history.replaceState({}, '', `${url}${variantId ? `?variant=${variantId}` : ''}`);
+      }
+
+      updateShareUrl(url, variantId) {
+        this.querySelector('share-url')?.updateUrl(
+          `${window.shopUrl}${url}${variantId ? `?variant=${variantId}` : ''}`
+        );
+      }
+
+      setUnavailable() {
+        this.productForm?.toggleSubmitButton(true, window.variantStrings.unavailable);
+
+        const selectors = ['price', 'Inventory', 'Sku', 'Price-Per-Item', 'Volume-Note', 'Volume', 'Quantity-Rules']
+          .map((id) => `#${id}-${this.dataset.section}`)
+          .join(', ');
+        document.querySelectorAll(selectors).forEach(({ classList }) => classList.add('hidden'));
+      }
+
+      updateMedia(html, variantFeaturedMediaId) {
+        const mediaGallerySource = this.querySelector('media-gallery ul');
+        const mediaGalleryDestination = html.querySelector(`media-gallery ul`);
+
+        const refreshSourceData = () => {
+          const mediaGallerySourceItems = Array.from(mediaGallerySource.querySelectorAll('li[data-media-id]'));
+          const sourceSet = new Set(mediaGallerySourceItems.map((item) => item.dataset.mediaId));
+          const sourceMap = new Map(
+            mediaGallerySourceItems.map((item, index) => [item.dataset.mediaId, { item, index }])
+          );
+          return [mediaGallerySourceItems, sourceSet, sourceMap];
+        };
+
+        if (mediaGallerySource && mediaGalleryDestination) {
+          let [mediaGallerySourceItems, sourceSet, sourceMap] = refreshSourceData();
+          const mediaGalleryDestinationItems = Array.from(
+            mediaGalleryDestination.querySelectorAll('li[data-media-id]')
+          );
+          const destinationSet = new Set(mediaGalleryDestinationItems.map(({ dataset }) => dataset.mediaId));
+          let shouldRefresh = false;
+
+          // add items from new data not present in DOM
+          for (let i = mediaGalleryDestinationItems.length - 1; i >= 0; i--) {
+            if (!sourceSet.has(mediaGalleryDestinationItems[i].dataset.mediaId)) {
+              mediaGallerySource.prepend(mediaGalleryDestinationItems[i]);
+              shouldRefresh = true;
+            }
+          }
+
+          // remove items from DOM not present in new data
+          for (let i = 0; i < mediaGallerySourceItems.length; i++) {
+            if (!destinationSet.has(mediaGallerySourceItems[i].dataset.mediaId)) {
+              mediaGallerySourceItems[i].remove();
+              shouldRefresh = true;
+            }
+          }
+
+          // refresh
+          if (shouldRefresh) [mediaGallerySourceItems, sourceSet, sourceMap] = refreshSourceData();
+
+          // if media galleries don't match, sort to match new data order
+          mediaGalleryDestinationItems.forEach((destinationItem, destinationIndex) => {
+            const sourceData = sourceMap.get(destinationItem.dataset.mediaId);
+
+            if (sourceData && sourceData.index !== destinationIndex) {
+              mediaGallerySource.insertBefore(
+                sourceData.item,
+                mediaGallerySource.querySelector(`li:nth-of-type(${destinationIndex + 1})`)
+              );
+
+              // refresh source now that it has been modified
+              [mediaGallerySourceItems, sourceSet, sourceMap] = refreshSourceData();
+            }
+          });
+        }
+
+        if (variantFeaturedMediaId) {
+          // set featured media as active in the media gallery
+          this.querySelector(`media-gallery`)?.setActiveMedia?.(
+            `${this.dataset.section}-${variantFeaturedMediaId}`,
+            false
+          );
+
+          // update media modal
+          const modalContent = this.productModal?.querySelector(`.product-media-modal__content`);
+          const newModalContent = html.querySelector(`product-modal .product-media-modal__content`);
+          if (modalContent && newModalContent) modalContent.innerHTML = newModalContent.innerHTML;
         }
       }
 
       setQuantityBoundries() {
         const data = {
-          cartQuantity: this.input.dataset.cartQuantity ? parseInt(this.input.dataset.cartQuantity) : 0,
-          min: this.input.dataset.min ? parseInt(this.input.dataset.min) : 1,
-          max: this.input.dataset.max ? parseInt(this.input.dataset.max) : null,
-          step: this.input.step ? parseInt(this.input.step) : 1,
+          cartQuantity: this.quantityInput.dataset.cartQuantity ? parseInt(this.quantityInput.dataset.cartQuantity) : 0,
+          min: this.quantityInput.dataset.min ? parseInt(this.quantityInput.dataset.min) : 1,
+          max: this.quantityInput.dataset.max ? parseInt(this.quantityInput.dataset.max) : null,
+          step: this.quantityInput.step ? parseInt(this.quantityInput.step) : 1,
         };
 
         let min = data.min;
         const max = data.max === null ? data.max : data.max - data.cartQuantity;
         if (max !== null) min = Math.min(min, max);
         if (data.cartQuantity >= data.min) min = Math.min(min, data.step);
-        this.input.min = min;
+
+        this.quantityInput.min = min;
 
         if (max) {
-          this.input.max = max;
+          this.quantityInput.max = max;
         } else {
-          this.input.removeAttribute('max');
+          this.quantityInput.removeAttribute('max');
         }
-        this.input.value = min;
+        this.quantityInput.value = min;
+
         publish(PUB_SUB_EVENTS.quantityUpdate, undefined);
       }
 
       fetchQuantityRules() {
-        if (!this.currentVariant || !this.currentVariant.value) return;
+        const currentVariantId = this.productForm?.variantIdInput?.value;
+        if (!currentVariantId) return;
+
         this.querySelector('.quantity__rules-cart .loading__spinner').classList.remove('hidden');
-        fetch(`${this.dataset.url}?variant=${this.currentVariant.value}&section_id=${this.dataset.section}`)
-          .then((response) => {
-            return response.text();
-          })
+        fetch(`${this.dataset.url}?variant=${currentVariantId}&section_id=${this.dataset.section}`)
+          .then((response) => response.text())
           .then((responseText) => {
             const html = new DOMParser().parseFromString(responseText, 'text/html');
             this.updateQuantityRules(this.dataset.section, html);
-            this.setQuantityBoundries();
           })
-          .catch((e) => {
-            console.error(e);
-          })
-          .finally(() => {
-            this.querySelector('.quantity__rules-cart .loading__spinner').classList.add('hidden');
-          });
+          .catch((e) => console.error(e))
+          .finally(() => this.querySelector('.quantity__rules-cart .loading__spinner').classList.add('hidden'));
       }
 
       updateQuantityRules(sectionId, html) {
+        this.setQuantityBoundries();
+
         const quantityFormUpdated = html.getElementById(`Quantity-Form-${sectionId}`);
         const selectors = ['.quantity__input', '.quantity__rules', '.quantity__label'];
         for (let selector of selectors) {
@@ -101,6 +355,42 @@ if (!customElements.get('product-info')) {
             current.innerHTML = updated.innerHTML;
           }
         }
+      }
+
+      get productForm() {
+        return this.querySelector(`product-form`);
+      }
+
+      get productModal() {
+        return document.querySelector(`#ProductModal-${this.dataset.section}`);
+      }
+
+      get pickupAvailability() {
+        return this.querySelector(`pickup-availability`);
+      }
+
+      get variantSelectors() {
+        return this.querySelector('variant-selects');
+      }
+
+      get relatedProducts() {
+        const relatedProductsSectionId = SectionId.getIdForSection(
+          SectionId.parseId(this.sectionId),
+          'related-products'
+        );
+        return document.querySelector(`product-recommendations[data-section-id^="${relatedProductsSectionId}"]`);
+      }
+
+      get quickOrderList() {
+        const quickOrderListSectionId = SectionId.getIdForSection(
+          SectionId.parseId(this.sectionId),
+          'quick_order_list'
+        );
+        return document.querySelector(`quick-order-list[data-id^="${quickOrderListSectionId}"]`);
+      }
+
+      get sectionId() {
+        return this.dataset.originalSection || this.dataset.section;
       }
     }
   );

--- a/assets/quick-add.css
+++ b/assets/quick-add.css
@@ -212,6 +212,10 @@
   width: 100%;
 }
 
+.quick-add-modal__content-info > product-info {
+  padding: 0;
+}
+
 @media screen and (max-width: 749px) {
   quick-add-modal .slider .product__media-item.grid__item {
     margin-left: 1.5rem;

--- a/assets/quick-add.js
+++ b/assets/quick-add.js
@@ -5,6 +5,10 @@ if (!customElements.get('quick-add-modal')) {
       constructor() {
         super();
         this.modalContent = this.querySelector('[id^="QuickAddInfo-"]');
+
+        this.addEventListener('product-info:loaded', ({ target }) => {
+          target.addPreProcessCallback(this.preprocessHTML.bind(this));
+        });
       }
 
       hide(preventFocus = false) {
@@ -25,10 +29,10 @@ if (!customElements.get('quick-add-modal')) {
           .then((response) => response.text())
           .then((responseText) => {
             const responseHTML = new DOMParser().parseFromString(responseText, 'text/html');
-            const productElement = responseHTML.querySelector('section[id^="MainProduct-"]');
+            const productElement = responseHTML.querySelector('product-info');
 
             this.preprocessHTML(productElement);
-            HTMLUpdateUtility.setInnerHTML(this.modalContent, productElement.innerHTML);
+            HTMLUpdateUtility.setInnerHTML(this.modalContent, productElement.outerHTML);
 
             if (window.Shopify && Shopify.PaymentButton) {
               Shopify.PaymentButton.init();
@@ -38,22 +42,10 @@ if (!customElements.get('quick-add-modal')) {
             super.show(opener);
           })
           .finally(() => {
-            this.bindProductChangeCallbacks();
             opener.removeAttribute('aria-disabled');
             opener.classList.remove('loading');
             opener.querySelector('.loading__spinner').classList.add('hidden');
           });
-      }
-
-      bindProductChangeCallbacks() {
-        const swapProductUtility = this.querySelector('variant-selects')?.swapProductUtility;
-        if (swapProductUtility) {
-          swapProductUtility.addPreProcessCallback(this.preprocessHTML.bind(this));
-          swapProductUtility.addPostProcessCallback(() => {
-            this.modalContent = this.querySelector('[id^="QuickAddInfo-"]');
-            this.bindProductChangeCallbacks();
-          });
-        }
       }
 
       preprocessHTML(productElement) {
@@ -69,10 +61,7 @@ if (!customElements.get('quick-add-modal')) {
       }
 
       preventVariantURLSwitching(productElement) {
-        const variantPicker = productElement.querySelector('variant-selects');
-        if (!variantPicker) return;
-
-        variantPicker.setAttribute('data-update-url', 'false');
+        productElement.setAttribute('data-update-url', 'false');
       }
 
       removeDOMElements(productElement) {
@@ -88,10 +77,8 @@ if (!customElements.get('quick-add-modal')) {
 
       preventDuplicatedIDs(productElement) {
         const sectionId = productElement.dataset.section;
-        productElement.innerHTML = productElement.innerHTML.replaceAll(sectionId, `quickadd-${sectionId}`);
-        productElement.querySelectorAll('variant-selects, product-info').forEach((element) => {
-          element.dataset.originalSection = sectionId;
-        });
+        productElement.outerHTML = productElement.outerHTML.replaceAll(sectionId, `quickadd-${sectionId}`);
+        productElement.dataset.originalSection = sectionId;
       }
 
       removeGalleryListSemantic(productElement) {

--- a/assets/quick-order-list.js
+++ b/assets/quick-order-list.js
@@ -106,7 +106,6 @@ if (!customElements.get('quick-order-list')) {
       }
 
       cartUpdateUnsubscriber = undefined;
-      sectionRefreshUnsubscriber = undefined;
 
       onSubmit(event) {
         event.preventDefault();
@@ -131,21 +130,11 @@ if (!customElements.get('quick-order-list')) {
             this.addMultipleDebounce();
           });
         });
-
-        this.sectionRefreshUnsubscriber = subscribe(PUB_SUB_EVENTS.sectionRefreshed, (event) => {
-          const isParentSectionUpdated =
-            this.sectionId && (event.data?.sectionId ?? '') === `${this.sectionId.split('__')[0]}__main`;
-
-          if (isParentSectionUpdated) {
-            this.refresh();
-          }
-        });
         this.sectionId = this.dataset.section;
       }
 
       disconnectedCallback() {
         this.cartUpdateUnsubscriber?.();
-        this.sectionRefreshUnsubscriber?.();
       }
 
       defineInputsAndQuickOrderTable() {

--- a/assets/section-main-product.css
+++ b/assets/section-main-product.css
@@ -1,3 +1,7 @@
+product-info {
+  display: block;
+}
+
 .product {
   margin: 0;
 }

--- a/sections/featured-product.liquid
+++ b/sections/featured-product.liquid
@@ -1,3 +1,9 @@
+{%- liquid
+  assign product = section.settings.product
+-%}
+
+<product-info data-section="{{ section.id }}" data-product-id="{{ product.id }}" data-update-url="false" data-url="{{ product.url }}">
+
 {{ 'section-main-product.css' | asset_url | stylesheet_tag }}
 {{ 'section-featured-product.css' | asset_url | stylesheet_tag }}
 {{ 'component-accordion.css' | asset_url | stylesheet_tag }}
@@ -28,10 +34,6 @@
 <script src="{{ 'product-info.js' | asset_url }}" defer="defer"></script>
 <script src="{{ 'show-more.js' | asset_url }}" defer="defer"></script>
 <script src="{{ 'price-per-item.js' | asset_url }}" defer="defer"></script>
-
-{%- liquid
-  assign product = section.settings.product
--%}
 
 {% comment %} TODO: assign `product.selected_or_first_available_variant` to variable and replace usage to reduce verbosity {% endcomment %}
 
@@ -74,7 +76,7 @@
         {%- endif -%}
       </div>
       <div class="product__info-wrapper grid__item{% if settings.animations_reveal_on_scroll %} scroll-trigger animate--slide-in{% endif %}">
-        <product-info
+        <section
           id="ProductInfo-{{ section.id }}"
           class="product__info-container"
           data-section="{{ section.id }}"
@@ -366,8 +368,7 @@
                 {% render 'product-variant-picker',
                   product: product,
                   block: block,
-                  product_form_id: product_form_id,
-                  update_url: false
+                  product_form_id: product_form_id
                 %}
               {%- when 'buy_buttons' -%}
                 {%- render 'buy-buttons',
@@ -431,7 +432,7 @@
             {{ 'products.product.view_full_details' | t }}
             {% render 'icon-arrow' %}
           </a>
-        </product-info>
+        </section>
       </div>
     </div>
     {% render 'product-media-modal', product: product, variant_images: variant_images %}
@@ -510,6 +511,7 @@
   <script src="{{ 'product-modal.js' | asset_url }}" defer="defer"></script>
   <script src="{{ 'media-gallery.js' | asset_url }}" defer="defer"></script>
 {% endif %}
+</product-info>
 
 {% schema %}
 {

--- a/sections/main-product.liquid
+++ b/sections/main-product.liquid
@@ -1,7 +1,10 @@
-<section
+<product-info
   id="MainProduct-{{ section.id }}"
   class="section-{{ section.id }}-padding gradient color-{{ section.settings.color_scheme }}"
   data-section="{{ section.id }}"
+  data-product-id="{{ product.id }}"
+  data-update-url="true"
+  data-url="{{ product.url }}"
 >
   {{ 'section-main-product.css' | asset_url | stylesheet_tag }}
   {{ 'component-accordion.css' | asset_url | stylesheet_tag }}
@@ -73,10 +76,8 @@
         {% render 'product-media-gallery', variant_images: variant_images %}
       </div>
       <div class="product__info-wrapper grid__item{% if settings.page_width > 1400 and section.settings.media_size == "small" %} product__info-wrapper--extra-padding{% endif %}{% if settings.animations_reveal_on_scroll %} scroll-trigger animate--slide-in{% endif %}">
-        <product-info
+        <section
           id="ProductInfo-{{ section.id }}"
-          data-section="{{ section.id }}"
-          data-url="{{ product.url }}"
           class="product__info-container{% if section.settings.enable_sticky_info %} product__column-sticky{% endif %}"
         >
           {%- assign product_form_id = 'product-form-' | append: section.id -%}
@@ -655,7 +656,7 @@
             {{ 'products.product.view_full_details' | t }}
             {% render 'icon-arrow' %}
           </a>
-        </product-info>
+        </section>
       </div>
     </div>
 
@@ -752,7 +753,7 @@
       }
     </script>
   </div>
-</section>
+</product-info>
 
 {% schema %}
 {

--- a/snippets/product-variant-picker.liquid
+++ b/snippets/product-variant-picker.liquid
@@ -5,7 +5,6 @@
   - product: {Object} product object.
   - block: {Object} passing the block information.
   - product_form_id: {String} Id of the product form to which the variant picker is associated.
-  - update_url: {Boolean} whether or not to update url when changing variants. If false, the url isn't updated. Default: true (optional).
   Usage:
   {% render 'product-variant-picker', product: product, block: block, product_form_id: product_form_id %}
 {% endcomment %}
@@ -13,11 +12,6 @@
   <variant-selects
     id="variant-selects-{{ section.id }}"
     data-section="{{ section.id }}"
-    data-url="{{ product.url }}"
-    data-product-id="{{ product.id }}"
-    {% if update_url == false %}
-      data-update-url="false"
-    {% endif %}
     {{ block.shopify_attributes }}
   >
     {%- for option in product.options_with_values -%}


### PR DESCRIPTION
⚠️  This PR builds on the work to support combined listings and 2k variants https://github.com/Shopify/dawn/pull/3378

tl;dr - this PR primarily copies code out of the variant picker class in `global.js` into `product-info.js`, which has been promoted to act as a wrapper for Product.

### Why are these changes introduced?

This PR came out of a conversation with @tyleralsbury earlier this year while working on [adding support for combined listings / 2k variants](https://github.com/Shopify/dawn/pull/3246). In that PR, the `VariantSelects` class needs to swap out the page content for its product when the selected variant is associated with a different Combined Listing child product. `VariantSelects` can be embedded in a few different product contexts (main product, featured product, quick add modal), and I was running into an issue where the class needed some pretty janky logic to determine its wrapping context ([here](https://github.com/Shopify/dawn/pull/3289/files#diff-47a8b2f1172e03da15783b379f0e007d8e3dfd27cbd9142adf9e32c4b9591079L1152-L1158) and [here](https://github.com/Shopify/dawn/pull/3289/files#diff-47a8b2f1172e03da15783b379f0e007d8e3dfd27cbd9142adf9e32c4b9591079L1170-L1172)). For a more stable architecture, child components shouldn't care what context they are rendered in.

An additional problem is that if components need to be updated when an event in a sibling happens, there wasn't a great "namespaced" context to manage the update. We had two primary patterns for handling this:

**Directly update sibling content** ([link](https://github.com/Shopify/dawn/blob/05e61a33d45358b09b85a089e0dd1b19109320c9/assets/global.js#L1092-L1102))
```js
class VariantSelects extends HTMLElement {
  
  onVariantChange(event) {
    ...
    this.updatePickupAvailability();
    ...
  }

  updatePickupAvailability() {
    const pickUpAvailability = document.querySelector('pickup-availability');
    if (!pickUpAvailability) return;

    if (this.currentVariant && this.currentVariant.available) {
      pickUpAvailability.fetchAvailability(this.currentVariant.id);
    } else {
      pickUpAvailability.removeAttribute('available');
      pickUpAvailability.innerHTML = '';
    }
  }
}
```

**Publish an event with the section, sibling subscription triggers update** ([link](https://github.com/Shopify/dawn/blob/05e61a33d45358b09b85a089e0dd1b19109320c9/assets/global.js#L1183-L1189))
```js
class VariantSelects extends HTMLElement {
    ...
    publish(PUB_SUB_EVENTS.variantChange, {
      data: {
        sectionId,
        html,
        variant: this.currentVariant,
      },
    });
  ...
}

class ProductInfo extends HTMLElement {
  connectedCallback() {
      this.variantChangeUnsubscriber = subscribe(PUB_SUB_EVENTS.variantChange, (event) => {
      const sectionId = this.dataset.originalSection ? this.dataset.originalSection : this.dataset.section;

      // check whether the event came from this ProductInfo's section
      if (event.data.sectionId !== sectionId) return;
      this.updateQuantityRules(event.data.sectionId, event.data.html);
      this.setQuantityBoundries();
    });
  }
}
```

### What approach did you take?

We have 2 primary issues: child components need to be context aware, and handling product component updates was complicated and inconsistent.

To solve both of these problems, I introduced a product class that wraps the entire rendered product and serves as an event handling puppeteer.

We already had a product wrapper class called `ProductInfo` that wrapped part of the rendered product; I moved it higher up the tree and extracted component update logic into it.

### Other considerations

I left a [comment](https://github.com/Shopify/dawn/pull/3289/files#r1499947293), but we possibly could decompose further by moving the old ProductInfo content into a QuantityForm class.

### Visual impact on existing themes

None


### Testing steps/scenarios

Here is a zip file for these theme changes: https://github.com/Shopify/dawn/archive/refs/heads/add-product-wrapper-class.zip

<!-- List all the testing tasks that applies to your fix to help peers review your work. -->
- [ ] Option value switching still works as expected
  - [ ] Switching between option values
  - [ ] Switching to an option value that has no associated variant
  - [ ] Switching between combined listings children
- [ ] Product recommendations load when switching between combined listings children
- [ ] Quick order list is updated when switching between combined listings children
- [ ] Quick add modal
  - [ ] works as expected for a normal product
  - [ ] works as expected for a combined listing product
- [ ] Quantity and volume price rules. (A catalog is set up on the shop, feel free to add yourself as a user or reach out to me for a test account)

### Demo links
<!-- Please include a link to a demo store that includes preconfigured sections and settings to allow reviewers to easily test the features you are working on. https://combined-listings-test.myshopify.com/products/chinos-black -->

- https://combined-listings-test.myshopify.com/products/chinos-orange


### Checklist
- [x] Added PR summary for [release notes](https://themes.shopify.com/themes/dawn/styles/default#ReleaseNotes)
- [ ] Requested review from UX (Only for changes that are affecting the experience or perceivable visual details)
- [ ] Created a ticket for the [help.shopify.com](https://help.shopify.com) documentation team about updates to theme settings. (Internal-only task)
- [x] Followed [theme code principles](https://github.com/Shopify/dawn/blob/main/.github/CONTRIBUTING.md#theme-code-principles)
- [x] Linted with [Theme Check](https://github.com/Shopify/theme-check)
- [x] Tested on [mobile](https://shopify.dev/themes/store/requirements#mobile-browser-requirements)
- [x] Tested on [multiple browsers](https://shopify.dev/themes/store/requirements#desktop-browser-requirements)
- [x] Tested for [accessibility](https://shopify.dev/themes/best-practices/accessibility)
