### PR TITLE
Bring back swatch-input snippet

### DIFF
--- a/assets/component-product-variant-picker.css
+++ b/assets/component-product-variant-picker.css
@@ -34,7 +34,7 @@ variant-selects {
   width: 1px;
 }
 
-.product-form__input input[type='radio']:not(.disabled) + label > .label-unavailable {
+.product-form__input input[type='radio']:not(.disabled):not(.visually-disabled) + label > .label-unavailable {
   display: none;
 }
 
@@ -42,7 +42,6 @@ variant-selects {
   --swatch-input--size: 2rem;
   margin-bottom: 1.6rem;
 }
-
 
 .product-form__input--dropdown .dropdown-swatch + select {
   padding-left: calc(2.4rem + var(--swatch-input--size));
@@ -56,7 +55,6 @@ variant-selects {
   height: var(--swatch-input--size);
   z-index: 1;
 }
-
 
 /* Custom styles for Pill display type */
 .product-form__input--pill input[type='radio'] + label {

--- a/assets/component-swatch-input.css
+++ b/assets/component-swatch-input.css
@@ -24,7 +24,7 @@
 }
 
 /* Visually disabled */
-.swatch-input__input.disabled:not(:active):not(:checked) + .swatch-input__label:hover {
+.swatch-input__input.visually-disabled:not(:active):not(:checked) + .swatch-input__label:hover {
   outline: none;
 }
 
@@ -35,14 +35,14 @@
 
 /* Overrides for swatch snippet when used inside disabled swatch-input */
 .swatch-input__input:disabled + .swatch-input__label > .swatch,
-.swatch-input__input.disabled + .swatch-input__label > .swatch {
+.swatch-input__input.visually-disabled + .swatch-input__label > .swatch {
   position: relative;
   overflow: hidden;
 }
 
 /* Display white semi-transparent overlay over swatch when input is disabled */
 .swatch-input__input:disabled + .swatch-input__label > .swatch::before,
-.swatch-input__input.disabled + .swatch-input__label > .swatch::before {
+.swatch-input__input.visually-disabled + .swatch-input__label > .swatch::before {
   content: '';
   position: absolute;
   inset: 0;
@@ -51,7 +51,7 @@
 
 /* Display crossed out line over swatch when input is disabled */
 .swatch-input__input:disabled + .swatch-input__label > .swatch::after,
-.swatch-input__input.disabled + .swatch-input__label > .swatch::after {
+.swatch-input__input.visually-disabled + .swatch-input__label > .swatch::after {
   /* Diagonal of a square = length of the side * sqrt(2)  */
   --diagonal--size: calc(var(--swatch-input--size) * 1.414);
   --crossed-line--size: 0.1rem;

--- a/snippets/product-variant-options.liquid
+++ b/snippets/product-variant-options.liquid
@@ -52,7 +52,7 @@
     elsif value.swatch.color
       assign swatch_value = 'rgb(' | append: value.swatch.color.rgb | append: ')'
     else
-      assign swatch_value = nil
+      assign swatch_value = null
     endif
   -%}
 
@@ -60,42 +60,35 @@
     {{ section.id }}-{{ option.position }}-{{ forloop.index0 -}}
   {%- endcapture -%}
 
-  {%- capture label_unavailable %}
+  {%- capture label_unavailable -%}
     <span class="visually-hidden label-unavailable">
       {{- 'products.product.variant_sold_out_or_unavailable' | t -}}
     </span>
-  {%- endcapture %}
+  {%- endcapture -%}
 
   {%- if picker_type == 'swatch' -%}
     {% liquid
       assign checked = false
-
       if option.selected_value == value
         assign checked = true
       endif
-
-      assign value_text = value | escape
     %}
-    <input
-      type="radio"
-      id="{{ input_id }}"
-      name="{{ option.name }}"
-      value="{{ value_text }}"
-      form="{{ product_form_id }}"
-      class="swatch-input__input{% if option_disabled %} disabled{% endif %}"
-      {% if checked %}
-        checked
-      {% endif %}
-    >
-    <label
-      for="{{ input_id }}"
-      title="{{ value_text }}"
-      class="swatch-input__label{% if block.settings.swatch_shape == 'square' %} swatch-input__label--square{% endif %}"
-    >
-      {% render 'swatch', swatch: value.swatch, shape: block.settings.swatch_shape %}
-      <span class="visually-hidden">{{ value_text }}</span>
+    {%- capture help_text -%}
+      <span class="visually-hidden">{{ value | escape }}</span>
       {{ label_unavailable }}
-    </label>
+    {%- endcapture -%}
+    {%
+      render 'swatch-input',
+      id: input_id,
+      name: option.name,
+      value: value | escape,
+      swatch: value.swatch,
+      product_form_id: product_form_id,
+      checked: checked,
+      visually_disabled: option_disabled,
+      shape: block.settings.swatch_shape,
+      help_text: help_text
+    %}
   {%- elsif picker_type == 'button' -%}
     <input
       type="radio"

--- a/snippets/swatch-input.liquid
+++ b/snippets/swatch-input.liquid
@@ -1,0 +1,48 @@
+{% comment %}
+  Renders a swatch input component.
+  Accepts:
+  - id: {String} unique input id
+  - type: {String} input type. Accepts 'radio' or 'checkbox', defaults to 'radio' (optional)
+  - name: {String} input name,
+  - value: {ProductOptionValueDrop} input value
+  - swatch: {SwatchDrop} the swatch drop
+  - product_form_id: {String} id of the form associted with the input
+  - checked: {Boolean} default checked status
+  - disabled: {Boolean} default disabled status (optional)
+  - visually_disabled: {Boolean} style the swatch as disabled, but leave the input enabled (optional)
+  - shape: {String} swatch shape. Accepts 'square', defaults to circle (optional)
+  - help_text: {String} additional content to render inside the label (optional)
+
+  Usage:
+   {% render 'swatch-input',
+      id: input_id,
+      name: input_name,
+      value: input_value,
+      swatch: swatch,
+      product_form_id: product_form_id,
+      checked: checked
+    %}
+{% endcomment %}
+
+<input
+  type="{{ type | default: 'radio' }}"
+  id="{{ id }}"
+  name="{{ name }}"
+  value="{{ value }}"
+  form="{{ product_form_id }}"
+  class="swatch-input__input{% if visually_disabled %} visually-disabled{% endif %}"
+  {% if checked %}
+    checked
+  {% endif %}
+  {% if disabled %}
+    disabled
+  {% endif %}
+>
+<label
+  for="{{ id }}"
+  title="{{ value }}"
+  class="swatch-input__label{% if shape == 'square' %} swatch-input__label--square{% endif %}"
+>
+  {% render 'swatch', swatch: swatch, shape: shape %}
+  {{ help_text }}
+</label>


### PR DESCRIPTION
### PR Summary: 

This brings back the `swatch-input` snippet which was removed in [this PR](https://github.com/Shopify/dawn/pull/3283). I will have a follow up PR which uses the swatch-input for filters, not just the PDP.


### Why are these changes introduced?

This is necessary for upcoming filter work.

### What approach did you take?

I copied/pasted the changes, along with a few small tweaks that the filters will use (namely, splitting the `.visually-disabled` class with the `disabled` attribute).

### Other considerations

### Visual impact on existing themes
<!-- How will this visually affect merchants who upgrade to a new theme version with this change? -->
None: this just allows for code sharing.

### Testing steps/scenarios
<!-- List all the testing tasks that applies to your fix to help peers review your work. -->
- [ ] View the editor link (link below)
- [ ] Verify that the swatches render their different states properly (visually_disabled, active, hover, etc).

### Demo links
<!-- Please include a link to a demo store that includes preconfigured sections and settings to allow reviewers to easily test the features you are working on. -->

- [Store](https://shop1.shopify.dawn-public.jason-addleman.us.spin.dev/?preview_theme_id=3)
- [Editor](https://admin.web.dawn-public.jason-addleman.us.spin.dev/store/shop1/themes/3/editor?previewPath=%2Fproducts%2Ftaxonomy-t-shirt&block=template--599__main%2Fvariant_picker&section=template--599__main)

### Checklist
- [x] Added PR summary for [release notes](https://themes.shopify.com/themes/dawn/styles/default#ReleaseNotes)
- [ ] Requested review from UX (Only for changes that are affecting the experience or perceivable visual details)
- [ ] Created a ticket for the [help.shopify.com](https://help.shopify.com) documentation team about updates to theme settings. (Internal-only task)
- [x] Followed [theme code principles](https://github.com/Shopify/dawn/blob/main/.github/CONTRIBUTING.md#theme-code-principles)
- [ ] Linted with [Theme Check](https://github.com/Shopify/theme-check)
- [ ] Tested on [mobile](https://shopify.dev/themes/store/requirements#mobile-browser-requirements)
- [ ] Tested on [multiple browsers](https://shopify.dev/themes/store/requirements#desktop-browser-requirements)
- [ ] Tested for [accessibility](https://shopify.dev/themes/best-practices/accessibility)
