### PR TITLE
Cart transform can send the title override for cart

### DIFF
--- a/sections/cart-notification-product.liquid
+++ b/sections/cart-notification-product.liquid
@@ -16,7 +16,7 @@
         {%- if settings.show_vendor -%}
           <p class="caption-with-letter-spacing light">{{ item.product.vendor }}</p>
         {%- endif -%}
-        <h3 class="cart-notification-product__name h4">{{ item.product.title | escape }}</h3>
+        <h3 class="cart-notification-product__name h4">{{ item.title | escape }}</h3>
         <dl>
           {%- unless item.product.has_only_default_variant -%}
             {%- for option in item.options_with_values -%}

--- a/sections/main-cart-items.liquid
+++ b/sections/main-cart-items.liquid
@@ -102,7 +102,7 @@
                         <p class="caption-with-letter-spacing">{{ item.product.vendor }}</p>
                       {%- endif -%}
 
-                      <a href="{{ item.url }}" class="cart-item__name h4 break">{{ item.product.title | escape }}</a>
+                      <a href="{{ item.url }}" class="cart-item__name h4 break">{{ item.title | escape }}</a>
 
                       {%- if item.original_price != item.final_price -%}
                         <div class="cart-item__discounted-prices">
@@ -243,7 +243,7 @@
                             <quantity-input class="quantity cart-quantity">
                               <button class="quantity__button no-js-hidden" name="minus" type="button">
                                 <span class="visually-hidden">
-                                  {{- 'products.product.quantity.decrease' | t: product: item.product.title | escape -}}
+                                  {{- 'products.product.quantity.decrease' | t: product: item.title | escape -}}
                                 </span>
                                 {% render 'icon-minus' %}
                               </button>
@@ -261,13 +261,13 @@
                                 {% endif %}
                                 step="{{ item.variant.quantity_rule.increment }}"
                                 {% # theme-check-enable %}
-                                aria-label="{{ 'products.product.quantity.input_label' | t: product: item.product.title | escape }}"
+                                aria-label="{{ 'products.product.quantity.input_label' | t: product: item.title | escape }}"
                                 id="Quantity-{{ item.index | plus: 1 }}"
                                 data-index="{{ item.index | plus: 1 }}"
                               >
                               <button class="quantity__button no-js-hidden" name="plus" type="button">
                                 <span class="visually-hidden">
-                                  {{- 'products.product.quantity.increase' | t: product: item.product.title | escape -}}
+                                  {{- 'products.product.quantity.increase' | t: product: item.title | escape -}}
                                 </span>
                                 {% render 'icon-plus' %}
                               </button>

--- a/snippets/cart-drawer.liquid
+++ b/snippets/cart-drawer.liquid
@@ -136,7 +136,7 @@
                           {%- endif -%}
 
                           <a href="{{ item.url }}" class="cart-item__name h4 break">
-                            {{- item.product.title | escape -}}
+                            {{- item.title | escape -}}
                           </a>
 
                           {%- if item.original_price != item.final_price -%}
@@ -282,7 +282,7 @@
                                     <span class="visually-hidden">
                                       {{-
                                         'products.product.quantity.decrease'
-                                        | t: product: item.product.title
+                                        | t: product: item.title
                                         | escape
                                       -}}
                                     </span>
@@ -302,7 +302,7 @@
                                     {% endif %}
                                     step="{{ item.variant.quantity_rule.increment }}"
                                     {% # theme-check-enable %}
-                                    aria-label="{{ 'products.product.quantity.input_label' | t: product: item.product.title | escape }}"
+                                    aria-label="{{ 'products.product.quantity.input_label' | t: product: item.title | escape }}"
                                     id="Drawer-quantity-{{ item.index | plus: 1 }}"
                                     data-index="{{ item.index | plus: 1 }}"
                                   >
@@ -310,7 +310,7 @@
                                     <span class="visually-hidden">
                                       {{-
                                         'products.product.quantity.increase'
-                                        | t: product: item.product.title
+                                        | t: product: item.title
                                         | escape
                                       -}}
                                     </span>


### PR DESCRIPTION
### PR Summary: 

<!-- Please include a short description (using non-technical terms, 1-2 sentences) about the changes you are introducing, what problem is being fixed and/or describe the benefit to merchants. This content will be used in our release notes for Dawn on [themes.shopify.com](https://themes.shopify.com/themes/dawn/styles/default#ReleaseNotes). -->

Cart Transform feature allows partners to override the title in the cart and checkout. For example, if "Fancy Watch" and "Warranty" are added to the cart, bundle is created and renamed as "Fancy Watch with warranty".
<img width="807" alt="image" src="https://github.com/Shopify/dawn/assets/1405211/6e78ce86-c0ff-45a3-9e30-e1a239cec6d6">
 
More details about cart transform can be found [here](https://shopify.dev/docs/api/functions/reference/cart-transform#example-expand-operation) 

### Why are these changes introduced?

Fixes [#67257 Display override title in cart line]https://github.com/Shopify/core-issues/issues/67257

Feature is released as of 2024-01, sfr is one of the surfaces that are not showing updated title for cart

### What approach did you take?

### Other considerations

Titles changed by cart transform operations will not be translated

### Visual impact on existing themes
<!-- How will this visually affect merchants who upgrade to a new theme version with this change? -->

Merchants who are using cart transform feature -they will see title overrides in cart.
This will have no impact to merchants who are not using Cart Transform, as `item.title` falls back to [variant's title ](https://github.com/Shopify/storefront-renderer/pull/23122/files#diff-95b2a1780335e999549788ad7a8ed339e719a11b85d445491ce611fdce4ad25aR19), which is defined [here](https://github.com/Shopify/storefront-renderer/blob/main/app/liquid/drops/product_variant_drop.rb#L749-L751) and eventually goes to [product title](https://github.com/Shopify/storefront-renderer/blob/main/app/liquid/drops/product_drop.rb#L168-L170)

### Testing steps/scenarios
<!-- List all the testing tasks that applies to your fix to help peers review your work. -->
- [ ] open https://quickstart-871572b0.myshopify.com/
- [ ] add [Snowboard bundle](https://quickstart-871572b0.myshopify.com/products/fancy-watch) to the cart
- [ ] `Snowboard Bundle - With Title Override` should be shown in the notification popup
- [ ] `Snowboard Bundle - With Title Override` should be seen in the cart
- [ ] `Snowboard Bundle - With Title Override` should be seen in the checkout
- [ ] Repeat steps for (Magic carpet)[https://quickstart-871572b0.myshopify.com/products/magic-carpet] with `update title` checked 
- [ ] You can try any other products that don't receive cart transform overrides to verify that expected title is returned (product's title by default)

### Demo links

- [Store](https://quickstart-871572b0.myshopify.com)
- [Editor](https://admin.shopify.com/store/quickstart-871572b0/themes/124846669911)

### Checklist
- [ ] Added PR summary for [release notes](https://themes.shopify.com/themes/dawn/styles/default#ReleaseNotes)
- [ ] Requested review from UX (Only for changes that are affecting the experience or perceivable visual details)
- [ ] Created a ticket for the [help.shopify.com](https://help.shopify.com) documentation team about updates to theme settings. (Internal-only task)
- [x] Followed [theme code principles](https://github.com/Shopify/dawn/blob/main/.github/CONTRIBUTING.md#theme-code-principles)
- [ ] Linted with [Theme Check](https://github.com/Shopify/theme-check)
- [ ] Tested on [mobile](https://shopify.dev/themes/store/requirements#mobile-browser-requirements)  _There is no changes to mark up that need to be re-tested_
- [ ] Tested on [multiple browsers](https://shopify.dev/themes/store/requirements#desktop-browser-requirements) _There is no changes to mark up that need to be re-tested_
- [ ] Tested for [accessibility](https://shopify.dev/themes/best-practices/accessibility) _There is no changes to mark up that need to be re-tested_
