### PR TITLE
Add collage image link support

### DIFF
--- a/locales/en.default.schema.json
+++ b/locales/en.default.schema.json
@@ -559,6 +559,9 @@
           "settings": {
             "image": {
               "label": "Image"
+            },
+            "link": {
+              "label": "Link"
             }
           }
         },

--- a/sections/collage.liquid
+++ b/sections/collage.liquid
@@ -39,8 +39,16 @@
           {%- case block.type -%}
             {%- when 'image' -%}
               <div class="collage-card {% if section.settings.card_styles == 'none' %}global-media-settings{% else %}card-wrapper {{ section.settings.card_styles }} color-{{ settings.card_color_scheme }} gradient{% endif %}">
+                {%- if block.settings.link -%}
+                  <a
+                    href="{{ block.settings.link }}"
+                    id="StandardCardNoMediaLink-{{ section_id }}-{{ block.id }}"
+                    class="full-unstyled-link"
+                    aria-labelledby="StandardCardNoMediaLink-{{ section_id }}-{{ block.id }} NoMediaStandardBadge-{{ section_id }}-{{ block.id }}"
+                  >
+                {%- endif -%}
                 <div
-                  class="media media--transparent ratio"
+                  class="media media--transparent ratio{% if block.settings.link %} media--hover-effect{% endif %}"
                   {% if block.settings.image != blank %}
                     style="--ratio-percent: {{ 1 | divided_by: block.settings.image.aspect_ratio | times: 100 }}%"
                   {% else %}
@@ -89,6 +97,9 @@
                     {{ 'detailed-apparel-1' | placeholder_svg_tag: 'placeholder-svg' }}
                   {%- endif -%}
                 </div>
+                {%- if block.settings.link -%}
+                  </a>
+                {%- endif -%}
               </div>
             {%- when 'product' -%}
               {%- assign placeholder_image = 'product-apparel-' | append: placeholder_image_index -%}
@@ -250,10 +261,7 @@
   "tag": "section",
   "class": "section",
   "disabled_on": {
-    "groups": [
-      "header",
-      "footer"
-    ]
+    "groups": ["header", "footer"]
   },
   "settings": [
     {
@@ -372,6 +380,11 @@
           "type": "image_picker",
           "id": "image",
           "label": "t:sections.collage.blocks.image.settings.image.label"
+        },
+        {
+          "type": "url",
+          "id": "link",
+          "label": "t:sections.collage.blocks.image.settings.link.label"
         }
       ]
     },
@@ -415,10 +428,7 @@
         {
           "type": "video_url",
           "id": "video_url",
-          "accept": [
-            "youtube",
-            "vimeo"
-          ],
+          "accept": ["youtube", "vimeo"],
           "default": "https://www.youtube.com/watch?v=_9VUPq3SxOc",
           "label": "t:sections.collage.blocks.video.settings.video_url.label",
           "placeholder": "t:sections.collage.blocks.video.settings.video_url.placeholder",


### PR DESCRIPTION
### PR Summary: 

Add support for links in the collage section to enable better engagement and storytelling.

### Why are these changes introduced?

The collage section is great for storytelling but, without links, images are not clickable so there is no possible engagement. Being able to specify a link enables merchants to make images clickable.

### Visual impact on existing themes

Images become clickable and add the hover effect if a link is specified.

### Checklist
- [ ] Added PR summary for [release notes](https://themes.shopify.com/themes/dawn/styles/default#ReleaseNotes)
- [ ] Requested review from UX (Only for changes that are affecting the experience or perceivable visual details)
- [ ] Created a ticket for the [help.shopify.com](https://help.shopify.com) documentation team about updates to theme settings. (Internal-only task)
- [ ] Followed [theme code principles](https://github.com/Shopify/dawn/blob/main/.github/CONTRIBUTING.md#theme-code-principles)
- [ ] Linted with [Theme Check](https://github.com/Shopify/theme-check)
- [ ] Tested on [mobile](https://shopify.dev/themes/store/requirements#mobile-browser-requirements)
- [ ] Tested on [multiple browsers](https://shopify.dev/themes/store/requirements#desktop-browser-requirements)
- [ ] Tested for [accessibility](https://shopify.dev/themes/best-practices/accessibility)