### PR TITLE
[Quick Order List] Clean and reset qty errors

### DIFF
--- a/assets/quick-order-list.js
+++ b/assets/quick-order-list.js
@@ -182,6 +182,8 @@ class QuickOrderList extends HTMLElement {
   }
 
   renderSections(parsedState, id) {
+    this.cleanErrors();
+
     this.getSectionsToRender().forEach((section => {
       const sectionElement = document.getElementById(section.id);
       if (sectionElement && sectionElement.parentElement && sectionElement.parentElement.classList.contains('drawer')) {
@@ -403,6 +405,11 @@ class QuickOrderList extends HTMLElement {
       message = window.cartStrings.quantityError.replace('[quantity]', updatedValue);
     }
     this.updateLiveRegions(id, message);
+  }
+
+  cleanErrors() {
+    this.querySelectorAll('.desktop-row-error').forEach((error) => error.classList.add('hidden'));
+    this.querySelectorAll(`.variant-item__error-text`).forEach((error) => error.innerHTML = '');
   }
 
   updateLiveRegions(id, message) {

--- a/assets/quick-order-list.js
+++ b/assets/quick-order-list.js
@@ -131,8 +131,6 @@ class QuickOrderList extends HTMLElement {
 
     const quantity = inputValue - cartQuantity;
 
-    this.cleanErrors();
-
     if (cartQuantity > 0) {
       this.updateQuantity(index, inputValue, name, this.actions.update);
     } else {
@@ -271,6 +269,7 @@ class QuickOrderList extends HTMLElement {
 
   updateQuantity(id, quantity, name, action) {
     this.toggleLoading(id, true);
+    this.cleanErrors();
 
     let routeUrl = routes.cart_change_url;
     let body = JSON.stringify({

--- a/assets/quick-order-list.js
+++ b/assets/quick-order-list.js
@@ -131,6 +131,8 @@ class QuickOrderList extends HTMLElement {
 
     const quantity = inputValue - cartQuantity;
 
+    this.cleanErrors();
+
     if (cartQuantity > 0) {
       this.updateQuantity(index, inputValue, name, this.actions.update);
     } else {
@@ -182,8 +184,6 @@ class QuickOrderList extends HTMLElement {
   }
 
   renderSections(parsedState, id) {
-    this.cleanErrors();
-
     this.getSectionsToRender().forEach((section => {
       const sectionElement = document.getElementById(section.id);
       if (sectionElement && sectionElement.parentElement && sectionElement.parentElement.classList.contains('drawer')) {


### PR DESCRIPTION
### PR Summary: 

<!-- Please include a short description (using non-technical terms, 1-2 sentences) about the changes you are introducing, what problem is being fixed and/or describe the benefit to merchants. This content will be used in our release notes for Dawn on [themes.shopify.com](https://themes.shopify.com/themes/dawn/styles/default#ReleaseNotes). -->

This PR is to clean qty errors in the Quick Order List. If you input/set a qty that exceeds available stock the qty in the input field will be reset to the previous value, and an error will be shown. This error will be removed as soon as you change qty of any variants in the Quick Order List.

!!! There is still a known issue. If you try to input/set a qty that exceeds available stock the qty in the input field will be reset to its previous value while all available qty of the variant will be added to the cart. This need to be fix on BE. 

### Why are these changes introduced?

Previously we didn't have to care about cleaning errors because after any qty change we would re-render the whole section Quick Order List. After we introduced the [Keyboard Interaction](https://github.com/Shopify/dawn/pull/2962) we don't re-render the whole section so we need to clean errors when any qty change happens at any row. 

### What approach did you take?
I built a function `cleanErrors()` and run it every time we run `renderSections()`. 

### Other considerations

### Decision log

| # | Decision | Alternatives | Rationale | Downsides |
|---|---|---|---|---|
| 1 |   |   |   |   |


### Visual impact on existing themes
<!-- How will this visually affect merchants who upgrade to a new theme version with this change? -->


### Testing steps/scenarios
<!-- List all the testing tasks that applies to your fix to help peers review your work. -->
- [ ] Go to PDP and add the Quick Order List section. 
- [ ] Via the Quick Order List add any qty but not exceeding stock to the cart. 
- [ ] Try to change this qty to a crazy number that exceeds stock. You should see an error.
- [ ] Change any qty of any variant in the Quick Order List. Make sure that the error message is gone and the Quick Order List works properly. 
- [ ] Do the same for mobile. 

### Demo links
<!-- Please include a link to a demo store that includes preconfigured sections and settings to allow reviewers to easily test the features you are working on. -->

- [Editor](https://admin.shopify.com/store/os2-demo/themes/162992816150/editor)

### Checklist
- [ ] Added PR summary for [release notes](https://themes.shopify.com/themes/dawn/styles/default#ReleaseNotes)
- [ ] Requested review from UX (Only for changes that are affecting the experience or perceivable visual details)
- [ ] Created a ticket for the [help.shopify.com](https://help.shopify.com) documentation team about updates to theme settings. (Internal-only task)
- [ ] Followed [theme code principles](https://github.com/Shopify/dawn/blob/main/.github/CONTRIBUTING.md#theme-code-principles)
- [ ] Linted with [Theme Check](https://github.com/Shopify/theme-check)
- [ ] Tested on [mobile](https://shopify.dev/themes/store/requirements#mobile-browser-requirements)
- [ ] Tested on [multiple browsers](https://shopify.dev/themes/store/requirements#desktop-browser-requirements)
- [ ] Tested for [accessibility](https://shopify.dev/themes/best-practices/accessibility)
