### PR TITLE
Remove block maxes for Collage and Collection List sections

### DIFF
--- a/sections/collage.liquid
+++ b/sections/collage.liquid
@@ -434,7 +434,6 @@
       ]
     }
   ],
-  "max_blocks": 3,
   "presets": [
     {
       "name": "t:sections.collage.presets.name",

--- a/sections/collection-list.liquid
+++ b/sections/collection-list.liquid
@@ -134,7 +134,6 @@
   "name": "t:sections.collection-list.name",
   "tag": "section",
   "class": "section section-collection-list",
-  "max_blocks": 15,
   "disabled_on": {
     "groups": [
       "header",


### PR DESCRIPTION
### PR Summary: 

As far as I can tell from my testing, there is no reason to limit the number of blocks in a Collage or Collection List.

### Why are these changes introduced?

There are cases where it’s helpful to have more than 3 or 15 blocks, respectively.

### What approach did you take?

### Other considerations

There may be performance or layout-related issues I am unaware of, but I have not come across any issues.