### PR TITLE
Fix keyboard navigation in QOL

### DIFF
--- a/assets/quick-order-list.js
+++ b/assets/quick-order-list.js
@@ -195,7 +195,7 @@ class QuickOrderList extends HTMLElement {
       }
       const elementToReplace = sectionElement && sectionElement.querySelector(section.selector) ? sectionElement.querySelector(section.selector) : sectionElement;
       if (elementToReplace) {
-        if (section.selector === '.js-contents' && id !== undefined) {
+        if (section.selector === '#${this.quickOrderListId} .js-contents' && id !== undefined) {
           elementToReplace.querySelector(`#Variant-${id}`).innerHTML =
           this.getSectionInnerHTML(parsedState.sections[section.section], `#Variant-${id}`);
         } else {

--- a/assets/quick-order-list.js
+++ b/assets/quick-order-list.js
@@ -195,7 +195,7 @@ class QuickOrderList extends HTMLElement {
       }
       const elementToReplace = sectionElement && sectionElement.querySelector(section.selector) ? sectionElement.querySelector(section.selector) : sectionElement;
       if (elementToReplace) {
-        if (section.selector === '#${this.quickOrderListId} .js-contents' && id !== undefined) {
+        if (section.selector === `#${this.quickOrderListId} .js-contents` && id !== undefined) {
           elementToReplace.querySelector(`#Variant-${id}`).innerHTML =
           this.getSectionInnerHTML(parsedState.sections[section.section], `#Variant-${id}`);
         } else {


### PR DESCRIPTION
## PR Summary

Fix issue where keyboard navigation `Enter` is not taking the buyer to the next input on a valid input

Also fixes this https://github.com/Shopify/dawn/issues/3327

Test Store: https://admin.shopify.com/store/os2-demo/themes/163004284950/editor


