### PR TITLE
[Quick Order List] Fix an issue for one-variant product

### DIFF
--- a/assets/quick-order-list.js
+++ b/assets/quick-order-list.js
@@ -80,12 +80,14 @@ class QuickOrderList extends HTMLElement {
       };
     }
     this.totalBar = this.querySelector('.quick-order-list__total');
-    this.totalBarPosition = this.totalBar ? window.innerHeight - this.totalBar.offsetHeight: null;
+    if (this.totalBar) {
+      this.totalBarPosition = window.innerHeight - this.totalBar.offsetHeight;
 
-    window.addEventListener('resize', () => {
-      this.totalBarPosition = this.totalBar ? window.innerHeight - this.totalBar.offsetHeight: null;
-      this.stickyHeader.height = this.stickyHeaderElement ? this.stickyHeaderElement.offsetHeight: null;
-    });
+      window.addEventListener('resize', () => {
+        this.totalBarPosition = window.innerHeight - this.totalBar.offsetHeight;
+        this.stickyHeader.height = this.stickyHeaderElement ? this.stickyHeaderElement.offsetHeight: 0;
+      });
+    }
 
     form.addEventListener('submit', this.onSubmit.bind(this));
     const debouncedOnChange = debounce((event) => {


### PR DESCRIPTION
### PR Summary: 

This PR is to fix an issue for one-variant product in the Quick Order List. After we introduced the Keyboard Interaction the Quick Order List stopped working for one-variant products.

[Video](https://screenshot.click/08-38-nlcwd-jgtl8.mp4) of the issue. 


### Why are these changes introduced?
In the Quick Order List products with one variant don't have the total bar as products with multiple variants do. It was not taken on account. When we try to calculate a position for the total bar we may face an error in JS because we use an element that doesn't exist for one-variant products. 

### What approach did you take?
I added an `if` statement to check if the total bar exists in the `constructor`. I also added an `if` statement inside `swicthVariant()` to avoid scrolling on one-variant products.  

### Demo links
[Editor](https://admin.shopify.com/store/os2-demo/themes/163004579862/editor)

- [ ] Make sure that the Quick Order List works properly when there is only one variant. ([this is a good example of a product](https://admin.shopify.com/store/os2-demo/themes/163004579862/editor?previewPath=%2Fproducts%2Fhobo-l-latte))
- [ ] Make sure that products with many variants still work properly. 
