### PR TITLE
Fix  qty rules when there is no max set

### DIFF
--- a/assets/product-info.js
+++ b/assets/product-info.js
@@ -84,10 +84,14 @@ if (!customElements.get('product-info')) {
           const updated = quantityFormUpdated.querySelector(selector);
           if (!current || !updated) continue;
           if (selector === '.quantity__input') {
-            const attributes = ['data-cart-quantity', 'data-min', 'data-max', 'step'];
+            const attributes = ['data-cart-quantity', 'data-min', 'data-max', 'step', 'max'];
             for (let attribute of attributes) {
               const valueUpdated = updated.getAttribute(attribute);
-              if (valueUpdated !== null) current.setAttribute(attribute, valueUpdated);
+              if (valueUpdated !== null) { 
+                current.setAttribute(attribute, valueUpdated)
+              } else {
+                current.removeAttribute(attribute)
+              }
             }
           } else {
             current.innerHTML = updated.innerHTML;

--- a/assets/product-info.js
+++ b/assets/product-info.js
@@ -49,9 +49,13 @@ if (!customElements.get('product-info')) {
         const max = data.max === null ? data.max : data.max - data.cartQuantity;
         if (max !== null) min = Math.min(min, max);
         if (data.cartQuantity >= data.min) min = Math.min(min, data.step);
-
         this.input.min = min;
-        this.input.max = max;
+
+        if (max) {
+          this.input.max = max;
+        } else {
+          this.input.removeAttribute('max')
+        }
         this.input.value = min;
         publish(PUB_SUB_EVENTS.quantityUpdate, undefined);
       }
@@ -84,7 +88,7 @@ if (!customElements.get('product-info')) {
           const updated = quantityFormUpdated.querySelector(selector);
           if (!current || !updated) continue;
           if (selector === '.quantity__input') {
-            const attributes = ['data-cart-quantity', 'data-min', 'data-max', 'step', 'max'];
+            const attributes = ['data-cart-quantity', 'data-min', 'data-max', 'step'];
             for (let attribute of attributes) {
               const valueUpdated = updated.getAttribute(attribute);
               if (valueUpdated !== null) { 


### PR DESCRIPTION
### PR Summary: 

Ensure the qty rules **max** updates when changing variants even when the new variant doesnt have qty rules. Max does not exist when there are no qty rules. While min and step are defaulted to 1. This is more visible when the max is 1 since the `+` is disabled right away

### Why are these changes introduced?

Fixes  https://github.com/Shopify/dawn/issues/3355

### What approach did you take?

Removing the max and data-max attributes when the attribute doesnt exist. In this case it is null, since there is no max set for qty rules in some cases 

### Testing steps/scenarios
<!-- List all the testing tasks that applies to your fix to help peers review your work. -->
- [ ] Test on `100 variant product` -> https://screenshot.click/18-31-s15di-qj4lr.mp4

### Demo links
<!-- Please include a link to a demo store that includes preconfigured sections and settings to allow reviewers to easily test the features you are working on. -->

- [Editor](https://admin.shopify.com/store/os2-demo/themes/163032301590/editor)

### Checklist
- [ ] Added PR summary for [release notes](https://themes.shopify.com/themes/dawn/styles/default#ReleaseNotes)
- [ ] Requested review from UX (Only for changes that are affecting the experience or perceivable visual details)
- [ ] Created a ticket for the [help.shopify.com](https://help.shopify.com) documentation team about updates to theme settings. (Internal-only task)
- [ ] Followed [theme code principles](https://github.com/Shopify/dawn/blob/main/.github/CONTRIBUTING.md#theme-code-principles)
- [ ] Linted with [Theme Check](https://github.com/Shopify/theme-check)
- [ ] Tested on [mobile](https://shopify.dev/themes/store/requirements#mobile-browser-requirements)
- [ ] Tested on [multiple browsers](https://shopify.dev/themes/store/requirements#desktop-browser-requirements)
- [ ] Tested for [accessibility](https://shopify.dev/themes/best-practices/accessibility)
