### PR TITLE
Close popover when tabbing away

### DIFF
--- a/assets/quantity-popover.js
+++ b/assets/quantity-popover.js
@@ -22,6 +22,7 @@ if (!customElements.get('quantity-popover')) {
 
         if (this.infoButtonDesktop) {
           this.infoButtonDesktop.addEventListener('click', this.togglePopover.bind(this));
+          this.infoButtonDesktop.addEventListener('focusout', this.closePopover.bind(this));
         }
 
         if (this.infoButtonMobile) {


### PR DESCRIPTION
### PR Summary: 

Use tab to open the popover (by `enter`) then tab away and the popover closes

### Why are these changes introduced?

We dont want multiple popovers to stay open when tabbing

Before:https://screenshot.click/21-02-p2kax-x4yra.mp4
After:https://screenshot.click/21-01-gc1cv-3im0n.mp4


### Demo links
<!-- Please include a link to a demo store that includes preconfigured sections and settings to allow reviewers to easily test the features you are working on. -->

- [Editor](https://admin.shopify.com/store/os2-demo/themes/163047800854/editor)

### Checklist
- [ ] Added PR summary for [release notes](https://themes.shopify.com/themes/dawn/styles/default#ReleaseNotes)
- [ ] Requested review from UX (Only for changes that are affecting the experience or perceivable visual details)
- [ ] Created a ticket for the [help.shopify.com](https://help.shopify.com) documentation team about updates to theme settings. (Internal-only task)
- [ ] Followed [theme code principles](https://github.com/Shopify/dawn/blob/main/.github/CONTRIBUTING.md#theme-code-principles)
- [ ] Linted with [Theme Check](https://github.com/Shopify/theme-check)
- [ ] Tested on [mobile](https://shopify.dev/themes/store/requirements#mobile-browser-requirements)
- [ ] Tested on [multiple browsers](https://shopify.dev/themes/store/requirements#desktop-browser-requirements)
- [ ] Tested for [accessibility](https://shopify.dev/themes/best-practices/accessibility)
