### PR TITLE
Fixed minor bug with multicolumn padding

### DIFF
--- a/assets/section-multicolumn.css
+++ b/assets/section-multicolumn.css
@@ -10,15 +10,16 @@
   margin-top: 0;
 }
 
+@media screen and (max-width: 749px) {
+  .multicolumn .title-wrapper-with-link {
+    margin-bottom: 3rem;
+  }
+}
+
 @media screen and (min-width: 750px) and (max-width: 989px) {
   .multicolumn__title {
     padding-left: 5rem;
     padding-right: 5rem;
-  }
-}
-@media screen and (max-width: 749px) {
-  .multicolumn .title-wrapper-with-link {
-    margin-bottom: 3rem;
   }
 }
 

--- a/assets/section-multicolumn.css
+++ b/assets/section-multicolumn.css
@@ -10,6 +10,12 @@
   margin-top: 0;
 }
 
+@media screen and (min-width: 750px) and (max-width: 989px) {
+  .multicolumn__title {
+    padding-left: 5rem;
+    padding-right: 5rem;
+  }
+}
 @media screen and (max-width: 749px) {
   .multicolumn .title-wrapper-with-link {
     margin-bottom: 3rem;
@@ -120,8 +126,7 @@
 }
 
 @media screen and (min-width: 750px) {
-  .multicolumn-list.slider,
-  .multicolumn-list.grid--4-col-desktop {
+  .multicolumn-list.slider {
     padding: 0;
   }
 

--- a/sections/multicolumn.liquid
+++ b/sections/multicolumn.liquid
@@ -31,7 +31,7 @@
     {% endif %}
   >
     {%- unless section.settings.title == blank -%}
-      <div class="title-wrapper-with-link title-wrapper--self-padded-mobile title-wrapper--no-top-margin">
+      <div class="title-wrapper-with-link title-wrapper--self-padded-mobile title-wrapper--no-top-margin multicolumn__title">
         <h2 class="title inline-richtext {{ section.settings.heading_size }}">
           {{ section.settings.title }}
         </h2>


### PR DESCRIPTION
### PR Summary: 

@melissaperreault noticed a bug with multicolumn padding at tablet sizes where, when on 4 columns, the multicolumn section would lose all of its padding.

I fixed this and the title which was also going flush against the edges of the screen.

### What approach did you take?

It lacked padding, so I added padding.

### Other considerations

This section could use a refactor - it's pretty complex for just a series of columns.

### Decision log

* I just added a new class for the header.  I wanted to avoid changing the generic class to avoid regressions in other sections.  Titles also need a refactor.

### Visual impact on existing themes

Makes them look pretty. 😎 

### Testing steps/scenarios
- [ ] Create a multicolumn section
- [ ] Set to 4 columns
- [ ] Check all screen widths - paddings should line up nicely.

### Checklist
- [ ] Added PR summary for [release notes](https://themes.shopify.com/themes/dawn/styles/default#ReleaseNotes)
- [ ] Requested review from UX (Only for changes that are affecting the experience or perceivable visual details)
- [ ] Created a ticket for the [help.shopify.com](https://help.shopify.com) documentation team about updates to theme settings. (Internal-only task)
- [ ] Followed [theme code principles](https://github.com/Shopify/dawn/blob/main/.github/CONTRIBUTING.md#theme-code-principles)
- [ ] Linted with [Theme Check](https://github.com/Shopify/theme-check)
- [ ] Tested on [mobile](https://shopify.dev/themes/store/requirements#mobile-browser-requirements)
- [ ] Tested on [multiple browsers](https://shopify.dev/themes/store/requirements#desktop-browser-requirements)
- [ ] Tested for [accessibility](https://shopify.dev/themes/best-practices/accessibility)
