### PR TITLE
[BUG] Fix pagination for Quick Add bulk on section rendering api

### DIFF
--- a/assets/quick-add-bulk.js
+++ b/assets/quick-add-bulk.js
@@ -194,7 +194,11 @@ if (!customElements.get('quick-add-bulk')) {
       }
 
       getSectionsUrl() {
-        return `${window.location.pathname}?page=${window.pageNumber}`
+        if (window.pageNumber) {
+          return `${window.location.pathname}?page=${window.pageNumber}`
+        } else {
+          return `${window.location.pathname}`
+        }      
       }
 
       getSectionInnerHTML(html, selector) {

--- a/assets/quick-add-bulk.js
+++ b/assets/quick-add-bulk.js
@@ -17,6 +17,8 @@ if (!customElements.get('quick-add-bulk')) {
         this.listenForActiveInput();
         this.listenForKeydown();
         this.lastActiveInputId = null;
+        const pageParams = new URLSearchParams(window.location.search);
+        window.pageNumber = decodeURIComponent(pageParams.get('page') || '');
       }
 
 
@@ -77,12 +79,14 @@ if (!customElements.get('quick-add-bulk')) {
 
       onCartUpdate() {
         return new Promise((resolve, reject) => {
-          fetch(`${window.location.pathname}?section_id=${this.closest('.collection').dataset.id}`)
+          fetch(`${this.getSectionsUrl()}?section_id=${this.closest('.collection').dataset.id}`)
             .then((response) => response.text())
             .then((responseText) => {
               const html = new DOMParser().parseFromString(responseText, 'text/html');
               const sourceQty = html.querySelector(`#quick-add-bulk-${this.dataset.id}-${this.closest('.collection').dataset.id}`);
-              this.innerHTML = sourceQty.innerHTML;
+              if (sourceQty) {
+                this.innerHTML = sourceQty.innerHTML;
+              }
               resolve();
             })
             .catch(e => {
@@ -100,7 +104,8 @@ if (!customElements.get('quick-add-bulk')) {
         const body = JSON.stringify({
           quantity: event.target.value,
           id: event.target.getAttribute('data-index'),
-          sections: this.getSectionsToRender().map((section) => section.section)
+          sections: this.getSectionsToRender().map((section) => section.section),
+          sections_url: this.getSectionsUrl()
         });
 
         fetch(`${routes.cart_change_url}`, { ...fetchConfig('javascript'), ...{ body } })
@@ -186,6 +191,10 @@ if (!customElements.get('quick-add-bulk')) {
             section: 'cart-drawer'
           }
         ];
+      }
+
+      getSectionsUrl() {
+        return `${window.location.pathname}?page=${window.pageNumber}`
       }
 
       getSectionInnerHTML(html, selector) {

--- a/assets/quick-order-list.js
+++ b/assets/quick-order-list.js
@@ -103,6 +103,8 @@ if (!customElements.get('quick-order-list')) {
           });
         }
 
+        const pageParams = new URLSearchParams(window.location.search);
+        window.pageNumber = decodeURIComponent(pageParams.get('page') || '');
         form.addEventListener('submit', this.onSubmit.bind(this));
         this.addMultipleDebounce()
       }
@@ -194,12 +196,14 @@ if (!customElements.get('quick-order-list')) {
 
       refresh() {
         return new Promise((resolve, reject) => {
-          fetch(`${window.location.pathname}?section_id=${this.sectionId}`)
+          fetch(`${this.getSectionsUrl()}?section_id=${this.sectionId}`)
             .then((response) => response.text())
             .then((responseText) => {
               const html = new DOMParser().parseFromString(responseText, 'text/html');
               const sourceQty = html.querySelector(`#${this.quickOrderListId}`);
-              this.innerHTML = sourceQty.innerHTML;
+              if (sourceQty) {
+                this.innerHTML = sourceQty.innerHTML;
+              }
               resolve();
             })
             .catch(e => {
@@ -366,7 +370,7 @@ if (!customElements.get('quick-order-list')) {
         const body = JSON.stringify({
           updates: items,
           sections: this.getSectionsToRender().map((section) => section.section),
-          sections_url: window.location.pathname
+          sections_url: this.getSectionsUrl()
         });
 
         this.updateMessage();
@@ -387,6 +391,10 @@ if (!customElements.get('quick-order-list')) {
           });
       }
 
+      getSectionsUrl() {
+        return `${window.location.pathname}?page=${window.pageNumber}`
+      }
+
       updateQuantity(id, quantity, name, action) {
         this.toggleLoading(id, true);
         this.cleanErrors();
@@ -396,7 +404,7 @@ if (!customElements.get('quick-order-list')) {
           quantity,
           id,
           sections: this.getSectionsToRender().map((section) => section.section),
-          sections_url: window.location.pathname
+          sections_url: this.getSectionsUrl()
         });
         let fetchConfigType;
         if (action === this.actions.add) {
@@ -410,7 +418,7 @@ if (!customElements.get('quick-order-list')) {
               }
             ],
             sections: this.getSectionsToRender().map((section) => section.section),
-            sections_url: window.location.pathname
+            sections_url: this.getSectionsUrl()
           });
         }
 

--- a/assets/quick-order-list.js
+++ b/assets/quick-order-list.js
@@ -392,7 +392,11 @@ if (!customElements.get('quick-order-list')) {
       }
 
       getSectionsUrl() {
-        return `${window.location.pathname}?page=${window.pageNumber}`
+        if (window.pageNumber) {
+          return `${window.location.pathname}?page=${window.pageNumber}`
+        } else {
+          return `${window.location.pathname}`
+        }
       }
 
       updateQuantity(id, quantity, name, action) {


### PR DESCRIPTION
### PR Summary: 

If the quick add bulk is located on the collection page and not on the first page, the section rendering API is not updating the respective page

Before: https://screenshot.click/01-48-nquyh-2ctsj.mp4
After: https://screenshot.click/01-47-r59l6-bveic.mp4

### Testing steps/scenarios
<!-- List all the testing tasks that applies to your fix to help peers review your work. -->
- [ ] Test quick order list and quick add bulk on a collection page (page 1 and also page 2 or 3)
- [ ] Ensure the qol still works on pdp
- [ ] Ensure quick add bulk works on feat collection in other templates

### Demo links
<!-- Please include a link to a demo store that includes preconfigured sections and settings to allow reviewers to easily test the features you are working on. -->

- [Editor](https://admin.shopify.com/store/os2-demo/themes/163070017558/editor)

### Checklist
- [ ] Added PR summary for [release notes](https://themes.shopify.com/themes/dawn/styles/default#ReleaseNotes)
- [ ] Requested review from UX (Only for changes that are affecting the experience or perceivable visual details)
- [ ] Created a ticket for the [help.shopify.com](https://help.shopify.com) documentation team about updates to theme settings. (Internal-only task)
- [ ] Followed [theme code principles](https://github.com/Shopify/dawn/blob/main/.github/CONTRIBUTING.md#theme-code-principles)
- [ ] Linted with [Theme Check](https://github.com/Shopify/theme-check)
- [ ] Tested on [mobile](https://shopify.dev/themes/store/requirements#mobile-browser-requirements)
- [ ] Tested on [multiple browsers](https://shopify.dev/themes/store/requirements#desktop-browser-requirements)
- [ ] Tested for [accessibility](https://shopify.dev/themes/best-practices/accessibility)
