### PR TITLE
Changed max products per page to 36

### DIFF
--- a/sections/main-collection-product-grid.liquid
+++ b/sections/main-collection-product-grid.liquid
@@ -198,7 +198,7 @@
       "type": "range",
       "id": "products_per_page",
       "min": 8,
-      "max": 24,
+      "max": 36,
       "step": 4,
       "default": 16,
       "label": "t:sections.main-collection-product-grid.settings.products_per_page.label"


### PR DESCRIPTION
### PR Summary: 

A quick PR to bump max products per page to 36.

### Why are these changes introduced?

6 column grid necessitates more products per page.

### What approach did you take?

Changed an integer. 🤯 

### Other considerations

Performance impact was assessed - document size is not significantly different.  TTFB did not change significantly either.

### Visual impact on existing themes

None, unless they change the setting.


### Testing steps/scenarios
- [ ] Add enough products to hit 36 on the all products page
- [ ] Change the setting in the main product grid
- [ ] Look upon the glory of a large product grid
- [ ] Cheer with excitement

### Demo links

[Store](https://os2-demo.myshopify.com/?_ab=0&_fd=0&_sc=1&preview_theme_id=163071721494)
[Editor](https://admin.shopify.com/store/os2-demo/themes/157707698198/editor)

### Checklist
- [ ] Added PR summary for [release notes](https://themes.shopify.com/themes/dawn/styles/default#ReleaseNotes)
- [ ] Requested review from UX (Only for changes that are affecting the experience or perceivable visual details)
- [ ] Created a ticket for the [help.shopify.com](https://help.shopify.com) documentation team about updates to theme settings. (Internal-only task)
- [ ] Followed [theme code principles](https://github.com/Shopify/dawn/blob/main/.github/CONTRIBUTING.md#theme-code-principles)
- [ ] Linted with [Theme Check](https://github.com/Shopify/theme-check)
- [ ] Tested on [mobile](https://shopify.dev/themes/store/requirements#mobile-browser-requirements)
- [ ] Tested on [multiple browsers](https://shopify.dev/themes/store/requirements#desktop-browser-requirements)
- [ ] Tested for [accessibility](https://shopify.dev/themes/best-practices/accessibility)
