### PR TITLE
Add Volume Pricing and Qty Rules Popover to Quick Add Bulk Input

### DIFF
--- a/assets/component-card.css
+++ b/assets/component-card.css
@@ -148,6 +148,21 @@
   color: rgba(var(--color-foreground), 0.75);
 }
 
+.card__information-volume-pricing-note--button {
+  text-decoration: underline;
+  position: relative;
+  grid-row-start: 4;
+  margin: 0 0 1rem;
+  z-index: 1;
+  cursor: pointer;
+}
+
+.card__information-volume-pricing-note--button + .global-settings-popup.quantity-popover__info {
+  transform: initial;
+  top: auto;
+  bottom: 2rem;
+}
+
 @media screen and (min-width: 750px) {
   .card__information {
     padding-bottom: 1.7rem;

--- a/assets/component-card.css
+++ b/assets/component-card.css
@@ -152,15 +152,17 @@
   text-decoration: underline;
   position: relative;
   grid-row-start: 4;
-  margin: 0 0 1rem;
+  /* margin: 0 0 1rem; */
   z-index: 1;
   cursor: pointer;
+  padding: 0;
+  margin: 0;
 }
 
 .card__information-volume-pricing-note--button + .global-settings-popup.quantity-popover__info {
   transform: initial;
   top: auto;
-  bottom: 2rem;
+  bottom: 4rem;
 }
 
 @media screen and (min-width: 750px) {

--- a/assets/quantity-popover.js
+++ b/assets/quantity-popover.js
@@ -21,7 +21,7 @@ if (!customElements.get('quantity-popover')) {
         }
 
         if (this.infoButtonDesktop) {
-          // this.infoButtonDesktop.addEventListener('click', this.togglePopover.bind(this));
+          this.infoButtonDesktop.addEventListener('click', this.togglePopover.bind(this));
           this.infoButtonDesktop.addEventListener('focusout', this.closePopover.bind(this));
         }
 

--- a/assets/quantity-popover.js
+++ b/assets/quantity-popover.js
@@ -21,7 +21,7 @@ if (!customElements.get('quantity-popover')) {
         }
 
         if (this.infoButtonDesktop) {
-          this.infoButtonDesktop.addEventListener('click', this.togglePopover.bind(this));
+          // this.infoButtonDesktop.addEventListener('click', this.togglePopover.bind(this));
           this.infoButtonDesktop.addEventListener('focusout', this.closePopover.bind(this));
         }
 

--- a/snippets/card-product.liquid
+++ b/snippets/card-product.liquid
@@ -205,9 +205,89 @@
 
             {% render 'price', product: card_product, price_class: '', show_compare_at_price: true %}
             {%- if card_product.quantity_price_breaks_configured? -%}
-              <div class="card__information-volume-pricing-note">
+              {% if card_product.variants.size == 1 %}
+                {% liquid
+                  assign has_qty_rules = false
+                  if variant.quantity_rule.increment > 1 or variant.quantity_rule.min > 1 or variant.quantity_rule.max != null
+                    assign has_qty_rules = true
+                  endif
+                %}
+                <quantity-popover>
+              {% endif %}
+              <div class="card__information-volume-pricing-note{% if card_product.variants.size == 1 %} card__information-volume-pricing-note--button quantity-popover__info-button--icon-only quantity-popover__info-button--icon-with-label{% endif %}">
                 <span class="caption">{{ 'products.product.volume_pricing.note' | t }}</span>
               </div>
+              {% if card_product.variants.size == 1 %}
+                <div
+                  class="global-settings-popup quantity-popover__info"
+                  tabindex="-1"
+                  hidden
+                  id="quantity-popover-info-{{ card_product.selected_or_first_available_variant.id }}"
+                >
+                  {%- if has_qty_rules == false -%}
+                    <span class="volume-pricing-label caption">{{ 'products.product.volume_pricing.title' | t }}</span>
+                  {%- endif -%}
+                  {%- if has_qty_rules -%}
+                    <div class="quantity__rules caption no-js-hidden">
+                      {%- if card_product.selected_or_first_available_variant.quantity_rule.increment > 1 -%}
+                        <span class="divider">
+                          {{-
+                            'products.product.quantity.multiples_of'
+                            | t: quantity: card_product.selected_or_first_available_variant.quantity_rule.increment
+                          -}}
+                        </span>
+                      {%- endif -%}
+                      {%- if variant.quantity_rule.min > 1 -%}
+                        <span class="divider">
+                          {{-
+                            'products.product.quantity.min_of'
+                            | t: quantity: card_product.selected_or_first_available_variant.quantity_rule.min
+                          -}}
+                        </span>
+                      {%- endif -%}
+                      {%- if variant.quantity_rule.max != null -%}
+                        <span class="divider">
+                          {{-
+                            'products.product.quantity.max_of'
+                            | t: quantity: card_product.selected_or_first_available_variant.quantity_rule.max
+                          -}}
+                        </span>
+                      {%- endif -%}
+                    </div>
+                  {%- endif -%}
+                  <button
+                    class="button-close button button--tertiary large-up-hide"
+                    type="button"
+                    aria-label="{{ 'accessibility.close' | t }}"
+                  >
+                    {%- render 'icon-close' -%}
+                  </button>
+                  {%- if card_product.selected_or_first_available_variant.quantity_price_breaks.size > 0 -%}
+                    <volume-pricing class="parent-display">
+                      <ul class="list-unstyled">
+                        <li>
+                          <span>{{ card_product.selected_or_first_available_variant.quantity_rule.min }}+</span>
+                          {%- assign price = card_product.selected_or_first_available_variant.price
+                            | money_with_currency
+                          -%}
+                          <span>{{ 'sections.quick_order_list.each' | t: money: price }}</span>
+                        </li>
+                        {%- for price_break in card_product.selected_or_first_available_variant.quantity_price_breaks -%}
+                          <li>
+                            <span>
+                              {{- price_break.minimum_quantity -}}
+                              <span aria-hidden="true">+</span></span
+                            >
+                            {%- assign price = price_break.price | money_with_currency -%}
+                            <span> {{ 'sections.quick_order_list.each' | t: money: price }}</span>
+                          </li>
+                        {%- endfor -%}
+                      </ul>
+                    </volume-pricing>
+                  {%- endif -%}
+                </div>
+                </quantity-popover>
+              {% endif %}
             {%- endif -%}
           </div>
         </div>

--- a/snippets/card-product.liquid
+++ b/snippets/card-product.liquid
@@ -205,7 +205,7 @@
 
             {% render 'price', product: card_product, price_class: '', show_compare_at_price: true %}
             {%- if card_product.quantity_price_breaks_configured? -%}
-              {% if card_product.variants.size == 1 %}
+              {% if card_product.variants.size == 1 and quick_add == 'bulk' %}
                 {% liquid
                   assign has_qty_rules = false
                   if variant.quantity_rule.increment > 1 or variant.quantity_rule.min > 1 or variant.quantity_rule.max != null
@@ -214,10 +214,19 @@
                 %}
                 <quantity-popover>
               {% endif %}
-              <div class="card__information-volume-pricing-note{% if card_product.variants.size == 1 %} card__information-volume-pricing-note--button quantity-popover__info-button--icon-only quantity-popover__info-button--icon-with-label{% endif %}">
-                <span class="caption">{{ 'products.product.volume_pricing.note' | t }}</span>
-              </div>
-              {% if card_product.variants.size == 1 %}
+              {% if card_product.variants.size == 1 and quick_add == 'bulk' %}
+                <button class="card__information-volume-pricing-note card__information-volume-pricing-note--button quantity-popover__info-button--icon-only button button button--tertiary small-hide">
+                  <span class="caption">{{ 'products.product.volume_pricing.note' | t }}</span>
+                </button>
+                <button class="card__information-volume-pricing-note card__information-volume-pricing-note--button quantity-popover__info-button--icon-with-label button button--tertiary medium-hide large-up-hide">
+                  <span class="caption">{{ 'products.product.volume_pricing.note' | t }}</span>
+                </button>
+              {% else %}
+                <div class="card__information-volume-pricing-note">
+                  <span class="caption">{{ 'products.product.volume_pricing.note' | t }}</span>
+                </div>
+              {% endif %}
+              {% if card_product.variants.size == 1 and quick_add == 'bulk' %}
                 <div
                   class="global-settings-popup quantity-popover__info"
                   tabindex="-1"


### PR DESCRIPTION
### PR Summary: 

Add the Qty Rules/Volume Pricing popover to the Quick Add Bulk Popover. This is the same as the QOL where you can access it by hover/tabbing on desktop and click on mobile

### Testing steps/scenarios
<!-- List all the testing tasks that applies to your fix to help peers review your work. -->
- [ ] Test a product with 1 variant and qty rules
- [ ] Test a product with 1 variant and qty rules + vol pricing
- [ ] Test a product with 1 variant + vol pricing
- [ ] Test mobile and desktop

### Demo links
<!-- Please include a link to a demo store that includes preconfigured sections and settings to allow reviewers to easily test the features you are working on. -->

- [Editor](https://admin.shopify.com/store/os2-demo/themes/163074768918/editor)

### Checklist
- [ ] Added PR summary for [release notes](https://themes.shopify.com/themes/dawn/styles/default#ReleaseNotes)
- [ ] Requested review from UX (Only for changes that are affecting the experience or perceivable visual details)
- [ ] Created a ticket for the [help.shopify.com](https://help.shopify.com) documentation team about updates to theme settings. (Internal-only task)
- [ ] Followed [theme code principles](https://github.com/Shopify/dawn/blob/main/.github/CONTRIBUTING.md#theme-code-principles)
- [ ] Linted with [Theme Check](https://github.com/Shopify/theme-check)
- [ ] Tested on [mobile](https://shopify.dev/themes/store/requirements#mobile-browser-requirements)
- [ ] Tested on [multiple browsers](https://shopify.dev/themes/store/requirements#desktop-browser-requirements)
- [ ] Tested for [accessibility](https://shopify.dev/themes/best-practices/accessibility)
