### PR TITLE
fix country drawer for small choices

### DIFF
--- a/assets/component-localization-form.css
+++ b/assets/component-localization-form.css
@@ -247,7 +247,7 @@
     bottom: -1rem;
     left: 0;
     width: 100%;
-    height: 80%;
+    height: auto;
     max-height: 80vh;
     border-radius: 0;
     border: none;


### PR DESCRIPTION
### PR Summary: 

QuickFix to next issue.

[Issue reference](https://github.com/Shopify/dawn/issues/3252)
> The country selector's height with not many countries on it feels a bit overwhelming on mobile in the menu drawer. ([Video reference](https://screenshot.click/17-19-dzmhz-ahqiv.mp4))

#### My fix : 

![image](https://github.com/Shopify/dawn/assets/15829643/7de78428-569b-474e-b4d3-c68d1aec926e)

### Why are these changes introduced?

Fixes #3252 .

### What approach did you take?

Minimum code modification for fix the issue.

### Visual impact on existing themes

If the country's choice is small the drawer was small too and the height was limited at 80% of screen's height.

### Checklist
- [x] Added PR summary for [release notes](https://themes.shopify.com/themes/dawn/styles/default#ReleaseNotes)
- [x] Requested review from UX (Only for changes that are affecting the experience or perceivable visual details)
- [ ] Created a ticket for the [help.shopify.com](https://help.shopify.com) documentation team about updates to theme settings. (Internal-only task)
- [x] Followed [theme code principles](https://github.com/Shopify/dawn/blob/main/.github/CONTRIBUTING.md#theme-code-principles)
- [x] Linted with [Theme Check](https://github.com/Shopify/theme-check)
- [x] Tested on [mobile](https://shopify.dev/themes/store/requirements#mobile-browser-requirements)
- [x] Tested on [multiple browsers](https://shopify.dev/themes/store/requirements#desktop-browser-requirements)
- [x] Tested for [accessibility](https://shopify.dev/themes/best-practices/accessibility)
