### PR TITLE
Fix width of popover in product card

### DIFF
--- a/assets/component-card.css
+++ b/assets/component-card.css
@@ -164,6 +164,8 @@
   transform: initial;
   top: auto;
   bottom: 3.5rem;
+  max-width: 20rem;
+  width: 80%;
 }
 
 .card-information quantity-popover volume-pricing {


### PR DESCRIPTION
### PR Summary: 

Ensure the popover is not set to 20rem and a max of 20rem instead when the rows are slimmer so the popover doesnt get pushed over

Before: 
![image](https://github.com/Shopify/dawn/assets/19962891/17ee1c14-3e7d-4044-aea8-e1b2d6c43d33)

After:
<img width="501" alt="Screenshot 2024-04-05 at 12 24 45 PM" src="https://github.com/Shopify/dawn/assets/19962891/69ac73fd-b036-4904-8f6f-d40cf9a291c4">




### Testing steps/scenarios
<!-- List all the testing tasks that applies to your fix to help peers review your work. -->
- [ ] test product cards with qty rules/vol pricing and play around with card settings

### Demo links
<!-- Please include a link to a demo store that includes preconfigured sections and settings to allow reviewers to easily test the features you are working on. -->

- [Editor](https://admin.shopify.com/store/os2-demo/themes/163090563094/editor)

### Checklist
- [ ] Added PR summary for [release notes](https://themes.shopify.com/themes/dawn/styles/default#ReleaseNotes)
- [ ] Requested review from UX (Only for changes that are affecting the experience or perceivable visual details)
- [ ] Created a ticket for the [help.shopify.com](https://help.shopify.com) documentation team about updates to theme settings. (Internal-only task)
- [ ] Followed [theme code principles](https://github.com/Shopify/dawn/blob/main/.github/CONTRIBUTING.md#theme-code-principles)
- [ ] Linted with [Theme Check](https://github.com/Shopify/theme-check)
- [ ] Tested on [mobile](https://shopify.dev/themes/store/requirements#mobile-browser-requirements)
- [ ] Tested on [multiple browsers](https://shopify.dev/themes/store/requirements#desktop-browser-requirements)
- [ ] Tested for [accessibility](https://shopify.dev/themes/best-practices/accessibility)
