### PR TITLE
Update width of popover card

### DIFF
--- a/assets/component-card.css
+++ b/assets/component-card.css
@@ -165,7 +165,7 @@
   top: auto;
   bottom: 3.5rem;
   max-width: 20rem;
-  width: 80%;
+  width: 95%;
 }
 
 .card-information quantity-popover volume-pricing {


### PR DESCRIPTION
### PR Summary: 

Update width of popover for product card

Before:
![screenshot_2024-04-05_at_4 23 04___pm](https://github.com/Shopify/dawn/assets/19962891/801eedd2-a125-4934-b650-486133bf5534)

After:
<img width="226" alt="Screenshot 2024-04-05 at 4 29 52 PM" src="https://github.com/Shopify/dawn/assets/19962891/cf636926-74c5-4234-a30e-c8913ba35fec">
