### PR TITLE
Add min/max values for single-variant products with quantity rules in Quick Add

### DIFF
--- a/assets/component-card.css
+++ b/assets/component-card.css
@@ -199,7 +199,7 @@
     width: calc(100% + var(--border-width) + 3.5rem);
   }
 
-  .card--standard .grid--6-col-desktop .card__information-volume-pricing-note--button + .global-settings-popup.quantity-popover__info {
+   .grid--6-col-desktop .card--standard .card__information-volume-pricing-note--button + .global-settings-popup.quantity-popover__info {
     width: calc(100% + var(--border-width) + 1rem);
   }
 }
@@ -210,6 +210,10 @@
   }
 
   .grid--2-col-tablet-down .card__information-volume-pricing-note--button + .global-settings-popup.quantity-popover__info {
+    width: calc(100% + var(--border-width) + 1rem);
+  }
+
+  .grid--2-col-tablet-down .card--standard .card__information-volume-pricing-note--button + .global-settings-popup.quantity-popover__info {
     width: calc(100% + var(--border-width) + 0.5rem);
   }
 

--- a/assets/component-card.css
+++ b/assets/component-card.css
@@ -215,12 +215,12 @@
 }
 
 .card-information quantity-popover volume-pricing {
-  margin-top: 4.2rem;
+  margin-top: 0;
 }
 
-@media screen and (min-width: 990px) {
-  .card-information quantity-popover volume-pricing {
-    margin-top: 0;
+@media screen and (max-width: 989px) {
+  .card-information quantity-popover div:not(.quantity__rules) ~ volume-pricing {
+    margin-top: 4.2rem;
   }
 }
 

--- a/assets/component-card.css
+++ b/assets/component-card.css
@@ -219,7 +219,11 @@
 }
 
 @media screen and (max-width: 989px) {
-  .card-information quantity-popover div:not(.quantity__rules) ~ volume-pricing {
+  .card-information quantity-popover .quantity__rules ~ volume-pricing {
+     margin-top: 0;
+  }
+
+  .card-information quantity-popover  volume-pricing {
     margin-top: 4.2rem;
   }
 }

--- a/assets/component-card.css
+++ b/assets/component-card.css
@@ -196,7 +196,7 @@
   .grid--6-col-desktop .card__information-volume-pricing-note--button + .global-settings-popup.quantity-popover__info {
     left: 50%;
     transform: translate(-50%);
-    width: calc(100% + var(--border-width) + 3.5rem);
+    width: calc(100% + var(--border-width) + 1rem);
   }
 }
 
@@ -206,7 +206,11 @@
   }
 
   .grid--2-col-tablet-down .card__information-volume-pricing-note--button + .global-settings-popup.quantity-popover__info {
-    width: calc(100% + var(--border-width) + 1rem);
+    width: calc(100% + var(--border-width) + 0.5rem);
+  }
+
+  .grid--2-col-tablet-down .card__information-volume-pricing-note--button + .global-settings-popup.quantity-popover__info .quantity__rules {
+    margin-top: 4.2rem;
   }
 
   .grid--2-col-tablet-down .card__content quick-add-bulk .quantity {

--- a/assets/component-card.css
+++ b/assets/component-card.css
@@ -196,6 +196,10 @@
   .grid--6-col-desktop .card__information-volume-pricing-note--button + .global-settings-popup.quantity-popover__info {
     left: 50%;
     transform: translate(-50%);
+    width: calc(100% + var(--border-width) + 3.5rem);
+  }
+
+  .card--standard .grid--6-col-desktop .card__information-volume-pricing-note--button + .global-settings-popup.quantity-popover__info {
     width: calc(100% + var(--border-width) + 1rem);
   }
 }

--- a/snippets/card-product.liquid
+++ b/snippets/card-product.liquid
@@ -207,8 +207,9 @@
             {%- if card_product.quantity_price_breaks_configured? -%}
               {% if card_product.variants.size == 1 and quick_add == 'bulk' %}
                 {% liquid
+                  assign quantity_rule = card_product.selected_or_first_available_variant.quantity_rule
                   assign has_qty_rules = false
-                  if variant.quantity_rule.increment > 1 or variant.quantity_rule.min > 1 or variant.quantity_rule.max != null
+                  if quantity_rule.increment > 1 or quantity_rule.min > 1 or quantity_rule.max != null
                     assign has_qty_rules = true
                   endif
                 %}
@@ -233,27 +234,27 @@
                 >
                   {%- if has_qty_rules -%}
                     <div class="quantity__rules caption no-js-hidden">
-                      {%- if card_product.selected_or_first_available_variant.quantity_rule.increment > 1 -%}
+                      {%- if quantity_rule.increment > 1 -%}
                         <span class="divider">
                           {{-
                             'products.product.quantity.multiples_of'
-                            | t: quantity: card_product.selected_or_first_available_variant.quantity_rule.increment
+                            | t: quantity: quantity_rule.increment
                           -}}
                         </span>
                       {%- endif -%}
-                      {%- if variant.quantity_rule.min > 1 -%}
+                      {%- if quantity_rule.min > 1 -%}
                         <span class="divider">
                           {{-
                             'products.product.quantity.min_of'
-                            | t: quantity: card_product.selected_or_first_available_variant.quantity_rule.min
+                            | t: quantity: quantity_rule.min
                           -}}
                         </span>
                       {%- endif -%}
-                      {%- if variant.quantity_rule.max != null -%}
+                      {%- if quantity_rule.max != null -%}
                         <span class="divider">
                           {{-
                             'products.product.quantity.max_of'
-                            | t: quantity: card_product.selected_or_first_available_variant.quantity_rule.max
+                            | t: quantity: quantity_rule.max
                           -}}
                         </span>
                       {%- endif -%}


### PR DESCRIPTION
### PR Summary:

We're currently not showing the min/max for quantity rules on product cards in quick add:

![image](https://github.com/Shopify/dawn/assets/590055/34c3ea54-edba-486e-8e6a-a24a3e2e68e4)

### What approach did you take?

We were using a mix of `variant.quantity_rule` and `card_product.selected_or_first_available_variant.quantity_rule`. It turns out the latter is correct, so this change always uses it:

![image](https://github.com/Shopify/dawn/assets/590055/4439e35e-55d6-49ec-b384-8b692781a0fb)

### Demo links

- [Editor](https://admin.shopify.com/store/84f654-2/themes/163099148310/editor)
