### PR TITLE
Fix padding for popover product card spacing mobile and cart popover media query

### DIFF
--- a/assets/component-card.css
+++ b/assets/component-card.css
@@ -214,9 +214,13 @@
   }
 
   .grid--2-col-tablet-down .card--standard .card__information-volume-pricing-note--button + .global-settings-popup.quantity-popover__info {
-    width: calc(100% + var(--border-width) + 4rem);
+    width: 100%;
     left: 50%;
     transform: translate(-50%);
+  }
+
+  .grid--2-col-tablet-down .card--card .card__information-volume-pricing-note--button + .global-settings-popup.quantity-popover__info {
+    width: calc(100% + var(--border-width) + 4rem);
   }
 
   .grid--2-col-tablet-down .card__content quick-add-bulk .quantity {

--- a/assets/component-card.css
+++ b/assets/component-card.css
@@ -213,10 +213,13 @@
     width: calc(3.5rem / var(--font-body-scale));
   }
 
-  .grid--2-col-tablet-down .card--standard .card__information-volume-pricing-note--button + .global-settings-popup.quantity-popover__info {
-    width: 100%;
+  .grid--2-col-tablet-down .card--card .card__information-volume-pricing-note--button + .global-settings-popup.quantity-popover__info,   .grid--2-col-tablet-down .card--standard .card__information-volume-pricing-note--button + .global-settings-popup.quantity-popover__info  {
     left: 50%;
     transform: translate(-50%);
+  }
+
+  .grid--2-col-tablet-down .card--standard .card__information-volume-pricing-note--button + .global-settings-popup.quantity-popover__info {
+    width: 100%;
   }
 
   .grid--2-col-tablet-down .card--card .card__information-volume-pricing-note--button + .global-settings-popup.quantity-popover__info {

--- a/assets/component-card.css
+++ b/assets/component-card.css
@@ -217,7 +217,7 @@
     width: calc(100% + var(--border-width) + 0.5rem);
   }
 
-  .grid--2-col-tablet-down .card__information-volume-pricing-note--button + .global-settings-popup.quantity-popover__info .quantity__rules {
+  .grid--2-col-tablet-down .card--border .card__information-volume-pricing-note--button + .global-settings-popup.quantity-popover__info .quantity__rules {
     margin-top: calc(var(--border-width) * 1.75);
   }
 

--- a/assets/component-card.css
+++ b/assets/component-card.css
@@ -218,7 +218,7 @@
   }
 
   .grid--2-col-tablet-down .card__information-volume-pricing-note--button + .global-settings-popup.quantity-popover__info .quantity__rules {
-    margin-top: 4.2rem;
+    margin-top: calc(var(--border-width) * 1.75);
   }
 
   .grid--2-col-tablet-down .card__content quick-add-bulk .quantity {

--- a/assets/component-card.css
+++ b/assets/component-card.css
@@ -184,6 +184,10 @@
   transform: translate(-50%);
 }
 
+.card__information-volume-pricing-note--button + .global-settings-popup.quantity-popover__info .quantity__rules {
+  text-align: left;
+}
+
 @media screen and (min-width: 990px) {
   .grid--6-col-desktop .card__content quick-add-bulk .quantity {
     width: auto;
@@ -209,16 +213,10 @@
     width: calc(3.5rem / var(--font-body-scale));
   }
 
-  .grid--2-col-tablet-down .card__information-volume-pricing-note--button + .global-settings-popup.quantity-popover__info {
-    width: calc(100% + var(--border-width) + 1rem);
-  }
-
   .grid--2-col-tablet-down .card--standard .card__information-volume-pricing-note--button + .global-settings-popup.quantity-popover__info {
-    width: calc(100% + var(--border-width) + 0.5rem);
-  }
-
-  .grid--2-col-tablet-down .card--border .card__information-volume-pricing-note--button + .global-settings-popup.quantity-popover__info .quantity__rules {
-    margin-top: calc(var(--border-width) * 1.75);
+    width: calc(100% + var(--border-width) + 4rem);
+    left: 50%;
+    transform: translate(-50%);
   }
 
   .grid--2-col-tablet-down .card__content quick-add-bulk .quantity {

--- a/assets/component-cart-items.css
+++ b/assets/component-cart-items.css
@@ -348,8 +348,8 @@ cart-remove-button .icon-remove {
   }
 }
 
-@media screen and (min-width: 749px) and (max-width: 990px) {
+@media screen and (max-width: 989px) {
   .cart-items .quantity-popover__info-button {
-    padding-left: 1.5rem;
+    padding-left: 0;
   }
 }

--- a/sections/main-cart-items.liquid
+++ b/sections/main-cart-items.liquid
@@ -235,7 +235,7 @@
                               <button
                                 type="button"
                                 aria-expanded="false"
-                                class="quantity-popover__info-button quantity-popover__info-button--icon-only button button--tertiary small-hide"
+                                class="quantity-popover__info-button quantity-popover__info-button--icon-only button button--tertiary small-hide medium-hide"
                               >
                                 {% render 'icon-info' %}
                               </button>
@@ -290,7 +290,7 @@
                         {%- if has_qty_rules or has_vol_pricing -%}
                           <button
                             type="button"
-                            class="quantity-popover__info-button quantity-popover__info-button--icon-with-label button button--tertiary medium-hide large-up-hide"
+                            class="quantity-popover__info-button quantity-popover__info-button--icon-with-label button button--tertiary large-up-hide"
                             aria-expanded="false"
                           >
                             {% render 'icon-info' %}

--- a/sections/main-cart-items.liquid
+++ b/sections/main-cart-items.liquid
@@ -341,7 +341,7 @@
                               {%- endif -%}
                             </div>
                             <button
-                              class="button-close button button--tertiary medium-hide large-up-hide"
+                              class="button-close button button--tertiary large-up-hide"
                               type="button"
                               aria-label="{{ 'accessibility.close' | t }}"
                             >

--- a/snippets/card-product.liquid
+++ b/snippets/card-product.liquid
@@ -43,7 +43,6 @@
     <div
       class="
         card card--{{ settings.card_style }}
-        {% if settings.card_border_thickness > 0 %} card--border{% endif %}
         {% if card_product.featured_media %} card--media{% else %} card--text{% endif %}
         {% if settings.card_style == 'card' %} color-{{ settings.card_color_scheme }} gradient{% endif %}
         {% if image_shape and image_shape != 'default' %} card--shape{% endif %}
@@ -545,7 +544,6 @@
     <div
       class="
         card card--{{ settings.card_style }}
-        {% if settings.card_border_thickness > 0 %} card--border{% endif %}
         {% if extend_height %} card--extend-height{% endif %}
         {% if image_shape and image_shape != 'default' %} card--shape{% endif %}
         {% if settings.card_style == 'card' %} color-{{ settings.card_color_scheme }} gradient{% endif %}

--- a/snippets/card-product.liquid
+++ b/snippets/card-product.liquid
@@ -43,6 +43,7 @@
     <div
       class="
         card card--{{ settings.card_style }}
+        {% if settings.card_border_thickness > 0 %} card--border{% endif %}
         {% if card_product.featured_media %} card--media{% else %} card--text{% endif %}
         {% if settings.card_style == 'card' %} color-{{ settings.card_color_scheme }} gradient{% endif %}
         {% if image_shape and image_shape != 'default' %} card--shape{% endif %}
@@ -236,26 +237,17 @@
                     <div class="quantity__rules caption no-js-hidden">
                       {%- if quantity_rule.increment > 1 -%}
                         <span class="divider">
-                          {{-
-                            'products.product.quantity.multiples_of'
-                            | t: quantity: quantity_rule.increment
-                          -}}
+                          {{- 'products.product.quantity.multiples_of' | t: quantity: quantity_rule.increment -}}
                         </span>
                       {%- endif -%}
                       {%- if quantity_rule.min > 1 -%}
                         <span class="divider">
-                          {{-
-                            'products.product.quantity.min_of'
-                            | t: quantity: quantity_rule.min
-                          -}}
+                          {{- 'products.product.quantity.min_of' | t: quantity: quantity_rule.min -}}
                         </span>
                       {%- endif -%}
                       {%- if quantity_rule.max != null -%}
                         <span class="divider">
-                          {{-
-                            'products.product.quantity.max_of'
-                            | t: quantity: quantity_rule.max
-                          -}}
+                          {{- 'products.product.quantity.max_of' | t: quantity: quantity_rule.max -}}
                         </span>
                       {%- endif -%}
                     </div>
@@ -553,6 +545,7 @@
     <div
       class="
         card card--{{ settings.card_style }}
+        {% if settings.card_border_thickness > 0 %} card--border{% endif %}
         {% if extend_height %} card--extend-height{% endif %}
         {% if image_shape and image_shape != 'default' %} card--shape{% endif %}
         {% if settings.card_style == 'card' %} color-{{ settings.card_color_scheme }} gradient{% endif %}


### PR DESCRIPTION
### PR Summary: 

- Ensure the padding for the popover in the product card has the correct spacing on mobile and respects the border added to it
- Ensure the popover can open on all media queries on cart 

To test:
- Play with this setting: https://screenshot.click/09-28-lysin-6u4up.png
- Ensure the `x` looks good with thick padding https://screenshot.click/09-28-j70aw-zfl6h.png
- And thin padding https://screenshot.click/09-29-91l74-1crm6.png
- No padding: https://screenshot.click/09-59-vaxxu-cxl6x.png

### Editor:
https://admin.shopify.com/store/os2-demo/themes/163102261270/editor
