### PR TITLE
Fix selector for Quick Add Bulk

### DIFF
--- a/assets/quick-add-bulk.js
+++ b/assets/quick-add-bulk.js
@@ -177,9 +177,9 @@ if (!customElements.get('quick-add-bulk')) {
       getSectionsToRender() {
         return [
           {
-            id: `quick-add-bulk-${this.dataset.id}-${this.closest('.collection').dataset.id}`,
+            id: `quick-add-bulk-${this.dataset.id}-${this.closest('.collection-quick-add-bulk').dataset.id}`,
             section: this.closest('.collection').dataset.id,
-            selector: `#quick-add-bulk-${this.dataset.id}-${this.closest('.collection').dataset.id}`
+            selector: `#quick-add-bulk-${this.dataset.id}-${this.closest('.collection-quick-add-bulk').dataset.id}`
           },
           {
             id: 'cart-icon-bubble',

--- a/assets/quick-add-bulk.js
+++ b/assets/quick-add-bulk.js
@@ -178,7 +178,7 @@ if (!customElements.get('quick-add-bulk')) {
         return [
           {
             id: `quick-add-bulk-${this.dataset.id}-${this.closest('.collection-quick-add-bulk').dataset.id}`,
-            section: this.closest('.collection').dataset.id,
+            section: this.closest('.collection-quick-add-bulk').dataset.id,
             selector: `#quick-add-bulk-${this.dataset.id}-${this.closest('.collection-quick-add-bulk').dataset.id}`
           },
           {

--- a/sections/featured-collection.liquid
+++ b/sections/featured-collection.liquid
@@ -62,7 +62,7 @@
   class="color-{{ section.settings.color_scheme }} isolate gradient"
 >
   <div
-    class="collection{% if section.settings.quick_add == 'bulk' %} collection-bulk-add{% endif %} section-{{ section.id }}-padding{% if section.settings.full_width %} collection--full-width{% endif %}"
+    class="collection{% if section.settings.quick_add == 'bulk' %} collection-quick-add-bulk{% endif %} section-{{ section.id }}-padding{% if section.settings.full_width %} collection--full-width{% endif %}"
     id="collection-{{ section.id }}"
     data-id="{{ section.id }}"
   >

--- a/sections/featured-collection.liquid
+++ b/sections/featured-collection.liquid
@@ -62,7 +62,7 @@
   class="color-{{ section.settings.color_scheme }} isolate gradient"
 >
   <div
-    class="collection section-{{ section.id }}-padding{% if section.settings.full_width %} collection--full-width{% endif %}"
+    class="collection{% if section.settings.quick_add == 'bulk' %} collection-bulk-add{% endif %} section-{{ section.id }}-padding{% if section.settings.full_width %} collection--full-width{% endif %}"
     id="collection-{{ section.id }}"
     data-id="{{ section.id }}"
   >

--- a/sections/main-collection-product-grid.liquid
+++ b/sections/main-collection-product-grid.liquid
@@ -147,7 +147,7 @@
               class="
                 grid product-grid grid--{{ section.settings.columns_mobile }}-col-tablet-down
                 grid--{{ section.settings.columns_desktop }}-col-desktop
-                {% if section.settings.quick_add == 'bulk' %} collection-bulk-add{% endif %}
+                {% if section.settings.quick_add == 'bulk' %} collection-quick-add-bulk{% endif %}
               "
             >
               {%- for product in collection.products -%}

--- a/sections/main-collection-product-grid.liquid
+++ b/sections/main-collection-product-grid.liquid
@@ -139,14 +139,15 @@
         {%- else -%}
           <div
             class="collection{% if section.settings.filter_type != 'vertical' %} page-width{% endif %}"
-            data-id="{{ section.id }}"
           >
             <div class="loading-overlay gradient"></div>
             <ul
               id="product-grid"
+              data-id="{{ section.id }}"
               class="
                 grid product-grid grid--{{ section.settings.columns_mobile }}-col-tablet-down
                 grid--{{ section.settings.columns_desktop }}-col-desktop
+                {% if section.settings.quick_add == 'bulk' %} collection-bulk-add{% endif %}
               "
             >
               {%- for product in collection.products -%}


### PR DESCRIPTION
### PR Summary: 

Originally we moved the `section.id` to account for Quick Add Bulk: https://github.com/Shopify/dawn/commit/889e2a08a6bdb452381a07cd9bcd5088e1018be6
https://screenshot.click/15-39-ew18j-2wwe4.png

This was causing an issue for Filtering: Clearing any filter throws this section_id undefined error 
https://screenshot.click/15-51-emwn5-ioys8.png https://github.com/Shopify/dawn/blob/main/assets/facets.js#L248

I have reverted where section.id is and created a different selector for Quick Add Bulk

Test
- Quick Add Bulk (in collection page and feat collection)
- Filtering

Editor: https://admin.shopify.com/store/os2-demo/themes/163124576278/editor