### PR TITLE
[Fix] quick add bulk disabled state

### DIFF
--- a/assets/quick-add-bulk.js
+++ b/assets/quick-add-bulk.js
@@ -4,6 +4,8 @@ if (!customElements.get('quick-add-bulk')) {
     class QuickAddBulk extends HTMLElement {
       constructor() {
         super();
+        this.quantity = this.querySelector('quantity-input');
+
         const debouncedOnChange = debounce((event) => {
           if (parseInt(event.target.dataset.cartQuantity) === 0) {
             this.addToCart(event);
@@ -102,7 +104,6 @@ if (!customElements.get('quick-add-bulk')) {
 
       updateCart(event) {
         this.lastActiveInputId = event.target.getAttribute('data-index');
-        this.quantity = this.querySelector('quantity-input');
         this.quantity.classList.add('quantity__input-disabled');
         this.selectProgressBar().classList.remove('hidden');
         const body = JSON.stringify({

--- a/assets/quick-add-bulk.js
+++ b/assets/quick-add-bulk.js
@@ -118,7 +118,7 @@ if (!customElements.get('quick-add-bulk')) {
           })
           .then((state) => {
             const parsedState = JSON.parse(state);
-
+            this.quantity.classList.remove('quantity__input-disabled');
             if (parsedState.description || parsedState.errors) {
               event.target.setCustomValidity(parsedState.description);
               event.target.reportValidity();
@@ -139,6 +139,7 @@ if (!customElements.get('quick-add-bulk')) {
       }
 
       addToCart(event) {
+        this.quantity.classList.add('quantity__input-disabled');
         this.selectProgressBar().classList.remove('hidden');
         this.lastActiveInputId = event.target.getAttribute('data-index');
         const body = JSON.stringify({
@@ -157,12 +158,12 @@ if (!customElements.get('quick-add-bulk')) {
           })
           .then((state) => {
             const parsedState = JSON.parse(state);
+            this.quantity.classList.remove('quantity__input-disabled');
             if (parsedState.description || parsedState.errors) {
               event.target.setCustomValidity(parsedState.description);
               event.target.reportValidity();
               this.resetQuantityInput(event.target.id);
               this.selectProgressBar().classList.add('hidden');
-              this.quantity.classList.remove('quantity__input-disabled');
               event.target.select();
               this.cleanErrorMessageOnType(event);
               // Error handling


### PR DESCRIPTION
### PR Summary: 

The Quick Add Bulk picker was not removing the class `disabled`. That is because we were only adding and removing the class in `updateCart` and `addCart` functions but they needed to be done in both

The buttons shouldnt be disabled after the API call is done

Before: https://screenshot.click/17-19-sqofb-d0krr.mp4

After: https://screenshot.click/17-20-qgdhm-rb7sj.mp4

