### PR TITLE
🐛 Fix js error switching variants when no media gallery exists

### DIFF
--- a/assets/global.js
+++ b/assets/global.js
@@ -1156,7 +1156,7 @@ class VariantSelects extends HTMLElement {
 
     document
       .querySelector(`[id^="MediaGallery-${this.dataset.section}"]`)
-      .setActiveMedia(`${this.dataset.section}-${this.currentVariant.featured_media?.id}`);
+      ?.setActiveMedia?.(`${this.dataset.section}-${this.currentVariant.featured_media?.id}`);
 
     // update media modal
     const modalContent = document.querySelector(`#ProductModal-${this.dataset.section} .product-media-modal__content`);


### PR DESCRIPTION
### PR Summary: 

Fixes JS error when switching variants for a product that has no media gallery

### Why are these changes introduced?

Demo of bug: https://screenshot.click/18-07-hs58z-owr7a.mp4

### What approach did you take?

Adds a null check by using optional chaining

### Tophatting
product without images: https://getmyducksinarow.myshopify.com/products/product-with-no-images
product with images: https://getmyducksinarow.myshopify.com/products/product-with-images

to see the "before" state, preview theme `dawn-release-14-0-0` in admin

### Checklist
- [ ] Added PR summary for [release notes](https://themes.shopify.com/themes/dawn/styles/default#ReleaseNotes)
- [ ] Requested review from UX (Only for changes that are affecting the experience or perceivable visual details)
- [ ] Created a ticket for the [help.shopify.com](https://help.shopify.com) documentation team about updates to theme settings. (Internal-only task)
- [ ] Followed [theme code principles](https://github.com/Shopify/dawn/blob/main/.github/CONTRIBUTING.md#theme-code-principles)
- [ ] Linted with [Theme Check](https://github.com/Shopify/theme-check)
- [ ] Tested on [mobile](https://shopify.dev/themes/store/requirements#mobile-browser-requirements)
- [ ] Tested on [multiple browsers](https://shopify.dev/themes/store/requirements#desktop-browser-requirements)
- [ ] Tested for [accessibility](https://shopify.dev/themes/best-practices/accessibility)
