### PR TITLE
[Prod page] Add check to prevent errors if no feat. image exists

### DIFF
--- a/assets/global.js
+++ b/assets/global.js
@@ -1154,9 +1154,11 @@ class VariantSelects extends HTMLElement {
       });
     }
 
-    document
-      .querySelector(`[id^="MediaGallery-${this.dataset.section}"]`)
-      ?.setActiveMedia?.(`${this.dataset.section}-${this.currentVariant.featured_media?.id}`);
+    if (this.currentVariant.featured_media) {
+      document
+        .querySelector(`[id^="MediaGallery-${this.dataset.section}"]`)
+        ?.setActiveMedia?.(`${this.dataset.section}-${this.currentVariant.featured_media?.id}`);
+    }
 
     // update media modal
     const modalContent = document.querySelector(`#ProductModal-${this.dataset.section} .product-media-modal__content`);

--- a/assets/global.js
+++ b/assets/global.js
@@ -1157,7 +1157,7 @@ class VariantSelects extends HTMLElement {
     if (this.currentVariant.featured_media) {
       document
         .querySelector(`[id^="MediaGallery-${this.dataset.section}"]`)
-        ?.setActiveMedia?.(`${this.dataset.section}-${this.currentVariant.featured_media?.id}`);
+        ?.setActiveMedia?.(`${this.dataset.section}-${this.currentVariant.featured_media.id}`);
     }
 
     // update media modal


### PR DESCRIPTION
I wonder if this still works with combined listing or not? 

Does the media id needs to grab `product.featured_media.id` in its place when there is no variant id attached to the currently selected option to re render the new product page ?

