### PR TITLE
Restore standard quick add to complementary products

### DIFF
--- a/sections/main-product.liquid
+++ b/sections/main-product.liquid
@@ -559,12 +559,17 @@
                                     offset: continue
                                   -%}
                                     <li>
+                                      {%- if block.settings.enable_quick_add -%}
+                                        {% assign quick_add = "standard" %}
+                                      {%- else -%}
+                                        {% assign quick_add = "none" %}
+                                      {%- endif -%}
                                       {% render 'card-product',
                                         card_product: product,
                                         media_aspect_ratio: block.settings.image_ratio,
                                         show_secondary_image: false,
                                         lazy_load: false,
-                                        show_quick_add: block.settings.enable_quick_add,
+                                        quick_add: quick_add,
                                         section_id: section.id,
                                         horizontal_class: true,
                                         horizontal_quick_add: true


### PR DESCRIPTION
### PR Summary: 

Fixes a bug where we weren't showing standard quick add on complementary products, when the setting was selected in the editor.

**Before:**
<img width="604" alt="image" src="https://github.com/Shopify/dawn/assets/590055/d777dc49-2406-4cfd-867e-ca1d410d1e9a">

**After:**
<img width="585" alt="image" src="https://github.com/Shopify/dawn/assets/590055/f5dfb5eb-9ac9-4a70-a2d0-0567077892a9">

### What approach did you take?

Used an assign to set the quick_add to either standard or none, based on the value of the enable_quick_add boolean setting.
