### PR TITLE
Fix quick add color scheme

### DIFF
--- a/sections/quick-order-list.liquid
+++ b/sections/quick-order-list.liquid
@@ -23,7 +23,8 @@
 {% render 'quick-order-list',
   product: product,
   show_image: section.settings.show_image,
-  show_sku: section.settings.show_sku
+  show_sku: section.settings.show_sku,
+  is_section: true
 %}
 
 {% schema %}

--- a/snippets/card-product.liquid
+++ b/snippets/card-product.liquid
@@ -503,12 +503,7 @@
                           </div>
                         {%- endif -%}
                       </div>
-                      {%- render 'quick-order-list',
-                        product: card_product,
-                        show_image: true,
-                        show_sku: true,
-                        is_modal: true
-                      -%}
+                      {%- render 'quick-order-list', product: card_product, show_image: true, show_sku: true -%}
                     </div>
                   </div>
                 </div>

--- a/snippets/quick-order-list-row.liquid
+++ b/snippets/quick-order-list-row.liquid
@@ -22,7 +22,7 @@
   <td class="variant-item__inner{% unless sku and show_sku %} variant-item__inner--no-sku{% endunless %}">
     {%- if show_image -%}
       <div class="variant-item__media">
-        <div class="variant-item__image-container global-media-settings{% unless is_modal %} gradient{% endunless %}{% unless image %} variant-item__image-container--no-img{% endunless %}">
+        <div class="variant-item__image-container global-media-settings{% if is_section %} gradient{% endif %}{% unless image %} variant-item__image-container--no-img{% endunless %}">
           {% if image %}
             {%- assign img_height = 43 | divided_by: image.aspect_ratio | ceil -%}
             {{

--- a/snippets/quick-order-list.liquid
+++ b/snippets/quick-order-list.liquid
@@ -3,9 +3,9 @@
 {%- assign items_in_cart = cart | line_items_for: product | sum: 'quantity' -%}
 {% # theme-check-enable %}
 <div
-  {% unless is_modal %}
+  {% if is_section %}
     class="color-{{ section.settings.color_scheme }} gradient"
-  {% endunless %}
+  {% endif %}
 >
   <quick-order-list
     class="page-width section-{{ section.id }}-padding"
@@ -71,8 +71,7 @@
                   sku: product.selected_or_first_available_variant.sku,
                   variant: product.selected_or_first_available_variant,
                   show_image: show_image,
-                  show_sku: show_sku,
-                  is_modal: is_modal
+                  show_sku: show_sku
                 -%}
               {%- else -%}
                 {%- for variant in product.variants -%}
@@ -82,8 +81,7 @@
                     sku: variant.sku,
                     variant: variant,
                     show_image: show_image,
-                    show_sku: show_sku,
-                    is_modal: is_modal
+                    show_sku: show_sku
                   -%}
                 {%- endfor -%}
               {%- endif -%}
@@ -115,7 +113,7 @@
       </span>
     {%- else -%}
       <div
-        class="quick-order-list__total{% unless is_modal %} gradient{% endunless %}"
+        class="quick-order-list__total{% if is_section %} gradient{% endif %}"
         id="quick-order-list-total-{{ product.id }}"
       >
         <div class="quick-order-list-total__info">


### PR DESCRIPTION
### PR Summary: 
Moving the `color-scheme` class further up the DOM by a few elements fixes color issue in Quick Add modal.

### Why are these changes introduced?
When using a quick add modal in a product grid, the color-scheme setting of the section only partially applied to the modal.
[![](https://screenshot.click/22-17-9opuw-brkns.png)](https://screenshot.click/22-17-9opuw-brkns.png)

### What approach did you take?
Moved the class a bit

### Visual impact on existing themes
Fixes color issue

### Testing steps/scenarios
- [ ] Install Dawn 14
- [ ] Navigate to collection page
- [ ] Enable Quick add (standard or bulk) – make sure to reload to test
- [ ] Change the color scheme of the section and check issue is fixed

Fix demo: https://screenshot.click/22-21-234hq-ru38a.gif