### PR TITLE
Fix variant media not changing in the quick add modal

### DIFF
--- a/assets/global.js
+++ b/assets/global.js
@@ -1103,10 +1103,9 @@ class VariantSelects extends HTMLElement {
   }
 
   updateMedia(html) {
+    const sectionId = this.dataset.originalSection ? this.dataset.originalSection : this.dataset.section;
     const mediaGallerySource = document.querySelector(`[id^="MediaGallery-${this.dataset.section}"] ul`);
-    const mediaGalleryDestination = html.querySelector(
-      `[id^="MediaGallery-${this.dataset.section.replace('quickadd-', '')}"] ul`
-    );
+    const mediaGalleryDestination = html.querySelector(`[id^="MediaGallery-${sectionId}"] ul`);
 
     const refreshSourceData = () => {
       const mediaGallerySourceItems = Array.from(mediaGallerySource.querySelectorAll('li[data-media-id]'));


### PR DESCRIPTION
### PR Summary: 

<!-- Please include a short description (using non-technical terms, 1-2 sentences) about the changes you are introducing, what problem is being fixed and/or describe the benefit to merchants. This content will be used in our release notes for Dawn on [themes.shopify.com](https://themes.shopify.com/themes/dawn/styles/default#ReleaseNotes). -->
In the quick add modal, on version 14, when you change variant it doesn't update media shown when it used to. 

### Why are these changes introduced?

Fixes https://github.com/Shopify/dawn/issues/3448

### What approach did you take?

From what I see it's looking a `mediaGalleyDestination` but it can't grab any cause `this.dataset.section` can't be found in the new `html`. ([recording](https://screenshot.click/01-59-692om-f0isq.mp4))

With this new approach, it seems like the issue comes from the fact that we have `preventDuplicatedIDs()` to prevent duplicate IDs in the quick add modal by adding `quickadd-`. So when we do 
```javascript
const mediaGalleryDestination = html.querySelector(`[id^="MediaGallery-${this.dataset.section}"] ul`);
```
It's not finding that destination as it doesn't have a similar `ID`. 
~We could tweak that `data-section` and remove the `quickadd-`  within `updateMedia(html){...}` 🤷~

In the function that prevents the duplicate IDs we're setting a data attribute that keeps the original section ID. So we're using this in priority if it's present and we don't need to do the string manipulation 👍 

If I do this instead it seem to fix the issue: 
```javascript
const sectionId = this.dataset.originalSection ? this.dataset.originalSection : this.dataset.section;
...
const mediaGalleryDestination =
      html.querySelector(`[id^="MediaGallery-${sectionId}"] ul`);
```

### Visual impact on existing themes
<!-- How will this visually affect merchants who upgrade to a new theme version with this change? -->
It now works when changing variant that has a feat. image

### Testing steps/scenarios
<!-- List all the testing tasks that applies to your fix to help peers review your work. -->
- [ ] Set the feat. collection on the homepage to use quick add standard
- [ ] Then open the modal for a product with variant images like Louise slide sandal or Puppy
- [ ] Change variant to see the image updated
- [ ] Also test and make sure it still works as expected on the product page and feat. product section

### Demo links
<!-- Please include a link to a demo store that includes preconfigured sections and settings to allow reviewers to easily test the features you are working on. -->

- [Editor](https://admin.shopify.com/store/os2-demo/themes/163207184406/editor)

### Checklist
- [ ] Added PR summary for [release notes](https://themes.shopify.com/themes/dawn/styles/default#ReleaseNotes)
- [ ] Requested review from UX (Only for changes that are affecting the experience or perceivable visual details)
- [ ] Created a ticket for the [help.shopify.com](https://help.shopify.com) documentation team about updates to theme settings. (Internal-only task)
- [ ] Followed [theme code principles](https://github.com/Shopify/dawn/blob/main/.github/CONTRIBUTING.md#theme-code-principles)
- [ ] Linted with [Theme Check](https://github.com/Shopify/theme-check)
- [ ] Tested on [mobile](https://shopify.dev/themes/store/requirements#mobile-browser-requirements)
- [ ] Tested on [multiple browsers](https://shopify.dev/themes/store/requirements#desktop-browser-requirements)
- [ ] Tested for [accessibility](https://shopify.dev/themes/best-practices/accessibility)
