### PR TITLE
Add null check for `summary.NextElementSibling` in `global.js`

### DIFF
--- a/assets/global.js
+++ b/assets/global.js
@@ -10,7 +10,7 @@ document.querySelectorAll('[id^="Details-"] summary').forEach((summary) => {
   summary.setAttribute('role', 'button');
   summary.setAttribute('aria-expanded', summary.parentNode.hasAttribute('open'));
 
-  if (summary.nextElementSibling.getAttribute('id')) {
+  if (summary.nextElementSibling?.getAttribute('id')) {
     summary.setAttribute('aria-controls', summary.nextElementSibling.id);
   }
 


### PR DESCRIPTION
### PR Summary: 

This PR adds a check in `global.js` that prevents trying to access a `<summary>` element sibling if it doesn't exist.

### Why are these changes introduced?

Fixes https://github.com/Shopify/dawn/issues/3452

### What approach did you take?

Use optional chaining on the `nextElementSibling` query.

### Visual impact on existing themes
Merchants that have a `<summary>` element that matches the default `global.js` selector but don't have a sibling won't cause the page's javascript to thrown an exception.

### Testing steps/scenarios
Customizing the theme's product page by adding an html snippet like the one below shouldn't break option/variant selection:

```html
<div id="Details-001">
  <details>
    <summary>This is the only child</summary>
    <!-- There is no nextElementSibling for this summary -->
  </details>
</div>
```

### Checklist
- [x] Added PR summary for [release notes](https://themes.shopify.com/themes/dawn/styles/default#ReleaseNotes)
- [ ] Requested review from UX (Only for changes that are affecting the experience or perceivable visual details)
- [ ] Created a ticket for the [help.shopify.com](https://help.shopify.com) documentation team about updates to theme settings. (Internal-only task)
- [ ] Followed [theme code principles](https://github.com/Shopify/dawn/blob/main/.github/CONTRIBUTING.md#theme-code-principles)
- [ ] Linted with [Theme Check](https://github.com/Shopify/theme-check)
- [ ] Tested on [mobile](https://shopify.dev/themes/store/requirements#mobile-browser-requirements)
- [ ] Tested on [multiple browsers](https://shopify.dev/themes/store/requirements#desktop-browser-requirements)
- [ ] Tested for [accessibility](https://shopify.dev/themes/best-practices/accessibility)
