### PR TITLE
Add qty rules client side validation to cart

### DIFF
--- a/assets/cart.js
+++ b/assets/cart.js
@@ -62,13 +62,10 @@ class CartItems extends HTMLElement {
 
     if (inputValue < event.target.dataset.min) {
       message = window.quickOrderListStrings.min_error.replace('[min]', event.target.dataset.min);
-      this.setValidity(event, index, message);
     } else if (inputValue > parseInt(event.target.max)) {
       message = window.quickOrderListStrings.max_error.replace('[max]', event.target.max);
-      this.setValidity(event, index, message);
     } else if (inputValue % parseInt(event.target.step) !== 0) {
       message = window.quickOrderListStrings.step_error.replace('[step]', event.target.step);
-      this.setValidity(event, index, message);
     }
 
     if (message) {


### PR DESCRIPTION
### PR Summary: 

Ensuring the qty rules validation happens before the cart API is called (this way the error doesnt need to come back from the API)

Before:

![14-03-h9usw-7v7uo](https://github.com/Shopify/dawn/assets/19962891/d96e036b-02a5-4650-90a0-40343f8b918c)

After:

![14-03-ve10n-sdzwn](https://github.com/Shopify/dawn/assets/19962891/ac733588-085f-4986-92a5-dd51aa6f452b)


### Why are these changes introduced?

Fixes #3399 

### What approach did you take?

I am pulling the same functions I use in QOL and Quick Add Bulk

### Testing steps/scenarios
<!-- List all the testing tasks that applies to your fix to help peers review your work. -->
- [ ] Test a variant with qty rules (increment, max and min)
- [ ] Test a variant without qty rules
- [ ] Test the cart drawer and cart page

### Demo links
<!-- Please include a link to a demo store that includes preconfigured sections and settings to allow reviewers to easily test the features you are working on. -->

- [Editor](https://admin.shopify.com/store/os2-demo/themes/163247947798/editor)

### Checklist
- [ ] Added PR summary for [release notes](https://themes.shopify.com/themes/dawn/styles/default#ReleaseNotes)
- [ ] Requested review from UX (Only for changes that are affecting the experience or perceivable visual details)
- [ ] Created a ticket for the [help.shopify.com](https://help.shopify.com) documentation team about updates to theme settings. (Internal-only task)
- [ ] Followed [theme code principles](https://github.com/Shopify/dawn/blob/main/.github/CONTRIBUTING.md#theme-code-principles)
- [ ] Linted with [Theme Check](https://github.com/Shopify/theme-check)
- [ ] Tested on [mobile](https://shopify.dev/themes/store/requirements#mobile-browser-requirements)
- [ ] Tested on [multiple browsers](https://shopify.dev/themes/store/requirements#desktop-browser-requirements)
- [ ] Tested for [accessibility](https://shopify.dev/themes/best-practices/accessibility)
