### PR TITLE
[Product] fix product modal not showing variant image

### DIFF
--- a/assets/global.js
+++ b/assets/global.js
@@ -1163,7 +1163,7 @@ class VariantSelects extends HTMLElement {
 
     // update media modal
     const modalContent = document.querySelector(`#ProductModal-${this.dataset.section} .product-media-modal__content`);
-    const newModalContent = html.querySelector(`product-modal`);
+    const newModalContent = html.querySelector(`#ProductModal-${this.dataset.section} .product-media-modal__content`);
     if (modalContent && newModalContent) modalContent.innerHTML = newModalContent.innerHTML;
   }
 


### PR DESCRIPTION
### PR Summary: 

<!-- Please include a short description (using non-technical terms, 1-2 sentences) about the changes you are introducing, what problem is being fixed and/or describe the benefit to merchants. This content will be used in our release notes for Dawn on [themes.shopify.com](https://themes.shopify.com/themes/dawn/styles/default#ReleaseNotes). -->
Address issue where when changing a the variant selected, and clicking on its variant image, it won't show anything in the product modal where it should be showing a bigger version of that image. 
[Recording](https://screenshot.click/21-18-tpkos-1dwmx.mp4)

### Why are these changes introduced?

Fixes issue where the image in the product modal to see images on mobile isn't showing anything.

### What approach did you take?

It's coming from some [refactor that happened recently](https://github.com/Shopify/dawn/pull/3233/files#diff-47a8b2f1172e03da15783b379f0e007d8e3dfd27cbd9142adf9e32c4b9591079). 

The issue is that with that refactor we're re inserting some HTML in the modal that's repeating the content that was already there. 

This code specifically: 
```javascript
    // update media modal
    const modalContent = document.querySelector(`#ProductModal-${this.dataset.section} .product-media-modal__content`);
    const newModalContent = html.querySelector(`product-modal`);
    if (modalContent && newModalContent) modalContent.innerHTML = newModalContent.innerHTML;
```

Here we're grabbing the `product-media-modal__content` and to update the media that should be showing we replace the HTML within it, except that inserting the content of `product-modal` instead of specifically the content that's within `product-media-modal__content`. So then the CSS selector isn't working as expected and hiding the content due to 
```css
.product-media-modal__content > *:not(.active),
.product__media-list .deferred-media {
  display: none;
}
```

### Visual impact on existing themes
<!-- How will this visually affect merchants who upgrade to a new theme version with this change? -->
Not showing mobile users the zoomed/bigger version of the media. 

### Testing steps/scenarios
<!-- List all the testing tasks that applies to your fix to help peers review your work. -->
- [ ] Go to a product page on mobile that has multiple variants and images attached to them
- [ ] Change variant selection
- [ ] Click the image to see the bigger version
- [ ] You should be seeing the image as expected 

Make sure to confirm there isn't any regression. Test desktop, and other areas where product medias come up. 

### Demo links
<!-- Please include a link to a demo store that includes preconfigured sections and settings to allow reviewers to easily test the features you are working on. -->

- [Editor](https://admin.shopify.com/store/os2-demo/themes/163283894294/editor)

### Checklist
- [ ] Added PR summary for [release notes](https://themes.shopify.com/themes/dawn/styles/default#ReleaseNotes)
- [ ] Requested review from UX (Only for changes that are affecting the experience or perceivable visual details)
- [ ] Created a ticket for the [help.shopify.com](https://help.shopify.com) documentation team about updates to theme settings. (Internal-only task)
- [ ] Followed [theme code principles](https://github.com/Shopify/dawn/blob/main/.github/CONTRIBUTING.md#theme-code-principles)
- [ ] Linted with [Theme Check](https://github.com/Shopify/theme-check)
- [ ] Tested on [mobile](https://shopify.dev/themes/store/requirements#mobile-browser-requirements)
- [ ] Tested on [multiple browsers](https://shopify.dev/themes/store/requirements#desktop-browser-requirements)
- [ ] Tested for [accessibility](https://shopify.dev/themes/best-practices/accessibility)
