### PR TITLE
Add an out of stock note for quick add bulk, like the one for quick add standard

### DIFF
--- a/snippets/card-product.liquid
+++ b/snippets/card-product.liquid
@@ -287,10 +287,10 @@
             {%- endif -%}
           </div>
         </div>
+        {% assign product_form_id = 'quick-add-' | append: section_id | append: card_product.id %}
         {% if quick_add == 'standard' %}
           <div class="quick-add no-js-hidden">
             {%- liquid
-              assign product_form_id = 'quick-add-' | append: section_id | append: card_product.id
               assign qty_rules = false
               if card_product.selected_or_first_available_variant.quantity_rule.min > 1 or card_product.selected_or_first_available_variant.quantity_rule.max != null or card_product.selected_or_first_available_variant.quantity_rule.increment > 1
                 assign qty_rules = true
@@ -391,7 +391,24 @@
               class="quick-add-bulk"
               data-index="{{ card_product.selected_or_first_available_variant.id }}"
             >
-              {% render 'quantity-input', variant: card_product.selected_or_first_available_variant, min: 0 %}
+              {% if card_product.selected_or_first_available_variant.available == false %}
+                <button
+                  id="{{ product_form_id }}-submit"
+                  type="submit"
+                  name="add"
+                  class="quick-add__submit button button--full-width button--secondary"
+                  aria-labelledby="{{ product_form_id }}-submit title-{{ section_id }}-{{ card_product.id }}"
+                  data-sold-out-message="true"
+                  disabled
+                >
+                  <span>{{ 'products.product.sold_out' | t }}</span>
+                  <span class="sold-out-message hidden">
+                    {{ 'products.product.sold_out' | t }}
+                  </span>
+                </button>
+              {% else %}
+                {% render 'quantity-input', variant: card_product.selected_or_first_available_variant, min: 0 %}
+              {% endif %}
             </quick-add-bulk>
           {% else %}
             <div class="quick-add no-js-hidden">


### PR DESCRIPTION
Fixes https://github.com/Shopify/dawn/issues/3445

I copied the button code over from the quick-add-standard block ([here](https://github.com/Shopify/dawn/pull/3487/files#diff-167fc70beb2d8c5dbf3e81a213fd3808f6b2e1d1c60590a6863724dc0dca3ea6R354-R381)) and tweaked it a bit, so there's some duplication. I picked this approach because:

(1) Extracting the common code into a snippet is messy, because it uses so many local assigns and passing a huge thing of assigns is almost as messy and more indirect than duplicating some liquid markup.

(2) Modifying the quantity-input snippet to include out of stock would have consequences on other pages, I didn't want to bite off that much scope.

But let me know if there's another approach I should have considered, or a strong preference for one of the approaches above.

Here's how it looks before:
![image](https://github.com/Shopify/dawn/assets/590055/aa4df203-81d9-47a6-a68e-c4f43d25c417)

Here's how it looks in this PR:
![image](https://github.com/Shopify/dawn/assets/590055/6001467d-e8c6-47ee-a1a5-a694cf223dc8)

- [Editor](https://admin.shopify.com/store/dan-theme-test-shop/themes/159008751672/editor)
