### PR TITLE
[Quick Order List] Ensure variant id is converted to an integer

### DIFF
--- a/assets/quick-order-list.js
+++ b/assets/quick-order-list.js
@@ -120,8 +120,9 @@ if (!customElements.get('quick-order-list')) {
           });
           if (
             event.source === this.quickOrderListId ||
-            (event.cartData.items && event.cartData.items.some((element) => !variantIds.includes(element.variant_id)))
+            !event.cartData.items?.some((element) => variantIds.includes(element.variant_id))
           ) {
+            console.log('should be mostly true');
             return;
           }
           // If its another section that made the update

--- a/assets/quick-order-list.js
+++ b/assets/quick-order-list.js
@@ -118,10 +118,9 @@ if (!customElements.get('quick-order-list')) {
           this.querySelectorAll('.variant-item').forEach((item) => {
             variantIds.push(parseInt(item.dataset.variantId));
           });
-
           if (
             event.source === this.quickOrderListId ||
-            (event.cartData.items && variantIds.some((element) => !event.cartData.items.includes(element)))
+            (event.cartData.items && event.cartData.items.some((element) => !variantIds.includes(element.variant_id)))
           ) {
             return;
           }

--- a/assets/quick-order-list.js
+++ b/assets/quick-order-list.js
@@ -116,7 +116,7 @@ if (!customElements.get('quick-order-list')) {
         this.cartUpdateUnsubscriber = subscribe(PUB_SUB_EVENTS.cartUpdate, (event) => {
           const variantIds = [];
           this.querySelectorAll('.variant-item').forEach((item) => {
-            variantIds.push(item.dataset.variantId);
+            variantIds.push(parseInt(item.dataset.variantId));
           });
 
           if (

--- a/assets/quick-order-list.js
+++ b/assets/quick-order-list.js
@@ -122,7 +122,6 @@ if (!customElements.get('quick-order-list')) {
             event.source === this.quickOrderListId ||
             !event.cartData.items?.some((element) => variantIds.includes(element.variant_id))
           ) {
-            console.log('should be mostly true');
             return;
           }
           // If its another section that made the update


### PR DESCRIPTION
### PR Summary: 

When comparing the items added to cart (and the variant ids) and the variant ids to be updated, they were numbers and strings. Because of that, this would always turn out false

I have updated it to ensure it is always a number

### To test

- Turn on `quick add bulk` in the collection page
- Add a feat collection to the same page and turn on `bulk` as well 
- Ensure there are two products that exist in both the collection and the feat collection modal
- Add one item to cart by opening the modal in the collection. Ensure the modal in feat collection also updated

Video:  https://screenshot.click/28-32-99kt3-lx6e4.mp4

