### PR TITLE
🐛 Combined listings bugfixes

### DIFF
--- a/assets/component-volume-pricing.css
+++ b/assets/component-volume-pricing.css
@@ -19,7 +19,7 @@ volume-pricing li {
   justify-content: space-between;
 }
 
-.volume-pricing-note {
+div.volume-pricing-note {
   margin-top: -2.6rem;
 }
 

--- a/assets/global.js
+++ b/assets/global.js
@@ -51,8 +51,6 @@ class HTMLUpdateUtility {
     const newNodeWrapper = document.createElement('div');
     HTMLUpdateUtility.setInnerHTML(newNodeWrapper, newContent.outerHTML);
     const newNode = newNodeWrapper.firstChild;
-    oldNode.parentNode.insertBefore(newNode, oldNode);
-    oldNode.style.display = 'none';
 
     // dedupe IDs
     const uniqueKey = Date.now();
@@ -60,6 +58,9 @@ class HTMLUpdateUtility {
       element.id && (element.id = `${element.id}-${uniqueKey}`);
       element.form && element.setAttribute('form', `${element.form.getAttribute('id')}-${uniqueKey}`);
     });
+
+    oldNode.parentNode.insertBefore(newNode, oldNode);
+    oldNode.style.display = 'none';
 
     this.#postProcessCallbacks.forEach((callback) => callback(newNode));
 

--- a/assets/quick-add.js
+++ b/assets/quick-add.js
@@ -77,7 +77,16 @@ if (!customElements.get('quick-add-modal')) {
 
       preventDuplicatedIDs(productElement) {
         const sectionId = productElement.dataset.section;
-        productElement.outerHTML = productElement.outerHTML.replaceAll(sectionId, `quickadd-${sectionId}`);
+
+        const oldId = sectionId;
+        const newId = `quickadd-${sectionId}`;
+        productElement.innerHTML = productElement.innerHTML.replaceAll(oldId, newId);
+        Array.from(productElement.attributes).forEach((attribute) => {
+          if (attribute.value.includes(oldId)) {
+            productElement.setAttribute(attribute.name, attribute.value.replace(oldId, newId));
+          }
+        });
+
         productElement.dataset.originalSection = sectionId;
       }
 


### PR DESCRIPTION
### PR Summary: 

Catch-all for a few UX issues with combined listing and 2k variant products

<!-- Please include a short description (using non-technical terms, 1-2 sentences) about the changes you are introducing, what problem is being fixed and/or describe the benefit to merchants. This content will be used in our release notes for Dawn on [themes.shopify.com](https://themes.shopify.com/themes/dawn/styles/default#ReleaseNotes). -->


### Why are these changes introduced?

1) Jumpiness on volume pricing message when switching between combined listings
2) Update page title when switching between combined listing children
3) Fix unselected option value bug on Safari
4) Fix IDs not being deduped in quick add modal context

### What approach did you take?

**1) Jumpiness on volume pricing message when switching between combined listings**

Jumpiness was due to the volume pricing selector not being specific enough and being overridden depending on stylesheet import order. Fix was to increase selector specificity from 0,1,0 to 0,1,1.

[Before](https://screenshot.click/30-48-mt747-1a7cu.mp4) | [After](https://screenshot.click/30-49-l7sgk-xaz7o.mp4)

**2) Update page title when switching between combined listing children**

After switching from pants - orange to pants - black, the page title still showed pants - orange. Fix was to grab the title from the response on option value change and update.

[Before](https://screenshot.click/30-52-7732m-23zb2.mp4) | [After](https://screenshot.click/30-50-h1pf1-7jo0r.mp4)

**3) Fix unselected option value bug on Safari**

When changing option values in Safari, some option values would appear to become unselected. This was happening because when we did a view transition, there were temporarily duplicate IDs in the DOM. Fixed by updating the ID dedupe to occur prior to the new view being added to the DOM.

[Before](https://screenshot.click/30-53-okg9t-tb5ki.mp4) | [After](https://screenshot.click/30-53-ab4t7-uk0cl.mp4)

**4) Fix IDs not being deduped in quick add modal context**

This bug [was introduced here](https://github.com/Shopify/dawn/pull/3289/files#diff-f43b7f1db6d69790a4e803f8a0f2c0602987a0f6473d4177b93368c697a5b65eR80-R81). Because the quick add modal now pre-processes HTML on a `<product-info>` component and injects it, instead of on a `<section>` and then injecting the innerHTML, the code had been updated to dedupe on outerHTML instead of innerHTML. The problem with this is because the node is detached and has no parent, setting outerHTML has no effect.

The code change was to replace content on innerHTML as it did before, and manually dedupe the node's attributes to account for the wrapper.

[Before](https://screenshot.click/30-42-h1eg2-jahab.png) | [After](https://screenshot.click/30-47-hnout-kxc0k.png)

### Testing steps/scenarios
Store: https://combined-listings-test.myshopify.com

Theme is `pr_3492`


### Checklist
- [x] Added PR summary for [release notes](https://themes.shopify.com/themes/dawn/styles/default#ReleaseNotes)
- [ ] Requested review from UX (Only for changes that are affecting the experience or perceivable visual details)
- [ ] Created a ticket for the [help.shopify.com](https://help.shopify.com) documentation team about updates to theme settings. (Internal-only task)
- [ ] Followed [theme code principles](https://github.com/Shopify/dawn/blob/main/.github/CONTRIBUTING.md#theme-code-principles)
- [ ] Linted with [Theme Check](https://github.com/Shopify/theme-check)
- [ ] Tested on [mobile](https://shopify.dev/themes/store/requirements#mobile-browser-requirements)
- [x] Tested on [multiple browsers](https://shopify.dev/themes/store/requirements#desktop-browser-requirements)
- [x] Tested for [accessibility](https://shopify.dev/themes/best-practices/accessibility)
