### PR TITLE
🐛 Avoid invalid variant state after rapid option value switching

### DIFF
--- a/assets/constants.js
+++ b/assets/constants.js
@@ -3,7 +3,7 @@ const ON_CHANGE_DEBOUNCE_TIMER = 300;
 const PUB_SUB_EVENTS = {
   cartUpdate: 'cart-update',
   quantityUpdate: 'quantity-update',
-  variantChangeStart: 'variant-change-start',
+  optionValueSelectionChange: 'option-value-selection-change',
   variantChange: 'variant-change',
   cartError: 'cart-error',
   sectionRefreshed: 'section-refreshed',

--- a/assets/global.js
+++ b/assets/global.js
@@ -1075,11 +1075,11 @@ class VariantSelects extends HTMLElement {
       this.currentVariant = this.getVariantData(target.id);
       this.updateSelectedSwatchValue(event);
 
-      publish(PUB_SUB_EVENTS.variantChangeStart, {
+      publish(PUB_SUB_EVENTS.optionValueSelectionChange, {
         data: {
           event,
           target,
-          variant: this.currentVariant,
+          selectedOptionValues: this.selectedOptionValues,
         },
       });
     });

--- a/snippets/product-variant-picker.liquid
+++ b/snippets/product-variant-picker.liquid
@@ -84,5 +84,7 @@
         </div>
       {%- endif -%}
     {%- endfor -%}
+
+    <script type="application/json" data-selected-variant>{{ product.selected_or_first_available_variant | json }}</script>
   </variant-selects>
 {%- endunless -%}


### PR DESCRIPTION
### PR Summary: 

Fixes a bug where option value selection is incorrect if the buyer changes options while the new option state is loading

### Why are these changes introduced?

During an internal team bughunt on 2k variants and combined listings, we found 2 issues when switching rapidly between option values:
1) The option value selection would sometimes revert to previously selected option values ([demo](https://screenshot.click/22-35-4s9z1-v7i6g.mp4))
2) The variant added to the cart would sometimes be incorrect ([demo](https://screenshot.click/30-53-5vo00-7jtbo.mp4)) 

In both cases, the reason for this is for high-variant products to be performant, we _need_ to not serialize all the product's variants when rendering the page, and instead only include the variants associated with the currently displayed option values. See [the `Supporting high-high variant products` guide](https://shopify.dev/docs/storefronts/themes/product-merchandising/variants/support-high-variant-products) for more information.

On option value change, we were calling the section rendering api with the variant ID associated with the clicked option value. The issue with this, is that the variant associated with option values is inherently tied to the option value selection.

For example, say we have a combined listing product with color and size:

```
color: [red] green blue
size:   [small] medium large
```

If the buyer selected `medium` here, we would call the section rendering api with the variant ID associated with `red/medium`. However, we only have the variants a "render snapshot" at a time, so the variant IDs are not updated until the option value picker is rerendered. Going back to our example, the impact of this is that if the buyer selects `medium` and then selects `blue` _before_ the first section rendering api call resolves, the final network call would be for the variant `blue/small` and NOT `blue/medium`. When the response comes back, the option value selection state may be mismatched with the values the buyer most recently selected.

### What approach did you take?

Instead of calling the section rendering API with a variant ID, we instead call it with the selected option value IDs. This enables us to always return the response based on the latest buyer selection. Once the API response returns, we know which variant (or no variant) is associated with the option value selection, and can then update the page accordingly (forms, urls, etc).

### Visual impact on existing themes

There should be no impact


### Testing steps/scenarios
- [ ] With your network panel open, change option values quickly and then add to your cart. It is easier to trigger cancelled API requests if you throttle to slow or fast 3g.
- [ ] Also verify that this change works as expected in the quick add modal

### Demo links

- store url: https://combined-listings-test.myshopify.com/products/chinos-blue

> This store has a few themes, please test with theme `pr_3495`


### Checklist
- [x] Added PR summary for [release notes](https://themes.shopify.com/themes/dawn/styles/default#ReleaseNotes)
- [ ] Requested review from UX (Only for changes that are affecting the experience or perceivable visual details)
- [ ] Created a ticket for the [help.shopify.com](https://help.shopify.com) documentation team about updates to theme settings. (Internal-only task)
- [ ] Followed [theme code principles](https://github.com/Shopify/dawn/blob/main/.github/CONTRIBUTING.md#theme-code-principles)
- [ ] Linted with [Theme Check](https://github.com/Shopify/theme-check)
- [ ] Tested on [mobile](https://shopify.dev/themes/store/requirements#mobile-browser-requirements)
- [ ] Tested on [multiple browsers](https://shopify.dev/themes/store/requirements#desktop-browser-requirements)
- [ ] Tested for [accessibility](https://shopify.dev/themes/best-practices/accessibility)
