### PR TITLE
Create CSS variables to support the base-focus focus-visible properties

### DIFF
--- a/assets/base.css
+++ b/assets/base.css
@@ -3,6 +3,9 @@
   --alpha-button-border: 1;
   --alpha-link: 0.85;
   --alpha-badge-border: 0.1;
+  --focused-base-outline: 0.2rem solid rgba(var(--color-foreground), 0.5);
+  --focused-base-outline-offset: 0.3rem;
+  --focused-base-box-shadow: 0 0 0 0.3rem rgb(var(--color-background)), 0 0 0.5rem 0.4rem rgba(var(--color-foreground), 0.3);
 }
 
 .product-card-wrapper .card,
@@ -689,16 +692,16 @@ summary::-webkit-details-marker {
 }
 
 *:focus-visible {
-  outline: 0.2rem solid rgba(var(--color-foreground), 0.5);
-  outline-offset: 0.3rem;
-  box-shadow: 0 0 0 0.3rem rgb(var(--color-background)), 0 0 0.5rem 0.4rem rgba(var(--color-foreground), 0.3);
+  outline: var(--focused-base-outline);
+  outline-offset: var(--focused-base-outline-offset);
+  box-shadow: var(--focused-base-box-shadow);
 }
 
 /* Fallback - for browsers that don't support :focus-visible, a fallback is set for :focus */
 .focused {
-  outline: 0.2rem solid rgba(var(--color-foreground), 0.5);
-  outline-offset: 0.3rem;
-  box-shadow: 0 0 0 0.3rem rgb(var(--color-background)), 0 0 0.5rem 0.4rem rgba(var(--color-foreground), 0.3);
+  outline: var(--focused-base-outline);
+  outline-offset: var(--focused-base-outline-offset);
+  box-shadow: var(--focused-base-box-shadow);
 }
 
 /*


### PR DESCRIPTION
### PR Summary: 

<!-- Please include a short description (using non-technical terms, 1-2 sentences) about the changes you are introducing, what problem is being fixed and/or describe the benefit to merchants. This content will be used in our release notes for Dawn on [themes.shopify.com](https://themes.shopify.com/themes/dawn/styles/default#ReleaseNotes). -->

Define CSS variables for base focus-visible behaviors

### Why are these changes introduced?

Part of https://github.com/Shopify/portable-wallets/issues/489

As part of the migration of Shop Pay into the portable-wallets project, we're now injecting a Shop Pay button styled using the Button component exposed by the Gravity repo (which will be the source of all Shop-surface elements).

Currently this button is being [styled manually](https://github.com/Shopify/gravity/blob/9a3fb1cf11b11065899c7f82540acd24aafcd61d/packages/gravity-web/src/Button/Button.ts#L93-L97) to support `focus`, however we'd want to be able to leverage a CSS variable instead (if present) to ensure that the behaviour is in sync with the theme (and thus other buttons on the page).

### What approach did you take?

Define CSS variables in the base theme that can be injected via the portable-wallets library ([as we do with other CSS values](https://github.com/Shopify/portable-wallets/blob/7859c616306e13068a7e2d9e271cb025ea3ff97b/src/components/ShopPayButton/ShopPayButton.css#L1-L6)) into the gravity component

### Other considerations

First PR in the repo, but changes are not buyer/merchant facing. Are there any other considerations I'm missing?

### Visual impact on existing themes
<!-- How will this visually affect merchants who upgrade to a new theme version with this change? -->
None

### Testing steps/scenarios
<!-- List all the testing tasks that applies to your fix to help peers review your work. -->
- Setup the theme on a shop, ensure that new CSS variables are defined in `base.css`
- Navigate to a PDP page and tab around. Ensure that focus-visibility is still applied as expected


### Checklist
- [x] Added PR summary for [release notes](https://themes.shopify.com/themes/dawn/styles/default#ReleaseNotes)
- [x] ~Requested review from UX (Only for changes that are affecting the experience or perceivable visual details)~
- [ ] Created a ticket for the [help.shopify.com](https://help.shopify.com) documentation team about updates to theme settings. (Internal-only task)
- [x] Followed [theme code principles](https://github.com/Shopify/dawn/blob/main/.github/CONTRIBUTING.md#theme-code-principles)
- [ ] Linted with [Theme Check](https://github.com/Shopify/theme-check)
- [x] ~Tested on [mobile](https://shopify.dev/themes/store/requirements#mobile-browser-requirements)~
- [x] ~Tested on [multiple browsers](https://shopify.dev/themes/store/requirements#desktop-browser-requirements)~
- [x] ~Tested for [accessibility](https://shopify.dev/themes/best-practices/accessibility)~
