### PR TITLE
Set thumbnail when selected variant featured media changes

### DIFF
--- a/assets/media-gallery.js
+++ b/assets/media-gallery.js
@@ -16,7 +16,7 @@ if (!customElements.get('media-gallery')) {
         this.elements.thumbnails.querySelectorAll('[data-target]').forEach((mediaToSwitch) => {
           mediaToSwitch
             .querySelector('button')
-            .addEventListener('click', this.setActiveMedia.bind(this, mediaToSwitch.dataset.target));
+            .addEventListener('click', this.setActiveMedia.bind(this, mediaToSwitch.dataset.target, false));
         });
         if (this.dataset.desktopLayout.includes('thumbnail') && this.mql.matches) this.removeListSemantic();
       }
@@ -28,7 +28,7 @@ if (!customElements.get('media-gallery')) {
         this.setActiveThumbnail(thumbnail);
       }
 
-      setActiveMedia(mediaId) {
+      setActiveMedia(mediaId, prepend) {
         const activeMedia =
           this.elements.viewer.querySelector(`[data-media-id="${mediaId}"]`) ||
           this.elements.viewer.querySelector('[data-media-id]');
@@ -39,6 +39,15 @@ if (!customElements.get('media-gallery')) {
           element.classList.remove('is-active');
         });
         activeMedia?.classList?.add('is-active');
+
+        if (prepend) {
+          activeMedia.parentElement.prepend(activeMedia);
+          if (this.elements.thumbnails) {
+            const activeThumbnail = this.elements.thumbnails.querySelector(`[data-target="${mediaId}"]`);
+            activeThumbnail.parentElement.prepend(activeThumbnail);
+          }
+          if (this.elements.viewer.slider) this.elements.viewer.resetPages();
+        }
 
         this.preventStickyHeader();
         window.setTimeout(() => {

--- a/assets/product-info.js
+++ b/assets/product-info.js
@@ -286,7 +286,7 @@ if (!customElements.get('product-info')) {
           // set featured media as active in the media gallery
           this.querySelector(`media-gallery`)?.setActiveMedia?.(
             `${this.dataset.section}-${variantFeaturedMediaId}`,
-            false
+            true
           );
 
           // update media modal


### PR DESCRIPTION
### PR Summary: 

Fixes bug where image thumbnail is not updated when variant featured media changes

### Why are these changes introduced?

Fixes https://github.com/Shopify/dawn/issues/3502

### Testing steps/scenarios
- https://os2-demo.myshopify.com/products/puppy
- use theme `dawn-lh-thumbnail-image-is-not-updated-when-var`
- check that the thumbnail is updated to display the correct image after switching variants

### Checklist
- [ ] Added PR summary for [release notes](https://themes.shopify.com/themes/dawn/styles/default#ReleaseNotes)
- [ ] Requested review from UX (Only for changes that are affecting the experience or perceivable visual details)
- [ ] Created a ticket for the [help.shopify.com](https://help.shopify.com) documentation team about updates to theme settings. (Internal-only task)
- [ ] Followed [theme code principles](https://github.com/Shopify/dawn/blob/main/.github/CONTRIBUTING.md#theme-code-principles)
- [ ] Linted with [Theme Check](https://github.com/Shopify/theme-check)
- [ ] Tested on [mobile](https://shopify.dev/themes/store/requirements#mobile-browser-requirements)
- [ ] Tested on [multiple browsers](https://shopify.dev/themes/store/requirements#desktop-browser-requirements)
- [ ] Tested for [accessibility](https://shopify.dev/themes/best-practices/accessibility)
