### PR TITLE
Fix display of multiple order-level discounts so they show on separate rows

### DIFF
--- a/sections/main-order.liquid
+++ b/sections/main-order.liquid
@@ -237,8 +237,8 @@
             </td>
           </tr>
           {%- if order.cart_level_discount_applications != blank -%}
-            <tr role="row">
-              {%- for discount_application in order.cart_level_discount_applications -%}
+            {%- for discount_application in order.cart_level_discount_applications -%}
+              <tr role="row">
                 <td id="RowDiscount" role="rowheader" scope="row" colspan="4">
                   {{ 'customer.order.discount' | t }}
                   <span class="cart-discount">
@@ -259,8 +259,8 @@
                     </span>
                   </div>
                 </td>
-              {%- endfor -%}
-            </tr>
+              </tr>
+            {%- endfor -%}
           {%- endif -%}
           {%- for shipping_method in order.shipping_methods -%}
             <tr role="row">


### PR DESCRIPTION
### PR Summary: 

There's a bug in `main-order.liquid` where it loops through multiple discounts by adding more `<td>` instead of displaying on separate rows.

### Why are these changes introduced?

### What approach did you take?

### Other considerations

### Decision log

| # | Decision | Alternatives | Rationale | Downsides |
|---|---|---|---|---|
| 1 |   |   |   |   |


### Visual impact on existing themes
<!-- How will this visually affect merchants who upgrade to a new theme version with this change? -->


### Testing steps/scenarios
<!-- List all the testing tasks that applies to your fix to help peers review your work. -->
- [ ] Step 1

### Demo links
<!-- Please include a link to a demo store that includes preconfigured sections and settings to allow reviewers to easily test the features you are working on. -->

- [Store](url)
- [Editor](url)

### Checklist
- [ ] Added PR summary for [release notes](https://themes.shopify.com/themes/dawn/styles/default#ReleaseNotes)
- [ ] Requested review from UX (Only for changes that are affecting the experience or perceivable visual details)
- [ ] Created a ticket for the [help.shopify.com](https://help.shopify.com) documentation team about updates to theme settings. (Internal-only task)
- [ ] Followed [theme code principles](https://github.com/Shopify/dawn/blob/main/.github/CONTRIBUTING.md#theme-code-principles)
- [ ] Linted with [Theme Check](https://github.com/Shopify/theme-check)
- [ ] Tested on [mobile](https://shopify.dev/themes/store/requirements#mobile-browser-requirements)
- [ ] Tested on [multiple browsers](https://shopify.dev/themes/store/requirements#desktop-browser-requirements)
- [ ] Tested for [accessibility](https://shopify.dev/themes/best-practices/accessibility)
