### PR TITLE
Fixed templates not allowed, Section limit

### DIFF
--- a/sections/email-signup-banner.liquid
+++ b/sections/email-signup-banner.liquid
@@ -393,6 +393,8 @@
       ]
     }
   ],
-  "templates": ["password"]
+  "enabled_on": {
+    "templates": ["password"]
+  }
 }
 {% endschema %}


### PR DESCRIPTION
### PR Summary: 

<!-- The Email signup banner section includes a templates property to restrict its usage to the password template.  -->


### Why are these changes introduced?
To fix the templates not allowed issue.


### What approach did you take?
Replace "templates": ["password"] with 
"enabled_on": {
    "templates": ["password"]
  }