### PR TITLE
Combined listings with multiple product templates

### DIFF
--- a/assets/constants.js
+++ b/assets/constants.js
@@ -6,9 +6,4 @@ const PUB_SUB_EVENTS = {
   optionValueSelectionChange: 'option-value-selection-change',
   variantChange: 'variant-change',
   cartError: 'cart-error',
-  sectionRefreshed: 'section-refreshed',
-};
-
-const SECTION_REFRESH_RESOURCE_TYPE = {
-  product: 'product',
 };


### PR DESCRIPTION
### PR Summary: 

Adds support for combined listings where the products use different templates

### Why are these changes introduced?

If a combined listing parent or children products used different templates, the query selector for reading the selected variant from the section rendering api response was returning null. This PR enables multiple product templates by explicitly selecting for the `MainProduct` if there may be multiple `<product-info>` elements in the response, or `<product-info>` if there is only one.

### Testing steps/scenarios

Please use this product for testing: https://combined-listings-test.myshopify.com/products/multiple-product-templates

The parent product is set up with the `default product` template, black and orange child products use `product - 1`, and blue uses `product - 2`. There is a banner that indicates whether the product is the main product or a featured product.

Scenarios to test:
- Switching between `color` options on the main product loads the appropriate combined listing child product, and returns sections for the template.
- When on the `blue` product, the first product on the page is a featured product. Verify that switching between option values loads the correct combined listing child product. (*note -- static featured products still don't work for combined listings, this case _does_ work because it is set up dynamically using a metafield)
- On the collection page, open the `multiple product templates` product's quick-add modal. Verify that changing color options loads the correct combined listing child product.

### Checklist
- [ ] Added PR summary for [release notes](https://themes.shopify.com/themes/dawn/styles/default#ReleaseNotes)
- [ ] Requested review from UX (Only for changes that are affecting the experience or perceivable visual details)
- [ ] Created a ticket for the [help.shopify.com](https://help.shopify.com) documentation team about updates to theme settings. (Internal-only task)
- [ ] Followed [theme code principles](https://github.com/Shopify/dawn/blob/main/.github/CONTRIBUTING.md#theme-code-principles)
- [ ] Linted with [Theme Check](https://github.com/Shopify/theme-check)
- [ ] Tested on [mobile](https://shopify.dev/themes/store/requirements#mobile-browser-requirements)
- [ ] Tested on [multiple browsers](https://shopify.dev/themes/store/requirements#desktop-browser-requirements)
- [ ] Tested for [accessibility](https://shopify.dev/themes/best-practices/accessibility)
