### PR TITLE
Update quick order list to use variant title

### DIFF
--- a/snippets/quick-order-list-row.liquid
+++ b/snippets/quick-order-list-row.liquid
@@ -13,12 +13,6 @@
 {% assign cart_qty = cart | item_count_for_variant: variant.id %}
 {% # theme-check-enable %}
 
-{%- capture escaped_options -%}
-  {% for option in variant.options -%}
-    {{ option | escape }}{%- unless forloop.last -%}{{ ' / ' }}{%- endunless -%}
-  {%- endfor %}
-{%- endcapture -%}
-
 <tr
   class="variant-item{% unless show_image %} variant-item--no-media{% endunless %}{% if item.available and item.unit_price_measurement %} variant-item--unit-price{% endif %}"
   id="Variant-{{ variant.id }}"
@@ -50,7 +44,7 @@
       </div>
     {%- endif -%}
     <div class="small-hide medium-hide">
-      <span class="variant-item__name h4 break">{{ escaped_options }}</span>
+      <span class="variant-item__name h4 break">{{ item.title | escape }}</span>
       {%- if show_sku -%}
         <span class="variant-item__sku break">{{ sku | escape }}</span>
       {%- endif -%}
@@ -59,7 +53,7 @@
 
   <td class="variant-item__details large-up-hide">
     <div class="variant-item__info">
-      <span class="variant-item__name h4 break">{{ escaped_options }}</span>
+      <span class="variant-item__name h4 break">{{ item.title | escape }}</span>
       {%- if show_sku -%}
         <span class="variant-item__sku break">{{ sku | escape }}</span>
       {%- endif -%}
@@ -298,7 +292,7 @@
             <a
               href="{{ item.url_to_remove }}"
               class="button button--tertiary"
-              aria-label="{{ 'sections.cart.remove_title' | t: title: escaped_options }}"
+              aria-label="{{ 'sections.cart.remove_title' | t: title: item.title }}"
             >
               {% render 'icon-remove' %}
             </a>


### PR DESCRIPTION
### PR Summary: 

Simpler variant title code in the quick order list section

### Why are these changes introduced?

Right now we generate the title for quick order list variants by combining the option values. The downside of this is that it displays `Default Title` for products with only a default variant or combined listings where a child product only contains a default variant.

The reason this change was introduced in the first place was to solve for the combined listing use case where the variant title did not include the parent product's option values. However, this logic arguably makes more sense to solve on the server within the variant's title field.

### What approach did you take?

Reverted the changes to quick-order-list-row.liquid introduced [here](https://github.com/Shopify/dawn/pull/3378/files#diff-67d65f871b7c42c36bfa842e5815fb08ead9c709dbc35f5e29b779f34c10a751R16)

### Testing steps/scenarios

Use this theme preview: https://os2-demo.myshopify.com/?_ab=0&_fd=0&_sc=1&key=426fb1f420e906418fa2448926c74e347c9832a999315511ee1be9880525803a&preview_theme_id=163405103126

- check that [this product](https://os2-demo.myshopify.com/products/helix-denim) shows the product title instead of `default variant`
- check that [this product](https://os2-demo.myshopify.com/products/crop-pants-olive) shows the appropriate variant titles
- check that [this combined listing product](https://os2-demo.myshopify.com/products/complex-combined-listing) displays either `Default title` or the child product option values (i.e. no color or material values). This will be fixed in a follow up API pr.

### Checklist
- [x] Added PR summary for [release notes](https://themes.shopify.com/themes/dawn/styles/default#ReleaseNotes)
- [ ] Requested review from UX (Only for changes that are affecting the experience or perceivable visual details)
- [ ] Created a ticket for the [help.shopify.com](https://help.shopify.com) documentation team about updates to theme settings. (Internal-only task)
- [ ] Followed [theme code principles](https://github.com/Shopify/dawn/blob/main/.github/CONTRIBUTING.md#theme-code-principles)
- [ ] Linted with [Theme Check](https://github.com/Shopify/theme-check)
- [ ] Tested on [mobile](https://shopify.dev/themes/store/requirements#mobile-browser-requirements)
- [ ] Tested on [multiple browsers](https://shopify.dev/themes/store/requirements#desktop-browser-requirements)
- [ ] Tested for [accessibility](https://shopify.dev/themes/best-practices/accessibility)
