### PR TITLE
Fixed bug where videos were not showing up on Safari

### DIFF
--- a/assets/global.js
+++ b/assets/global.js
@@ -712,6 +712,7 @@ class DeferredMedia extends HTMLElement {
         deferredElement.play();
       }
 
+      // Workaround for safari iframe bug
       const formerStyle = deferredElement.getAttribute('style');
       deferredElement.setAttribute('style', 'display: block;');
       window.setTimeout(() => {

--- a/assets/global.js
+++ b/assets/global.js
@@ -711,6 +711,12 @@ class DeferredMedia extends HTMLElement {
         // force autoplay for safari
         deferredElement.play();
       }
+
+      const formerStyle = deferredElement.getAttribute('style');
+      deferredElement.setAttribute('style', 'display: block;');
+      window.setTimeout(() => {
+        deferredElement.setAttribute('style', formerStyle);
+      }, 0);
     }
   }
 }


### PR DESCRIPTION
### PR Summary: 

The video section was not loading Youtube videos properly on Safari.  This is because of a rendering bug with iframes that made it so that the video just didn't show up - audio would play, the element would exist, but it just wouldn't render.  This fixes it.

### What approach did you take?

The element needs to be repainted to have it show up.  So I just apply a display value into the `style` attribute, then put back whatever was there before (should usually be nothing, but just in case).  That part needs to be done in a `setTimeout` to force it to execute after the completion of the part that adds `display: block`, otherwise it happens before the repaint and doesn't work.  See [mdn](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Event_loop) for details on how that stuff works.

### Other considerations

It shouldn't affect other things that use DeferredMedia since it's just adding and removing a style really quickly, but we should thoroughly test that.

### Testing steps/scenarios
- [ ] On Dawn 15.0.0, add a video section and put a Youtube video in
- [ ] Click to load the video.
- [ ] Notice that it doesn't work.
- [ ] On this branch, do the same
- [ ] Notice it does! Yay!

### Demo links

- [Store](https://os2-demo.myshopify.com/?_ab=0&_fd=0&_sc=1&preview_theme_id=163513892886)
- [Editor](https://admin.shopify.com/store/os2-demo/themes/163513892886/editor)
