### PR TITLE
Escape product variant option names

### DIFF
--- a/snippets/product-variant-options.liquid
+++ b/snippets/product-variant-options.liquid
@@ -80,7 +80,7 @@
     <input
       type="radio"
       id="{{ input_id }}"
-      name="{{ input_name }}"
+      name="{{ input_name | escape }}"
       value="{{ value | escape }}"
       form="{{ product_form_id }}"
       {% if value.selected %}


### PR DESCRIPTION
These can include quote characters ("") which cause undesirable side-effects, since the quotes are rendered as such in the HTML and can lead to messes like this:

```html
<input type="radio" id="template--21660179595286__main-1-0" name="" oh="" brother"="" tee="" (3="" options)="" (style)-1="" "="" value="Oh Brother Sun Tee" form="product-form-template--21660179595286__main" checked="" data-product-url="" data-option-value-id="3017450192918">
```