### PR TITLE
Fix issue with quantity break price

### DIFF
--- a/snippets/price.liquid
+++ b/snippets/price.liquid
@@ -23,8 +23,8 @@
 
   assign compare_at_price = target.compare_at_price
   assign price = target.price | default: 1999
-  assign price_min = target.price_min
-  assign price_max = target.price_max
+  assign price_min = product.price_min
+  assign price_max = product.price_max
   assign available = target.available | default: false
   assign money_price = price | money
   assign money_price_min = price_min | money


### PR DESCRIPTION
### PR Summary: 

<!-- Please include a short description (using non-technical terms, 1-2 sentences) about the changes you are introducing, what problem is being fixed and/or describe the benefit to merchants. This content will be used in our release notes for Dawn on [themes.shopify.com](https://themes.shopify.com/themes/dawn/styles/default#ReleaseNotes). -->
Fixes issue mentioned in [this comment](https://github.com/Shopify/colorblock/pull/47/files#r1693076327)
Min and max price weren't assign properly due to a recent change that wasn't necessary

### What approach did you take?
Made sure it still reference the product object. 

### Visual impact on existing themes
<!-- How will this visually affect merchants who upgrade to a new theme version with this change? -->
![](https://screenshot.click/26-41-mcqxq-e0sn8.png)

### Testing steps/scenarios
<!-- List all the testing tasks that applies to your fix to help peers review your work. -->
- [ ] Sign in as a b2b customer and check products that have volume pricing available 
- [ ] Check those PDP and the price should come up just fine like in the screenshot above
- [ ] Add a feat. collection, collage section, and feat. product section to make sure their placeholder content and specifically price is still coming up as $19.99

### Demo links
<!-- Please include a link to a demo store that includes preconfigured sections and settings to allow reviewers to easily test the features you are working on. -->

- [Editor](https://admin.shopify.com/store/os2-demo/themes/163608330262/editor)
