### PR TITLE
Release 15.1.0

### DIFF
--- a/assets/section-main-product.css
+++ b/assets/section-main-product.css
@@ -185,6 +185,10 @@ product-info {
   max-width: 100%;
 }
 
+.product-form__input .svg-wrapper {
+  right: 1rem;
+}
+
 .product-form__submit {
   margin-bottom: 1rem;
 }

--- a/assets/section-main-product.css
+++ b/assets/section-main-product.css
@@ -186,7 +186,7 @@ product-info {
 }
 
 .product-form__input .svg-wrapper {
-  right: 1rem;
+  right: 1.5rem;
 }
 
 .product-form__submit {

--- a/config/settings_schema.json
+++ b/config/settings_schema.json
@@ -2,7 +2,7 @@
   {
     "name": "theme_info",
     "theme_name": "Dawn",
-    "theme_version": "15.0.1",
+    "theme_version": "15.1.0",
     "theme_author": "Shopify",
     "theme_documentation_url": "https://help.shopify.com/manual/online-store/themes",
     "theme_support_url": "https://support.shopify.com/"

--- a/release-notes.md
+++ b/release-notes.md
@@ -1,6 +1,4 @@
-Dawn 15.0.1 introduces a few bug fixes.
+Dawn 15.1.0 changes the way SVGs are rendered in Dawn
 ### Fixes and improvements
-- Fix issues where when the header section is hidden, some functionalities were broken.
-- Update cart errors to be output as a string rather than a HTML element.
-- Escape variant option names so that when an option includes quotation marks it doesn’t cause undesired effects.
-- Fix placeholder product cards that were not showing a default price and make the check more robust.
+- Moves SVGs from Liquid snippets to `.svg` files in the `/assets` folder
+- Uses new `inline_asset_content` Liquid filter to render SVGs

--- a/release-notes.md
+++ b/release-notes.md
@@ -1,4 +1,4 @@
-Dawn 15.1.0 changes the way SVGs are rendered in Dawn
+Dawn 15.1.0 changes the way SVGs are rendered
 ### Fixes and improvements
 - Moves SVGs from Liquid snippets to `.svg` files in the `/assets` folder
 - Uses new `inline_asset_content` Liquid filter to render SVGs

--- a/sections/announcement-bar.liquid
+++ b/sections/announcement-bar.liquid
@@ -43,9 +43,7 @@
           <p class="announcement-bar__message h5">
             <span>{{ section.blocks.first.settings.text | escape }}</span>
             {%- if section.blocks.first.settings.link != blank -%}
-              <span class="svg-wrapper">
-                {{- 'icon-arrow.svg' | inline_asset_content -}}
-              </span>
+              {{- 'icon-arrow.svg' | inline_asset_content -}}
             {%- endif -%}
           </p>
           {%- if section.blocks.first.settings.link != blank -%}

--- a/sections/announcement-bar.liquid
+++ b/sections/announcement-bar.liquid
@@ -104,9 +104,7 @@
                     <p class="announcement-bar__message h5">
                       <span>{{ block.settings.text | escape }}</span>
                       {%- if block.settings.link != blank -%}
-                        <span class="svg-wrapper">
-                          {{- 'icon-arrow.svg' | inline_asset_content -}}
-                        </span>
+                        {{- 'icon-arrow.svg' | inline_asset_content -}}
                       {%- endif -%}
                     </p>
                     {%- if block.settings.link != blank -%}

--- a/sections/multicolumn.liquid
+++ b/sections/multicolumn.liquid
@@ -135,7 +135,9 @@
                     {% endif %}
                   >
                     {{- block.settings.link_label | escape -}}
-                    <<span class="svg-wrapper">span class="icon-wrap">&nbsp;{{ 'icon-arrow.svg' | inline_asset_content }}</span></span>
+                    <span class="svg-wrapper"
+                      ><span class="icon-wrap">&nbsp;{{ 'icon-arrow.svg' | inline_asset_content }}</span></span
+                    >
                   </a>
                 {%- endif -%}
               </div>

--- a/snippets/header-mega-menu.liquid
+++ b/snippets/header-mega-menu.liquid
@@ -23,9 +23,7 @@
                 >
                   {{- link.title | escape -}}
                 </span>
-                <span class="svg-wrapper">
-                  {{- 'icon-caret.svg' | inline_asset_content -}}
-                </span>
+                {{- 'icon-caret.svg' | inline_asset_content -}}
               </summary>
               <div
                 id="MegaMenu-Content-{{ forloop.index }}"


### PR DESCRIPTION
Version `15.1.0` of Dawn

Dawn 15.1.0 changes the way SVGs are rendered in Dawn
### Fixes and improvements
- Moves SVGs from Liquid snippets to `.svg` files in the `/assets` folder
- Uses new `inline_asset_content` Liquid filter to render SVGs
