### PR TITLE
Fix syntax error in multicolumn.liquid

### DIFF
--- a/sections/multicolumn.liquid
+++ b/sections/multicolumn.liquid
@@ -135,7 +135,7 @@
                     {% endif %}
                   >
                     {{- block.settings.link_label | escape -}}
-                    <<span class="svg-wrapper">span class="icon-wrap">&nbsp;{{ 'icon-arrow.svg' | inline_asset_content }}</span></span>
+                    <span class="svg-wrapper"><span class="icon-wrap">&nbsp;{{ 'icon-arrow.svg' | inline_asset_content }}</span></span>
                   </a>
                 {%- endif -%}
               </div>


### PR DESCRIPTION
### PR Summary: 

Fixes a small syntax error introduced in https://github.com/Shopify/dawn/pull/3582

### Checklist
- [ ] Added PR summary for [release notes](https://themes.shopify.com/themes/dawn/styles/default#ReleaseNotes)
- [ ] Requested review from UX (Only for changes that are affecting the experience or perceivable visual details)
- [ ] Created a ticket for the [help.shopify.com](https://help.shopify.com) documentation team about updates to theme settings. (Internal-only task)
- [x] Followed [theme code principles](https://github.com/Shopify/dawn/blob/main/.github/CONTRIBUTING.md#theme-code-principles)
- [x] Linted with [Theme Check](https://github.com/Shopify/theme-check)
- [ ] Tested on [mobile](https://shopify.dev/themes/store/requirements#mobile-browser-requirements)
- [ ] Tested on [multiple browsers](https://shopify.dev/themes/store/requirements#desktop-browser-requirements)
- [ ] Tested for [accessibility](https://shopify.dev/themes/best-practices/accessibility)
