### PR TITLE
No follow for Account Login header url

### DIFF
--- a/sections/header.liquid
+++ b/sections/header.liquid
@@ -227,7 +227,11 @@
       {% render 'header-search', input_id: 'Search-In-Modal' %}
 
       {%- if shop.customer_accounts_enabled -%}
-        <a href="{%- if customer -%}{{ routes.account_url }}{%- else -%}{{ routes.account_login_url }}{%- endif -%}" class="header__icon header__icon--account link focus-inset{% if section.settings.menu != blank %} small-hide{% endif %}">
+        <a
+          href="{%- if customer -%}{{ routes.account_url }}{%- else -%}{{ routes.account_login_url }}{%- endif -%}"
+          class="header__icon header__icon--account link focus-inset{% if section.settings.menu != blank %} small-hide{% endif %}"
+          rel="nofollow"
+        >
           {%- if section.settings.enable_customer_avatar -%}
             <account-icon>
               {%- if customer and customer.has_avatar? -%}

--- a/snippets/header-drawer.liquid
+++ b/snippets/header-drawer.liquid
@@ -140,6 +140,7 @@
               <a
                 href="{%- if customer -%}{{ routes.account_url }}{%- else -%}{{ routes.account_login_url }}{%- endif -%}"
                 class="menu-drawer__account link focus-inset h5 medium-hide large-up-hide"
+                rel="nofollow"
               >
                 {%- if section.settings.enable_customer_avatar -%}
                   <account-icon>


### PR DESCRIPTION
### PR Summary: 

Added `nofollow` to account login anchor-links in header.

### Why are these changes introduced?

Shopify's merchant shop links currently lack a "nofollow" directive. Without this directive, Google may interpret these links as spammy backlinking.

More analysis details [available here](https://github.com/Shopify/growth-labs-sdp/issues/1039).

### What approach did you take?
Implemented a "nofollow" directive on all merchant shop links pointing to shopify.com/account. 

### Visual impact on existing themes
None

### Testing steps/scenarios
- Review for valid HTML syntax.

### Demo links
Can be tested locally via:
```sh
shopify theme dev --store=<your store url>
```

### Checklist
- [x] Added PR summary for [release notes](https://themes.shopify.com/themes/dawn/styles/default#ReleaseNotes)
- [ ] ~Requested review from UX (Only for changes that are affecting the experience or perceivable visual details)~
- [ ] Created a ticket for the [help.shopify.com](https://help.shopify.com) documentation team about updates to theme settings. (Internal-only task)
- [x] Followed [theme code principles](https://github.com/Shopify/dawn/blob/main/.github/CONTRIBUTING.md#theme-code-principles)
- [x] Linted with [Theme Check](https://github.com/Shopify/theme-check)
- [ ] Tested on [mobile](https://shopify.dev/themes/store/requirements#mobile-browser-requirements)
- [ ] Tested on [multiple browsers](https://shopify.dev/themes/store/requirements#desktop-browser-requirements)
- [ ] Tested for [accessibility](https://shopify.dev/themes/best-practices/accessibility)
