### PR TITLE
Remove doubled semicolons in CSS

### DIFF
--- a/assets/base.css
+++ b/assets/base.css
@@ -1321,12 +1321,12 @@ button.shopify-payment-button__button--unbranded {
 shopify-accelerated-checkout {
   --shopify-accelerated-checkout-button-border-radius: var(--buttons-radius-outset);
   --shopify-accelerated-checkout-button-box-shadow: var(--shadow-horizontal-offset) var(--shadow-vertical-offset) var(--shadow-blur-radius)
-  rgba(var(--color-shadow), var(--shadow-opacity));;
+  rgba(var(--color-shadow), var(--shadow-opacity));
 }
 shopify-accelerated-checkout-cart {
   --shopify-accelerated-checkout-button-border-radius: var(--buttons-radius-outset);
   --shopify-accelerated-checkout-button-box-shadow: var(--shadow-horizontal-offset) var(--shadow-vertical-offset) var(--shadow-blur-radius)
-  rgba(var(--color-shadow), var(--shadow-opacity));;
+  rgba(var(--color-shadow), var(--shadow-opacity));
 }
 
 


### PR DESCRIPTION
### PR Summary: 

Removed doubled semicolons in CSS. 