### PR TITLE
Remove overflow hidden on body when section with opened modal is deleted

### DIFF
--- a/assets/theme-editor.js
+++ b/assets/theme-editor.js
@@ -39,6 +39,7 @@ document.addEventListener('shopify:section:load', () => {
 document.addEventListener('shopify:section:unload', (event) => {
   document.querySelectorAll(`[data-section="${event.detail.sectionId}"]`).forEach((element) => {
     element.remove();
+    document.body.classList.remove('overflow-hidden');
   });
 });
 


### PR DESCRIPTION
Fixes the issue that you could replicate by following the steps in [this video](https://screenshot.click/03-31-1q0ee-xhqt4.mp4). 