### PR TITLE
X-UA-Compatible meta tag no longer in use

### DIFF
--- a/layout/password.liquid
+++ b/layout/password.liquid
@@ -2,7 +2,6 @@
 <html class="js full-height" lang="{{ request.locale.iso_code }}">
   <head>
     <meta charset="utf-8">
-    <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width,initial-scale=1">
     <meta name="theme-color" content="">
     <link rel="canonical" href="{{ canonical_url }}">

--- a/layout/theme.liquid
+++ b/layout/theme.liquid
@@ -2,7 +2,6 @@
 <html class="js" lang="{{ request.locale.iso_code }}">
   <head>
     <meta charset="utf-8">
-    <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width,initial-scale=1">
     <meta name="theme-color" content="">
     <link rel="canonical" href="{{ canonical_url }}">

--- a/templates/gift_card.liquid
+++ b/templates/gift_card.liquid
@@ -5,7 +5,6 @@
   <head>
     <script src="{{ 'vendor/qrcode.js' | shopify_asset_url }}" defer></script>
     <meta charset="utf-8">
-    <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width,initial-scale=1">
     <meta name="theme-color" content="{{ settings.color_background }}">
     <link rel="canonical" href="{{ canonical_url }}">


### PR DESCRIPTION
### PR Summary: 

The X-UA-Compatible meta tag is no longer used because modern web browsers, like Microsoft Edge and others, have moved away from supporting older versions of Internet Explorer, making the tag unnecessary for ensuring website compatibility with outdated browser technology.


### Why are these changes introduced?

Less code !
