### PR TITLE
[AnnouncementBar] Fixing an issue with block attributes

### DIFF
--- a/sections/announcement-bar.liquid
+++ b/sections/announcement-bar.liquid
@@ -20,7 +20,6 @@
 
 <div
   class="utility-bar color-{{ section.settings.color_scheme }} gradient{% if section.settings.show_line_separator and section.blocks.size > 0 %} utility-bar--bottom-border{% elsif section.settings.show_line_separator and section.settings.show_social and social_icons%} utility-bar--bottom-border-social-only{% endif %}{% if section.settings.enable_country_selector or section.settings.enable_language_selector %} header-localization{% endif %}"
-  {{ block.shopify_attributes }}
 >
   <div class="page-width utility-bar__grid{% if announcement_bar and language_country_selector or section.settings.show_social and social_icons %} utility-bar__grid--3-col{% elsif language_country_selector or section.settings.show_social and social_icons %} utility-bar__grid--2-col{% endif %}">
     {%- if section.settings.show_social and social_icons -%}
@@ -31,7 +30,7 @@
         class="announcement-bar{% if section.settings.show_social %} announcement-bar--one-announcement{% endif %}"
         role="region"
         aria-label="{{ 'sections.header.announcement' | t }}"
-        {{ block.shopify_attributes }}
+        {{ section.blocks.first.shopify_attributes }}
       >
         {%- if section.blocks.first.settings.text != blank -%}
           {%- if section.blocks.first.settings.link != blank -%}
@@ -92,7 +91,6 @@
                   class="announcement-bar__announcement"
                   role="region"
                   aria-label="{{ 'sections.header.announcement' | t }}"
-                  {{ block.shopify_attributes }}
                 >
                   {%- if block.settings.text != blank -%}
                     {%- if block.settings.link != blank -%}


### PR DESCRIPTION
### PR Summary: 
1. Shopify attributes were not rendered when the section contained only one block
2. The attributes were rendered multiple times per block when the section contained multiple blocks 

### Why are these changes introduced?
Improving the Theme Editor experience.

### Testing steps/scenarios
1. Open the theme editor
2. Add the slideshow section with one block
3. Hover the block in the sidebar, be sure the power preview outlines the block properly.
4. Add another block to the section
5. Hover the first block, be sure the power preview outlines the block properly.

### Checklist
- [x] Added PR summary for [release notes](https://themes.shopify.com/themes/dawn/styles/default#ReleaseNotes)
