### PR TITLE
Update cart-notification.liquid

### DIFF
--- a/snippets/cart-notification.liquid
+++ b/snippets/cart-notification.liquid
@@ -20,10 +20,10 @@
       tabindex="-1"
     >
       <div class="cart-notification__header">
-        <h2 class="cart-notification__heading caption-large text-body">
+        <p class="h2 cart-notification__heading caption-large text-body">
           {{- 'icon-checkmark.svg' | inline_asset_content -}}
           {{ 'general.cart.item_added' | t }}
-        </h2>
+        </p>
         <button
           type="button"
           class="cart-notification__close modal__close-button link link--text focus-inset"


### PR DESCRIPTION
Update <h2> balise by <p> to improve SEO hierarchy. H2 should be before the H1 of collection and product title.

### PR Summary: 

I update the html balise used to show the notification message when a product is added to the card.


### Why are these changes introduced?

H2 balise for notification replaced by a P balise.
Class h2 has been added to get the exact same style.

### What approach did you take?

### Other considerations

### Decision log

| # | Decision | Alternatives | Rationale | Downsides |
|---|---|---|---|---|
| 1 |   |   |   |   |


### Visual impact on existing themes
There will have no visual change.


### Testing steps/scenarios
<!-- List all the testing tasks that applies to your fix to help peers review your work. -->
- Step 1: Add a product, and I checked that message is shown as before. No change introduced.

### Demo links
- [Store][(url)](https://www.njutjewelry.com/products/nj_t)
- [Editor](url)

### Checklist
- [x ] Added PR summary for [release notes](https://themes.shopify.com/themes/dawn/styles/default#ReleaseNotes)
- [ ] Requested review from UX (Only for changes that are affecting the experience or perceivable visual details)
- [ ] Created a ticket for the [help.shopify.com](https://help.shopify.com) documentation team about updates to theme settings. (Internal-only task)
- [ x] Followed [theme code principles](https://github.com/Shopify/dawn/blob/main/.github/CONTRIBUTING.md#theme-code-principles)
- [ x] Linted with [Theme Check](https://github.com/Shopify/theme-check)
- [ x] Tested on [mobile](https://shopify.dev/themes/store/requirements#mobile-browser-requirements)
- [ x] Tested on [multiple browsers](https://shopify.dev/themes/store/requirements#desktop-browser-requirements)
- [x ] Tested for [accessibility](https://shopify.dev/themes/best-practices/accessibility)
