### PR TITLE
updating copy to help docs to be more clear

### DIFF
--- a/locales/cs.schema.json
+++ b/locales/cs.schema.json
@@ -1693,7 +1693,7 @@
             },
             "swatch_shape": {
               "label": "Vzorník",
-              "info": "Zapněte [vzorníky](https://help.shopify.com/en/manual/online-store/themes/theme-structure/theme-settings#options-with-swatches) u možností produktů.",
+              "info": "Zjistěte více o  [vzornících](https://help.shopify.com/en/manual/online-store/themes/theme-structure/theme-settings#options-with-swatches) v možnostech produktu",
               "options__1": {
                 "label": "Kruh"
               },
@@ -2567,7 +2567,7 @@
             },
             "swatch_shape": {
               "label": "Vzorník",
-              "info": "Zapněte [vzorníky](https://help.shopify.com/en/manual/online-store/themes/theme-structure/theme-settings#options-with-swatches) u možností produktů.",
+              "info": "Zjistěte více o  [vzornících](https://help.shopify.com/en/manual/online-store/themes/theme-structure/theme-settings#options-with-swatches) v možnostech produktu",
               "options__1": {
                 "label": "Kruh"
               },

--- a/locales/da.schema.json
+++ b/locales/da.schema.json
@@ -1693,7 +1693,7 @@
             },
             "swatch_shape": {
               "label": "Prøve",
-              "info": "Aktivér [prøver](https://help.shopify.com/en/manual/online-store/themes/theme-structure/theme-settings#options-with-swatches) for produktmuligheder.",
+              "info": "Få mere at vide om [prøver](https://help.shopify.com/en/manual/online-store/themes/theme-structure/theme-settings#options-with-swatches) på produktmuligheder",
               "options__1": {
                 "label": "Cirkel"
               },
@@ -2567,7 +2567,7 @@
             },
             "swatch_shape": {
               "label": "Prøve",
-              "info": "Aktivér [prøver](https://help.shopify.com/en/manual/online-store/themes/theme-structure/theme-settings#options-with-swatches) for produktmuligheder.",
+              "info": "Få mere at vide om [prøver](https://help.shopify.com/en/manual/online-store/themes/theme-structure/theme-settings#options-with-swatches) på produktmuligheder",
               "options__1": {
                 "label": "Cirkel"
               },

--- a/locales/de.schema.json
+++ b/locales/de.schema.json
@@ -1692,7 +1692,7 @@
             },
             "swatch_shape": {
               "label": "Farbfeld",
-              "info": "Aktiviere [Farbfelder](https://help.shopify.com/en/manual/online-store/themes/theme-structure/theme-settings#options-with-swatches) für Produktoptionen.",
+              "info": "Mehr Informationen zu [Farbfelder ](https://help.shopify.com/en/manual/online-store/themes/theme-structure/theme-settings#options-with-swatches) für Produktoptionen",
               "options__1": {
                 "label": "Kreis"
               },
@@ -2567,7 +2567,7 @@
             },
             "swatch_shape": {
               "label": "Farbfeld",
-              "info": "Aktiviere [Farbfelder](https://help.shopify.com/en/manual/online-store/themes/theme-structure/theme-settings#options-with-swatches) für Produktoptionen.",
+              "info": "Mehr Informationen zu [Farbfelder ](https://help.shopify.com/en/manual/online-store/themes/theme-structure/theme-settings#options-with-swatches) für Produktoptionen",
               "options__1": {
                 "label": "Kreis"
               },

--- a/locales/en.default.schema.json
+++ b/locales/en.default.schema.json
@@ -877,7 +877,7 @@
             },
             "swatch_shape": {
               "label": "Swatch",
-              "info": "Enable [swatches](https://help.shopify.com/en/manual/online-store/themes/theme-structure/theme-settings#options-with-swatches) on product options.",
+              "info": "Learn more about [swatches](https://help.shopify.com/en/manual/online-store/themes/theme-structure/theme-settings#options-with-swatches) on product options",
               "options__1": {
                 "label": "Circle"
               },
@@ -2036,7 +2036,7 @@
             },
             "swatch_shape": {
               "label": "Swatch",
-              "info": "Enable [swatches](https://help.shopify.com/en/manual/online-store/themes/theme-structure/theme-settings#options-with-swatches) on product options.",
+              "info": "Learn more about [swatches](https://help.shopify.com/en/manual/online-store/themes/theme-structure/theme-settings#options-with-swatches) on product options",
               "options__1": {
                 "label": "Circle"
               },

--- a/locales/es.schema.json
+++ b/locales/es.schema.json
@@ -1693,7 +1693,7 @@
             },
             "swatch_shape": {
               "label": "Muestra",
-              "info": "Habilita [muestras](https://help.shopify.com/en/manual/online-store/themes/theme-structure/theme-settings#options-with-swatches) en las opciones de producto.",
+              "info": "Obtén más información acerca de las [muestras](https://help.shopify.com/en/manual/online-store/themes/theme-structure/theme-settings#options-with-swatches) en las opciones de producto",
               "options__1": {
                 "label": "Círculo"
               },
@@ -2567,7 +2567,7 @@
             },
             "swatch_shape": {
               "label": "Muestra",
-              "info": "Habilita [muestras](https://help.shopify.com/en/manual/online-store/themes/theme-structure/theme-settings#options-with-swatches) en las opciones de producto.",
+              "info": "Obtén más información acerca de las [muestras](https://help.shopify.com/en/manual/online-store/themes/theme-structure/theme-settings#options-with-swatches) en las opciones de producto",
               "options__1": {
                 "label": "Círculo"
               },

--- a/locales/fi.schema.json
+++ b/locales/fi.schema.json
@@ -1692,7 +1692,7 @@
             },
             "swatch_shape": {
               "label": "Väriruutu",
-              "info": "Ota [väriruudut](https://help.shopify.com/en/manual/online-store/themes/theme-structure/theme-settings#options-with-swatches) käyttöön tuotevaihtoehtoihin.",
+              "info": "Lue lisää tuotevaihtoehtojen [väriruuduista](https://help.shopify.com/en/manual/online-store/themes/theme-structure/theme-settings#options-with-swatches)",
               "options__1": {
                 "label": "Ympyrä"
               },
@@ -2567,7 +2567,7 @@
             },
             "swatch_shape": {
               "label": "Väriruutu",
-              "info": "Ota [väriruudut](https://help.shopify.com/en/manual/online-store/themes/theme-structure/theme-settings#options-with-swatches) käyttöön tuotevaihtoehtoihin.",
+              "info": "Lue lisää tuotevaihtoehtojen [väriruuduista](https://help.shopify.com/en/manual/online-store/themes/theme-structure/theme-settings#options-with-swatches)",
               "options__1": {
                 "label": "Ympyrä"
               },

--- a/locales/fr.schema.json
+++ b/locales/fr.schema.json
@@ -1692,7 +1692,7 @@
             },
             "swatch_shape": {
               "label": "Échantillon",
-              "info": "Activez [échantillons](https://help.shopify.com/en/manual/online-store/themes/theme-structure/theme-settings#options-with-swatches) sur les options produits.",
+              "info": "En savoir plus sur [échantillons](https://help.shopify.com/en/manual/online-store/themes/theme-structure/theme-settings#options-with-swatches) sur les options de produits",
               "options__1": {
                 "label": "Cercle"
               },
@@ -2567,7 +2567,7 @@
             },
             "swatch_shape": {
               "label": "Échantillon",
-              "info": "Activez [échantillons](https://help.shopify.com/en/manual/online-store/themes/theme-structure/theme-settings#options-with-swatches) sur les options produits.",
+              "info": "En savoir plus sur [échantillons](https://help.shopify.com/en/manual/online-store/themes/theme-structure/theme-settings#options-with-swatches) sur les options de produits",
               "options__1": {
                 "label": "Cercle"
               },

--- a/locales/it.schema.json
+++ b/locales/it.schema.json
@@ -1693,7 +1693,7 @@
             },
             "swatch_shape": {
               "label": "Campione di colore",
-              "info": "Abilita i [campioni di colore](https://help.shopify.com/en/manual/online-store/themes/theme-structure/theme-settings#options-with-swatches) nelle opzioni del prodotto.",
+              "info": "Maggiori informazioni sui [campioni di colore](https://help.shopify.com/en/manual/online-store/themes/theme-structure/theme-settings#options-with-swatches) nelle opzioni del prodotto",
               "options__1": {
                 "label": "Tondo"
               },
@@ -2567,7 +2567,7 @@
             },
             "swatch_shape": {
               "label": "Campione di colore",
-              "info": "Abilita i [campioni di colore](https://help.shopify.com/en/manual/online-store/themes/theme-structure/theme-settings#options-with-swatches) nelle opzioni del prodotto.",
+              "info": "Maggiori informazioni sui [campioni di colore](https://help.shopify.com/en/manual/online-store/themes/theme-structure/theme-settings#options-with-swatches) nelle opzioni del prodotto",
               "options__1": {
                 "label": "Tondo"
               },

--- a/locales/ja.schema.json
+++ b/locales/ja.schema.json
@@ -1684,7 +1684,7 @@
             },
             "swatch_shape": {
               "label": "見本",
-              "info": "商品オプションの[見本](https://help.shopify.com/en/manual/online-store/themes/theme-structure/theme-settings#options-with-swatches)を有効にする。",
+              "info": "商品オプションの [見本](https://help.shopify.com/en/manual/online-store/themes/theme-structure/theme-settings#options-with-swatches)の詳細を確認する",
               "options__1": {
                 "label": "円形"
               },
@@ -2567,7 +2567,7 @@
             },
             "swatch_shape": {
               "label": "見本",
-              "info": "商品オプションの[見本](https://help.shopify.com/en/manual/online-store/themes/theme-structure/theme-settings#options-with-swatches)を有効にする。",
+              "info": "商品オプションの [見本](https://help.shopify.com/en/manual/online-store/themes/theme-structure/theme-settings#options-with-swatches)の詳細を確認する",
               "options__1": {
                 "label": "円形"
               },

--- a/locales/ko.schema.json
+++ b/locales/ko.schema.json
@@ -1684,7 +1684,7 @@
             },
             "swatch_shape": {
               "label": "견본",
-              "info": "제품 옵션에서 [견본](https://help.shopify.com/en/manual/online-store/themes/theme-structure/theme-settings#options-with-swatches)을 활성화합니다.",
+              "info": "제품 옵션의 [견본](https://help.shopify.com/en/manual/online-store/themes/theme-structure/theme-settings#options-with-swatches)에 대해 자세히 알아보기",
               "options__1": {
                 "label": "원형"
               },
@@ -2567,7 +2567,7 @@
             },
             "swatch_shape": {
               "label": "견본",
-              "info": "제품 옵션에서 [견본](https://help.shopify.com/en/manual/online-store/themes/theme-structure/theme-settings#options-with-swatches)을 활성화합니다.",
+              "info": "제품 옵션의 [견본](https://help.shopify.com/en/manual/online-store/themes/theme-structure/theme-settings#options-with-swatches)에 대해 자세히 알아보기",
               "options__1": {
                 "label": "원형"
               },

--- a/locales/nb.schema.json
+++ b/locales/nb.schema.json
@@ -1692,7 +1692,7 @@
             },
             "swatch_shape": {
               "label": "Fargekart",
-              "info": "Aktiver [fargekart](https://help.shopify.com/en/manual/online-store/themes/theme-structure/theme-settings#options-with-swatches) på produktalternativer.",
+              "info": "Finn ut mer om [fargekart](https://help.shopify.com/en/manual/online-store/themes/theme-structure/theme-settings#options-with-swatches) for produktalternativer",
               "options__1": {
                 "label": "Sirkel"
               },
@@ -2567,7 +2567,7 @@
             },
             "swatch_shape": {
               "label": "Fargekart",
-              "info": "Aktiver [fargekart](https://help.shopify.com/en/manual/online-store/themes/theme-structure/theme-settings#options-with-swatches) på produktalternativer.",
+              "info": "Finn ut mer om [fargekart](https://help.shopify.com/en/manual/online-store/themes/theme-structure/theme-settings#options-with-swatches) for produktalternativer",
               "options__1": {
                 "label": "Sirkel"
               },

--- a/locales/nl.schema.json
+++ b/locales/nl.schema.json
@@ -1693,7 +1693,7 @@
             },
             "swatch_shape": {
               "label": "Staal",
-              "info": "Schakel [stalen](https://help.shopify.com/en/manual/online-store/themes/theme-structure/theme-settings#options-with-swatches) in bij productopties.",
+              "info": "Meer informatie over [stalen](https://help.shopify.com/en/manual/online-store/themes/theme-structure/theme-settings#options-with-swatches) voor productopties",
               "options__1": {
                 "label": "Cirkel"
               },
@@ -2567,7 +2567,7 @@
             },
             "swatch_shape": {
               "label": "Staal",
-              "info": "Schakel [stalen](https://help.shopify.com/en/manual/online-store/themes/theme-structure/theme-settings#options-with-swatches) in bij productopties.",
+              "info": "Meer informatie over [stalen](https://help.shopify.com/en/manual/online-store/themes/theme-structure/theme-settings#options-with-swatches) voor productopties",
               "options__1": {
                 "label": "Cirkel"
               },

--- a/locales/pl.schema.json
+++ b/locales/pl.schema.json
@@ -1693,7 +1693,7 @@
             },
             "swatch_shape": {
               "label": "Próbka",
-              "info": "Włącz [próbki](https://help.shopify.com/en/manual/online-store/themes/theme-structure/theme-settings#options-with-swatches) w opcjach produktu.",
+              "info": "Dowiedz się więcej o [próbkach](https://help.shopify.com/en/manual/online-store/themes/theme-structure/theme-settings#options-with-swatches) w opcjach produktu",
               "options__1": {
                 "label": "Koło"
               },
@@ -2567,7 +2567,7 @@
             },
             "swatch_shape": {
               "label": "Próbka",
-              "info": "Włącz [próbki](https://help.shopify.com/en/manual/online-store/themes/theme-structure/theme-settings#options-with-swatches) w opcjach produktu.",
+              "info": "Dowiedz się więcej o [próbkach](https://help.shopify.com/en/manual/online-store/themes/theme-structure/theme-settings#options-with-swatches) w opcjach produktu",
               "options__1": {
                 "label": "Koło"
               },

--- a/locales/pt-BR.schema.json
+++ b/locales/pt-BR.schema.json
@@ -1692,7 +1692,7 @@
             },
             "swatch_shape": {
               "label": "Amostra",
-              "info": "Habilite [amostras](https://help.shopify.com/en/manual/online-store/themes/theme-structure/theme-settings#options-with-swatches) nas opções de produtos.",
+              "info": "Saiba mais sobre as [amostras](https://help.shopify.com/en/manual/online-store/themes/theme-structure/theme-settings#options-with-swatches) nas opções de produtos",
               "options__1": {
                 "label": "Círculo"
               },
@@ -2567,7 +2567,7 @@
             },
             "swatch_shape": {
               "label": "Amostra",
-              "info": "Habilite [amostras](https://help.shopify.com/en/manual/online-store/themes/theme-structure/theme-settings#options-with-swatches) nas opções de produtos.",
+              "info": "Saiba mais sobre as [amostras](https://help.shopify.com/en/manual/online-store/themes/theme-structure/theme-settings#options-with-swatches) nas opções de produtos",
               "options__1": {
                 "label": "Círculo"
               },

--- a/locales/pt-PT.schema.json
+++ b/locales/pt-PT.schema.json
@@ -1684,7 +1684,7 @@
             },
             "swatch_shape": {
               "label": "Paleta",
-              "info": "Ative [paletas](https://help.shopify.com/en/manual/online-store/themes/theme-structure/theme-settings#options-with-swatches) nas opções de produto.",
+              "info": "Saber mais sobre as [amostras](https://help.shopify.com/en/manual/online-store/themes/theme-structure/theme-settings#options-with-swatches) nas opções de produtos",
               "options__1": {
                 "label": "Círculo"
               },
@@ -2567,7 +2567,7 @@
             },
             "swatch_shape": {
               "label": "Paleta",
-              "info": "Ative [paletas](https://help.shopify.com/en/manual/online-store/themes/theme-structure/theme-settings#options-with-swatches) nas opções de produto.",
+              "info": "Saber mais sobre as [amostras](https://help.shopify.com/en/manual/online-store/themes/theme-structure/theme-settings#options-with-swatches) nas opções de produtos",
               "options__1": {
                 "label": "Círculo"
               },

--- a/locales/sv.schema.json
+++ b/locales/sv.schema.json
@@ -1684,7 +1684,7 @@
             },
             "swatch_shape": {
               "label": "Prov",
-              "info": "Aktivera [swatches](https://help.shopify.com/en/manual/online-store/themes/theme-structure/theme-settings#options-with-swatches) på produktalternativ.",
+              "info": "Läs mer om [swatches](https://help.shopify.com/en/manual/online-store/themes/theme-structure/theme-settings#options-with-swatches) på produktalternativ",
               "options__1": {
                 "label": "Cirkel"
               },
@@ -2567,7 +2567,7 @@
             },
             "swatch_shape": {
               "label": "Prov",
-              "info": "Aktivera [swatches](https://help.shopify.com/en/manual/online-store/themes/theme-structure/theme-settings#options-with-swatches) på produktalternativ.",
+              "info": "Läs mer om [swatches](https://help.shopify.com/en/manual/online-store/themes/theme-structure/theme-settings#options-with-swatches) på produktalternativ",
               "options__1": {
                 "label": "Cirkel"
               },

--- a/locales/th.schema.json
+++ b/locales/th.schema.json
@@ -1684,7 +1684,7 @@
             },
             "swatch_shape": {
               "label": "ตัวอย่าง",
-              "info": "เปิดใช้งาน [แผงสี](https://help.shopify.com/en/manual/online-store/themes/theme-structure/theme-settings#options-with-swatches) ในตัวเลือกสินค้า",
+              "info": "ดูข้อมูลเพิ่มเติมเกี่ยวกับ [แผงสี](https://help.shopify.com/en/manual/online-store/themes/theme-structure/theme-settings#options-with-swatches) ในตัวเลือกสินค้า",
               "options__1": {
                 "label": "วงกลม"
               },
@@ -2567,7 +2567,7 @@
             },
             "swatch_shape": {
               "label": "ตัวอย่าง",
-              "info": "เปิดใช้งาน [แผงสี](https://help.shopify.com/en/manual/online-store/themes/theme-structure/theme-settings#options-with-swatches) ในตัวเลือกสินค้า",
+              "info": "ดูข้อมูลเพิ่มเติมเกี่ยวกับ [แผงสี](https://help.shopify.com/en/manual/online-store/themes/theme-structure/theme-settings#options-with-swatches) ในตัวเลือกสินค้า",
               "options__1": {
                 "label": "วงกลม"
               },

--- a/locales/tr.schema.json
+++ b/locales/tr.schema.json
@@ -1692,7 +1692,7 @@
             },
             "swatch_shape": {
               "label": "Numune parça",
-              "info": "Ürün seçeneklerinde [numune parçaları](https://help.shopify.com/en/manual/online-store/themes/theme-structure/theme-settings#options-with-swatches) etkinleştirin.",
+              "info": "Ürün seçeneklerinde [numune parçalar](https://help.shopify.com/en/manual/online-store/themes/theme-structure/theme-settings#options-with-swatches) hakkında daha fazla bilgi edinin.",
               "options__1": {
                 "label": "Yuvarlak"
               },
@@ -2567,7 +2567,7 @@
             },
             "swatch_shape": {
               "label": "Numune parça",
-              "info": "Ürün seçeneklerinde [numune parçaları](https://help.shopify.com/en/manual/online-store/themes/theme-structure/theme-settings#options-with-swatches) etkinleştirin.",
+              "info": "Ürün seçeneklerinde [numune parçalar](https://help.shopify.com/en/manual/online-store/themes/theme-structure/theme-settings#options-with-swatches) hakkında daha fazla bilgi edinin.",
               "options__1": {
                 "label": "Yuvarlak"
               },

--- a/locales/zh-CN.schema.json
+++ b/locales/zh-CN.schema.json
@@ -1684,7 +1684,7 @@
             },
             "swatch_shape": {
               "label": "样本",
-              "info": "在产品选项上启用[样本](https://help.shopify.com/en/manual/online-store/themes/theme-structure/theme-settings#options-with-swatches)。",
+              "info": "详细了解如何在产品选项上启用[样本](https://help.shopify.com/en/manual/online-store/themes/theme-structure/theme-settings#options-with-swatches)",
               "options__1": {
                 "label": "圆形"
               },
@@ -2567,7 +2567,7 @@
             },
             "swatch_shape": {
               "label": "样本",
-              "info": "在产品选项上启用[样本功能](https://help.shopify.com/en/manual/online-store/themes/theme-structure/theme-settings#options-with-swatches)。",
+              "info": "详细了解如何在产品选项上启用[样本](https://help.shopify.com/en/manual/online-store/themes/theme-structure/theme-settings#options-with-swatches)",
               "options__1": {
                 "label": "圆形"
               },

--- a/locales/zh-TW.schema.json
+++ b/locales/zh-TW.schema.json
@@ -1684,7 +1684,7 @@
             },
             "swatch_shape": {
               "label": "色樣",
-              "info": "為商品選項啟用 [色樣](https://help.shopify.com/en/manual/online-store/themes/theme-structure/theme-settings#options-with-swatches)。",
+              "info": "瞭解為商品選項啟用 [色樣](https://help.shopify.com/en/manual/online-store/themes/theme-structure/theme-settings#options-with-swatches)的詳情。",
               "options__1": {
                 "label": "圓形"
               },
@@ -2567,7 +2567,7 @@
             },
             "swatch_shape": {
               "label": "色樣",
-              "info": "為商品選項啟用 [色樣](https://help.shopify.com/en/manual/online-store/themes/theme-structure/theme-settings#options-with-swatches)。",
+              "info": "瞭解為商品選項啟用 [色樣](https://help.shopify.com/en/manual/online-store/themes/theme-structure/theme-settings#options-with-swatches)的詳情。",
               "options__1": {
                 "label": "圓形"
               },


### PR DESCRIPTION
### PR Summary: 
Updates the copy for helper text in the swatch selector to say "learn more" instead of "enable" which was causing confusion. 

### Why are these changes introduced?
Currently the swatch helper text is not as clear as it could be. it says: 
![Screenshot 2024-10-21 at 12 01 39 PM](https://github.com/user-attachments/assets/33811bb0-804f-44e8-9f5f-f5e5a5e9fc34)

This PR updates it to "Learn more about..." and it also removed the `.` at the end of the sentence per updated style guidelines. 


### Visual impact on existing themes
<!-- How will this visually affect merchants who upgrade to a new theme version with this change? -->


### Testing steps/scenarios
<!-- List all the testing tasks that applies to your fix to help peers review your work. -->
- [ ] Step 1

### Demo links
<!-- Please include a link to a demo store that includes preconfigured sections and settings to allow reviewers to easily test the features you are working on. -->

- [Store](url)
- [Editor](url)

### Checklist
- [x] Added PR summary for [release notes](https://themes.shopify.com/themes/dawn/styles/default#ReleaseNotes)
- [x] Requested review from UX (Only for changes that are affecting the experience or perceivable visual details)
- [x] Created a ticket for the [help.shopify.com](https://help.shopify.com) documentation team about updates to theme settings. (Internal-only task)
- [x] Followed [theme code principles](https://github.com/Shopify/dawn/blob/main/.github/CONTRIBUTING.md#theme-code-principles)
- [] Linted with [Theme Check](https://github.com/Shopify/theme-check)
- [ ] Tested on [mobile](https://shopify.dev/themes/store/requirements#mobile-browser-requirements)
- [ ] Tested on [multiple browsers](https://shopify.dev/themes/store/requirements#desktop-browser-requirements)
- [ ] Tested for [accessibility](https://shopify.dev/themes/best-practices/accessibility)
