### PR TITLE
[Slideshow] Fixing an issue with block attributes

### DIFF
--- a/sections/slideshow.liquid
+++ b/sections/slideshow.liquid
@@ -166,7 +166,7 @@
               </h2>
             {%- endif -%}
             {%- if block.settings.subheading != blank -%}
-              <div class="banner__text rte" {{ block.shopify_attributes }}>
+              <div class="banner__text rte">
                 <p>{{ block.settings.subheading }}</p>
               </div>
             {%- endif -%}


### PR DESCRIPTION
### PR Summary: 
1. The attributes were rendered multiple times per block

### Why are these changes introduced?
Improving the Theme Editor experience.

### Testing steps/scenarios
1. Open the theme editor
2. Add the slideshow section
3. Hover the block in the sidebar, be sure the power preview outlines the block properly.

### Checklist
- [x] Added PR summary for [release notes](https://themes.shopify.com/themes/dawn/styles/default#ReleaseNotes)
