### PR TITLE
Fix syntax issue in schema for email-signup-banner section

### DIFF
--- a/sections/email-signup-banner.liquid
+++ b/sections/email-signup-banner.liquid
@@ -147,6 +147,9 @@
   "name": "t:sections.email-signup-banner.name",
   "tag": "section",
   "class": "section",
+  "enabled_on": {
+    "templates": ["password"]
+  },
   "settings": [
     {
       "type": "paragraph",
@@ -398,7 +401,6 @@
         }
       ]
     }
-  ],
-  "templates": ["password"]
+  ]
 }
 {% endschema %}


### PR DESCRIPTION
### PR Summary: 
Fixes syntax error in email-signup-banner section.
While it currently "works", `"templates": ["password"]` should be invalid if not nested into `"enabled_on"` or `"disabled_on"`, as shown by Theme check
[![](https://screenshot.click/05-39-hkaaw-f2zld.png)](https://screenshot.click/05-39-hkaaw-f2zld.png)

### Why are these changes introduced?
Fixes invalid schema syntax.

### Visual impact on existing themes
No impact on theme

### Testing steps/scenarios
- [ ] Install dawn
- [ ] Check that the Email signup banner section _can_ be added on the password template
- [ ] Check that the Email signup banner section _cannot_ be added on other templates (e.g. index)