### PR TITLE
Fix overflow scrolling on options modal

### DIFF
--- a/assets/quick-add.css
+++ b/assets/quick-add.css
@@ -214,6 +214,7 @@
   padding-right: 4.4rem;
   display: flex;
   overflow-y: auto;
+  overflow-x: hidden;
   padding: var(--modal-padding);
   height: 100%;
 }


### PR DESCRIPTION
### PR Summary: 

Testing a fix for horizontal scrolling on quick add options modal

### Why are these changes introduced?

Fixes https://github.com/Shopify/dawn/issues/1952

### What approach did you take?

Just removed horizontal scroll...

### Other considerations

We could try to find the exact source of the scrolling, but this is a more blunt solution.

### Visual impact on existing themes

Should just fix the bug.


### Testing steps/scenarios
<!-- List all the testing tasks that applies to your fix to help peers review your work. -->
- [x] Open a quick add modal on mobile.
- [x] Can you scroll horizontally?  If not, yay!

### Demo links

- [Editor](https://admin.shopify.com/store/os2-demo/themes/174251671574/editor)

### Checklist
- [ ] Added PR summary for [release notes](https://themes.shopify.com/themes/dawn/styles/default#ReleaseNotes)
- [ ] Requested review from UX (Only for changes that are affecting the experience or perceivable visual details)
- [ ] Created a ticket for the [help.shopify.com](https://help.shopify.com) documentation team about updates to theme settings. (Internal-only task)
- [ ] Followed [theme code principles](https://github.com/Shopify/dawn/blob/main/.github/CONTRIBUTING.md#theme-code-principles)
- [ ] Linted with [Theme Check](https://github.com/Shopify/theme-check)
- [ ] Tested on [mobile](https://shopify.dev/themes/store/requirements#mobile-browser-requirements)
- [ ] Tested on [multiple browsers](https://shopify.dev/themes/store/requirements#desktop-browser-requirements)
- [ ] Tested for [accessibility](https://shopify.dev/themes/best-practices/accessibility)
