### PR TITLE
Fixed safari swatch inputs in facets

### DIFF
--- a/assets/component-facets.css
+++ b/assets/component-facets.css
@@ -495,6 +495,8 @@
   z-index: 1;
   margin: 0;
   opacity: 0;
+  width: 100%;
+  height: 100%;
 }
 
 .facets-layout-list--swatch .facets__label {


### PR DESCRIPTION
### PR Summary: 

Safari doesn't like just using `top: 0; bottom: 0; ...` to full size absolute positioned elements in a container, causing the swatches to have a much narrower click range than intended.

### Why are these changes introduced?

Report from Merchant Support.

### What approach did you take?

Added width and height to the checkbox.

### Visual impact on existing themes

It won't.

### Testing steps/scenarios
<!-- List all the testing tasks that applies to your fix to help peers review your work. -->
- [ ] Open up Safari
- [ ] Go to a collection page with colour swatches
- [ ] See that you can now click the entire width of their line item, previously only the swatch itself could be clicked

### Demo links
<!-- Please include a link to a demo store that includes preconfigured sections and settings to allow reviewers to easily test the features you are working on. -->

- [Editor](https://admin.shopify.com/store/os2-demo/themes/174277296150/editor)

### Checklist
- [ ] Added PR summary for [release notes](https://themes.shopify.com/themes/dawn/styles/default#ReleaseNotes)
- [ ] Requested review from UX (Only for changes that are affecting the experience or perceivable visual details)
- [ ] Created a ticket for the [help.shopify.com](https://help.shopify.com) documentation team about updates to theme settings. (Internal-only task)
- [ ] Followed [theme code principles](https://github.com/Shopify/dawn/blob/main/.github/CONTRIBUTING.md#theme-code-principles)
- [ ] Linted with [Theme Check](https://github.com/Shopify/theme-check)
- [ ] Tested on [mobile](https://shopify.dev/themes/store/requirements#mobile-browser-requirements)
- [ ] Tested on [multiple browsers](https://shopify.dev/themes/store/requirements#desktop-browser-requirements)
- [ ] Tested for [accessibility](https://shopify.dev/themes/best-practices/accessibility)
