### PR TITLE
Adds missing alt text for secondary image (displayed on hover) to car…

### DIFF
--- a/snippets/card-product.liquid
+++ b/snippets/card-product.liquid
@@ -96,7 +96,7 @@
                   "
                   src="{{ card_product.media[1] | image_url: width: 533 }}"
                   sizes="(min-width: {{ settings.page_width }}px) {{ settings.page_width | minus: 130 | divided_by: 4 }}px, (min-width: 990px) calc((100vw - 130px) / 4), (min-width: 750px) calc((100vw - 120px) / 3), calc((100vw - 35px) / 2)"
-                  alt=""
+                  alt="{{ card_product.media[1].alt | escape }}"
                   class="motion-reduce"
                   loading="lazy"
                   width="{{ card_product.media[1].width }}"


### PR DESCRIPTION
### PR Summary: 

<!-- Please include a short description (using non-technical terms, 1-2 sentences) about the changes you are introducing, what problem is being fixed and/or describe the benefit to merchants. This content will be used in our release notes for Dawn on [themes.shopify.com](https://themes.shopify.com/themes/dawn/styles/default#ReleaseNotes). -->

When secondary images are enabled on the product card (showing a second image on hover), the alt text attribute on that secondary image is empty. This PR fixes that, using Liquid to grab the second product image. 

### Why are these changes introduced?

No active issue for this, but fixes a missing alt attribute. 

### Visual impact on existing themes
<!-- How will this visually affect merchants who upgrade to a new theme version with this change? -->

This should not impact any part of the theme visually, it is for accessibility. 

### Checklist
- [X] Added PR summary for [release notes](https://themes.shopify.com/themes/dawn/styles/default#ReleaseNotes)
- [ ] Requested review from UX (Only for changes that are affecting the experience or perceivable visual details)
- [ ] Created a ticket for the [help.shopify.com](https://help.shopify.com) documentation team about updates to theme settings. (Internal-only task)
- [X] Followed [theme code principles](https://github.com/Shopify/dawn/blob/main/.github/CONTRIBUTING.md#theme-code-principles)
- [ ] Linted with [Theme Check](https://github.com/Shopify/theme-check)
- [X] Tested on [mobile](https://shopify.dev/themes/store/requirements#mobile-browser-requirements)
- [ ] Tested on [multiple browsers](https://shopify.dev/themes/store/requirements#desktop-browser-requirements)
- [X] Tested for [accessibility](https://shopify.dev/themes/best-practices/accessibility)
