### PR TITLE
replace all instances of product.variants.size with product.variants_count.

### DIFF
--- a/snippets/card-product.liquid
+++ b/snippets/card-product.liquid
@@ -206,7 +206,7 @@
 
             {% render 'price', product: card_product, price_class: '', show_compare_at_price: true %}
             {%- if card_product.quantity_price_breaks_configured? -%}
-              {% if card_product.variants.size == 1 and quick_add == 'bulk' %}
+              {% if card_product.variants_count == 1 and quick_add == 'bulk' %}
                 {% liquid
                   assign quantity_rule = card_product.selected_or_first_available_variant.quantity_rule
                   assign has_qty_rules = false
@@ -226,7 +226,7 @@
                   <span class="caption">{{ 'products.product.volume_pricing.note' | t }}</span>
                 </div>
               {% endif %}
-              {% if card_product.variants.size == 1 and quick_add == 'bulk' %}
+              {% if card_product.variants_count == 1 and quick_add == 'bulk' %}
                 <div
                   class="global-settings-popup quantity-popover__info"
                   tabindex="-1"
@@ -297,7 +297,7 @@
                 assign qty_rules = true
               endif
             -%}
-            {%- if card_product.variants.size > 1 or qty_rules -%}
+            {%- if card_product.variants_count > 1 or qty_rules -%}
               <modal-opener data-modal="#QuickAdd-{{ card_product.id }}">
                 <button
                   id="{{ product_form_id }}-submit"
@@ -389,7 +389,7 @@
             {%- endif -%}
           </div>
         {% elsif quick_add == 'bulk' %}
-          {% if card_product.variants.size == 1 %}
+          {% if card_product.variants_count == 1 %}
             <quick-add-bulk
               data-min="{{ card_product.selected_or_first_available_variant.quantity_rule.min }}"
               id="quick-add-bulk-{{ card_product.selected_or_first_available_variant.id }}-{{ section.id }}"

--- a/snippets/quick-order-list.liquid
+++ b/snippets/quick-order-list.liquid
@@ -118,7 +118,7 @@
       </p>
     </form>
 
-    {%- if product.has_only_default_variant or product.variants.size == 1 -%}
+    {%- if product.has_only_default_variant or product.variants_count == 1 -%}
       <span class="quick-order-list-error">
         {% comment %} Populated by JS {% endcomment %}
       </span>


### PR DESCRIPTION
### PR Summary: 

PR Summary:
closes https://github.com/Shopify/dawn-private/issues/414

In this PR we replace all instances of Product.variants.size with product.variants_count.

variants_count will be added to the liquid API as part of introducing [product variant pagination](https://github.com/Shopify/storefront-renderer/pull/32566).


### Why are these changes introduced?

Fixes #0.

### What approach did you take?

### Other considerations

### Decision log

| # | Decision | Alternatives | Rationale | Downsides |
|---|---|---|---|---|
| 1 |   |   |   |   |


### Visual impact on existing themes
<!-- How will this visually affect merchants who upgrade to a new theme version with this change? -->


### Testing steps/scenarios
<!-- List all the testing tasks that applies to your fix to help peers review your work. -->
- [ ] Step 1

### Demo links
<!-- Please include a link to a demo store that includes preconfigured sections and settings to allow reviewers to easily test the features you are working on. -->

- [Store](url)
- [Editor](url)

### Checklist
- [x] Added PR summary for [release notes](https://themes.shopify.com/themes/dawn/styles/default#ReleaseNotes)
- [ ] Requested review from UX (Only for changes that are affecting the experience or perceivable visual details)
- [ ] Created a ticket for the [help.shopify.com](https://help.shopify.com) documentation team about updates to theme settings. (Internal-only task)
- [x] Followed [theme code principles](https://github.com/Shopify/dawn/blob/main/.github/CONTRIBUTING.md#theme-code-principles)
- [x] Linted with [Theme Check](https://github.com/Shopify/theme-check)
- [x] Tested on [mobile](https://shopify.dev/themes/store/requirements#mobile-browser-requirements)
- [x] Tested on [multiple browsers](https://shopify.dev/themes/store/requirements#desktop-browser-requirements)
- [x] Tested for [accessibility](https://shopify.dev/themes/best-practices/accessibility)
