### PR TITLE
Fix: Adjust `disclosure__list` dropdown position for RTL layout in header localization

### DIFF
--- a/assets/component-localization-form.css
+++ b/assets/component-localization-form.css
@@ -417,6 +417,14 @@
   transform: translateY(0);
 }
 
+[dir="rtl"] .header-localization:not(.menu-drawer__localization) .disclosure__list-wrapper {
+  bottom: initial;
+  top: 100%;
+  right: auto;
+  left: 0;
+  transform: translateY(0);
+}
+
 /* Menu drawer */
 @media screen and (min-width: 990px) {
   .menu-drawer__localization {


### PR DESCRIPTION
Ensured the dropdown aligns correctly and remains fully visible without causing overflow.