### PR TITLE
Set `translation_profile` on `translation.yml`

### DIFF
--- a/translation.yml
+++ b/translation.yml
@@ -2,6 +2,7 @@ source_language: en
 target_languages: [bg, cs, da, de, el, es, fi, fr, hr, hu, id, it, ja, ko, lt, nb, nl, pl, pt-BR, pt-PT, ro, ru, sk, sl, sv, th, tr, vi, zh-CN, zh-TW]
 non_blocking_languages: []
 async_pr_mode: per_pr
+translation_profile: apps_and_themes
 components:
   - name: buyer
     audience: buyer


### PR DESCRIPTION
#### What does this PR do?

Part of https://github.com/Shopify/translation-platform/issues/7494

Set the `translation_profile` attribute in `translation.yml`.

#### Why is this needed?

The new [`translation_profile`](https://vault.shopify.io/page/Translation-Platform~xKWVdhb9daa.md#component---translation-profile) config setting determines the workflows and processes used by Translation Platform to translate the components' contents.

It ensures that the correct term bases and translators are assigned based on the type of content in each component.

For any questions, reeach out to [#help-localization](https://shopify.slack.com/messages/C7TJQLVC7/).
