### PR TITLE
Update quick order list to not override table until all enqueued requests are processed

### DIFF
--- a/assets/global.js
+++ b/assets/global.js
@@ -279,26 +279,14 @@ class QuantityInput extends HTMLElement {
 
 customElements.define('quantity-input', QuantityInput);
 
-function debounce(fn, wait, leading = false) {
+function debounce(fn, wait) {
   let t;
-  let invoked = false;
-
   return (...args) => {
-    const context = this;
-
-    if (leading && !invoked) {
-      // Invoke immediately on the leading edge
-      fn.apply(context, args);
-      invoked = true;
-    }
-
     clearTimeout(t);
-    t = setTimeout(() => {
-      invoked = false;
-      fn.apply(context, args);
-    }, wait);
+    t = setTimeout(() => fn.apply(this, args), wait);
   };
 }
+
 
 function throttle(fn, delay) {
   let lastCall = 0;
@@ -1342,4 +1330,3 @@ class CartPerformance {
     );
   }
 }
-

--- a/assets/global.js
+++ b/assets/global.js
@@ -279,11 +279,24 @@ class QuantityInput extends HTMLElement {
 
 customElements.define('quantity-input', QuantityInput);
 
-function debounce(fn, wait) {
+function debounce(fn, wait, leading = false) {
   let t;
+  let invoked = false;
+
   return (...args) => {
+    const context = this;
+
+    if (leading && !invoked) {
+      // Invoke immediately on the leading edge
+      fn.apply(context, args);
+      invoked = true;
+    }
+
     clearTimeout(t);
-    t = setTimeout(() => fn.apply(this, args), wait);
+    t = setTimeout(() => {
+      invoked = false;
+      fn.apply(context, args);
+    }, wait);
   };
 }
 

--- a/assets/quick-order-list.js
+++ b/assets/quick-order-list.js
@@ -79,7 +79,7 @@ if (!customElements.get('quick-order-list')) {
         this.allInputsArray = Array.from(this.querySelectorAll('input[type="number"]'));
 
         this.querySelectorAll('quantity-input').forEach((qty) => {
-          const debouncedOnChange = debounce(this.onChange.bind(this), BulkAdd.ASYNC_REQUEST_DELAY);
+          const debouncedOnChange = debounce(this.onChange.bind(this), BulkAdd.ASYNC_REQUEST_DELAY, true);
           qty.addEventListener('change', debouncedOnChange);
         });
 
@@ -201,6 +201,8 @@ if (!customElements.get('quick-order-list')) {
           const newSection = new DOMParser().parseFromString(sections[section], 'text/html').querySelector(selector);
 
           if (section === this.dataset.section) {
+            if (this.queue.length > 0) return;
+
             const focusedElement = document.activeElement;
             let focusTarget = focusedElement?.dataset?.target;
             if (focusTarget?.includes('remove')) {
@@ -208,28 +210,18 @@ if (!customElements.get('quick-order-list')) {
                 ?.dataset.target;
             }
 
-            // if requests are still pending, inject loading state in response
-            if (this.queue.length > 0) this.toggleLoading(true, newSection);
-
             const total = this.getTotalBar();
             if (total) {
               total.innerHTML = newSection.querySelector('.quick-order-list__total').innerHTML;
             }
 
+            const table = this.quickOrderListTable;
             const newTable = newSection.querySelector('.quick-order-list__table');
 
             // only update variants if they are from the active page
             const shouldUpdateVariants =
               this.currentPage === (newSection.querySelector('.pagination-wrapper')?.dataset.page ?? '1');
             if (newTable && shouldUpdateVariants) {
-              const table = this.quickOrderListTable;
-
-              // skip variants that are queued for update
-              [...new Set(this.queue.map(({ id }) => id))].forEach(
-                (id) =>
-                  (newTable.querySelector(`#Variant-${id}`).innerHTML = table.querySelector(`#Variant-${id}`).innerHTML)
-              );
-
               table.innerHTML = newTable.innerHTML;
 
               const newFocusTarget = this.querySelector(`[data-target='${focusTarget}']`);


### PR DESCRIPTION
### PR Summary: 

Fix race condition where quick order list API response overwrites pending updates

### Why are these changes introduced?

See error demo: https://screenshot.click/24-55-no7v6-ykoj7.mp4

The problem was that pending updates were enqueued with a debounce, so if the previous network call came back in the ~200ms or so between when a new request was queued it would overwrite the input value -> then the pending request would get queued -> then the request response would update the input to the correct value.

### What approach did you take?

My fix here was to tweak how we process updates. I modified the debounce to take a [leading](https://css-tricks.com/debouncing-throttling-explained-examples/#aa-leading-edge-or-immediate) arg, and simplified the response handler to not update the table until all requests are completed. The potential downside of this is that the table quantity will not be updated until the last request completes, whereas before it would update as each request came back. The other impact is that if a buyer clicks a quantity increase button quickly, there will always be a minimum of 2 requests (leading edge call, debounced call)--however, this is transparent to the buyer. I think these are probably reasonable tradeoffs.

### Other considerations

Another way we could fix this is to go back to the behavior before [this PR was merged](https://github.com/Shopify/dawn/pull/3710), where we would only update the table for the IDs that were being processed in that request. The downside of this is that if the cart quantities were to change in the background (another browser tab, etc), those changes would not be reflected in the quick order list table until the page is refreshed. This is also fairly simple to implement, here's a gist of the diff: https://gist.github.com/lhoffbeck/143b5b62d82a2d4d73807edb6c713936

🛑  PR reviewer, WDYT about the 2 approaches and tradeoffs?

### Visual impact on existing themes

- quick order total will not be updated until the last request completes


### Testing steps/scenarios
<!-- List all the testing tasks that applies to your fix to help peers review your work. -->
- [ ] Are there any cases where the updates / UI behaves unexpectedly?

### Demo links

https://getmyducksinarow.myshopify.com/products/250-variant-product?_pos=1&_psq=250+variant+product&_ss=e&_v=1.0


### Checklist
- [ ] Added PR summary for [release notes](https://themes.shopify.com/themes/dawn/styles/default#ReleaseNotes)
- [ ] Requested review from UX (Only for changes that are affecting the experience or perceivable visual details)
- [ ] Created a ticket for the [help.shopify.com](https://help.shopify.com) documentation team about updates to theme settings. (Internal-only task)
- [ ] Followed [theme code principles](https://github.com/Shopify/dawn/blob/main/.github/CONTRIBUTING.md#theme-code-principles)
- [ ] Linted with [Theme Check](https://github.com/Shopify/theme-check)
- [ ] Tested on [mobile](https://shopify.dev/themes/store/requirements#mobile-browser-requirements)
- [ ] Tested on [multiple browsers](https://shopify.dev/themes/store/requirements#desktop-browser-requirements)
- [ ] Tested for [accessibility](https://shopify.dev/themes/best-practices/accessibility)
