### PR TITLE
Update query selectors to fix selection issue

### DIFF
--- a/assets/quick-add-bulk.js
+++ b/assets/quick-add-bulk.js
@@ -77,15 +77,21 @@ if (!customElements.get('quick-add-bulk')) {
         );
       }
 
+      get sectionId() {
+        if (!this._sectionId) {
+          this._sectionId = this.closest('.collection-quick-add-bulk').dataset.id;
+        }
+
+        return this._sectionId;
+      }
+
       onCartUpdate() {
         return new Promise((resolve, reject) => {
-          fetch(`${this.getSectionsUrl()}?section_id=${this.closest('.collection').dataset.id}`)
+          fetch(`${this.getSectionsUrl()}?section_id=${this.sectionId}`)
             .then((response) => response.text())
             .then((responseText) => {
               const html = new DOMParser().parseFromString(responseText, 'text/html');
-              const sourceQty = html.querySelector(
-                `#quick-add-bulk-${this.dataset.id}-${this.closest('.collection').dataset.id}`
-              );
+              const sourceQty = html.querySelector(`#quick-add-bulk-${this.dataset.index}-${this.sectionId}`);
               if (sourceQty) {
                 this.innerHTML = sourceQty.innerHTML;
               }
@@ -142,9 +148,9 @@ if (!customElements.get('quick-add-bulk')) {
       getSectionsToRender() {
         return [
           {
-            id: `quick-add-bulk-${this.dataset.index}-${this.closest('.collection-quick-add-bulk').dataset.id}`,
-            section: this.closest('.collection-quick-add-bulk').dataset.id,
-            selector: `#quick-add-bulk-${this.dataset.index}-${this.closest('.collection-quick-add-bulk').dataset.id}`,
+            id: `quick-add-bulk-${this.dataset.index}-${this.sectionId}`,
+            section: this.sectionId,
+            selector: `#quick-add-bulk-${this.dataset.index}-${this.sectionId}`,
           },
           {
             id: 'cart-icon-bubble',


### PR DESCRIPTION
### PR Summary: 

Fixes bulk quick order component bug where invalid ID prevented cart subscription handler from working

### Why are these changes introduced?

This PR from last April tweaked which html element cached the section.id in a data attribute, but missed some query selectors in the corresponding JS.

The impact of this is that if there are multiple quick order bulk widgets present on a collection page, the component isn't able to read the section ID from the dom and (ultimately) a network call 404s. [Demo video](https://screenshot.click/25-27-a6yb4-5b8br.mp4).

Credit to @stanley-xu for finding this issue.

### What approach did you take?

Updated the selector to point to the correct location in the DOM.

### Demo links

https://6483d52vk55uzev9-58156712071.shopifypreview.com
- open this collection page: https://multivariant-storefront.myshopify.com/collections/quick-order-list-testing
- increase quantity on Apples
- open dev tools
- click `choose options` and increase a quantity in the quick order list
- nothing should 404


### Checklist
- [x] Added PR summary for [release notes](https://themes.shopify.com/themes/dawn/styles/default#ReleaseNotes)
- [ ] Requested review from UX (Only for changes that are affecting the experience or perceivable visual details)
- [ ] Created a ticket for the [help.shopify.com](https://help.shopify.com) documentation team about updates to theme settings. (Internal-only task)
- [x] Followed [theme code principles](https://github.com/Shopify/dawn/blob/main/.github/CONTRIBUTING.md#theme-code-principles)
- [x] Linted with [Theme Check](https://github.com/Shopify/theme-check)
- [x] Tested on [mobile](https://shopify.dev/themes/store/requirements#mobile-browser-requirements)
- [x] Tested on [multiple browsers](https://shopify.dev/themes/store/requirements#desktop-browser-requirements)
- [x] Tested for [accessibility](https://shopify.dev/themes/best-practices/accessibility)
