### PR TITLE
Add fallback for missing subscribers

### DIFF
--- a/assets/pubsub.js
+++ b/assets/pubsub.js
@@ -19,5 +19,7 @@ function publish(eventName, data) {
     const promises = subscribers[eventName]
       .map((callback) => callback(data))
     return Promise.all(promises);
+  } else {
+    return Promise.resolve()
   }
 }


### PR DESCRIPTION
### PR Summary: 

In some cases, the `eventName` doesn't have any subscribers. To make sure that the method always return a Promise, let's catch these cases.

### Checklist
- [ ] Added PR summary for [release notes](https://themes.shopify.com/themes/dawn/styles/default#ReleaseNotes)
- [ ] Requested review from UX (Only for changes that are affecting the experience or perceivable visual details)
- [ ] Created a ticket for the [help.shopify.com](https://help.shopify.com) documentation team about updates to theme settings. (Internal-only task)
- [ ] Followed [theme code principles](https://github.com/Shopify/dawn/blob/main/.github/CONTRIBUTING.md#theme-code-principles)
- [ ] Linted with [Theme Check](https://github.com/Shopify/theme-check)
- [ ] Tested on [mobile](https://shopify.dev/themes/store/requirements#mobile-browser-requirements)
- [ ] Tested on [multiple browsers](https://shopify.dev/themes/store/requirements#desktop-browser-requirements)
- [ ] Tested for [accessibility](https://shopify.dev/themes/best-practices/accessibility)
