### PR TITLE
Update UX for quick order list mobile view

### DIFF
--- a/assets/quick-order-list.css
+++ b/assets/quick-order-list.css
@@ -219,6 +219,10 @@ quick-order-list .pagination-wrapper {
     height: 1.5rem;
   }
 
+  .quick-order-list-total__column.large-up-hide .loading__spinner {
+    margin-top: 2.5rem;
+  }
+
   quick-order-list-remove-all-button {
     margin-left: -1.5rem;
     margin-top: 1rem;
@@ -540,6 +544,16 @@ quick-order-list .pagination-wrapper {
 
   quick-order-list-remove-all-button {
     margin-left: 0.9rem;
+  }
+}
+
+.quick-order-list-total__column.large-up-hide .variant-remove-total {
+  display: flex;
+  justify-content: center;
+  margin: 0;
+
+  .loading__spinner {
+    margin-top: 1.5rem;
   }
 }
 

--- a/assets/quick-order-list.js
+++ b/assets/quick-order-list.js
@@ -435,7 +435,9 @@ if (!customElements.get('quick-order-list')) {
 
       toggleLoading(loading, target = this) {
         target.querySelector('#shopping-cart-variant-item-status').toggleAttribute('aria-hidden', !loading);
-        target.querySelector('.variant-remove-total .loading__spinner')?.classList.toggle('hidden', !loading);
+        target
+          .querySelectorAll('.variant-remove-total .loading__spinner')
+          ?.forEach((spinner) => spinner.classList.toggle('hidden', !loading));
       }
     }
   );

--- a/snippets/quick-order-list.liquid
+++ b/snippets/quick-order-list.liquid
@@ -233,7 +233,7 @@
               <div class="variant-remove-total">
                 {%- render 'loading-spinner' -%}
                 <quick-order-list-remove-all-button
-                  class="no-js-hidden"
+                  class="{% if items_in_cart == 0 %}hidden{% endif %}"
                   data-action="confirm"
                 >
                   <button class="button button--tertiary" type="button">


### PR DESCRIPTION
### PR Summary: 

Updates quick order list mobile view to hide the `remove all` button if the product has no variants in the cart, and display the loading spinner for pending requests.

### Why are these changes introduced?

Found this behavior while testing V15.3.0 release and it seemed unexpected, confirmed desired behavior with @Oliviammarcello from UX. From the existing code it looks like this was the original intent and probably just got missed at some point.

Note there is a layout shift when the button is shown/hidden. Olivia and I paired and determined the layout shift is preferable to maintaining the spacing, since (1) that makes it seem like the component padding is incorrect and (2) we already have a layout shift when going through the remove all flow already.

**Before**

https://screenshot.click/26-59-n5ou5-3gs0f.mp4

**After**

https://screenshot.click/26-57-n82jf-ggk7a.mp4

### Demo links

- https://admin.shopify.com/store/os2-demo/themes/174907195414/editor?previewPath=%2Fproducts%2F100-variant-product&section=template--24194134900758__quick_order_list_r9a7rM&category=gid%3A%2F%2Fshopify%2FOnlineStoreThemeSettingsCategory%2FTypography%3Ftheme_id%3D174907195414%26first_setting_id%3Dtype_header_font

### Checklist
- [x] Added PR summary for [release notes](https://themes.shopify.com/themes/dawn/styles/default#ReleaseNotes)
- [x] Requested review from UX (Only for changes that are affecting the experience or perceivable visual details)
- [ ] Created a ticket for the [help.shopify.com](https://help.shopify.com) documentation team about updates to theme settings. (Internal-only task)
- [x] Followed [theme code principles](https://github.com/Shopify/dawn/blob/main/.github/CONTRIBUTING.md#theme-code-principles)
- [x] Linted with [Theme Check](https://github.com/Shopify/theme-check)
- [x] Tested on [mobile](https://shopify.dev/themes/store/requirements#mobile-browser-requirements)
- [x] Tested on [multiple browsers](https://shopify.dev/themes/store/requirements#desktop-browser-requirements)
- [x] Tested for [accessibility](https://shopify.dev/themes/best-practices/accessibility)
