### PR TITLE
Move initializer outside of performance callback

### DIFF
--- a/assets/cart.js
+++ b/assets/cart.js
@@ -160,9 +160,9 @@ class CartItems extends HTMLElement {
         return response.text();
       })
       .then((state) => {
+        const parsedState = JSON.parse(state);
 
         CartPerformance.measure(`${eventTarget}:paint-updated-sections"`, () => {
-          const parsedState = JSON.parse(state);
           const quantityElement =
             document.getElementById(`Quantity-${line}`) || document.getElementById(`Drawer-quantity-${line}`);
           const items = document.querySelectorAll('.cart-item');


### PR DESCRIPTION
### PR Summary: 

Fix JS error when updating cart quantity

### Why are these changes introduced?

Updating line item quantity in cart was causing a JS error. Source of the problem was ultimately that we were referencing a variable outside of it's defined scope.

Demo: https://screenshot.click/28-50-m3p8k-e1xpf.mp4

### What approach did you take?

Confirmed that perf measurement doesn't need to include JSON parsing, moved the initializer to the parent scope

### Demo links

- https://admin.shopify.com/store/os2-demo/themes/174907785238/editor?category=gid%3A%2F%2Fshopify%2FOnlineStoreThemeSettingsCategory%2FCart%3Ftheme_id%3D174907785238%26first_setting_id%3Dcart_type&previewPath=%2Fcart
- Check that you can change a line item quantity in cart. Line item and total are updated correctly and no error is displayed

### Checklist
- [ ] Added PR summary for [release notes](https://themes.shopify.com/themes/dawn/styles/default#ReleaseNotes)
- [ ] Requested review from UX (Only for changes that are affecting the experience or perceivable visual details)
- [ ] Created a ticket for the [help.shopify.com](https://help.shopify.com) documentation team about updates to theme settings. (Internal-only task)
- [ ] Followed [theme code principles](https://github.com/Shopify/dawn/blob/main/.github/CONTRIBUTING.md#theme-code-principles)
- [ ] Linted with [Theme Check](https://github.com/Shopify/theme-check)
- [ ] Tested on [mobile](https://shopify.dev/themes/store/requirements#mobile-browser-requirements)
- [ ] Tested on [multiple browsers](https://shopify.dev/themes/store/requirements#desktop-browser-requirements)
- [ ] Tested for [accessibility](https://shopify.dev/themes/best-practices/accessibility)
