### PR TITLE
Include prefix in performance measurement

### DIFF
--- a/assets/global.js
+++ b/assets/global.js
@@ -1298,7 +1298,7 @@ class CartPerformance {
     const endMarker = performance.mark(`${metricName}:end`);
 
     performance.measure(
-      benchmarkName,
+      metricName,
       `${metricName}:start`,
       `${metricName}:end`
     );
@@ -1309,7 +1309,7 @@ class CartPerformance {
     const endMarker = performance.mark(`${metricName}:end`);
 
     performance.measure(
-      benchmarkName,
+      metricName,
       startMarker.name,
       `${metricName}:end`
     );
@@ -1324,7 +1324,7 @@ class CartPerformance {
     const endMarker = performance.mark(`${metricName}:end`);
 
     performance.measure(
-      benchmarkName,
+      metricName,
       `${metricName}:start`,
       `${metricName}:end`
     );


### PR DESCRIPTION
### PR Summary: 

Including the prefix in the cart performance metric measurement. This was properly prefixed in the markers.

<img width="632" alt="image" src="https://github.com/user-attachments/assets/10420ed3-c8db-46e2-9b4a-8d1e5faf1d6b" />


### Checklist
- [ ] Added PR summary for [release notes](https://themes.shopify.com/themes/dawn/styles/default#ReleaseNotes)
- [ ] Requested review from UX (Only for changes that are affecting the experience or perceivable visual details)
- [ ] Created a ticket for the [help.shopify.com](https://help.shopify.com) documentation team about updates to theme settings. (Internal-only task)
- [ ] Followed [theme code principles](https://github.com/Shopify/dawn/blob/main/.github/CONTRIBUTING.md#theme-code-principles)
- [ ] Linted with [Theme Check](https://github.com/Shopify/theme-check)
- [ ] Tested on [mobile](https://shopify.dev/themes/store/requirements#mobile-browser-requirements)
- [ ] Tested on [multiple browsers](https://shopify.dev/themes/store/requirements#desktop-browser-requirements)
- [ ] Tested for [accessibility](https://shopify.dev/themes/best-practices/accessibility)
