### PR TITLE
feat(meta-tags): use https instead of http for og:image

### DIFF
--- a/snippets/meta-tags.liquid
+++ b/snippets/meta-tags.liquid
@@ -20,7 +20,7 @@
 <meta property="og:description" content="{{ og_description | escape }}">
 
 {%- if page_image -%}
-  <meta property="og:image" content="http:{{ page_image | image_url }}">
+  <meta property="og:image" content="https:{{ page_image | image_url }}">
   <meta property="og:image:secure_url" content="https:{{ page_image | image_url }}">
   <meta property="og:image:width" content="{{ page_image.width }}">
   <meta property="og:image:height" content="{{ page_image.height }}">


### PR DESCRIPTION
### PR Summary: 
We don’t want hardcoded `http://` links, since the web developed into forcing `https://` anywhere, especially in onlinestores.
I don’t see any reason or benefit using hardcoded `http://` since its referencing to an Shopify CDN Source anyways.

### Why are these changes introduced?

Enforcing https

### What approach did you take?
hardcode `https://`

### Other considerations
Resolve dynamically the protocol.

### Visual impact on existing themes
OG:Images will be correctly loaded via https://


### Testing steps/scenarios
<!-- List all the testing tasks that applies to your fix to help peers review your work. -->
- [x] Tested Share Dialogs (Slack, FB Debugger) if there is any drawbacks by forcing `https://`

### Checklist
- [ ] Added PR summary for [release notes](https://themes.shopify.com/themes/dawn/styles/default#ReleaseNotes)
- [ ] Created a ticket for the [help.shopify.com](https://help.shopify.com) documentation team about updates to theme settings. (Internal-only task)
- [x] Followed [theme code principles](https://github.com/Shopify/dawn/blob/main/.github/CONTRIBUTING.md#theme-code-principles)
- [] Linted with [Theme Check](https://github.com/Shopify/theme-check)
- [] Tested on [mobile](https://shopify.dev/themes/store/requirements#mobile-browser-requirements)
- [ ] Tested on [multiple browsers](https://shopify.dev/themes/store/requirements#desktop-browser-requirements)
- [ ] Tested for [accessibility](https://shopify.dev/themes/best-practices/accessibility)
