### PR TITLE
Use documented endpoints for cart

### DIFF
--- a/assets/cart.js
+++ b/assets/cart.js
@@ -89,7 +89,7 @@ class CartItems extends HTMLElement {
 
   onCartUpdate() {
     if (this.tagName === 'CART-DRAWER-ITEMS') {
-      return fetch(`${routes.cart_url}?section_id=cart-drawer`)
+      return fetch(`${routes.cart_url}.js?section_id=cart-drawer`)
         .then((response) => response.text())
         .then((responseText) => {
           const html = new DOMParser().parseFromString(responseText, 'text/html');
@@ -106,7 +106,7 @@ class CartItems extends HTMLElement {
           console.error(e);
         });
     } else {
-      return fetch(`${routes.cart_url}?section_id=main-cart-items`)
+      return fetch(`${routes.cart_url}.js?section_id=main-cart-items`)
         .then((response) => response.text())
         .then((responseText) => {
           const html = new DOMParser().parseFromString(responseText, 'text/html');
@@ -155,7 +155,7 @@ class CartItems extends HTMLElement {
     });
     const eventTarget = event.currentTarget instanceof CartRemoveButton ? 'clear' : 'change';
 
-    fetch(`${routes.cart_change_url}`, { ...fetchConfig(), ...{ body } })
+    fetch(`${routes.cart_change_url}.js`, { ...fetchConfig(), ...{ body } })
       .then((response) => {
         return response.text();
       })
@@ -284,7 +284,7 @@ if (!customElements.get('cart-note')) {
           'input',
           debounce((event) => {
             const body = JSON.stringify({ note: event.target.value });
-            fetch(`${routes.cart_update_url}`, { ...fetchConfig(), ...{ body } })
+            fetch(`${routes.cart_update_url}.js`, { ...fetchConfig(), ...{ body } })
               .then(() => CartPerformance.measureFromEvent('note-update:user-action', event));
           }, ON_CHANGE_DEBOUNCE_TIMER)
         );

--- a/assets/cart.js
+++ b/assets/cart.js
@@ -89,7 +89,7 @@ class CartItems extends HTMLElement {
 
   onCartUpdate() {
     if (this.tagName === 'CART-DRAWER-ITEMS') {
-      return fetch(`${routes.cart_url}.js?section_id=cart-drawer`)
+      return fetch(`${routes.cart_url}?section_id=cart-drawer`)
         .then((response) => response.text())
         .then((responseText) => {
           const html = new DOMParser().parseFromString(responseText, 'text/html');
@@ -106,7 +106,7 @@ class CartItems extends HTMLElement {
           console.error(e);
         });
     } else {
-      return fetch(`${routes.cart_url}.js?section_id=main-cart-items`)
+      return fetch(`${routes.cart_url}?section_id=main-cart-items`)
         .then((response) => response.text())
         .then((responseText) => {
           const html = new DOMParser().parseFromString(responseText, 'text/html');

--- a/assets/product-form.js
+++ b/assets/product-form.js
@@ -42,7 +42,7 @@ if (!customElements.get('product-form')) {
         }
         config.body = formData;
 
-        fetch(`${routes.cart_add_url}`, config)
+        fetch(`${routes.cart_add_url}.js`, config)
           .then((response) => response.json())
           .then((response) => {
             if (response.status) {

--- a/assets/quick-add-bulk.js
+++ b/assets/quick-add-bulk.js
@@ -121,7 +121,7 @@ if (!customElements.get('quick-add-bulk')) {
           sections_url: this.getSectionsUrl(),
         });
 
-        fetch(`${routes.cart_update_url}`, { ...fetchConfig(), ...{ body } })
+        fetch(`${routes.cart_update_url}.js`, { ...fetchConfig(), ...{ body } })
           .then((response) => {
             return response.text();
           })

--- a/assets/quick-order-list.js
+++ b/assets/quick-order-list.js
@@ -338,7 +338,7 @@ if (!customElements.get('quick-order-list')) {
         this.updateMessage();
         this.setErrorMessage();
 
-        fetch(`${routes.cart_update_url}`, { ...fetchConfig(), ...{ body } })
+        fetch(`${routes.cart_update_url}.js`, { ...fetchConfig(), ...{ body } })
           .then((response) => response.text())
           .then(async (state) => {
             const parsedState = JSON.parse(state);


### PR DESCRIPTION
Fixes #3207

Last year, Shopify introduced a massive bug to the cart endpoints, that took several weeks and a lot of effort on my end to have the issue properly investigated and fixed by Shopify. This bug was reproducible on all documented Ajax endpoints (https://shopify.dev/docs/api/ajax/reference/cart#get-locale-cart-js).

Since last week, another important regression has been introduced to the documented Cart Ajax API, where products can't be removed and their quantity can't be changed from the cart (!!) as soon as you are in a market URL containing a country and language (such as mysite.com/en-fr).

The problem is that, for some reason, Dawn (and all other themes built on top of Dawn) are using undocumented endpoints to interact with the Cart. It looked to me initially that the `cart/xxx` and `cart/xxx.js` endpoints are more or less alias, but there are definitely not. It is the second time in one year where a critical regression is introduced that only happens on the `/cart/xxx.js` documented endpoints, but not on the `/cart/xxx` undocumented endpoints.

Please note that, as per the official Ajax documentation (https://shopify.dev/docs/api/ajax/reference/cart), all Ajax API calls must be made with the .js suffix. There are no mention on being able to use the non-JS URL in Ajax. The non `.js` routes are supposed to be used only when POSTing in the browser.

## Why this change

The main problem is that, when such issues arise, merchants are contacting Shopify support. Shopify support proceeds to a very basic debugging by trying to reproduce the merchant's issue in Dawn, found that it works on Dawn but not on our themes, and concludes the issue is coming from our theme (when it is not). It is nearly impossible for merchants to escalate the issue to a technical team at Shopify, so we end up having to explain to merchant, and try to find someone working at Shopify to investigate the issue. This takes time, cause a lot of frustration on both merchant and our side, and can cost merchants a lot of money as this is about critical parts of the system (the cart).

I am sure that, when releasing a new feature, the Shopify dev team also just test the feature on Dawn, as this is by far the most installed theme in the platform.

Ensuring that Dawn is using documented endpoints (the same as most themes following the docs) will ensure that such bugs can be spotted sooner, and that such issues can be reproduced by the support team at Shopify when testing in Dawn.

## Why not updating our themes to use undocumented endpoints?

One might argue that it would be easier for us to update our code. The problem is that I've been always extremely reluctant to use undocumented endpoints for anything critical. Dawn might be using it, which gives some guarantee that it won't break, but still, it is not documented, and as a consequence we have no guarantee on the exact behavior of those endpoints, nothing to back us up when reaching the technical team.
