### PR TITLE
[Cart] Support nested lines

### DIFF
--- a/assets/component-cart-drawer.css
+++ b/assets/component-cart-drawer.css
@@ -218,6 +218,11 @@ cart-drawer-items {
   max-width: 100%;
 }
 
+.cart-drawer .cart-item__nested-line .cart-item__image {
+  max-width: 66%;
+  float: right;
+}
+
 .cart-drawer .cart-items thead {
   margin-bottom: 0.5rem;
 }
@@ -253,6 +258,10 @@ cart-drawer-items {
 
 .cart-drawer .cart-items td {
   padding-top: 1.7rem;
+}
+
+.cart-drawer .cart-items .cart-item__nested-line td {
+  padding-top: 1rem;
 }
 
 .cart-drawer .cart-item > td + td {

--- a/assets/component-cart-drawer.css
+++ b/assets/component-cart-drawer.css
@@ -260,7 +260,7 @@ cart-drawer-items {
   padding-top: 1.7rem;
 }
 
-.cart-drawer .cart-items .cart-item__nested-line td {
+.cart-drawer .cart-items .cart-item__nested-line td:not(.cart-item__quantity) {
   padding-top: 1rem;
 }
 

--- a/assets/component-cart-drawer.css
+++ b/assets/component-cart-drawer.css
@@ -219,7 +219,7 @@ cart-drawer-items {
 }
 
 .cart-drawer .cart-item__nested-line .cart-item__image {
-  max-width: 66%;
+  max-width: 60%;
   float: right;
 }
 

--- a/assets/component-cart-items.css
+++ b/assets/component-cart-items.css
@@ -65,6 +65,13 @@ cart-items .title-wrapper-with-link {
   position: relative;
 }
 
+.cart-item__nested-line .cart-item__media {
+  text-align: right;
+  .cart-item__image-container {
+    width: 50%;
+  }
+}
+
 .cart-item__link {
   display: block;
   bottom: 0;
@@ -288,6 +295,10 @@ cart-remove-button .icon-remove {
   .cart-items td {
     vertical-align: top;
     padding-top: 4rem;
+  }
+
+  .cart-items .cart-item__nested-line td {
+    padding-top: 1rem;
   }
 
   .cart-item {

--- a/assets/component-cart-items.css
+++ b/assets/component-cart-items.css
@@ -68,7 +68,7 @@ cart-items .title-wrapper-with-link {
 .cart-item__nested-line .cart-item__media {
   text-align: right;
   .cart-item__image-container {
-    width: 50%;
+    width: 66%;
   }
 }
 

--- a/assets/component-cart-items.css
+++ b/assets/component-cart-items.css
@@ -32,6 +32,14 @@ cart-items .title-wrapper-with-link {
   align-items: flex-start;
 }
 
+.cart-item__nested-line .cart-item__image-container {
+  min-width: calc(10rem / var(--font-body-scale));
+  justify-content: right;
+  img {
+    width: 66%;
+  }
+}
+
 .cart-item__image-container:after {
   content: none;
 }
@@ -63,13 +71,6 @@ cart-items .title-wrapper-with-link {
 
 .cart-item__media {
   position: relative;
-}
-
-.cart-item__nested-line .cart-item__media {
-  text-align: right;
-  .cart-item__image-container {
-    width: 66%;
-  }
 }
 
 .cart-item__link {
@@ -242,6 +243,10 @@ cart-remove-button .icon-remove {
     grid-template: repeat(2, auto) / repeat(4, 1fr);
     gap: 1.5rem;
     margin-bottom: 3.5rem;
+  }
+
+  .cart-item:has(+ .cart-item__nested-line) {
+    margin-bottom: 1.5rem;
   }
 
   .cart-item:last-child {

--- a/assets/component-cart-items.css
+++ b/assets/component-cart-items.css
@@ -36,7 +36,7 @@ cart-items .title-wrapper-with-link {
   min-width: calc(10rem / var(--font-body-scale));
   justify-content: right;
   img {
-    width: 66%;
+    width: 60%;
   }
 }
 

--- a/locales/bg.json
+++ b/locales/bg.json
@@ -154,6 +154,7 @@
         "load_video": "Пускане на видео {{ index }} във визуализатора на галерията",
         "image_available": "Изображение {{ index }} вече е налично във визуализатора на галерията"
       },
+      "nested_label": "{{ product_title }} за {{ parent_title }}",
       "view_full_details": "Покажи пълните подробности",
       "shipping_policy_html": "<a href=\"{{ link }}\">Доставката</a> се изчислява при плащане.",
       "choose_options": "Изберете опции",

--- a/locales/cs.json
+++ b/locales/cs.json
@@ -156,6 +156,7 @@
         "load_video": "Přehrát video {{ index }} v zobrazení galerie",
         "image_available": "Obrázek {{ index }} je nyní k dispozici v zobrazení galerie"
       },
+      "nested_label": "{{ product_title }} pro {{ parent_title }}",
       "view_full_details": "Zobrazit veškeré podrobnosti",
       "shipping_policy_html": "<a href=\"{{ link }}\">Poštovné</a> se vypočítá na pokladně.",
       "choose_options": "Výběr možností",

--- a/locales/da.json
+++ b/locales/da.json
@@ -154,6 +154,7 @@
         "load_video": "Afspil videoen {{ index }} i gallerivisning",
         "image_available": "Billedet {{ index }} er nu tilgængeligt i gallerivisning"
       },
+      "nested_label": "{{ product_title }} til {{ parent_title }}",
       "view_full_details": "Se komplette oplysninger",
       "shipping_policy_html": "<a href=\"{{ link }}\">Levering</a> beregnes ved betaling.",
       "choose_options": "Vælg muligheder",

--- a/locales/de.json
+++ b/locales/de.json
@@ -154,6 +154,7 @@
         "load_video": "Video {{ index }} in Galerieansicht abspielen",
         "image_available": "Bild {{ index }} ist nun in der Galerieansicht verfügbar"
       },
+      "nested_label": "{{ product_title }} für {{ parent_title }}",
       "view_full_details": "Vollständige Details anzeigen",
       "shipping_policy_html": "<a href=\"{{ link }}\">Versand</a> wird beim Checkout berechnet",
       "choose_options": "Optionen auswählen",

--- a/locales/el.json
+++ b/locales/el.json
@@ -155,6 +155,7 @@
         "load_video": "Αναπαραγωγή βίντεο {{ index }} στην προβολή συλλογής",
         "image_available": "Η εικόνα {{ index }} είναι τώρα διαθέσιμη στην προβολή συλλογής"
       },
+      "nested_label": "{{ product_title }} για {{ parent_title }}",
       "view_full_details": "Προβολή όλων των λεπτομερειών",
       "shipping_policy_html": "Τα <a href=\"{{ link }}\">έξοδα αποστολής</a> υπολογίζονται κατά την ολοκλήρωση της αγοράς.",
       "choose_options": "Ορίστε επιλογές",

--- a/locales/en.default.json
+++ b/locales/en.default.json
@@ -129,6 +129,7 @@
         "play_model": "Play 3D Viewer",
         "play_video": "Play video"
       },
+      "nested_label": "{{ title }} for {{ parent_title }}",
       "quantity": {
         "label": "Quantity",
         "input_label": "Quantity for {{ product }}",

--- a/locales/es.json
+++ b/locales/es.json
@@ -155,6 +155,7 @@
         "load_video": "Reproducir el video {{ index }} en la vista de la galería",
         "image_available": "La imagen {{ index }} ya está disponible en la vista de la galería"
       },
+      "nested_label": "{{ product_title }} para {{ parent_title }}",
       "view_full_details": "Ver todos los detalles",
       "shipping_policy_html": "Los <a href=\"{{ link }}\">gastos de envío</a> se calculan en la pantalla de pago.",
       "choose_options": "Seleccionar opciones",

--- a/locales/fi.json
+++ b/locales/fi.json
@@ -154,6 +154,7 @@
         "load_video": "Toista video {{ index }} gallerianäkymässä",
         "image_available": "Kuva {{ index }} on nyt saatavilla gallerianäkymässä"
       },
+      "nested_label": "{{ product_title }} {{ parent_title }}:lle",
       "view_full_details": "Näytä kaikki tiedot",
       "shipping_policy_html": "<a href=\"{{ link }}\">Toimituskulut</a> lasketaan kassalla.",
       "choose_options": "Valitse vaihtoehdot",

--- a/locales/fr.json
+++ b/locales/fr.json
@@ -156,6 +156,7 @@
         "load_video": "Lire la vidéo {{ index }} dans la galerie",
         "image_available": "L'image {{ index }} est maintenant disponible dans la galerie"
       },
+      "nested_label": "{{ product_title }} pour {{ parent_title }}",
       "view_full_details": "Afficher tous les détails",
       "shipping_policy_html": "<a href=\"{{ link }}\">Frais d'expédition</a> calculés à l'étape de paiement.",
       "choose_options": "Choisir des options",

--- a/locales/hr.json
+++ b/locales/hr.json
@@ -156,6 +156,7 @@
         "load_video": "Reproduciraj videozapis {{ index }} u galerijskom prikazu",
         "image_available": "Slika {{ index }} sada je dostupna za prikaz u galeriji"
       },
+      "nested_label": "{{ product_title }} za {{ parent_title }}",
       "view_full_details": "Prikaži sve pojedinosti",
       "shipping_policy_html": "<a href=\"{{ link }}\">Poštarina </a> se obračunava prilikom završetka kupnje.",
       "choose_options": "Odaberite opcije",

--- a/locales/hu.json
+++ b/locales/hu.json
@@ -155,6 +155,7 @@
         "load_video": "{{ index }}. videó lejátszása galérianézetben",
         "image_available": "{{ index }}. kép betöltve galérianézetben"
       },
+      "nested_label": "{{ product_title }} {{ parent_title }} számára",
       "view_full_details": "Minden részlet megtekintése",
       "shipping_policy_html": "A <a href=\"{{ link }}\">szállítási költséget</a> a megrendeléskor számítjuk ki.",
       "choose_options": "Válassz a lehetőségek közül",

--- a/locales/id.json
+++ b/locales/id.json
@@ -155,6 +155,7 @@
         "load_video": "Putar video {{ index }} di tampilan galeri",
         "image_available": "Gambar {{ index }} kini tersedia di tampilan galeri"
       },
+      "nested_label": "{{ product_title }} untuk {{ parent_title }}",
       "view_full_details": "Lihat detail lengkap",
       "shipping_policy_html": "<a href=\"{{ link }}\">Biaya pengiriman</a> dihitung saat checkout.",
       "choose_options": "Pilih opsi",

--- a/locales/it.json
+++ b/locales/it.json
@@ -155,6 +155,7 @@
         "load_video": "Riproduci video {{ index }} in visualizzazione galleria",
         "image_available": "L'immagine {{ index }} è ora disponibile in visualizzazione galleria"
       },
+      "nested_label": "{{ product_title }} per {{ parent_title }}",
       "view_full_details": "Visualizza dettagli completi",
       "shipping_policy_html": "<a href=\"{{ link }}\">Spese di spedizione</a> calcolate al check-out.",
       "choose_options": "Scegli opzioni",

--- a/locales/ja.json
+++ b/locales/ja.json
@@ -155,6 +155,7 @@
         "load_video": "ギャラリービューでビデオ ({{ index }}) を再生する",
         "image_available": "ギャラリービューで画像 ({{ index }}) が利用できるようになりました"
       },
+      "nested_label": "{{ parent_title }}用の{{ product_title }}",
       "view_full_details": "詳細を表示する",
       "shipping_policy_html": "<a href=\"{{ link }}\">配送料</a>はチェックアウト時に計算されます。",
       "choose_options": "オプションを選択",

--- a/locales/ko.json
+++ b/locales/ko.json
@@ -155,6 +155,7 @@
         "load_video": "갤러리 뷰에서 동영상 {{ index }} 재생",
         "image_available": "이제 갤러리 뷰에서 이미지 {{ index }} 사용 가능"
       },
+      "nested_label": "{{ parent_title }}용 {{ product_title }}",
       "view_full_details": "전체 세부 정보 보기",
       "shipping_policy_html": "<a href=\"{{ link }}\">배송료</a>는 결제 시 계산됩니다.",
       "choose_options": "옵션 선택하기",

--- a/locales/lt.json
+++ b/locales/lt.json
@@ -157,6 +157,7 @@
         "load_video": "Leisti vaizdo įrašą {{ index }} galerijos rodinyje",
         "image_available": "Vaizdas {{ index }} dabar prieinamas galerijos rodinyje"
       },
+      "nested_label": "{{ product_title }} {{ parent_title }}",
       "view_full_details": "Žiūrėti visą informaciją",
       "shipping_policy_html": "<a href=\"{{ link }}\">Siuntimo išlaidos</a> apskaičiuojamos atsiskaitant.",
       "choose_options": "Rinktis variantus",

--- a/locales/nb.json
+++ b/locales/nb.json
@@ -154,6 +154,7 @@
         "load_video": "Spill av video {{ index }} i gallerivisning",
         "image_available": "Bilde {{ index }} er nå tilgjengelig i gallerivisning"
       },
+      "nested_label": "{{ product_title }} for {{ parent_title }}",
       "view_full_details": "Vis alle detaljer",
       "shipping_policy_html": "<a href=\"{{ link }}\">Frakt</a> beregnes ved kassen.",
       "choose_options": "Velg alternativer",

--- a/locales/nl.json
+++ b/locales/nl.json
@@ -154,6 +154,7 @@
         "load_video": "Video {{ index }} afspelen in gallery-weergave",
         "image_available": "Afbeelding {{ index }} is nu beschikbaar in gallery-weergave"
       },
+      "nested_label": "{{ product_title }} voor {{ parent_title }}",
       "view_full_details": "Alle details bekijken",
       "shipping_policy_html": "<a href=\"{{ link }}\">Verzendkosten</a> worden berekend bij de checkout.",
       "choose_options": "Opties kiezen",

--- a/locales/pl.json
+++ b/locales/pl.json
@@ -156,6 +156,7 @@
         "load_video": "Odtwórz film {{ index }} w widoku galerii",
         "image_available": "Obraz {{ index }} jest teraz dostępny w widoku galerii"
       },
+      "nested_label": "{{ product_title }} dla {{ parent_title }}",
       "view_full_details": "Pokaż kompletne dane",
       "shipping_policy_html": "<a href=\"{{ link }}\">Koszt wysyłki</a> obliczony przy realizacji zakupu.",
       "choose_options": "Wybierz opcje",

--- a/locales/pt-BR.json
+++ b/locales/pt-BR.json
@@ -155,6 +155,7 @@
         "load_video": "Reproduzir vídeo {{ index }} no visualizador da galeria",
         "image_available": "A imagem {{ index }} está disponível no visualizador da galeria"
       },
+      "nested_label": "{{ product_title }} para {{ parent_title }}",
       "view_full_details": "Ver informações completas",
       "shipping_policy_html": "<a href=\"{{ link }}\">Frete</a> calculado no checkout.",
       "choose_options": "Escolher opções",

--- a/locales/pt-PT.json
+++ b/locales/pt-PT.json
@@ -156,6 +156,7 @@
         "load_video": "Reproduzir vídeo {{ index }} na vista de galeria",
         "image_available": "A imagem {{ index }} está agora disponível na vista de galeria"
       },
+      "nested_label": "{{ product_title }} para {{ parent_title }}",
       "view_full_details": "Ver detalhes completos",
       "shipping_policy_html": "<a href=\"{{ link }}\">Envio</a> calculado na finalização da compra.",
       "choose_options": "Escolher opções",

--- a/locales/ro.json
+++ b/locales/ro.json
@@ -156,6 +156,7 @@
         "load_video": "Redă videoclipul {{ index }} în vizualizarea galeriei",
         "image_available": "Imaginea {{ index }} este disponibilă acum în vizualizarea galeriei"
       },
+      "nested_label": "{{ product_title }} pentru {{ parent_title }}",
       "view_full_details": "Vedeți detaliile complete",
       "shipping_policy_html": "<a href=\"{{ link }}\">Taxele de expediere</a> sunt calculate la finalizarea comenzii.",
       "choose_options": "Alege opțiunile",

--- a/locales/ru.json
+++ b/locales/ru.json
@@ -156,6 +156,7 @@
         "load_video": "Загрузить видео {{ index }} в средство просмотра галереи",
         "image_available": "Изображение {{ index }} доступно в средстве просмотра галереи"
       },
+      "nested_label": "{{ product_title }} для {{ parent_title }}",
       "view_full_details": "Просмотреть всю информацию",
       "shipping_policy_html": "<a href=\"{{ link }}\">Стоимость доставки</a> рассчитывается при оформлении заказа.",
       "choose_options": "Выберите варианты",

--- a/locales/sk.json
+++ b/locales/sk.json
@@ -157,6 +157,7 @@
         "load_video": "Prehrať video {{ index }} v zobrazení galérie",
         "image_available": "Obrázok {{ index }} je teraz dostupný v zobrazení galérie"
       },
+      "nested_label": "{{ product_title }} pre {{ parent_title }}",
       "view_full_details": "Zobraziť všetky podrobnosti",
       "shipping_policy_html": "<a href=\"{{ link }}\">Doprava</a> sa vypočíta pri platbe.",
       "choose_options": "Vybrať možnosti",

--- a/locales/sl.json
+++ b/locales/sl.json
@@ -157,6 +157,7 @@
         "load_video": "Predvajajte videoposnetek {{ index }} v pogledu galerije",
         "image_available": "Slika {{ index }} je zdaj na voljo v pogledu galerije"
       },
+      "nested_label": "{{ product_title }} za {{ parent_title }}",
       "view_full_details": "Prikaži vse podrobnosti",
       "shipping_policy_html": "<a href=\"{{ link }}\">Dostava</a> se obračuna ob zaključku nakupa.",
       "choose_options": "Izberite možnosti",

--- a/locales/sv.json
+++ b/locales/sv.json
@@ -154,6 +154,7 @@
         "load_video": "Spela videon {{ index }} i gallerivisning",
         "image_available": "Bilden {{ index }} är nu tillgänglig i gallerivisning"
       },
+      "nested_label": "{{ product_title }} för {{ parent_title }}",
       "view_full_details": "Visa alla uppgifter",
       "shipping_policy_html": "<a href=\"{{ link }}\">Frakt</a> beräknas i kassan.",
       "choose_options": "Välj alternativ",

--- a/locales/th.json
+++ b/locales/th.json
@@ -154,6 +154,7 @@
         "load_video": "เล่นวิดีโอ {{ index }} ในมุมมองแกลเลอรี",
         "image_available": "รูปภาพ {{ index }} พร้อมใช้งานในมุมมองแกลเลอรี"
       },
+      "nested_label": "{{ product_title }} สำหรับ {{ parent_title }}",
       "view_full_details": "ดูรายละเอียดทั้งหมด",
       "shipping_policy_html": "<a href=\"{{ link }}\">ค่าจัดส่ง</a>ที่คำนวณในขั้นตอนการชำระเงิน",
       "choose_options": "เลือกตัวเลือก",

--- a/locales/tr.json
+++ b/locales/tr.json
@@ -154,6 +154,7 @@
         "load_video": "Video {{ index }} galeri görüntüleyicide oynatın",
         "image_available": "Görsel {{ index }} artık galeri görüntüleyicide kullanılabilir"
       },
+      "nested_label": "{{ parent_title }} için {{ product_title }}",
       "view_full_details": "Tüm ayrıntıları görüntüle",
       "shipping_policy_html": "<a href=\"{{ link }}\">Kargo</a>, ödeme sayfasında hesaplanır.",
       "choose_options": "Seçenekleri belirle",

--- a/locales/vi.json
+++ b/locales/vi.json
@@ -155,6 +155,7 @@
         "load_video": "Phát video {{ index }} trong chế độ xem thư viện",
         "image_available": "Hình ảnh {{ index }} hiện đã có trong chế độ xem thư viện"
       },
+      "nested_label": "{{ product_title }} cho {{ parent_title }}",
       "view_full_details": "Xem toàn bộ chi tiết",
       "shipping_policy_html": "<a href=\"{{ link }}\">Phí vận chuyển</a> được tính khi thanh toán.",
       "choose_options": "Chọn các tùy chọn",

--- a/locales/zh-CN.json
+++ b/locales/zh-CN.json
@@ -155,6 +155,7 @@
         "load_video": "在图库视图中播放视频 {{ index }}",
         "image_available": "图片 {{ index }} 现已在图库视图中可用"
       },
+      "nested_label": "{{ parent_title }}的{{ product_title }}",
       "view_full_details": "查看完整详细信息",
       "shipping_policy_html": "结账时计算的<a href=\"{{ link }}\">运费</a>。",
       "choose_options": "选择选项",

--- a/locales/zh-TW.json
+++ b/locales/zh-TW.json
@@ -155,6 +155,7 @@
         "load_video": "在圖庫檢視畫面播放影片 {{ index }}",
         "image_available": "現在可在圖庫檢視畫面中查看圖片 {{ index }}"
       },
+      "nested_label": "{{ parent_title }}的{{ product_title }}",
       "view_full_details": "查看完整資訊",
       "shipping_policy_html": "結帳時計算<a href=\"{{ link }}\">運費</a>。",
       "choose_options": "選擇選項",

--- a/sections/main-cart-items.liquid
+++ b/sections/main-cart-items.liquid
@@ -79,7 +79,10 @@
 
               <tbody>
                 {%- for item in cart.items -%}
-                  <tr class="cart-item" id="CartItem-{{ item.index | plus: 1 }}">
+                  <tr
+                    class="{% if item.parent_relationship.parent == null %}cart-item{% else %}cart-item cart-item__nested-line{% endif %}"
+                    id="CartItem-{{ item.index | plus: 1 }}"
+                  >
                     <td class="cart-item__media">
                       {% if item.image %}
                         {% comment %} Leave empty space due to a:empty CSS display: none rule {% endcomment %}

--- a/sections/main-cart-items.liquid
+++ b/sections/main-cart-items.liquid
@@ -80,17 +80,17 @@
               <tbody>
                 {%- for item in cart.items -%}
                   <tr
-                    class="{% if item.parent_relationship.parent == null %}cart-item{% else %}cart-item cart-item__nested-line{% endif %}"
+                    class="cart-item {% if item.parent_relationship.parent != null %}cart-item__nested-line{% endif %}"
                     id="CartItem-{{ item.index | plus: 1 }}"
                   >
                     <td class="cart-item__media">
                       {% if item.image %}
                         {% comment %} Leave empty space due to a:empty CSS display: none rule {% endcomment %}
                         <a href="{{ item.url }}" class="cart-item__link" aria-hidden="true" tabindex="-1"> </a>
-                        <div class="cart-item__image-container gradient global-media-settings">
+                        <div class="cart-item__image-container gradient {% if item.parent_relationship.parent == null %}global-media-settings{% endif %}">
                           <img
                             src="{{ item.image | image_url: width: 300 }}"
-                            class="cart-item__image"
+                            class="cart-item__image {% if item.parent_relationship.parent != null %}global-media-settings{% endif %}"
                             alt="{{ item.image.alt | escape }}"
                             loading="lazy"
                             width="150"

--- a/sections/main-cart-items.liquid
+++ b/sections/main-cart-items.liquid
@@ -240,7 +240,8 @@
                                 class="quantity__button"
                                 name="minus"
                                 type="button"
-                                {% if item.instructions and item.instructions.can_update_quantity == false %}
+                                {% assign can_update_quantity = item.instructions.can_update_quantity | default: true %}
+                                {% if can_update_quantity == false %}
                                   disabled
                                 {% endif %}
                               >
@@ -269,7 +270,7 @@
                                 aria-label="{{ 'products.product.quantity.input_label' | t: product: item.product.title | escape }}"
                                 id="Quantity-{{ item.index | plus: 1 }}"
                                 data-index="{{ item.index | plus: 1 }}"
-                                {% if item.instructions and item.instructions.can_update_quantity == false %}
+                                {% if can_update_quantity == false %}
                                   disabled
                                 {% endif %}
                               >
@@ -277,7 +278,7 @@
                                 class="quantity__button"
                                 name="plus"
                                 type="button"
-                                {% if item.instructions and item.instructions.can_update_quantity == false %}
+                                {% if can_update_quantity == false %}
                                   disabled
                                 {% endif %}
                               >
@@ -293,7 +294,8 @@
                           <cart-remove-button
                             id="Remove-{{ item.index | plus: 1 }}"
                             data-index="{{ item.index | plus: 1 }}"
-                            {% if item.instructions and item.instructions.can_remove == false %}
+                            {% assign can_remove = item.instructions.can_remove | default: true %}
+                            {% if can_remove == false %}
                               class="hidden"
                             {% endif %}
                           >

--- a/sections/main-cart-items.liquid
+++ b/sections/main-cart-items.liquid
@@ -236,11 +236,11 @@
                               </button>
                             {%- endif -%}
                             <quantity-input class="quantity cart-quantity">
+                              {% assign can_update_quantity = item.instructions.can_update_quantity | default: true %}
                               <button
                                 class="quantity__button"
                                 name="minus"
                                 type="button"
-                                {% assign can_update_quantity = item.instructions.can_update_quantity | default: true %}
                                 {% if can_update_quantity == false %}
                                   disabled
                                 {% endif %}

--- a/sections/main-cart-items.liquid
+++ b/sections/main-cart-items.liquid
@@ -82,6 +82,9 @@
                   <tr
                     class="cart-item {% if item.parent_relationship.parent != null %}cart-item__nested-line{% endif %}"
                     id="CartItem-{{ item.index | plus: 1 }}"
+                    {% if item.parent_relationship.parent != null %}
+                      aria-label="{{- 'products.product.nested_label' | t: title: item.product.title, parent_title: item.parent_relationship.parent.title | escape -}}"
+                    {% endif %}
                   >
                     <td class="cart-item__media">
                       {% if item.image %}
@@ -233,7 +236,14 @@
                               </button>
                             {%- endif -%}
                             <quantity-input class="quantity cart-quantity">
-                              <button class="quantity__button" name="minus" type="button">
+                              <button
+                                class="quantity__button"
+                                name="minus"
+                                type="button"
+                                {% if item.instructions and item.instructions.can_update_quantity == false %}
+                                  disabled
+                                {% endif %}
+                              >
                                 <span class="visually-hidden">
                                   {{- 'products.product.quantity.decrease' | t: product: item.product.title | escape -}}
                                 </span>
@@ -259,8 +269,18 @@
                                 aria-label="{{ 'products.product.quantity.input_label' | t: product: item.product.title | escape }}"
                                 id="Quantity-{{ item.index | plus: 1 }}"
                                 data-index="{{ item.index | plus: 1 }}"
+                                {% if item.instructions and item.instructions.can_update_quantity == false %}
+                                  disabled
+                                {% endif %}
                               >
-                              <button class="quantity__button" name="plus" type="button">
+                              <button
+                                class="quantity__button"
+                                name="plus"
+                                type="button"
+                                {% if item.instructions and item.instructions.can_update_quantity == false %}
+                                  disabled
+                                {% endif %}
+                              >
                                 <span class="visually-hidden">
                                   {{- 'products.product.quantity.increase' | t: product: item.product.title | escape -}}
                                 </span>
@@ -273,6 +293,9 @@
                           <cart-remove-button
                             id="Remove-{{ item.index | plus: 1 }}"
                             data-index="{{ item.index | plus: 1 }}"
+                            {% if item.instructions and item.instructions.can_remove == false %}
+                              class="hidden"
+                            {% endif %}
                           >
                             <a
                               href="{{ item.url_to_remove }}"

--- a/snippets/cart-drawer.liquid
+++ b/snippets/cart-drawer.liquid
@@ -119,7 +119,11 @@
                   <tbody role="rowgroup">
                     {%- for item in cart.items -%}
                       <tr id="CartDrawer-Item-{{ item.index | plus: 1 }}" class="cart-item" role="row">
-                        <td class="cart-item__media" role="cell" headers="CartDrawer-ColumnProductImage">
+                        <td
+                          class="cart-item__media  {% if item.parent_relationship.parent != null %}cart-item__nested-line{% endif %}"
+                          role="cell"
+                          headers="CartDrawer-ColumnProductImage"
+                        >
                           {% if item.image %}
                             {% comment %} Leave empty space due to a:empty CSS display: none rule {% endcomment %}
                             <a href="{{ item.url }}" class="cart-item__link" tabindex="-1" aria-hidden="true"> </a>

--- a/snippets/cart-drawer.liquid
+++ b/snippets/cart-drawer.liquid
@@ -118,9 +118,13 @@
 
                   <tbody role="rowgroup">
                     {%- for item in cart.items -%}
-                      <tr id="CartDrawer-Item-{{ item.index | plus: 1 }}" class="cart-item" role="row">
+                      <tr
+                        id="CartDrawer-Item-{{ item.index | plus: 1 }}"
+                        class="cart-item  {% if item.parent_relationship.parent != null %}cart-item__nested-line{% endif %}"
+                        role="row"
+                      >
                         <td
-                          class="cart-item__media  {% if item.parent_relationship.parent != null %}cart-item__nested-line{% endif %}"
+                          class="cart-item__media"
                           role="cell"
                           headers="CartDrawer-ColumnProductImage"
                         >

--- a/snippets/cart-drawer.liquid
+++ b/snippets/cart-drawer.liquid
@@ -120,8 +120,11 @@
                     {%- for item in cart.items -%}
                       <tr
                         id="CartDrawer-Item-{{ item.index | plus: 1 }}"
-                        class="cart-item  {% if item.parent_relationship.parent != null %}cart-item__nested-line{% endif %}"
+                        class="cart-item{% if item.parent_relationship.parent != null %} cart-item__nested-line{% endif %}"
                         role="row"
+                        {% if item.parent_relationship.parent != null %}
+                          aria-label="{{- 'products.product.nested_label' | t: title: item.product.title, parent_title: item.parent_relationship.parent.title | escape -}}"
+                        {% endif %}
                       >
                         <td
                           class="cart-item__media"
@@ -279,7 +282,14 @@
                             <div class="cart-item__quantity-wrapper quantity-popover-wrapper">
                               <div class="quantity-popover-container{% if has_qty_rules or has_vol_pricing %} quantity-popover-container--hover{% endif %}">
                                 <quantity-input class="quantity cart-quantity">
-                                  <button class="quantity__button" name="minus" type="button">
+                                  <button
+                                    class="quantity__button"
+                                    name="minus"
+                                    type="button"
+                                    {% if item.instructions and item.instructions.can_update_quantity == false %}
+                                      disabled
+                                    {% endif %}
+                                  >
                                     <span class="visually-hidden">
                                       {{-
                                         'products.product.quantity.decrease'
@@ -309,8 +319,18 @@
                                     aria-label="{{ 'products.product.quantity.input_label' | t: product: item.product.title | escape }}"
                                     id="Drawer-quantity-{{ item.index | plus: 1 }}"
                                     data-index="{{ item.index | plus: 1 }}"
+                                    {% if item.instructions and item.instructions.can_update_quantity == false %}
+                                      disabled
+                                    {% endif %}
                                   >
-                                  <button class="quantity__button" name="plus" type="button">
+                                  <button
+                                    class="quantity__button"
+                                    name="plus"
+                                    type="button"
+                                    {% if item.instructions and item.instructions.can_update_quantity == false %}
+                                      disabled
+                                    {% endif %}
+                                  >
                                     <span class="visually-hidden">
                                       {{-
                                         'products.product.quantity.increase'
@@ -333,6 +353,9 @@
                                   class="button button--tertiary cart-remove-button"
                                   aria-label="{{ 'sections.cart.remove_title' | t: title: item.title | escape }}"
                                   data-variant-id="{{ item.variant.id }}"
+                                  {% if item.instructions and item.instructions.can_remove == false %}
+                                    class="hidden"
+                                  {% endif %}
                                 >
                                   <span class="svg-wrapper">
                                     {{- 'icon-remove.svg' | inline_asset_content -}}


### PR DESCRIPTION
### PR Summary: 

Surface Nested Cart Lines

### Why are these changes introduced?

Addresses https://github.com/Shopify/horizon/issues/4768

### What approach did you take?

The [mocks provided to us by UX](https://www.figma.com/design/A7Hei3wsnqQRd4etZLe5ye/%E2%9E%95-Nested-Cart-Lines--formerly-Add-Ons-?node-id=5492-21592&p=f&t=iCiLdmxXRfpg9ZBY-0) use the indentation and size of the thumbnail to indicate that the item is nested. Therefore, I conditionally applied a class `.cart-item__nested-line` to the `tr` if the `cart.item` had a `parent`. There is also slightly less padding between the nested line and the parent line, so I updated the top padding of the nested line to be `1rem` instead of `4rem` for desktop screens, and the bottom margin to be `1.5rem` instead of `3.5rem` for mobile screens. For the cart drawer, the top padding is `1rem` instead of `1.7rem`.

### Other considerations

1. The relationship between the parent and the nested line is created at the time of adding the item to the cart, by passing along the `key` of the parent item as `parent_line_key` in the nested line. This is not something we are building natively into the themes, as the expectation is that 3p apps would handle this (with app blocks etc.). For the purposes of my test store linked below for demo-ing, I hard coded a block into my `buy-button.liquid` to assign the `Smart TV` as parent if added to the cart. If you would like to test on your own store though, you can update your `buy-button.liquid` with the following block of code, where `{ID}` is the id of the nested line product, and `{KEY}` is the key of the parent line.
```liquid
        {% comment %} line 59, within the 'product' form {% endcomment %}
        {% if product.selected_or_first_available_variant.id == {ID} %}
          <input
            type="hidden"
            name="parent_line_key"
            value="{KEY}"
          >
        {% endif %}
```


### Visual impact on existing themes
If the merchant has nested lines enabled, any nested lines will appear nested under their parents, as opposed to a flat list in the cart.

**desktop view**
<img width="1160" alt="image" src="https://github.com/user-attachments/assets/49bd3835-044c-4603-a448-0de605452de0" />

**mobile view**
<img width="289" alt="image" src="https://github.com/user-attachments/assets/9c220ff7-ccf2-4293-9214-bed8d46164ea" />

**cart drawer**
<img width="1299" alt="image" src="https://github.com/user-attachments/assets/73e52144-bd93-42ac-a0a3-f694851af3b4" />



### Testing steps/scenarios
Note: the products described in this testing steps are related to the linked demo store. See the Other Considerations 2 point about using your own test shop.
- [ ] Add the Smart TV to your cart
- [ ] Navigate to the Warranty product page and add the item to your cart (Quick buy button on main page won't work)
- [ ] Navigate to cart, notice that the Warranty thumbnail is smaller and indented slightly in comparison to the other items in the cart.
- [ ] Ensure expected style is maintained across multiple screen sizes


### Demo links

- [Store](https://abc-add-ons.myshopify.com/)
- [Editor](https://admin.shopify.com/store/abc-add-ons/themes/151048814822/editor)

### Checklist
- [x] Added PR summary for [release notes](https://themes.shopify.com/themes/dawn/styles/default#ReleaseNotes)
- [x] Requested review from UX (Only for changes that are affecting the experience or perceivable visual details)
- [ ] Created a ticket for the [help.shopify.com](https://help.shopify.com) documentation team about updates to theme settings. (Internal-only task)
- [x] Followed [theme code principles](https://github.com/Shopify/dawn/blob/main/.github/CONTRIBUTING.md#theme-code-principles)
- [x] Linted with [Theme Check](https://github.com/Shopify/theme-check)
- [x] Tested on [mobile](https://shopify.dev/themes/store/requirements#mobile-browser-requirements)
- [x] Tested on [multiple browsers](https://shopify.dev/themes/store/requirements#desktop-browser-requirements)
- [x] Tested for [accessibility](https://shopify.dev/themes/best-practices/accessibility)
