### PR TITLE
Improve unit price display with the `unit_price_with_measurement` filter

### DIFF
--- a/assets/component-price.css
+++ b/assets/component-price.css
@@ -96,6 +96,5 @@
   letter-spacing: 0.04rem;
   line-height: calc(1 + 0.2 / var(--font-body-scale));
   margin-top: 0.2rem;
-  text-transform: uppercase;
   color: rgba(var(--color-foreground), 0.7);
 }

--- a/assets/customer.css
+++ b/assets/customer.css
@@ -644,7 +644,6 @@
   letter-spacing: 0.07rem;
   line-height: calc(1 + 0.2 / var(--font-body-scale));
   margin-top: 0.2rem;
-  text-transform: uppercase;
   color: rgba(var(--color-foreground), 0.7);
 }
 

--- a/sections/main-cart-items.liquid
+++ b/sections/main-cart-items.liquid
@@ -198,18 +198,7 @@
                         {%- endif -%}
 
                         {%- if item.variant.available and item.unit_price_measurement -%}
-                          <div class="unit-price caption">
-                            <span class="visually-hidden">{{ 'products.product.price.unit_price' | t }}</span>
-                            {{ item.unit_price | money }}
-                            <span aria-hidden="true">/</span>
-                            <span class="visually-hidden"
-                              >&nbsp;{{ 'accessibility.unit_price_separator' | t }}&nbsp;</span
-                            >
-                            {%- if item.unit_price_measurement.reference_value != 1 -%}
-                              {{- item.unit_price_measurement.reference_value -}}
-                            {%- endif -%}
-                            {{ item.unit_price_measurement.reference_unit }}
-                          </div>
+                          {% render 'unit-price', price: item.unit_price, measurement: item.unit_price_measurement %}
                         {%- endif -%}
                       </div>
                     </td>
@@ -414,18 +403,7 @@
                         {%- endif -%}
 
                         {%- if item.variant.available and item.unit_price_measurement -%}
-                          <div class="unit-price caption">
-                            <span class="visually-hidden">{{ 'products.product.price.unit_price' | t }}</span>
-                            {{ item.unit_price | money }}
-                            <span aria-hidden="true">/</span>
-                            <span class="visually-hidden"
-                              >&nbsp;{{ 'accessibility.unit_price_separator' | t }}&nbsp;</span
-                            >
-                            {%- if item.unit_price_measurement.reference_value != 1 -%}
-                              {{- item.unit_price_measurement.reference_value -}}
-                            {%- endif -%}
-                            {{ item.unit_price_measurement.reference_unit }}
-                          </div>
+                          {% render 'unit-price', price: item.unit_price, measurement: item.unit_price_measurement %}
                         {%- endif -%}
                       </div>
                     </td>

--- a/sections/main-order.liquid
+++ b/sections/main-order.liquid
@@ -166,21 +166,7 @@
                         <span class="visually-hidden">{{ 'products.product.price.unit_price' | t }}</span>
                       </dt>
                       <dd class="unit-price">
-                        <span>
-                          {%- capture unit_price_separator -%}
-                            <span aria-hidden="true">/</span
-                            ><span class="visually-hidden">{{ 'accessibility.unit_price_separator' | t }}&nbsp;</span>
-                          {%- endcapture -%}
-                          {%- capture unit_price_base_unit -%}
-                            {%- if line_item.unit_price_measurement.reference_value != 1 -%}
-                              {{- line_item.unit_price_measurement.reference_value -}}
-                            {%- endif -%}
-                            {{ line_item.unit_price_measurement.reference_unit }}
-                          {%- endcapture -%}
-                          <span data-unit-price>{{ line_item.unit_price | money }}</span>
-                          {{- unit_price_separator -}}
-                          {{- unit_price_base_unit -}}
-                        </span>
+                        {% render 'unit-price', price: line_item.unit_price, measurement: line_item.unit_price_measurement, hide_accessibility_label: true %}
                       </dd>
                     {%- endif -%}
                   </dl>

--- a/snippets/cart-drawer.liquid
+++ b/snippets/cart-drawer.liquid
@@ -247,18 +247,7 @@
                             {%- endif -%}
 
                             {%- if item.variant.available and item.unit_price_measurement -%}
-                              <div class="unit-price caption">
-                                <span class="visually-hidden">{{ 'products.product.price.unit_price' | t }}</span>
-                                {{ item.unit_price | money }}
-                                <span aria-hidden="true">/</span>
-                                <span class="visually-hidden"
-                                  >&nbsp;{{ 'accessibility.unit_price_separator' | t }}&nbsp;</span
-                                >
-                                {%- if item.unit_price_measurement.reference_value != 1 -%}
-                                  {{- item.unit_price_measurement.reference_value -}}
-                                {%- endif -%}
-                                {{ item.unit_price_measurement.reference_unit }}
-                              </div>
+                              {% render 'unit-price', price: item.unit_price, measurement: item.unit_price_measurement %}
                             {%- endif -%}
                           </div>
                         </td>

--- a/snippets/price.liquid
+++ b/snippets/price.liquid
@@ -108,20 +108,9 @@
           {{ money_price }}
         </span>
       </div>
-      <small class="unit-price caption{% if product.selected_or_first_available_variant.unit_price_measurement == nil %} hidden{% endif %}">
-        <span class="visually-hidden">{{ 'products.product.price.unit_price' | t }}</span>
-        <span class="price-item price-item--last">
-          <span>{{- product.selected_or_first_available_variant.unit_price | money -}}</span>
-          <span aria-hidden="true">/</span>
-          <span class="visually-hidden">&nbsp;{{ 'accessibility.unit_price_separator' | t }}&nbsp;</span>
-          <span>
-            {%- if product.selected_or_first_available_variant.unit_price_measurement.reference_value != 1 -%}
-              {{- product.selected_or_first_available_variant.unit_price_measurement.reference_value -}}
-            {%- endif -%}
-            {{ product.selected_or_first_available_variant.unit_price_measurement.reference_unit }}
-          </span>
-        </span>
-      </small>
+      {%- if product.selected_or_first_available_variant.unit_price_measurement -%}
+        {% render 'unit-price', price: product.selected_or_first_available_variant.unit_price, measurement: product.selected_or_first_available_variant.unit_price_measurement %}
+      {%- endif -%}
     </div>
     {%- if show_badges -%}
       <span class="badge price__badge-sale color-{{ settings.sale_badge_color_scheme }}">

--- a/snippets/quick-order-list-row.liquid
+++ b/snippets/quick-order-list-row.liquid
@@ -145,16 +145,7 @@
     {%- endif -%}
 
     {%- if item.available and item.unit_price_measurement -%}
-      <div class="unit-price caption">
-        <span class="visually-hidden">{{ 'products.product.price.unit_price' | t }}</span>
-        {{ item.unit_price | money }}
-        <span aria-hidden="true">/</span>
-        <span class="visually-hidden">&nbsp;{{ 'accessibility.unit_price_separator' | t }}&nbsp;</span>
-        {%- if item.unit_price_measurement.reference_value != 1 -%}
-          {{- item.unit_price_measurement.reference_value -}}
-        {%- endif -%}
-        {{ item.unit_price_measurement.reference_unit }}
-      </div>
+      {% render 'unit-price', price: item.unit_price, measurement: item.unit_price_measurement %}
     {%- endif -%}
   </td>
 
@@ -417,16 +408,7 @@
     {%- endif -%}
 
     {%- if item.available and item.unit_price_measurement -%}
-      <div class="unit-price caption">
-        <span class="visually-hidden">{{ 'products.product.price.unit_price' | t }}</span>
-        {{ item.unit_price | money }}
-        <span aria-hidden="true">/</span>
-        <span class="visually-hidden">&nbsp;{{ 'accessibility.unit_price_separator' | t }}&nbsp;</span>
-        {%- if item.unit_price_measurement.reference_value != 1 -%}
-          {{- item.unit_price_measurement.reference_value -}}
-        {%- endif -%}
-        {{ item.unit_price_measurement.reference_unit }}
-      </div>
+      {% render 'unit-price', price: item.unit_price, measurement: item.unit_price_measurement %}
     {%- endif -%}
   </td>
   <td class="variant-item__totals right small-hide medium-hide">

--- a/snippets/unit-price.liquid
+++ b/snippets/unit-price.liquid
@@ -1,0 +1,21 @@
+{%- doc -%}
+  Renders the unit price, including its measurement.
+
+  @param {object} price - The unit price (money or string).
+  @param {object} measurement - The unit_price_measurement object.
+  @param {boolean} [hide_accessibility_label] - Whether to hide the accessibility label (default: false).
+
+  @example
+  {% render 'unit-price', price: variant.unit_price, measurement: variant.unit_price_measurement %}
+
+  @example
+  {% render 'unit-price', price: line_item.unit_price | money_with_currency, measurement: line_item.unit_price_measurement }
+{%- enddoc -%}
+<small class="unit-price caption">
+  {%- unless hide_accessibility_label -%}
+    <span class="visually-hidden">{{ 'products.product.price.unit_price' | t }}</span>
+  {%- endunless -%}
+  <span class="price-item price-item--last">
+    {{ price | unit_price_with_measurement: measurement }}
+  </span>
+</small>


### PR DESCRIPTION
### PR Summary: 

<!-- Please include a short description (using non-technical terms, 1-2 sentences) about the changes you are introducing, what problem is being fixed and/or describe the benefit to merchants. This content will be used in our release notes for Dawn on [themes.shopify.com](https://themes.shopify.com/themes/dawn/styles/default#ReleaseNotes). -->

Part of https://github.com/shop/issues-international/issues/95

Improve and localize how unit price is displayed using the new [`unit_price_with_measurement` filter](https://shopify.dev/docs/api/liquid/filters/unit_price_with_measurement).

### Why are these changes introduced?

The `reference_unit` field is a constant, and it was previously being displayed as-is, without interpreting it into a displayable value or translating it. This resulted in `m2` and `m3` being displayed instead of `m²` or `m³`.

The `unit_price_with_measurement` filter fully localizes the price with measurement, with overridable translations shared with Checkout for consistency.

| <img width="360" alt="Screenshot 2025-06-12 at 9 03 48 AM" src="https://github.com/user-attachments/assets/2a341bd0-b6c9-48d9-9300-2ef74a899fc6" /> | <img width="336" alt="Screenshot 2025-06-12 at 9 27 56 AM" src="https://github.com/user-attachments/assets/33b99711-acc5-494e-bdb7-ad47cb193995" /> |
| - | - |

### What approach did you take?

Unit price is referenced in several places. For consistency and ease of maintenance, I introduced a `unit-price` snippet that accepts:
- `price` - the unit price to display (`money` or `string`). If Money is used, the price will be formatted with the `money` filter.
- `measurement` - the unit price measurement (`unit_price_measurement`)

### Other considerations

### Decision log

| # | Decision | Alternatives | Rationale | Downsides |
|---|---|---|---|---|
| 1 | Update unit price with the new `unit_price_with_measurement` liquid filter | Make all necessary changes within the theme itself (see [PR](https://github.com/Shopify/dawn/pull/3772)). Requires a significant amount of theme code and translations within the theme, which increases maintenance, and can become out of sync with Checkout. | Simpler and easier to maintain, with better localization and consistency. | It may not be obvious to developers and merchants that they can override the default content and translations, and where to find them.  |

### Visual impact on existing themes
<!-- How will this visually affect merchants who upgrade to a new theme version with this change? -->

Unit price will be improved and localized wherever it is displayed, most notably on product pages and the cart.

#### Before

| Language | Page | | | | |
| - | - | - | - | - | - |
| English | Product | <img width="102" alt="Screenshot 2025-06-12 at 3 48 23 PM" src="https://github.com/user-attachments/assets/2934bb4e-1ac7-4477-ade1-6bb3df8c1ce4" /> | <img width="109" alt="Screenshot 2025-06-12 at 3 48 17 PM" src="https://github.com/user-attachments/assets/5cdd0c6f-7344-4c36-91eb-1b7708bc29b3" /> | <img width="106" alt="Screenshot 2025-06-12 at 3 48 12 PM" src="https://github.com/user-attachments/assets/3d29c9e8-e260-4f3b-a3a4-18dbf07f2ef0" /> | <img width="106" alt="Screenshot 2025-06-12 at 3 48 06 PM" src="https://github.com/user-attachments/assets/e7a5b17d-49d9-4b93-91eb-c97b4ba37b2e" /> |
| French | Product | <img width="104" alt="Screenshot 2025-06-12 at 3 49 09 PM" src="https://github.com/user-attachments/assets/298361b1-079a-47cc-9977-bfd657ec2446" /> | <img width="110" alt="Screenshot 2025-06-12 at 3 49 04 PM" src="https://github.com/user-attachments/assets/9a84c4d4-9d46-4612-8143-947f0af77b2f" /> | <img width="104" alt="Screenshot 2025-06-12 at 3 48 58 PM" src="https://github.com/user-attachments/assets/17defb11-e077-4e9c-9d7b-1c66b2c7ce6e" /> | <img width="108" alt="Screenshot 2025-06-12 at 3 48 52 PM" src="https://github.com/user-attachments/assets/4609e8e7-f18e-41c3-a703-26dac9edefe9" /> |
| English | Cart | <img width="79" alt="Screenshot 2025-06-12 at 3 59 30 PM" src="https://github.com/user-attachments/assets/e78f4800-5963-4dec-9c60-6e9b074cd8ee" /> | <img width="78" alt="Screenshot 2025-06-12 at 3 59 20 PM" src="https://github.com/user-attachments/assets/e308788e-f0dd-4d2c-b976-38d30901f21c" /> | <img width="79" alt="Screenshot 2025-06-12 at 3 59 15 PM" src="https://github.com/user-attachments/assets/5b0128eb-585d-4048-9c42-6de4632eecd7" /> | <img width="79" alt="Screenshot 2025-06-12 at 3 59 11 PM" src="https://github.com/user-attachments/assets/03207669-dfb9-446d-90c1-27884f87ecfc" /> |
| French | Cart | <img width="79" alt="Screenshot 2025-06-12 at 3 59 30 PM" src="https://github.com/user-attachments/assets/e78f4800-5963-4dec-9c60-6e9b074cd8ee" /> | <img width="78" alt="Screenshot 2025-06-12 at 3 59 20 PM" src="https://github.com/user-attachments/assets/e308788e-f0dd-4d2c-b976-38d30901f21c" /> | <img width="79" alt="Screenshot 2025-06-12 at 3 59 15 PM" src="https://github.com/user-attachments/assets/5b0128eb-585d-4048-9c42-6de4632eecd7" /> | <img width="79" alt="Screenshot 2025-06-12 at 3 59 11 PM" src="https://github.com/user-attachments/assets/03207669-dfb9-446d-90c1-27884f87ecfc" /> |

#### After

| Language | Page | | | | |
| - | - | - | - | - | - |
| English | Product | <img width="117" alt="Screenshot 2025-06-12 at 3 42 33 PM" src="https://github.com/user-attachments/assets/cce8287f-8987-40c4-8260-bb5a8c21c783" /> | <img width="109" alt="Screenshot 2025-06-12 at 3 42 27 PM" src="https://github.com/user-attachments/assets/50ad938f-7e21-4eaf-9317-744a9d0d3855" /> | <img width="115" alt="Screenshot 2025-06-12 at 3 42 21 PM" src="https://github.com/user-attachments/assets/43bc032f-32b4-4f76-bf0a-e53830d9f05b" /> |<img width="119" alt="Screenshot 2025-06-12 at 3 42 14 PM" src="https://github.com/user-attachments/assets/b16b4a36-ae2f-4a88-9921-2d5280d86454" /> |
| French | Product | <img width="122" alt="Screenshot 2025-06-12 at 3 43 33 PM" src="https://github.com/user-attachments/assets/ef356603-5013-4ab7-874f-b9be9e6828a9" /> | <img width="106" alt="Screenshot 2025-06-12 at 3 43 26 PM" src="https://github.com/user-attachments/assets/d43eda75-fa88-44b1-ba04-6bd5e9a1d1b3" /> | <img width="100" alt="Screenshot 2025-06-12 at 3 43 19 PM" src="https://github.com/user-attachments/assets/4c0e86c3-43c5-4b1d-b2c4-ed64aeaf2009" /> | <img width="106" alt="Screenshot 2025-06-12 at 3 43 13 PM" src="https://github.com/user-attachments/assets/aff2ad0f-50a6-4538-8968-178af1e45305" /> |
| English | Cart | <img width="105" alt="Screenshot 2025-06-12 at 3 54 09 PM" src="https://github.com/user-attachments/assets/ffd7d2f9-3133-44c3-abb4-124265f9dc77" /> | <img width="65" alt="Screenshot 2025-06-12 at 3 54 03 PM" src="https://github.com/user-attachments/assets/9560d1e0-0dc0-4b5a-bf25-fe89ab6b9342" /> | <img width="70" alt="Screenshot 2025-06-12 at 3 53 57 PM" src="https://github.com/user-attachments/assets/5449df96-0208-4019-8180-7e4ab31b8b0c" /> | <img width="81" alt="Screenshot 2025-06-12 at 3 56 28 PM" src="https://github.com/user-attachments/assets/17e0a6c9-75f9-4281-b4db-918e32447fd1" /> |
| French | Cart | <img width="118" alt="Screenshot 2025-06-12 at 3 55 37 PM" src="https://github.com/user-attachments/assets/188ee2c9-638a-4c28-9ed5-b1d8a0691935" /> | <img width="65" alt="Screenshot 2025-06-12 at 3 55 32 PM" src="https://github.com/user-attachments/assets/5464bcc3-7992-48e7-928f-4b9ea5420654" /> | <img width="74" alt="Screenshot 2025-06-12 at 3 55 28 PM" src="https://github.com/user-attachments/assets/a136b86a-6107-4340-a2f2-2e296fecaebb" /> | <img width="76" alt="Screenshot 2025-06-12 at 3 55 24 PM" src="https://github.com/user-attachments/assets/a4d035ef-5d41-49f0-868c-8ca7d957caea" /> |


### Testing steps/scenarios

1. Zip or push the theme from this branch with Shopify CLI
   - `shopify theme package` or `shopify theme push`

2. Publish the theme on your store

3. Set up product variants with unit prices
   - For full coverage, set up variants with:
      - Reference unit "item", reference value 1
      - Reference unit "item", reference value > 1
      - Reference unit something else, reference value 1
      - Reference unit something else, reference value > 1

4. On storefront, view the variants with unit price.
5. Add the variants to the cart and view the cart.
6. Change the storefront language and repeat steps 4 and 5.

### Demo links
<!-- Please include a link to a demo store that includes preconfigured sections and settings to allow reviewers to easily test the features you are working on. -->

- [Store](https://trish-test-store.myshopify.com/products/test) (message me for the password)

### Checklist
- [x] Added PR summary for [release notes](https://themes.shopify.com/themes/dawn/styles/default#ReleaseNotes)
- [ ] Requested review from UX (Only for changes that are affecting the experience or perceivable visual details)
- [ ] Created a ticket for the [help.shopify.com](https://help.shopify.com) documentation team about updates to theme settings. (Internal-only task)
- [x] Followed [theme code principles](https://github.com/Shopify/dawn/blob/main/.github/CONTRIBUTING.md#theme-code-principles)
- [x] Linted with [Theme Check](https://github.com/Shopify/theme-check)
- [x] Tested on [mobile](https://shopify.dev/themes/store/requirements#mobile-browser-requirements)
- [ ] Tested on [multiple browsers](https://shopify.dev/themes/store/requirements#desktop-browser-requirements)
- [ ] Tested for [accessibility](https://shopify.dev/themes/best-practices/accessibility)
