### PR TITLE
Fix Cart quantity performance measurement bug

### DIFF
--- a/assets/cart.js
+++ b/assets/cart.js
@@ -145,6 +145,9 @@ class CartItems extends HTMLElement {
   }
 
   updateQuantity(line, quantity, event, name, variantId) {
+    const eventTarget = event.currentTarget instanceof CartRemoveButton ? 'clear' : 'change';
+    const cartPerformanceUpdateMarker = CartPerformance.createStartingMarker(`${eventTarget}:user-action`);
+
     this.enableLoading(line);
 
     const body = JSON.stringify({
@@ -153,7 +156,6 @@ class CartItems extends HTMLElement {
       sections: this.getSectionsToRender().map((section) => section.section),
       sections_url: window.location.pathname,
     });
-    const eventTarget = event.currentTarget instanceof CartRemoveButton ? 'clear' : 'change';
 
     fetch(`${routes.cart_change_url}`, { ...fetchConfig(), ...{ body } })
       .then((response) => {
@@ -162,7 +164,7 @@ class CartItems extends HTMLElement {
       .then((state) => {
         const parsedState = JSON.parse(state);
 
-        CartPerformance.measure(`${eventTarget}:paint-updated-sections"`, () => {
+        CartPerformance.measure(`${eventTarget}:paint-updated-sections`, () => {
           const quantityElement =
             document.getElementById(`Quantity-${line}`) || document.getElementById(`Drawer-quantity-${line}`);
           const items = document.querySelectorAll('.cart-item');
@@ -182,7 +184,8 @@ class CartItems extends HTMLElement {
 
           this.getSectionsToRender().forEach((section) => {
             const elementToReplace =
-              document.getElementById(section.id).querySelector(section.selector) || document.getElementById(section.id);
+              document.getElementById(section.id).querySelector(section.selector) ||
+              document.getElementById(section.id);
             elementToReplace.innerHTML = this.getSectionInnerHTML(
               parsedState.sections[section.section],
               section.selector
@@ -212,8 +215,6 @@ class CartItems extends HTMLElement {
           }
         });
 
-        CartPerformance.measureFromEvent(`${eventTarget}:user-action`, event);
-
         publish(PUB_SUB_EVENTS.cartUpdate, { source: 'cart-items', cartData: parsedState, variantId: variantId });
       })
       .catch(() => {
@@ -223,6 +224,7 @@ class CartItems extends HTMLElement {
       })
       .finally(() => {
         this.disableLoading(line);
+        CartPerformance.measureFromMarker(`${eventTarget}:user-action`, cartPerformanceUpdateMarker);
       });
   }
 
@@ -284,8 +286,9 @@ if (!customElements.get('cart-note')) {
           'input',
           debounce((event) => {
             const body = JSON.stringify({ note: event.target.value });
-            fetch(`${routes.cart_update_url}`, { ...fetchConfig(), ...{ body } })
-              .then(() => CartPerformance.measureFromEvent('note-update:user-action', event));
+            fetch(`${routes.cart_update_url}`, { ...fetchConfig(), ...{ body } }).then(() =>
+              CartPerformance.measureFromEvent('note-update:user-action', event)
+            );
           }, ON_CHANGE_DEBOUNCE_TIMER)
         );
       }


### PR DESCRIPTION
This PR addresses a discrepancy in how we measure the time it takes to update the quantity events in Dawn versus Horizon. Dawn's current implementation has resulted in surprisingly high durations for quantity changes that we do not believe reflect reality. The difference in implementation is that Horizon uses `createStartingMarker` and `measureFromMarker` whereas Dawn uses `measureFromEvent`.

I manually tested the quantity change buttons and see some bogus looking durations measured by `measureFromEvent` where the event is the debounced click event on the quantity change buttons.

When I change the quantity 3 times, each time waiting for the debounce timeout, I do see 3 `cart-performance:change:user-action` events. However, the durations are much longer than the duration I actually perceived as the user. It's not clear to me why `measureFromEvent` is reporting such long durations, but it does seem isolated to this implementation, as the data we collect for Horizon does not have this problem.

```json
"cart_performance_metrics": [
    {
      "name": "cart-performance:change:user-action",
      "entryType": "measure",
      "startTime": 263.79999999701977,
      "duration": 4320.4000000059605
    },
    {
      "name": "cart-performance:change:paint-updated-sections\"",
      "entryType": "measure",
      "startTime": 4575.5999999940395,
      "duration": 8.400000005960464
    },
    {
      "name": "cart-performance:change:user-action",
      "entryType": "measure",
      "startTime": 4578.70000000298,
      "duration": 5506.199999988079
    },
    {
      "name": "cart-performance:change:paint-updated-sections\"",
      "entryType": "measure",
      "startTime": 10077,
      "duration": 7.799999997019768
    },
    {
      "name": "cart-performance:change:user-action",
      "entryType": "measure",
      "startTime": 10079.79999999702,
      "duration": 4953.4000000059605
    },
    {
      "name": "cart-performance:change:paint-updated-sections\"",
      "entryType": "measure",
      "startTime": 15024.59999999404,
      "duration": 8.400000005960464
    }
  ]
```