### PR TITLE
Add separate custom font support for heading and body

### DIFF
--- a/config/settings_schema.json
+++ b/config/settings_schema.json
@@ -109,10 +109,29 @@
         "content": "t:settings_schema.typography.settings.header__1.content"
       },
       {
+        "type": "checkbox",
+        "id": "enable_custom_heading_font",
+        "label": "Enable Custom Font"
+      },
+      {
         "type": "font_picker",
         "id": "type_header_font",
         "default": "assistant_n4",
-        "label": "t:settings_schema.typography.settings.type_header_font.label"
+        "label": "t:settings_schema.typography.settings.type_header_font.label",
+        "visible_if": "{{ settings.enable_custom_heading_font == false }}"
+      },
+      {
+        "type": "text",
+        "id": "heading_font_url",
+        "label": "Font URL",
+        "info": "Use a local .woff2 Regular font file URL or a Google Fonts online URL.",
+        "visible_if": "{{ settings.enable_custom_heading_font }}"
+      },
+      {
+        "type": "text",
+        "id": "heading_font_family",
+        "label": "Font Name",
+        "visible_if": "{{ settings.enable_custom_heading_font }}"
       },
       {
         "type": "range",
@@ -129,10 +148,29 @@
         "content": "t:settings_schema.typography.settings.header__2.content"
       },
       {
+        "type": "checkbox",
+        "id": "enable_custom_body_font",
+        "label": "Enable Custom Font"
+      },
+      {
         "type": "font_picker",
         "id": "type_body_font",
         "default": "assistant_n4",
-        "label": "t:settings_schema.typography.settings.type_body_font.label"
+        "label": "t:settings_schema.typography.settings.type_body_font.label",
+        "visible_if": "{{ settings.enable_custom_body_font == false }}"
+      },
+      {
+        "type": "text",
+        "id": "body_font_url",
+        "label": "Font URL",
+        "info": "Use a local .woff2 Regular font file URL or a Google Fonts online URL.",
+        "visible_if": "{{ settings.enable_custom_body_font }}"
+      },
+      {
+        "type": "text",
+        "id": "body_font_family",
+        "label": "Font Family Name",
+        "visible_if": "{{ settings.enable_custom_body_font }}"
       },
       {
         "type": "range",

--- a/layout/theme.liquid
+++ b/layout/theme.liquid
@@ -47,56 +47,53 @@
   body:enable_custom_body_font:body_font_url:body_font_family
   ' | split: ',' -%}
 
-<style>
-{% for font in fonts %}
-  {% assign parts = font | strip | split: ':' %}
-  {% assign enabled = settings[parts[1]] %}
-  {% assign font_url = settings[parts[2]] %}
-  {% assign font_family = settings[parts[3]] %}
-
-  {% if enabled and font_url != blank %}
-    {% if font_url contains '.woff2' %}
-      {% assign full_url = font_url | split:'?' | first %}
-      {% assign file_name = full_url | split:'/' | last %}
-      {% assign file_base = file_name | split:'.' | first %}
-      {% assign file_path = full_url | remove: file_name %}
-
-      {%- assign font_variants = "
-        Thin:100:normal,ThinItalic:100:italic,
-        ExtraLight:200:normal,ExtraLightItalic:200:italic,
-        Light:300:normal,LightItalic:300:italic,
-        Regular:400:normal,RegularItalic:400:italic,
-        Medium:500:normal,MediumItalic:500:italic,
-        SemiBold:600:normal,SemiBoldItalic:600:italic,
-        Bold:700:normal,BoldItalic:700:italic,
-        ExtraBold:800:normal,ExtraBoldItalic:800:italic,
-        Black:900:normal,BlackItalic:900:italic
-      " | split: ',' -%}
-
-      {% for variant in font_variants %}
-        {% assign v = variant | strip | split: ':' %}
-        {% assign name = v[0] %}
-        {% assign weight = v[1] %}
-        {% assign style = v[2] %}
-
-        @font-face {
-          font-family: '{{ font_family }}';
-          src: url('{{ file_path }}{{ file_base }}.woff2') format('woff2');
-          font-weight: {{ weight }};
-          font-style: {{ style }};
-        }
-      {% endfor %}
-    {% else %}
-      </style>
-      <link href="{{ font_url }}" rel="stylesheet">
-      <style>
+  <style>
+  {% for font in fonts %}
+    {% assign parts = font | strip | split: ':' %}
+    {% assign enabled = settings[parts[1]] %}
+    {% assign font_url = settings[parts[2]] %}
+    {% assign font_family = settings[parts[3]] %}
+  
+    {% if enabled and font_url != blank %}
+      {% if font_url contains '.woff2' %}
+        {% assign full_url = font_url | split:'?' | first %}
+        {% assign file_name = full_url | split:'/' | last %}
+        {% assign file_base = file_name | split:'.' | first %}
+        {% assign file_path = full_url | remove: file_name %}
+  
+        {%- assign font_variants = "
+          Thin:100:normal,ThinItalic:100:italic,
+          ExtraLight:200:normal,ExtraLightItalic:200:italic,
+          Light:300:normal,LightItalic:300:italic,
+          Regular:400:normal,RegularItalic:400:italic,
+          Medium:500:normal,MediumItalic:500:italic,
+          SemiBold:600:normal,SemiBoldItalic:600:italic,
+          Bold:700:normal,BoldItalic:700:italic,
+          ExtraBold:800:normal,ExtraBoldItalic:800:italic,
+          Black:900:normal,BlackItalic:900:italic
+        " | split: ',' -%}
+  
+        {% for variant in font_variants %}
+          {% assign v = variant | strip | split: ':' %}
+          {% assign name = v[0] %}
+          {% assign weight = v[1] %}
+          {% assign style = v[2] %}
+  
+          @font-face {
+            font-family: '{{ font_family }}';
+            src: url('{{ file_path }}{{ file_base }}.woff2') format('woff2');
+            font-weight: {{ weight }};
+            font-style: {{ style }};
+          }
+        {% endfor %}
+      {% else %}
+        </style>
+        <link href="{{ font_url }}" rel="stylesheet">
+        <style>
+      {% endif %}
     {% endif %}
-  {% endif %}
-{% endfor %}
-</style>
-
-
-
+  {% endfor %}
+  </style>
 
     {%- liquid
       assign body_font_bold = settings.type_body_font | font_modify: 'weight', 'bold'
@@ -158,20 +155,20 @@
 
       :root {
         {% if settings.enable_custom_body_font and settings.body_font_family != blank and settings.body_font_url != blank %}
-    --font-body-family: {{ settings.body_font_family }}, {{ settings.type_body_font.fallback_families }};
-  {% else %}
-    --font-body-family: {{ settings.type_body_font.family }}, {{ settings.type_body_font.fallback_families }};
-  {% endif %}
+          --font-body-family: {{ settings.body_font_family }}, {{ settings.type_body_font.fallback_families }};
+        {% else %}
+          --font-body-family: {{ settings.type_body_font.family }}, {{ settings.type_body_font.fallback_families }};
+        {% endif %}
         /* --font-body-family: {{ settings.type_body_font.family }}, {{ settings.type_body_font.fallback_families }}; */
         --font-body-style: {{ settings.type_body_font.style }};
         --font-body-weight: {{ settings.type_body_font.weight }};
         --font-body-weight-bold: {{ settings.type_body_font.weight | plus: 300 | at_most: 1000 }};
 
         {% if settings.enable_custom_heading_font and settings.heading_font_family != blank and settings.heading_font_url != blank %}
-    --font-heading-family: {{ settings.heading_font_family }}, {{ settings.type_header_font.fallback_families }};
-  {% else %}
-    --font-heading-family: {{ settings.type_header_font.family }}, {{ settings.type_header_font.fallback_families }};
-  {% endif %}
+          --font-heading-family: {{ settings.heading_font_family }}, {{ settings.type_header_font.fallback_families }};
+        {% else %}
+          --font-heading-family: {{ settings.type_header_font.family }}, {{ settings.type_header_font.fallback_families }};
+        {% endif %}
         /* --font-heading-family: {{ settings.type_header_font.family }}, {{ settings.type_header_font.fallback_families }}; */
         --font-heading-style: {{ settings.type_header_font.style }};
         --font-heading-weight: {{ settings.type_header_font.weight }};

--- a/layout/theme.liquid
+++ b/layout/theme.liquid
@@ -41,27 +41,41 @@
 
     {{ content_for_header }}
 
-   {%- assign fonts = 
-    '
-    heading:enable_custom_heading_font:heading_font_url:heading_font_family,
-    body:enable_custom_body_font:body_font_url:body_font_family
-    ' | split: ',' -%}
-
-    {% for font in fonts %}
-      {% assign parts = font | strip | split: ':' %}
-      {% assign enabled = settings[parts[1]] %}
-      {% assign font_url = settings[parts[2]] %}
-      {% assign font_family = settings[parts[3]] %}
-      
-      {% if enabled and font_url != blank %}
-        {% if font_url contains '.woff2' %}
+   {%- assign fonts = '
+      heading:enable_custom_heading_font:heading_font_url:heading_font_family,
+      body:enable_custom_body_font:body_font_url:body_font_family
+      '
+      | split: ','
+    -%}
+    {%- for font in fonts -%}
+      {%- assign parts = font | strip | split: ':' -%}
+      {%- assign enabled = settings[parts[1]] -%}
+      {%- assign font_url = settings[parts[2]] -%}
+      {%- assign font_family = settings[parts[3]] -%}
+      {%- if enabled and font_url != blank -%}
+        {%- if font_url contains '.woff2' -%}
           <style>
-          {% assign full_url = font_url | split:'?' | first %}
-          {% assign file_name = full_url | split:'/' | last %}
-          {% assign file_base = file_name | split:'.' | first %}
-          {% assign file_path = full_url | remove: file_name %}
-
-          {%- assign font_variants = "
+            {%- assign full_url = font_url | split:'?' | first -%}
+            {%- assign file_name = full_url | split:'/' | last -%}
+            {%- assign file_base = file_name | split:'.' | first -%}
+            {%- assign file_path = full_url | remove: file_name -%}
+            {%- assign parts_arr = file_base | split: '-' -%}
+            {%- assign prefix = '' -%}
+            {%- if parts_arr.size > 1 -%}
+              {%- for p in parts_arr -%}
+                {%- if forloop.last == false -%}
+                  {%- if prefix == '' -%}
+                    {%- assign prefix = p -%}
+                  {%- else -%}
+                    {%- assign prefix = prefix | append: '-' | append: p -%}
+                  {%- endif -%}
+                {%- endif -%}
+              {%- endfor -%}
+            {%- endif -%}
+            {%- if prefix == '' -%}
+              {%- assign prefix = file_base -%}
+            {%- endif -%}
+            {%- assign font_variants = "
             Thin:100:normal,ThinItalic:100:italic,
             ExtraLight:200:normal,ExtraLightItalic:200:italic,
             Light:300:normal,LightItalic:300:italic,
@@ -71,27 +85,40 @@
             Bold:700:normal,BoldItalic:700:italic,
             ExtraBold:800:normal,ExtraBoldItalic:800:italic,
             Black:900:normal,BlackItalic:900:italic
-          " | split: ',' -%}
-
-          {% for variant in font_variants %}
-            {% assign v = variant | strip | split: ':' %}
-            {% assign name = v[0] %}
-            {% assign weight = v[1] %}
-            {% assign style = v[2] %}
-
-            @font-face {
-              font-family: '{{ font_family }}';
-              src: url('{{ file_path }}{{ file_base }}.woff2') format('woff2');
-              font-weight: {{ weight }};
-              font-style: {{ style }};
-            }
-          {% endfor %}
-        </style>
-        {% else %}
-          <link href="{{ font_url }}" rel="stylesheet">
-        {% endif %}
-      {% endif %}
-    {% endfor %}
+            " | split: ',' -%}
+            {% for variant in font_variants -%}
+              {%- assign v = variant | strip | split: ':' -%}
+              {%- assign name = v[0] -%}
+              {%- assign weight = v[1] -%}
+              {%- assign style = v[2] -%}
+              {%- assign name_dash = name | replace: 'Italic', '-Italic' -%}
+              {%- assign name_camel = name -%}
+              {%- assign name_plain = name | replace: 'Italic', '' -%}
+              {%- assign cand1 = file_base | append: '.woff2' -%}
+              {%- assign cand2 = prefix | append: '-' | append: name_dash | append: '.woff2' -%}
+              {%- assign cand3 = prefix | append: '-' | append: name_camel | append: '.woff2' -%}
+              {%- assign cand4 = prefix | append: '-' | append: name_plain | append: '.woff2' -%}
+              {%- assign cand5 = prefix | append: '-Italic.woff2' -%}
+              {%- assign cand6 = prefix | append: '.woff2' -%}
+              {%- assign sources = cand1 | append: ',' | append: cand2 | append: ',' | append: cand3 | append: ',' | append: cand4 | append: ',' | append: cand5 | append: ',' | append: cand6 -%}
+              {%- assign sources_list = sources | split: ',' -%}
+              @font-face {
+                font-family: '{{ font_family }}';
+                src:
+                {%- for s in sources_list %}
+                  url('{{ file_path }}{{ s }}') format('woff2'){%- if forloop.last == false -%},{%- endif -%}
+                {% endfor -%};
+                font-weight: {{ weight }};
+                font-style: {{ style }};
+                font-display: swap;
+              }
+            {% endfor %}
+          </style>
+        {%- else -%}
+          <link href="{{ font_url | asset_url }}" rel="stylesheet">
+        {%- endif -%}
+      {%- endif -%}
+    {%- endfor -%}
 
     {%- liquid
       assign body_font_bold = settings.type_body_font | font_modify: 'weight', 'bold'

--- a/layout/theme.liquid
+++ b/layout/theme.liquid
@@ -41,6 +41,63 @@
 
     {{ content_for_header }}
 
+   {%- assign fonts = 
+  '
+  heading:enable_custom_heading_font:heading_font_url:heading_font_family,
+  body:enable_custom_body_font:body_font_url:body_font_family
+  ' | split: ',' -%}
+
+<style>
+{% for font in fonts %}
+  {% assign parts = font | strip | split: ':' %}
+  {% assign enabled = settings[parts[1]] %}
+  {% assign font_url = settings[parts[2]] %}
+  {% assign font_family = settings[parts[3]] %}
+
+  {% if enabled and font_url != blank %}
+    {% if font_url contains '.woff2' %}
+      {% assign full_url = font_url | split:'?' | first %}
+      {% assign file_name = full_url | split:'/' | last %}
+      {% assign file_base = file_name | split:'.' | first %}
+      {% assign file_path = full_url | remove: file_name %}
+
+      {%- assign font_variants = "
+        Thin:100:normal,ThinItalic:100:italic,
+        ExtraLight:200:normal,ExtraLightItalic:200:italic,
+        Light:300:normal,LightItalic:300:italic,
+        Regular:400:normal,RegularItalic:400:italic,
+        Medium:500:normal,MediumItalic:500:italic,
+        SemiBold:600:normal,SemiBoldItalic:600:italic,
+        Bold:700:normal,BoldItalic:700:italic,
+        ExtraBold:800:normal,ExtraBoldItalic:800:italic,
+        Black:900:normal,BlackItalic:900:italic
+      " | split: ',' -%}
+
+      {% for variant in font_variants %}
+        {% assign v = variant | strip | split: ':' %}
+        {% assign name = v[0] %}
+        {% assign weight = v[1] %}
+        {% assign style = v[2] %}
+
+        @font-face {
+          font-family: '{{ font_family }}';
+          src: url('{{ file_path }}{{ file_base }}.woff2') format('woff2');
+          font-weight: {{ weight }};
+          font-style: {{ style }};
+        }
+      {% endfor %}
+    {% else %}
+      </style>
+      <link href="{{ font_url }}" rel="stylesheet">
+      <style>
+    {% endif %}
+  {% endif %}
+{% endfor %}
+</style>
+
+
+
+
     {%- liquid
       assign body_font_bold = settings.type_body_font | font_modify: 'weight', 'bold'
       assign body_font_italic = settings.type_body_font | font_modify: 'style', 'italic'
@@ -100,12 +157,22 @@
       }
 
       :root {
-        --font-body-family: {{ settings.type_body_font.family }}, {{ settings.type_body_font.fallback_families }};
+        {% if settings.enable_custom_body_font and settings.body_font_family != blank and settings.body_font_url != blank %}
+    --font-body-family: {{ settings.body_font_family }}, {{ settings.type_body_font.fallback_families }};
+  {% else %}
+    --font-body-family: {{ settings.type_body_font.family }}, {{ settings.type_body_font.fallback_families }};
+  {% endif %}
+        /* --font-body-family: {{ settings.type_body_font.family }}, {{ settings.type_body_font.fallback_families }}; */
         --font-body-style: {{ settings.type_body_font.style }};
         --font-body-weight: {{ settings.type_body_font.weight }};
         --font-body-weight-bold: {{ settings.type_body_font.weight | plus: 300 | at_most: 1000 }};
 
-        --font-heading-family: {{ settings.type_header_font.family }}, {{ settings.type_header_font.fallback_families }};
+        {% if settings.enable_custom_heading_font and settings.heading_font_family != blank and settings.heading_font_url != blank %}
+    --font-heading-family: {{ settings.heading_font_family }}, {{ settings.type_header_font.fallback_families }};
+  {% else %}
+    --font-heading-family: {{ settings.type_header_font.family }}, {{ settings.type_header_font.fallback_families }};
+  {% endif %}
+        /* --font-heading-family: {{ settings.type_header_font.family }}, {{ settings.type_header_font.fallback_families }}; */
         --font-heading-style: {{ settings.type_header_font.style }};
         --font-heading-weight: {{ settings.type_header_font.weight }};
 

--- a/layout/theme.liquid
+++ b/layout/theme.liquid
@@ -42,58 +42,56 @@
     {{ content_for_header }}
 
    {%- assign fonts = 
-  '
-  heading:enable_custom_heading_font:heading_font_url:heading_font_family,
-  body:enable_custom_body_font:body_font_url:body_font_family
-  ' | split: ',' -%}
+    '
+    heading:enable_custom_heading_font:heading_font_url:heading_font_family,
+    body:enable_custom_body_font:body_font_url:body_font_family
+    ' | split: ',' -%}
 
-  <style>
-  {% for font in fonts %}
-    {% assign parts = font | strip | split: ':' %}
-    {% assign enabled = settings[parts[1]] %}
-    {% assign font_url = settings[parts[2]] %}
-    {% assign font_family = settings[parts[3]] %}
-  
-    {% if enabled and font_url != blank %}
-      {% if font_url contains '.woff2' %}
-        {% assign full_url = font_url | split:'?' | first %}
-        {% assign file_name = full_url | split:'/' | last %}
-        {% assign file_base = file_name | split:'.' | first %}
-        {% assign file_path = full_url | remove: file_name %}
-  
-        {%- assign font_variants = "
-          Thin:100:normal,ThinItalic:100:italic,
-          ExtraLight:200:normal,ExtraLightItalic:200:italic,
-          Light:300:normal,LightItalic:300:italic,
-          Regular:400:normal,RegularItalic:400:italic,
-          Medium:500:normal,MediumItalic:500:italic,
-          SemiBold:600:normal,SemiBoldItalic:600:italic,
-          Bold:700:normal,BoldItalic:700:italic,
-          ExtraBold:800:normal,ExtraBoldItalic:800:italic,
-          Black:900:normal,BlackItalic:900:italic
-        " | split: ',' -%}
-  
-        {% for variant in font_variants %}
-          {% assign v = variant | strip | split: ':' %}
-          {% assign name = v[0] %}
-          {% assign weight = v[1] %}
-          {% assign style = v[2] %}
-  
-          @font-face {
-            font-family: '{{ font_family }}';
-            src: url('{{ file_path }}{{ file_base }}.woff2') format('woff2');
-            font-weight: {{ weight }};
-            font-style: {{ style }};
-          }
-        {% endfor %}
-      {% else %}
+    {% for font in fonts %}
+      {% assign parts = font | strip | split: ':' %}
+      {% assign enabled = settings[parts[1]] %}
+      {% assign font_url = settings[parts[2]] %}
+      {% assign font_family = settings[parts[3]] %}
+      
+      {% if enabled and font_url != blank %}
+        {% if font_url contains '.woff2' %}
+          <style>
+          {% assign full_url = font_url | split:'?' | first %}
+          {% assign file_name = full_url | split:'/' | last %}
+          {% assign file_base = file_name | split:'.' | first %}
+          {% assign file_path = full_url | remove: file_name %}
+
+          {%- assign font_variants = "
+            Thin:100:normal,ThinItalic:100:italic,
+            ExtraLight:200:normal,ExtraLightItalic:200:italic,
+            Light:300:normal,LightItalic:300:italic,
+            Regular:400:normal,RegularItalic:400:italic,
+            Medium:500:normal,MediumItalic:500:italic,
+            SemiBold:600:normal,SemiBoldItalic:600:italic,
+            Bold:700:normal,BoldItalic:700:italic,
+            ExtraBold:800:normal,ExtraBoldItalic:800:italic,
+            Black:900:normal,BlackItalic:900:italic
+          " | split: ',' -%}
+
+          {% for variant in font_variants %}
+            {% assign v = variant | strip | split: ':' %}
+            {% assign name = v[0] %}
+            {% assign weight = v[1] %}
+            {% assign style = v[2] %}
+
+            @font-face {
+              font-family: '{{ font_family }}';
+              src: url('{{ file_path }}{{ file_base }}.woff2') format('woff2');
+              font-weight: {{ weight }};
+              font-style: {{ style }};
+            }
+          {% endfor %}
         </style>
-        <link href="{{ font_url }}" rel="stylesheet">
-        <style>
+        {% else %}
+          <link href="{{ font_url }}" rel="stylesheet">
+        {% endif %}
       {% endif %}
-    {% endif %}
-  {% endfor %}
-  </style>
+    {% endfor %}
 
     {%- liquid
       assign body_font_bold = settings.type_body_font | font_modify: 'weight', 'bold'


### PR DESCRIPTION
- **Added checkboxes to enable custom heading and custom body fonts independently.**
- **Updated settings_schema.json with font URL and family fields for both heading and body.**
- **Improved font loader logic to handle all common font variants (100–900, normal & italic).**
- **Supports both local .woff2 fonts and Google Fonts URLs.**
- **This makes theme font customization more flexible, maintainable, and clear for merchants.**