### PR TITLE
feat(section): Teksty + Przycisk (≤2×Text + 1×Button, mobile/desktop,…

### DIFF
--- a/assets/section-texts-and-button.css
+++ b/assets/section-texts-and-button.css
@@ -1,0 +1,172 @@
+.text-button-section {
+  padding-top: var(--pt-mobile);
+  padding-bottom: var(--pb-mobile);
+}
+@media (min-width: 750px) {
+  .text-button-section {
+    padding-top: var(--pt-desktop);
+    padding-bottom: var(--pb-desktop);
+  }
+}
+
+.text-button-section .tb-wrapper {
+  display: grid;
+  gap: 0.75rem;
+}
+.text-button-section .tb-text {
+  margin: 0;
+}
+
+.text-button-section .tb-text[data-align-mobile='left'] {
+  text-align: left;
+}
+.text-button-section .tb-text[data-align-mobile='center'] {
+  text-align: center;
+}
+.text-button-section .tb-text[data-align-mobile='right'] {
+  text-align: right;
+}
+
+@media (min-width: 750px) {
+  .text-button-section .tb-text[data-align-desktop='left'] {
+    text-align: left;
+  }
+  .text-button-section .tb-text[data-align-desktop='center'] {
+    text-align: center;
+  }
+  .text-button-section .tb-text[data-align-desktop='right'] {
+    text-align: right;
+  }
+}
+
+.text-button-section .tb-text[data-size-mobile='xs'] {
+  font-size: 0.75rem;
+}
+.text-button-section .tb-text[data-size-mobile='sm'] {
+  font-size: 0.875rem;
+}
+.text-button-section .tb-text[data-size-mobile='base'] {
+  font-size: 1rem;
+}
+.text-button-section .tb-text[data-size-mobile='lg'] {
+  font-size: 1.125rem;
+}
+.text-button-section .tb-text[data-size-mobile='xl'] {
+  font-size: 1.25rem;
+}
+.text-button-section .tb-text[data-size-mobile='2xl'] {
+  font-size: 1.5rem;
+}
+.text-button-section .tb-text[data-size-mobile='3xl'] {
+  font-size: 1.875rem;
+}
+
+@media (min-width: 750px) {
+  .text-button-section .tb-text[data-size-desktop='xs'] {
+    font-size: 0.75rem;
+  }
+  .text-button-section .tb-text[data-size-desktop='sm'] {
+    font-size: 0.875rem;
+  }
+  .text-button-section .tb-text[data-size-desktop='base'] {
+    font-size: 1rem;
+  }
+  .text-button-section .tb-text[data-size-desktop='lg'] {
+    font-size: 1.125rem;
+  }
+  .text-button-section .tb-text[data-size-desktop='xl'] {
+    font-size: 1.25rem;
+  }
+  .text-button-section .tb-text[data-size-desktop='2xl'] {
+    font-size: 1.5rem;
+  }
+  .text-button-section .tb-text[data-size-desktop='3xl'] {
+    font-size: 1.875rem;
+  }
+}
+
+.text-button-section .tb-button {
+  display: flex;
+}
+.text-button-section .tb-button {
+  justify-content: flex-start;
+}
+.text-button-section .tb-button[style*='--align-mobile: center'] {
+  justify-content: center;
+}
+.text-button-section .tb-button[style*='--align-mobile: right'] {
+  justify-content: flex-end;
+}
+
+@media (min-width: 750px) {
+  .text-button-section .tb-button {
+    justify-content: flex-start;
+  }
+  .text-button-section .tb-button[style*='--align-desktop: center'] {
+    justify-content: center;
+  }
+  .text-button-section .tb-button[style*='--align-desktop: right'] {
+    justify-content: flex-end;
+  }
+}
+
+.animated-text {
+  opacity: 0;
+}
+.animated-text.in {
+  animation-duration: var(--anim-dur, 600ms);
+  animation-delay: var(--anim-delay, 0ms);
+  animation-fill-mode: both;
+}
+
+.animated-text.anim--fade.in {
+  animation-name: tb-fade;
+}
+.animated-text.anim--slide-up.in {
+  animation-name: tb-slide-up;
+}
+.animated-text.anim--slide-left.in {
+  animation-name: tb-slide-left;
+}
+.animated-text.anim--slide-right.in {
+  animation-name: tb-slide-right;
+}
+
+@keyframes tb-fade {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+}
+@keyframes tb-slide-up {
+  from {
+    opacity: 0;
+    transform: translateY(12px);
+  }
+  to {
+    opacity: 1;
+    transform: none;
+  }
+}
+@keyframes tb-slide-left {
+  from {
+    opacity: 0;
+    transform: translateX(12px);
+  }
+  to {
+    opacity: 1;
+    transform: none;
+  }
+}
+@keyframes tb-slide-right {
+  from {
+    opacity: 0;
+    transform: translateX(-12px);
+  }
+  to {
+    opacity: 1;
+    transform: none;
+  }
+}

--- a/assets/section-texts-and-button.js
+++ b/assets/section-texts-and-button.js
@@ -1,0 +1,32 @@
+class AnimatedText extends HTMLElement {
+  connectedCallback() {
+    this.classList.add('animated-text');
+
+    const effect = this.getAttribute('effect') || 'fade';
+    const dur = parseInt(this.getAttribute('duration') || '600', 10);
+    const delay = parseInt(this.getAttribute('delay') || '0', 10);
+
+    this.classList.add(`anim--${effect}`);
+    this.style.setProperty('--anim-dur', `${dur}ms`);
+    this.style.setProperty('--anim-delay', `${delay}ms`);
+
+    this._io = new IntersectionObserver(
+      (entries, io) => {
+        entries.forEach((entry) => {
+          if (entry.isIntersecting) {
+            this.classList.add('in');
+            io.unobserve(this);
+          }
+        });
+      },
+      { threshold: 0.2 }
+    );
+
+    this._io.observe(this);
+  }
+
+  disconnectedCallback() {
+    if (this._io) this._io.disconnect();
+  }
+}
+customElements.define('animated-text', AnimatedText);

--- a/sections/texts-and-button.liquid
+++ b/sections/texts-and-button.liquid
@@ -1,0 +1,128 @@
+{{ 'section-texts-and-button.css' | asset_url | stylesheet_tag }}
+
+<section
+  class="text-button-section"
+  style="--pt-mobile: {{ section.settings.padding_top_mobile }}px; --pb-mobile: {{ section.settings.padding_bottom_mobile }}px; --pt-desktop: {{ section.settings.padding_top_desktop }}px; --pb-desktop: {{ section.settings.padding_bottom_desktop }}px;"
+>
+  <div class="page-width">
+    <div class="tb-wrapper">
+      {% for block in section.blocks %}
+        {% case block.type %}
+          {% when 'text' %}
+            <animated-text
+              class="tb-text"
+              data-size-mobile="{{ block.settings.size_mobile }}"
+              data-size-desktop="{{ block.settings.size_desktop }}"
+              data-align-mobile="{{ block.settings.align_mobile }}"
+              data-align-desktop="{{ block.settings.align_desktop }}"
+              effect="{{ block.settings.animation_effect }}"
+              duration="{{ block.settings.animation_duration }}"
+              delay="{{ block.settings.animation_delay }}"
+              {{ block.shopify_attributes }}
+            >
+              {{ block.settings.content }}
+            </animated-text>
+
+          {% when 'button' %}
+            <div class="tb-button"
+                 style="--align-mobile: {{ block.settings.align_mobile }}; --align-desktop: {{ block.settings.align_desktop }};"
+                 {{ block.shopify_attributes }}>
+              {% assign btn_classes = 'button' %}
+              {% if block.settings.style != blank %}
+                {% assign btn_classes = btn_classes | append: ' ' | append: block.settings.style %}
+              {% endif %}
+              <a class="{{ btn_classes }}" href="{{ block.settings.link | default: '#' }}">
+                {{ block.settings.label | escape }}
+              </a>
+            </div>
+        {% endcase %}
+      {% endfor %}
+    </div>
+  </div>
+</section>
+
+<script src="{{ 'section-texts-and-button.js' | asset_url }}" defer="defer"></script>
+
+{% schema %}
+{
+  "name": "Teksty + Przycisk",
+  "tag": "section",
+  "class": "section text-button-section",
+  "max_blocks": 3,
+  "blocks": [
+    {
+      "type": "text",
+      "name": "Tekst",
+      "limit": 2,
+      "settings": [
+        { "type": "richtext", "id": "content", "label": "Treść", "default": "<p>Przykładowy tekst</p>" },
+        { "type": "select", "id": "size_mobile", "label": "Rozmiar (mobile)", "default": "base",
+          "options": [
+            { "value": "xs", "label": "XS" }, { "value": "sm", "label": "SM" }, { "value": "base", "label": "Base" },
+            { "value": "lg", "label": "LG" }, { "value": "xl", "label": "XL" }, { "value": "2xl", "label": "2XL" }, { "value": "3xl", "label": "3XL" }
+          ]
+        },
+        { "type": "select", "id": "size_desktop", "label": "Rozmiar (desktop)", "default": "lg",
+          "options": [
+            { "value": "xs", "label": "XS" }, { "value": "sm", "label": "SM" }, { "value": "base", "label": "Base" },
+            { "value": "lg", "label": "LG" }, { "value": "xl", "label": "XL" }, { "value": "2xl", "label": "2XL" }, { "value": "3xl", "label": "3XL" }
+          ]
+        },
+        { "type": "select", "id": "align_mobile", "label": "Wyrównanie (mobile)", "default": "left",
+          "options": [
+            { "value": "left", "label": "Lewo" }, { "value": "center", "label": "Środek" }, { "value": "right", "label": "Prawo" }
+          ]
+        },
+        { "type": "select", "id": "align_desktop", "label": "Wyrównanie (desktop)", "default": "left",
+          "options": [
+            { "value": "left", "label": "Lewo" }, { "value": "center", "label": "Środek" }, { "value": "right", "label": "Prawo" }
+          ]
+        },
+        { "type": "select", "id": "animation_effect", "label": "Efekt animacji", "default": "fade",
+          "options": [
+            { "value": "fade", "label": "Fade-in" },
+            { "value": "slide-up", "label": "Slide-up" },
+            { "value": "slide-left", "label": "Slide-left" },
+            { "value": "slide-right", "label": "Slide-right" }
+          ]
+        },
+        { "type": "range", "id": "animation_duration", "label": "Czas trwania (ms)", "default": 600, "min": 100, "max": 2000, "step": 50 },
+        { "type": "range", "id": "animation_delay", "label": "Opóźnienie (ms)", "default": 0, "min": 0, "max": 2000, "step": 50 }
+      ]
+    },
+    {
+      "type": "button",
+      "name": "Przycisk",
+      "limit": 1,
+      "settings": [
+        { "type": "text", "id": "label", "label": "Etykieta", "default": "Zobacz więcej" },
+        { "type": "url", "id": "link", "label": "Link" },
+        { "type": "select", "id": "style", "label": "Styl przycisku (Dawn)", "default": "",
+          "options": [
+            { "value": "", "label": "Primary (domyślny)" },
+            { "value": "button--secondary", "label": "Secondary" },
+            { "value": "button--tertiary", "label": "Tertiary" }
+          ]
+        },
+        { "type": "select", "id": "align_mobile", "label": "Wyrównanie (mobile)", "default": "left",
+          "options": [
+            { "value": "left", "label": "Lewo" }, { "value": "center", "label": "Środek" }, { "value": "right", "label": "Prawo" }
+          ]
+        },
+        { "type": "select", "id": "align_desktop", "label": "Wyrównanie (desktop)", "default": "left",
+          "options": [
+            { "value": "left", "label": "Lewo" }, { "value": "center", "label": "Środek" }, { "value": "right", "label": "Prawo" }
+          ]
+        }
+      ]
+    }
+  ],
+  "settings": [
+    { "type": "range", "id": "padding_top_mobile", "label": "Odstęp od góry (mobile)", "default": 24, "min": 0, "max": 120, "step": 4 },
+    { "type": "range", "id": "padding_bottom_mobile", "label": "Odstęp od dołu (mobile)", "default": 24, "min": 0, "max": 120, "step": 4 },
+    { "type": "range", "id": "padding_top_desktop", "label": "Odstęp od góry (desktop)", "default": 48, "min": 0, "max": 200, "step": 4 },
+    { "type": "range", "id": "padding_bottom_desktop", "label": "Odstęp od dołu (desktop)", "default": 48, "min": 0, "max": 200, "step": 4 }
+  ],
+  "presets": [{ "name": "Teksty + Przycisk" }]
+}
+{% endschema %}


### PR DESCRIPTION
# feat(section): Teksty + Przycisk (Dawn)

**Cel**  
Sekcja „**Teksty + Przycisk**” do motywu Dawn. Do 2 bloków **Tekst** + 1 blok **Przycisk**. Niezależne ustawienia rozmiaru i wyrównania dla **mobile/desktop** per blok, padding sekcji (góra/dół) mobile/desktop oraz lekka animacja wejścia tekstu.

---

## Zakres zmian (minimalny diff)
- `sections/texts-and-button.liquid`
- `assets/section-texts-and-button.css`
- `assets/section-texts-and-button.js`

> PR celowo zawiera wyłącznie powyższe pliki – względem czystego Dawn.

---

## Funkcjonalność
- ≤ **2× Tekst** + **1× Przycisk** (limity bloków).
- **Rozmiar i wyrównanie** per blok, osobno dla **mobile** i **desktop**.
- **Padding** sekcji (top/bottom) dla **mobile/desktop**.
- **Animacja** wejścia tekstów (efekt/czas/opóźnienie).
- Clean code: CSS/JS w `assets/`, JS z `defer`, scoping do `.text-button-section`.

---

## Jak testować (Theme Editor)
1. **Customize → Add section → „Teksty + Przycisk”**.
2. Dodaj **2× Tekst** i **1× Przycisk**.
3. Przełączaj **📱/🖥️** – sprawdź rozmiary i wyrównania per blok.
4. Zmień padding sekcji (mobile/desktop) i przewiń stronę, aby zobaczyć animację wejścia.

---

## Uwagi techniczne
- JS ładowany z `defer`, brak inline `<script>/<style>`.
- Klasy i atrybuty danych z sekcji mapowane 1:1 na stylowanie (tokenujące rozmiary `xs..3xl`, wyrównanie `left/center/right`).
