### PR TITLE
feat(section): Multi-step Quiz (Web Components + inline results)

### DIFF
--- a/assets/section-quiz.css
+++ b/assets/section-quiz.css
@@ -1,0 +1,174 @@
+.quiz-section {
+  padding-top: var(--pt-mobile);
+  padding-bottom: var(--pb-mobile);
+}
+@media (min-width: 750px) {
+  .quiz-section {
+    padding-top: var(--pt-desktop);
+    padding-bottom: var(--pb-desktop);
+  }
+}
+
+.quiz-section {
+  --h-m: 1.125rem;
+  --h-d: 1.5rem;
+  --q-m: 1rem;
+  --q-d: 1.125rem;
+}
+
+.quiz-section[data-hm='xs'] {
+  --h-m: 0.75rem;
+}
+.quiz-section[data-hm='sm'] {
+  --h-m: 0.875rem;
+}
+.quiz-section[data-hm='base'] {
+  --h-m: 1rem;
+}
+.quiz-section[data-hm='lg'] {
+  --h-m: 1.125rem;
+}
+.quiz-section[data-hm='xl'] {
+  --h-m: 1.25rem;
+}
+.quiz-section[data-hm='2xl'] {
+  --h-m: 1.5rem;
+}
+.quiz-section[data-hm='3xl'] {
+  --h-m: 1.875rem;
+}
+
+.quiz-section[data-qm='xs'] {
+  --q-m: 0.75rem;
+}
+.quiz-section[data-qm='sm'] {
+  --q-m: 0.875rem;
+}
+.quiz-section[data-qm='base'] {
+  --q-m: 1rem;
+}
+.quiz-section[data-qm='lg'] {
+  --q-m: 1.125rem;
+}
+.quiz-section[data-qm='xl'] {
+  --q-m: 1.25rem;
+}
+.quiz-section[data-qm='2xl'] {
+  --q-m: 1.5rem;
+}
+.quiz-section[data-qm='3xl'] {
+  --q-m: 1.875rem;
+}
+
+@media (min-width: 750px) {
+  .quiz-section[data-hd='xs'] {
+    --h-d: 0.75rem;
+  }
+  .quiz-section[data-hd='sm'] {
+    --h-d: 0.875rem;
+  }
+  .quiz-section[data-hd='base'] {
+    --h-d: 1rem;
+  }
+  .quiz-section[data-hd='lg'] {
+    --h-d: 1.125rem;
+  }
+  .quiz-section[data-hd='xl'] {
+    --h-d: 1.25rem;
+  }
+  .quiz-section[data-hd='2xl'] {
+    --h-d: 1.5rem;
+  }
+  .quiz-section[data-hd='3xl'] {
+    --h-d: 1.875rem;
+  }
+
+  .quiz-section[data-qd='xs'] {
+    --q-d: 0.75rem;
+  }
+  .quiz-section[data-qd='sm'] {
+    --q-d: 0.875rem;
+  }
+  .quiz-section[data-qd='base'] {
+    --q-d: 1rem;
+  }
+  .quiz-section[data-qd='lg'] {
+    --q-d: 1.125rem;
+  }
+  .quiz-section[data-qd='xl'] {
+    --q-d: 1.25rem;
+  }
+  .quiz-section[data-qd='2xl'] {
+    --q-d: 1.5rem;
+  }
+  .quiz-section[data-qd='3xl'] {
+    --q-d: 1.875rem;
+  }
+}
+
+.quiz-section .question__header h3 {
+  font-size: var(--h-m);
+  line-height: 1.3;
+  margin: 0;
+}
+@media (min-width: 750px) {
+  .quiz-section .question__header h3 {
+    font-size: var(--h-d);
+  }
+}
+.quiz-section .question__option span {
+  font-size: var(--q-m);
+}
+@media (min-width: 750px) {
+  .quiz-section .question__option span {
+    font-size: var(--q-d);
+  }
+}
+
+.quiz-section .question {
+  padding: 1rem 0;
+  border-bottom: 1px solid rgba(0, 0, 0, 0.08);
+}
+.quiz-section .question__header {
+  margin-bottom: 0.5rem;
+}
+.quiz-section .question__options {
+  display: grid;
+  gap: 0.5rem;
+  margin-bottom: 0.75rem;
+}
+.quiz-section .question__option {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+.quiz-section .question__next {
+  margin-top: 0.25rem;
+}
+
+.quiz-section [hidden] {
+  display: none !important;
+}
+
+.quiz-section .quiz__error {
+  color: #d72c0d;
+  font-size: 0.875rem;
+  min-height: 1.25rem;
+  margin: 0.25rem 0;
+}
+
+.quiz-section .quiz__final {
+  margin-top: 1.25rem;
+  display: grid;
+  gap: 1rem;
+}
+.quiz-section .quiz__results[data-state='loading'] {
+  opacity: 0.6;
+  pointer-events: none;
+}
+.quiz-section .quiz__results:empty::before {
+  content: 'No products found for selected tags.';
+  display: block;
+  color: rgba(0, 0, 0, 0.6);
+  font-size: 0.95rem;
+}

--- a/assets/section-quiz.js
+++ b/assets/section-quiz.js
@@ -1,0 +1,123 @@
+(() => {
+  const handleize = (s) =>
+    (s || '')
+      .toString()
+      .toLowerCase()
+      .normalize?.('NFKD')
+      .replace(/[\u0300-\u036f]/g, '')
+      .replace(/[^a-z0-9]+/g, '-')
+      .replace(/^-+|-+$/g, '');
+
+  class QuestionEl extends HTMLElement {
+    connectedCallback() {
+      this.nextBtn = this.querySelector('.question__next');
+      this.errorBox = this.querySelector('.quiz__error');
+      this.radios = Array.from(this.querySelectorAll('input[type="radio"]'));
+      this.nextBtn?.addEventListener('click', () => {
+        const checked = this.radios.find((r) => r.checked);
+        if (!checked) {
+          const quiz = this.closest('quiz-form');
+          const msg = quiz?.dataset.errorMessage || 'Please select an answer to continue.';
+          if (this.errorBox) this.errorBox.textContent = msg;
+          this.dispatchEvent(new CustomEvent('question-error', { bubbles: true }));
+          return;
+        }
+        if (this.errorBox) this.errorBox.textContent = '';
+        this.dispatchEvent(
+          new CustomEvent('question-next', {
+            bubbles: true,
+            detail: { tag: handleize(checked.value) },
+          })
+        );
+      });
+    }
+  }
+  if (!customElements.get('quiz-question')) {
+    customElements.define('quiz-question', QuestionEl);
+  }
+
+  class QuizEl extends HTMLElement {
+    connectedCallback() {
+      this.questions = Array.from(this.querySelectorAll('quiz-question'));
+      this.finalEl = this.querySelector('.quiz__final');
+      this.resultsLink = this.querySelector('.quiz__results-link');
+      this.resultsBox = this.querySelector('.quiz__results');
+
+      this.collectionPath = this.dataset.collectionPath || '/collections/all';
+      this.inline = String(this.dataset.inlineResults) === 'true';
+      this.sectionHandle = this.dataset.productGridHandle || 'main-collection-product-grid';
+
+      this.current = 0;
+      this.selectedTags = new Array(this.questions.length).fill(null);
+
+      this.questions.forEach((q, i) => q.toggleAttribute('hidden', i !== 0));
+
+      this.addEventListener('question-next', (ev) => {
+        const fromIndex = this.questions.indexOf(ev.target);
+        const tag = ev.detail?.tag || null;
+        if (fromIndex >= 0) this.selectedTags[fromIndex] = tag;
+
+        if (fromIndex < this.questions.length - 1) {
+          this.goto(fromIndex + 1);
+        } else {
+          this.finish();
+        }
+      });
+    }
+
+    goto(i) {
+      this.questions.forEach((q, idx) => q.toggleAttribute('hidden', idx !== i));
+      this.current = i;
+      this.scrollIntoView?.({ behavior: 'smooth', block: 'center' });
+    }
+
+    buildTagsPath() {
+      const tags = this.selectedTags.filter(Boolean).map(handleize).filter(Boolean);
+      return tags.length ? '/' + tags.join('+') : '';
+    }
+
+    finish() {
+      this.questions.forEach((q) => q.setAttribute('hidden', ''));
+      this.finalEl?.removeAttribute('hidden');
+
+      const url = this.collectionPath + this.buildTagsPath();
+      if (this.resultsLink) {
+        this.resultsLink.href = url;
+        this.resultsLink.textContent = this.dataset.resultsLabel || 'See results';
+      }
+      if (this.inline && this.resultsBox) this.loadInlineResults(url);
+    }
+
+    async loadInlineResults(urlBase) {
+      try {
+        this.resultsBox.dataset.state = 'loading';
+        this.resultsBox.innerHTML = '';
+        const url = `${urlBase}?sections=${encodeURIComponent(this.sectionHandle)}`;
+        const res = await fetch(url, { headers: { 'X-Requested-With': 'XMLHttpRequest' } });
+        const text = await res.text();
+        let html = '';
+        try {
+          const json = JSON.parse(text);
+          html = json[this.sectionHandle] || Object.values(json)[0] || '';
+        } catch {
+          html = text;
+        }
+        if (!html || !html.trim()) {
+          this.resultsBox.innerHTML = `<p>No products found for selected tags.</p>`;
+        } else {
+          const tmp = document.createElement('div');
+          tmp.innerHTML = html;
+          const grid = tmp.querySelector('[data-section-id], .collection, .collection-grid, .product-grid') || tmp;
+          this.resultsBox.innerHTML = grid.outerHTML || grid.innerHTML || html;
+        }
+      } catch {
+        this.resultsBox.innerHTML = `<p>Could not load results. Please use the button above.</p>`;
+      } finally {
+        this.resultsBox.dataset.state = 'idle';
+      }
+    }
+  }
+  if (!customElements.get('quiz-form')) {
+    customElements.define('quiz-form', QuizEl);
+  }
+})();

--- a/sections/quiz.liquid
+++ b/sections/quiz.liquid
@@ -1,0 +1,224 @@
+{{ 'section-quiz.css' | asset_url | stylesheet_tag }}
+
+<section
+  class="quiz-section"
+  data-section-id="{{ section.id }}"
+  data-hm="{{ section.settings.heading_size_mobile }}"
+  data-hd="{{ section.settings.heading_size_desktop }}"
+  data-qm="{{ section.settings.question_size_mobile }}"
+  data-qd="{{ section.settings.question_size_desktop }}"
+  style="
+    --pt-mobile: {{ section.settings.padding_top_mobile }}px;
+    --pb-mobile: {{ section.settings.padding_bottom_mobile }}px;
+    --pt-desktop: {{ section.settings.padding_top_desktop }}px;
+    --pb-desktop: {{ section.settings.padding_bottom_desktop }}px;
+  "
+>
+  <div class="page-width">
+    <quiz-form
+      id="quiz-{{ section.id }}"
+      data-collection-path="/collections/all"
+      data-error-message="{{ section.settings.error_message | escape }}"
+      data-results-label="{{ section.settings.results_button_label | escape }}"
+      data-inline-results="{{ section.settings.enable_inline_results }}"
+      data-product-grid-handle="{{ section.settings.product_grid_section_handle | escape }}"
+      data-results-heading="{{ section.settings.results_heading | escape }}"
+    >
+      {% for block in section.blocks %}
+        {% if block.type == 'question' %}
+          <quiz-question id="q-{{ block.id }}" {{ block.shopify_attributes }}>
+            <div class="question" role="group" aria-labelledby="q-title-{{ block.id }}">
+              <div class="question__header">
+                <h3 id="q-title-{{ block.id }}">{{ block.settings.question_title | escape }}</h3>
+              </div>
+
+              <div class="question__body">
+                <div class="question__options">
+                  <label class="question__option">
+                    <input type="radio" name="q-{{ block.id }}" value="{{ block.settings.answer_1_tag | handleize }}">
+                    <span>{{ block.settings.answer_1_label | escape }}</span>
+                  </label>
+
+                  <label class="question__option">
+                    <input type="radio" name="q-{{ block.id }}" value="{{ block.settings.answer_2_tag | handleize }}">
+                    <span>{{ block.settings.answer_2_label | escape }}</span>
+                  </label>
+                </div>
+
+                <div class="quiz__error" aria-live="polite"></div>
+
+                <button type="button" class="button question__next">
+                  {{ block.settings.next_label | escape }}
+                </button>
+              </div>
+            </div>
+          </quiz-question>
+        {% endif %}
+      {% endfor %}
+
+      <div class="quiz__final" hidden>
+        <a class="button quiz__results-link" href="#" rel="nofollow">
+          {{ section.settings.results_button_label | escape }}
+        </a>
+
+        {% if section.settings.enable_inline_results %}
+          <h3 class="quiz__results-heading">{{ section.settings.results_heading | escape }}</h3>
+          <div class="quiz__results" data-state="idle" aria-live="polite"></div>
+        {% endif %}
+      </div>
+    </quiz-form>
+  </div>
+</section>
+
+<script src="{{ 'section-quiz.js' | asset_url }}" defer="defer"></script>
+
+{% schema %}
+{
+  "name": "Quiz – Multi-step",
+  "tag": "section",
+  "class": "section quiz-section",
+  "max_blocks": 10,
+  "blocks": [
+    {
+      "type": "question",
+      "name": "Question",
+      "settings": [
+        { "type": "text", "id": "question_title", "label": "Question title", "default": "What do you prefer?" },
+
+        { "type": "text", "id": "answer_1_label", "label": "Answer 1 – label", "default": "Option A" },
+        { "type": "text", "id": "answer_1_tag", "label": "Answer 1 – tag", "default": "tag-a" },
+
+        { "type": "text", "id": "answer_2_label", "label": "Answer 2 – label", "default": "Option B" },
+        { "type": "text", "id": "answer_2_tag", "label": "Answer 2 – tag", "default": "tag-b" },
+
+        { "type": "text", "id": "next_label", "label": "Next button label", "default": "Next" }
+      ]
+    }
+  ],
+  "settings": [
+    { "type": "text", "id": "results_button_label", "label": "Results button label", "default": "See results" },
+    {
+      "type": "text",
+      "id": "error_message",
+      "label": "Error message (required selection)",
+      "default": "Please select an answer to continue."
+    },
+
+    { "type": "checkbox", "id": "enable_inline_results", "label": "Enable inline results (AJAX)", "default": true },
+    { "type": "text", "id": "results_heading", "label": "Inline results heading", "default": "Results" },
+    {
+      "type": "text",
+      "id": "product_grid_section_handle",
+      "label": "Product grid section handle (for Section Rendering API)",
+      "default": "main-collection-product-grid"
+    },
+
+    { "type": "header", "content": "Typography" },
+    {
+      "type": "select",
+      "id": "heading_size_mobile",
+      "label": "Heading font size (mobile)",
+      "default": "lg",
+      "options": [
+        { "value": "xs", "label": "XS" },
+        { "value": "sm", "label": "SM" },
+        { "value": "base", "label": "Base" },
+        { "value": "lg", "label": "LG" },
+        { "value": "xl", "label": "XL" },
+        { "value": "2xl", "label": "2XL" },
+        { "value": "3xl", "label": "3XL" }
+      ]
+    },
+    {
+      "type": "select",
+      "id": "heading_size_desktop",
+      "label": "Heading font size (desktop)",
+      "default": "2xl",
+      "options": [
+        { "value": "xs", "label": "XS" },
+        { "value": "sm", "label": "SM" },
+        { "value": "base", "label": "Base" },
+        { "value": "lg", "label": "LG" },
+        { "value": "xl", "label": "XL" },
+        { "value": "2xl", "label": "2XL" },
+        { "value": "3xl", "label": "3XL" }
+      ]
+    },
+
+    {
+      "type": "select",
+      "id": "question_size_mobile",
+      "label": "Question text size (mobile)",
+      "default": "base",
+      "options": [
+        { "value": "xs", "label": "XS" },
+        { "value": "sm", "label": "SM" },
+        { "value": "base", "label": "Base" },
+        { "value": "lg", "label": "LG" },
+        { "value": "xl", "label": "XL" },
+        { "value": "2xl", "label": "2XL" },
+        { "value": "3xl", "label": "3XL" }
+      ]
+    },
+    {
+      "type": "select",
+      "id": "question_size_desktop",
+      "label": "Question text size (desktop)",
+      "default": "lg",
+      "options": [
+        { "value": "xs", "label": "XS" },
+        { "value": "sm", "label": "SM" },
+        { "value": "base", "label": "Base" },
+        { "value": "lg", "label": "LG" },
+        { "value": "xl", "label": "XL" },
+        { "value": "2xl", "label": "2XL" },
+        { "value": "3xl", "label": "3XL" }
+      ]
+    },
+
+    { "type": "header", "content": "Spacing" },
+    {
+      "type": "range",
+      "id": "padding_top_mobile",
+      "label": "Padding top (mobile)",
+      "min": 0,
+      "max": 120,
+      "step": 4,
+      "default": 24
+    },
+    {
+      "type": "range",
+      "id": "padding_bottom_mobile",
+      "label": "Padding bottom (mobile)",
+      "min": 0,
+      "max": 120,
+      "step": 4,
+      "default": 24
+    },
+    {
+      "type": "range",
+      "id": "padding_top_desktop",
+      "label": "Padding top (desktop)",
+      "min": 0,
+      "max": 200,
+      "step": 4,
+      "default": 64
+    },
+    {
+      "type": "range",
+      "id": "padding_bottom_desktop",
+      "label": "Padding bottom (desktop)",
+      "min": 0,
+      "max": 200,
+      "step": 4,
+      "default": 64
+    }
+  ],
+  "presets": [
+    {
+      "name": "Quiz – Multi-step",
+      "blocks": [{ "type": "question" }, { "type": "question" }, { "type": "question" }]
+    }
+  ]
+}
+{% endschema %}


### PR DESCRIPTION
# feat(section): Quiz – Multi-step (Dawn)

**Cel**  
Sekcja „**Quiz – Multi-step**” do motywu Dawn. Użytkownik odpowiada na pytania krok po kroku, a z wybranych odpowiedzi zbierane są **tagi**. Po finiszu generowany jest przycisk **See results** kierujący do `/collections/all/<tag1>+<tag2>+...`.  
Bonus: **inline results** – wczytanie grida produktów pod nagłówkiem „Results” (Section Rendering API).

---

## Zakres zmian
**Nowe pliki**
- `sections/quiz.liquid`
- `assets/section-quiz.css`
- `assets/section-quiz.js`


---

## Funkcjonalność (wymagania bazowe)
- **Blok „Question”**: tytuł + **2 odpowiedzi** (radio: *label* + *tag*) + *label* przycisku **Next**.
- **Flow**: kroki w stylu **collapsible** (zawsze otwarty tylko bieżący).
- **Walidacja**: bez zaznaczenia odpowiedzi pokazujemy błąd i **nie przechodzimy dalej**.
- **Wynik**: po ostatnim kroku przycisk **See results** z linkiem do:  
  `/collections/all/tag1+tag2+tag3` (tagi **handleizowane** i łączone `+` → filtr AND).

---

## Editor settings (sekcja)
- **Heading font size**: osobno dla **mobile** i **desktop**.
- **Question text size**: osobno dla **mobile** i **desktop**.
- **Padding top / bottom** sekcji: osobno dla **mobile** i **desktop**.
- **Results button label** (etykieta przycisku wyników).
- (Opcja) **Enable inline results (AJAX)** + **Inline results heading** + **Product grid section handle** (domyślnie `main-collection-product-grid` w Dawn).

---

## Opcjonalne rozszerzenia – zrealizowane
- **Web Components**:
  - `<quiz-form>` – zarządza stanem/flow/walidacją,
  - `<quiz-question>` – pojedynczy krok z radio i przyciskiem **Next**.
- **Inline results (Section Rendering API)**:
  - ładowanie grida przez `/collections/all/<tags>?sections=<handle>`,
  - **loading state**, **empty state** (gdy brak produktów),
  - parsowanie odpowiedzi JSON/HTML i wstrzyknięcie grida do wyników.

---

## Jak testować (Theme Editor)
1. **Customize → Add section → „Quiz – Multi-step”** (min. 2–3 bloki).
2. W każdym **Question** ustaw:
   - *Question title*,
   - *Answer 1/2 label* i *tag* (dowolne słowo – sekcja sama je „handleizuje”),
   - *Next button label*.
3. Spróbuj kliknąć **Next** bez wyboru → powinien pojawić się **komunikat błędu** i quiz zostaje na tym kroku.
4. Przejdź wszystkie kroki → pojawia się **See results**.
5. **Skopiuj link** z przycisku → powinien być w formacie:  
   `/collections/all/<tag1>+<tag2>+...`
6. (Opcjonalnie) Włącz **Enable inline results (AJAX)** → po finiszu oprócz przycisku pokaże się **nagłówek „Results”** i **grid produktów**.  
   - “Product grid section handle”: `main-collection-product-grid` (Dawn).
   - Jeśli kolekcja nie ma produktów z danymi tagami, pojawi się **przyjazny empty state**.

> Uwaga: aby realnie zobaczyć filtrowanie, produkty w sklepie muszą mieć **te same tagi**, które wybierasz w quizie.

---

## Podgląd
- **Preview URL:** `https://agnieszka-task.myshopify.com/?preview_theme_id=153155633382`  
- **Hasło:** `paonta`
