### PR TITLE
Add GETCH-branded home layout, cyber promo popup, and universal 20% r…

### DIFF
--- a/assets/theme-grabad.css
+++ b/assets/theme-grabad.css
@@ -1,0 +1,839 @@
+/* GETCH visual theme overrides */
+:root {
+  --GETCH-orange: #ff6b00;
+  --GETCH-orange-strong: #d95b00;
+  --GETCH-orange-soft: #fff0e5;
+  --GETCH-ink: #141414;
+  --GETCH-slate: #5f6368;
+  --GETCH-radius-lg: 32px;
+  --GETCH-radius-pill: 999px;
+  --GETCH-shadow-soft: 0 18px 48px rgba(17, 17, 17, 0.08);
+  --font-body-family: 'Roboto', sans-serif;
+  --font-body-style: normal;
+  --font-body-weight: 400;
+  --font-heading-family: 'Changa', sans-serif;
+  --font-heading-weight: 700;
+}
+
+body {
+  font-family: 'Roboto', sans-serif;
+  background-color: #ffffff;
+  color: var(--GETCH-ink);
+  letter-spacing: 0.01em;
+}
+
+.cyber-popup {
+  position: fixed;
+  inset: 0;
+  display: none;
+  align-items: center;
+  justify-content: center;
+  z-index: 9999;
+}
+
+.cyber-popup.is-visible {
+  display: flex;
+}
+
+.cyber-popup__overlay {
+  position: absolute;
+  inset: 0;
+  background: rgba(20, 20, 20, 0.68);
+}
+
+.cyber-popup__dialog {
+  position: relative;
+  z-index: 1;
+  background: #ffffff;
+  border-radius: var(--GETCH-radius-lg);
+  box-shadow: 0 24px 60px rgba(0, 0, 0, 0.25);
+  padding: clamp(3rem, 5vw, 4.6rem);
+  width: min(90%, 480px);
+  display: grid;
+  gap: 1.4rem;
+  text-align: center;
+}
+
+.cyber-popup__close {
+  position: absolute;
+  top: 1.2rem;
+  right: 1.2rem;
+  background: transparent;
+  border: none;
+  font-size: 2.4rem;
+  line-height: 1;
+  color: var(--GETCH-ink);
+  cursor: pointer;
+}
+
+.cyber-popup__badge {
+  font-family: 'Changa', sans-serif;
+  letter-spacing: 0.5rem;
+  text-transform: uppercase;
+  font-size: 1.2rem;
+  color: var(--GETCH-orange-strong);
+  margin: 0;
+}
+
+.cyber-popup__heading {
+  font-family: 'Changa', sans-serif;
+  font-size: clamp(2.6rem, 4vw, 3.6rem);
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  margin: 0;
+  color: var(--GETCH-ink);
+}
+
+.cyber-popup__message {
+  font-size: 1.6rem;
+  color: var(--GETCH-slate);
+}
+
+.cyber-popup__cta {
+  justify-self: center;
+  min-width: 220px;
+}
+
+.home-hero {
+  position: relative;
+  overflow: hidden;
+  display: grid;
+  min-height: clamp(520px, 80vh, 720px);
+}
+
+.home-hero__media {
+  position: absolute;
+  inset: 0;
+}
+
+.home-hero__image,
+.home-hero__image-placeholder {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  filter: brightness(0.8);
+}
+
+.home-hero__image-placeholder {
+  background: linear-gradient(135deg, rgba(255, 107, 0, 0.6), rgba(255, 145, 77, 0.6));
+}
+
+.home-hero__overlay {
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  z-index: 1;
+}
+
+.home-hero__content {
+  position: relative;
+  z-index: 2;
+  margin: 0 auto;
+  width: min(92%, 1160px);
+  display: flex;
+  align-items: center;
+}
+
+.home-hero__inner {
+  max-width: 640px;
+  background: rgba(20, 20, 20, 0.55);
+  padding: clamp(3.2rem, 5vw, 5.6rem);
+  border-radius: var(--GETCH-radius-lg);
+  box-shadow: 0 24px 60px rgba(0, 0, 0, 0.25);
+  color: #ffffff;
+}
+
+.home-hero__eyebrow {
+  font-family: 'Changa', sans-serif;
+  font-size: 1.4rem;
+  letter-spacing: 0.6rem;
+  text-transform: uppercase;
+  margin: 0 0 1.6rem;
+  color: rgba(255, 255, 255, 0.72);
+}
+
+.home-hero__heading {
+  font-family: 'Changa', sans-serif;
+  font-size: clamp(3.6rem, 5vw, 6rem);
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  margin: 0 0 2rem;
+  color: #ffffff;
+}
+
+.home-hero__description {
+  font-size: 1.7rem;
+  color: rgba(255, 255, 255, 0.82);
+  margin-bottom: 2.4rem;
+}
+
+.home-hero__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1.4rem;
+  margin-bottom: 2.4rem;
+}
+
+.home-hero__highlights {
+  display: grid;
+  gap: 1.2rem;
+}
+
+.home-hero__highlight {
+  display: flex;
+  gap: 1.2rem;
+  align-items: center;
+  background: rgba(255, 255, 255, 0.08);
+  padding: 1.2rem 1.6rem;
+  border-radius: var(--GETCH-radius-pill);
+  border: 1px solid rgba(255, 255, 255, 0.14);
+}
+
+.home-hero__highlight-icon {
+  width: 36px;
+  height: 36px;
+  object-fit: contain;
+}
+
+.home-hero__highlight-title {
+  font-family: 'Changa', sans-serif;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  margin: 0;
+  color: #ffffff;
+}
+
+.home-hero__highlight-subtext {
+  margin: 0;
+  font-size: 1.4rem;
+  color: rgba(255, 255, 255, 0.7);
+}
+
+h1,
+h2,
+h3,
+h4,
+h5,
+h6,
+.title,
+.card__heading,
+.banner__heading,
+.footer-block__heading {
+  font-family: 'Changa', sans-serif;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: var(--GETCH-ink);
+}
+
+p,
+.rte {
+  color: var(--GETCH-slate);
+}
+
+a {
+  color: var(--GETCH-orange);
+  transition: color 0.2s ease;
+}
+
+a:hover,
+a:focus {
+  color: var(--GETCH-orange-strong);
+}
+
+.button,
+.shopify-challenge__button,
+.shopify-payment-button__button--unbranded,
+.customer button,
+button[type="submit"] {
+  background-color: var(--GETCH-orange);
+  border-color: var(--GETCH-orange);
+  border-radius: var(--GETCH-radius-pill);
+  color: #ffffff;
+  font-family: 'Changa', sans-serif;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  transition: background-color 0.2s ease, color 0.2s ease, transform 0.2s ease;
+}
+
+.button:hover,
+.button:focus-visible,
+.shopify-challenge__button:hover,
+.shopify-payment-button__button--unbranded:hover,
+.customer button:hover,
+button[type="submit"]:hover {
+  background-color: var(--GETCH-orange-strong);
+  border-color: var(--GETCH-orange-strong);
+  transform: translateY(-1px);
+}
+
+.button.button--secondary,
+.button--secondary,
+.shopify-payment-button__button--branded {
+  background-color: transparent;
+  border-color: var(--GETCH-orange);
+  color: var(--GETCH-orange);
+}
+
+.badge,
+.card__badge {
+  background-color: var(--GETCH-orange);
+  color: #ffffff;
+  font-family: 'Changa', sans-serif;
+  border-radius: var(--GETCH-radius-pill);
+}
+
+.header-wrapper {
+  background-color: #ffffff;
+  border-bottom: 3px solid rgba(255, 107, 0, 0.15);
+  box-shadow: var(--GETCH-shadow-soft);
+}
+
+.header {
+  max-width: 1280px;
+}
+
+.header__heading-link {
+  font-family: 'Changa', sans-serif;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  color: var(--GETCH-ink);
+}
+
+.header__heading-link:hover,
+.header__heading-link:focus {
+  color: var(--GETCH-orange);
+}
+
+.header__inline-menu .list-menu__item--link {
+  font-family: 'Changa', sans-serif;
+  font-weight: 600;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  font-size: 1.2rem;
+  color: var(--GETCH-ink);
+  transition: color 0.2s ease, transform 0.2s ease;
+}
+
+.header__inline-menu .list-menu__item--link:hover,
+.header__inline-menu .list-menu__item--link:focus {
+  color: var(--GETCH-orange);
+  transform: translateY(-2px);
+}
+
+.menu-drawer__menu-item {
+  font-family: 'Changa', sans-serif;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+}
+
+.search-modal__form .field__input,
+.search__input,
+.facets__summary,
+.facets__summary .icon-caret {
+  border-radius: var(--GETCH-radius-pill);
+}
+
+.shopify-section:not(#shopify-section-header, #shopify-section-announcement-bar) {
+  padding-block: clamp(4rem, 7vw, 8rem);
+}
+
+.title-wrapper-with-link {
+  align-items: flex-end;
+}
+
+.title-wrapper-with-link .title {
+  font-size: clamp(2.6rem, 3vw, 4.2rem);
+  color: var(--GETCH-ink);
+}
+
+.rich-text {
+  border-radius: var(--GETCH-radius-lg);
+  box-shadow: var(--GETCH-shadow-soft);
+}
+
+.rich-text__heading {
+  font-size: clamp(2.8rem, 4vw, 4.6rem);
+  color: var(--GETCH-ink);
+}
+
+.rich-text__text {
+  max-width: 70ch;
+  font-size: 1.7rem;
+}
+
+.rich-text__buttons {
+  gap: 1.2rem;
+}
+
+.rich-text__buttons .button.button--secondary {
+  background: transparent;
+  color: var(--GETCH-orange);
+  border-color: var(--GETCH-orange);
+}
+
+.collection__title.title-wrapper {
+  align-items: flex-end;
+}
+
+.collection__title .title {
+  font-size: clamp(2.4rem, 3vw, 3.8rem);
+  color: var(--GETCH-ink);
+}
+
+.banner {
+  border-radius: var(--GETCH-radius-lg);
+  overflow: hidden;
+  box-shadow: var(--GETCH-shadow-soft);
+}
+
+.banner__box {
+  padding: clamp(3rem, 4vw, 6rem);
+  border-radius: var(--GETCH-radius-lg);
+  background: linear-gradient(135deg, rgba(255, 107, 0, 0.92), rgba(255, 145, 77, 0.88));
+  color: #ffffff;
+}
+
+.banner__heading,
+.banner__heading * {
+  color: #ffffff;
+  font-size: clamp(3.2rem, 5vw, 6rem);
+  letter-spacing: 0.06em;
+}
+
+.banner__text {
+  color: #ffffff;
+  font-size: clamp(1.6rem, 2vw, 2.2rem);
+  max-width: 50rem;
+}
+
+.banner__text p {
+  color: inherit;
+}
+
+.banner__buttons .button.button--secondary {
+  background: #ffffff;
+  color: var(--GETCH-orange);
+}
+
+.home-feature-grid {
+  padding-block: clamp(4rem, 6vw, 7rem);
+}
+
+.home-feature-grid__header {
+  text-align: center;
+  margin-bottom: clamp(2.8rem, 5vw, 4.4rem);
+  display: grid;
+  gap: 1.2rem;
+}
+
+.home-feature-grid__eyebrow {
+  font-family: 'Changa', sans-serif;
+  letter-spacing: 0.5rem;
+  text-transform: uppercase;
+  font-size: 1.3rem;
+  color: var(--GETCH-orange-strong);
+  margin: 0;
+}
+
+.home-feature-grid__heading {
+  font-family: 'Changa', sans-serif;
+  font-size: clamp(2.8rem, 4vw, 4.6rem);
+  letter-spacing: 0.06em;
+  margin: 0;
+  color: var(--GETCH-ink);
+}
+
+.home-feature-grid__description {
+  max-width: 720px;
+  margin: 0 auto;
+  color: var(--GETCH-slate);
+  font-size: 1.6rem;
+}
+
+.home-feature-grid__actions {
+  margin-top: 1.6rem;
+}
+
+.home-feature-grid__items {
+  display: grid;
+  gap: 2.4rem;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.home-feature-grid__item {
+  background: #ffffff;
+  border-radius: 24px;
+  padding: clamp(2rem, 3vw, 3.2rem);
+  box-shadow: 0 16px 40px rgba(17, 17, 17, 0.08);
+  display: grid;
+  gap: 1.2rem;
+  text-align: left;
+}
+
+.home-feature-grid__icon {
+  width: 48px;
+  height: 48px;
+  object-fit: contain;
+}
+
+.home-feature-grid__item-title {
+  font-family: 'Changa', sans-serif;
+  font-size: 1.9rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  margin: 0;
+  color: var(--GETCH-ink);
+}
+
+.home-feature-grid__item-text {
+  color: var(--GETCH-slate);
+  font-size: 1.5rem;
+}
+
+.home-feature-grid__item-link {
+  font-family: 'Changa', sans-serif;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  color: var(--GETCH-orange);
+}
+
+.card,
+.card-wrapper {
+  border-radius: 20px;
+  overflow: hidden;
+  box-shadow: 0 14px 36px rgba(17, 17, 17, 0.06);
+}
+
+.product-card-wrapper {
+  position: relative;
+}
+
+.card__inner {
+  position: relative;
+}
+
+.product__media-wrapper {
+  position: relative;
+}
+
+.product-promo-ribbon {
+  position: absolute;
+  top: 1.2rem;
+  left: 0;
+  background: var(--GETCH-orange);
+  color: #ffffff;
+  font-family: 'Changa', sans-serif;
+  font-size: 1.2rem;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  padding: 0.4rem 1.8rem 0.4rem 1.4rem;
+  clip-path: polygon(0 0, 90% 0, 100% 50%, 90% 100%, 0 100%);
+  box-shadow: 0 8px 18px rgba(255, 107, 0, 0.32);
+  z-index: 3;
+}
+
+.product-promo-ribbon--product {
+  top: 2rem;
+  left: 1.5rem;
+}
+
+.card__information {
+  padding: 2rem;
+  background-color: #ffffff;
+}
+
+.card__heading a {
+  color: var(--GETCH-ink);
+  text-transform: uppercase;
+  font-size: 1.6rem;
+}
+
+.card-information__text {
+  color: var(--GETCH-slate);
+}
+
+.price-item,
+.price-item--regular,
+.price-item--sale {
+  font-family: 'Changa', sans-serif;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+}
+
+.product__title,
+.product__title + .product__info-container .product__text {
+  text-transform: uppercase;
+}
+
+.collapsible-content {
+  border-radius: 20px;
+  background-color: var(--GETCH-orange-soft);
+  padding: 2.4rem;
+}
+
+.home-plan-grid {
+  padding-block: clamp(5rem, 7vw, 8rem);
+}
+
+.home-plan-grid__header {
+  text-align: center;
+  display: grid;
+  gap: 1.2rem;
+  margin-bottom: clamp(3rem, 5vw, 4.8rem);
+}
+
+.home-plan-grid__eyebrow {
+  font-family: 'Changa', sans-serif;
+  letter-spacing: 0.45rem;
+  text-transform: uppercase;
+  font-size: 1.3rem;
+  color: var(--GETCH-orange-strong);
+  margin: 0;
+}
+
+.home-plan-grid__heading {
+  font-family: 'Changa', sans-serif;
+  font-size: clamp(3rem, 4.5vw, 4.8rem);
+  letter-spacing: 0.06em;
+  margin: 0;
+  color: var(--GETCH-ink);
+}
+
+.home-plan-grid__description {
+  max-width: 720px;
+  margin: 0 auto;
+  font-size: 1.6rem;
+  color: var(--GETCH-slate);
+}
+
+.home-plan-grid__items {
+  display: grid;
+  gap: 2.4rem;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+}
+
+.home-plan-card {
+  position: relative;
+  background: #ffffff;
+  border-radius: 28px;
+  padding: clamp(2.4rem, 4vw, 3.4rem);
+  box-shadow: 0 20px 48px rgba(17, 17, 17, 0.1);
+  display: grid;
+  gap: 1.4rem;
+  border: 1px solid rgba(255, 107, 0, 0.18);
+}
+
+.home-plan-card__badge {
+  position: absolute;
+  top: 1.6rem;
+  right: 1.6rem;
+  background: var(--GETCH-orange);
+  color: #ffffff;
+  font-family: 'Changa', sans-serif;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  padding: 0.4rem 1.4rem;
+  border-radius: var(--GETCH-radius-pill);
+  font-size: 1.2rem;
+}
+
+.home-plan-card__title {
+  font-family: 'Changa', sans-serif;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  font-size: 1.8rem;
+  margin: 0;
+  color: var(--GETCH-ink);
+}
+
+.home-plan-card__price {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.6rem;
+  align-items: baseline;
+}
+
+.home-plan-card__price-amount {
+  font-family: 'Changa', sans-serif;
+  font-size: 3rem;
+  color: var(--GETCH-orange);
+  letter-spacing: 0.08em;
+}
+
+.home-plan-card__price-suffix {
+  font-size: 1.3rem;
+  text-transform: uppercase;
+  letter-spacing: 0.28em;
+  color: var(--GETCH-slate);
+}
+
+.home-plan-card__features {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: grid;
+  gap: 0.6rem;
+  font-size: 1.5rem;
+  color: var(--GETCH-slate);
+}
+
+.home-plan-card__features li::before {
+  content: '•';
+  color: var(--GETCH-orange);
+  margin-right: 0.6rem;
+}
+
+.home-plan-card__actions {
+  margin-top: 1.2rem;
+}
+
+.home-cta-banner {
+  padding-block: clamp(4.2rem, 6vw, 6.4rem);
+}
+
+.home-cta-banner__inner {
+  background: linear-gradient(120deg, rgba(255, 107, 0, 0.92), rgba(255, 168, 92, 0.88));
+  border-radius: var(--GETCH-radius-lg);
+  padding: clamp(3.2rem, 5vw, 5.6rem);
+  display: grid;
+  gap: 1.4rem;
+  text-align: center;
+  color: #ffffff;
+  box-shadow: 0 20px 48px rgba(17, 17, 17, 0.12);
+}
+
+.home-cta-banner__heading {
+  font-family: 'Changa', sans-serif;
+  font-size: clamp(3rem, 5vw, 4.4rem);
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  margin: 0;
+  color: #ffffff;
+}
+
+.home-cta-banner__description {
+  font-size: 1.6rem;
+  margin: 0 auto;
+  max-width: 640px;
+  color: rgba(255, 255, 255, 0.86);
+}
+
+.multicolumn.background-primary {
+  background: var(--GETCH-orange-soft);
+}
+
+.multicolumn-card {
+  background: #ffffff;
+  border-radius: 24px;
+  box-shadow: 0 10px 32px rgba(20, 20, 20, 0.12);
+  padding: clamp(2rem, 3vw, 3.2rem);
+}
+
+.multicolumn-card__info h3 {
+  font-family: 'Changa', sans-serif;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  margin-bottom: 0.8rem;
+}
+
+.multicolumn-card__info .rte {
+  color: var(--GETCH-slate);
+  font-size: 1.6rem;
+}
+
+.multicolumn-card__info .link {
+  color: var(--GETCH-orange);
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+}
+
+.video-section {
+  border-radius: var(--GETCH-radius-lg);
+  background: var(--GETCH-orange-soft);
+  padding: clamp(3rem, 5vw, 5rem);
+  box-shadow: var(--GETCH-shadow-soft);
+}
+
+.video-section__poster,
+.video-section__media {
+  border-radius: 24px;
+  overflow: hidden;
+}
+
+.footer {
+  background: linear-gradient(180deg, rgba(20, 20, 20, 0.96), rgba(20, 20, 20, 0.98));
+  color: #ffffff;
+  padding-block: clamp(4rem, 6vw, 7rem);
+}
+
+.footer a,
+.footer p,
+.footer li,
+.footer .rte {
+  color: #ffffff;
+}
+
+.footer-block__heading {
+  color: #ffffff;
+}
+
+.footer-block__details-content a:hover {
+  color: var(--GETCH-orange);
+}
+
+.newsletter-form__field-wrapper .field__input {
+  border-radius: var(--GETCH-radius-pill);
+  border: 1px solid rgba(255, 255, 255, 0.4);
+}
+
+.newsletter-form__field-wrapper .field__button {
+  border-radius: var(--GETCH-radius-pill);
+}
+
+.quantity__button,
+.quantity__input {
+  border-radius: var(--GETCH-radius-pill);
+}
+
+.cart-notification,
+.cart-drawer {
+  border-radius: var(--GETCH-radius-lg);
+  box-shadow: var(--GETCH-shadow-soft);
+}
+
+.cart-notification__heading,
+.cart-drawer__heading {
+  font-family: 'Changa', sans-serif;
+  text-transform: uppercase;
+}
+
+@media screen and (max-width: 749px) {
+  .header__inline-menu {
+    display: none;
+  }
+
+  .banner__box {
+    padding: clamp(2.4rem, 6vw, 4.2rem);
+  }
+
+  .shopify-section:not(#shopify-section-header, #shopify-section-announcement-bar) {
+    padding-block: clamp(3.2rem, 12vw, 5rem);
+  }
+
+  .home-hero__inner {
+    padding: clamp(2.4rem, 8vw, 3.2rem);
+    background: rgba(20, 20, 20, 0.65);
+  }
+
+  .home-hero__highlights {
+    gap: 0.8rem;
+  }
+
+  .home-feature-grid__items,
+  .home-plan-grid__items {
+    grid-template-columns: 1fr;
+  }
+}

--- a/config/settings_data.json
+++ b/config/settings_data.json
@@ -8,55 +8,55 @@
           "settings": {
             "background": "#FFFFFF",
             "background_gradient": "",
-            "text": "#121212",
-            "button": "#121212",
+            "text": "#141414",
+            "button": "#FF6B00",
             "button_label": "#FFFFFF",
-            "secondary_button_label": "#121212",
-            "shadow": "#121212"
+            "secondary_button_label": "#FF6B00",
+            "shadow": "#141414"
           }
         },
         "scheme-2": {
           "settings": {
-            "background": "#F3F3F3",
+            "background": "#FFF6ED",
             "background_gradient": "",
-            "text": "#121212",
-            "button": "#121212",
-            "button_label": "#F3F3F3",
-            "secondary_button_label": "#121212",
-            "shadow": "#121212"
+            "text": "#1A1A1A",
+            "button": "#FF6B00",
+            "button_label": "#FFFFFF",
+            "secondary_button_label": "#FF6B00",
+            "shadow": "#D05400"
           }
         },
         "scheme-3": {
           "settings": {
-            "background": "#242833",
+            "background": "#FF6B00",
             "background_gradient": "",
             "text": "#FFFFFF",
             "button": "#FFFFFF",
-            "button_label": "#000000",
+            "button_label": "#FF6B00",
             "secondary_button_label": "#FFFFFF",
-            "shadow": "#121212"
+            "shadow": "#C24A00"
           }
         },
         "scheme-4": {
           "settings": {
-            "background": "#121212",
+            "background": "#141414",
             "background_gradient": "",
             "text": "#FFFFFF",
-            "button": "#FFFFFF",
-            "button_label": "#121212",
-            "secondary_button_label": "#FFFFFF",
-            "shadow": "#121212"
+            "button": "#FF6B00",
+            "button_label": "#FFFFFF",
+            "secondary_button_label": "#FF6B00",
+            "shadow": "#000000"
           }
         },
         "scheme-5": {
           "settings": {
-            "background": "#334FB4",
+            "background": "#FFE0CC",
             "background_gradient": "",
-            "text": "#FFFFFF",
-            "button": "#FFFFFF",
-            "button_label": "#334FB4",
-            "secondary_button_label": "#FFFFFF",
-            "shadow": "#121212"
+            "text": "#1A1A1A",
+            "button": "#FF6B00",
+            "button_label": "#FFFFFF",
+            "secondary_button_label": "#FF6B00",
+            "shadow": "#D05400"
           }
         }
       },
@@ -151,8 +151,8 @@
       "drawer_shadow_blur": 5,
       "badge_position": "bottom left",
       "badge_corner_radius": 40,
-      "sale_badge_color_scheme": "scheme-5",
-      "sold_out_badge_color_scheme": "scheme-3",
+      "sale_badge_color_scheme": "scheme-3",
+      "sold_out_badge_color_scheme": "scheme-4",
       "social_twitter_link": "",
       "social_facebook_link": "",
       "social_pinterest_link": "",

--- a/layout/theme.liquid
+++ b/layout/theme.liquid
@@ -14,6 +14,12 @@
     {%- unless settings.type_header_font.system? and settings.type_body_font.system? -%}
       <link rel="preconnect" href="https://fonts.shopifycdn.com" crossorigin>
     {%- endunless -%}
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link
+      rel="stylesheet"
+      href="https://fonts.googleapis.com/css2?family=Changa:wght@300;400;600;700;800&family=Roboto:wght@300;400;500;700&display=swap"
+    >
 
     <title>
       {{ page_title }}
@@ -256,6 +262,7 @@
     {% endstyle %}
 
     {{ 'base.css' | asset_url | stylesheet_tag }}
+    {{ 'theme-grabad.css' | asset_url | stylesheet_tag }}
     <link rel="stylesheet" href="{{ 'component-cart-items.css' | asset_url }}" media="print" onload="this.media='all'">
 
     {%- if settings.cart_type == 'drawer' -%}

--- a/sections/cyber-promo-popup.liquid
+++ b/sections/cyber-promo-popup.liquid
@@ -1,0 +1,124 @@
+{% comment %}
+  Cyber sale popup announcing 20% off. Appears once per session.
+{% endcomment %}
+
+{%- if section.settings.enable_popup -%}
+  <div class="cyber-popup" id="cyber-popup-{{ section.id }}" role="dialog" aria-modal="true" aria-hidden="true">
+    <div class="cyber-popup__overlay" data-cyber-popup-close></div>
+    <div class="cyber-popup__dialog" tabindex="-1">
+      <button type="button" class="cyber-popup__close" data-cyber-popup-close aria-label="{{ 'general.close' | t }}">
+        &times;
+      </button>
+      {%- if section.settings.badge_text != blank -%}
+        <p class="cyber-popup__badge">{{ section.settings.badge_text }}</p>
+      {%- endif -%}
+      {%- if section.settings.heading != blank -%}
+        <h2 class="cyber-popup__heading">{{ section.settings.heading }}</h2>
+      {%- endif -%}
+      {%- if section.settings.message != blank -%}
+        <div class="cyber-popup__message rte">{{ section.settings.message }}</div>
+      {%- endif -%}
+      {%- if section.settings.button_label != blank -%}
+        <a
+          {% if section.settings.button_link == blank %}
+            role="link" aria-disabled="true"
+          {% else %}
+            href="{{ section.settings.button_link }}"
+          {% endif %}
+          class="button button--primary cyber-popup__cta"
+        >
+          {{ section.settings.button_label | escape }}
+        </a>
+      {%- endif -%}
+    </div>
+  </div>
+
+  <script>
+    document.addEventListener('DOMContentLoaded', function () {
+      var popupId = 'cyber-popup-{{ section.id }}';
+      var storageKey = 'getch_cyber_popup_{{ section.settings.popup_identifier | default: '2024' }}';
+      var popup = document.getElementById(popupId);
+      if (!popup) return;
+
+      var hasShown = sessionStorage.getItem(storageKey);
+      if (!hasShown) {
+        window.setTimeout(function () {
+          popup.setAttribute('aria-hidden', 'false');
+          popup.classList.add('is-visible');
+          sessionStorage.setItem(storageKey, 'true');
+        }, {{ section.settings.delay_ms | default: 500 }});
+      }
+
+      popup.addEventListener('click', function (event) {
+        if (event.target.matches('[data-cyber-popup-close]')) {
+          popup.classList.remove('is-visible');
+          popup.setAttribute('aria-hidden', 'true');
+        }
+      });
+    });
+  </script>
+{%- endif -%}
+
+{% schema %}
+{
+  "name": "Cyber promo popup",
+  "tag": "section",
+  "class": "section",
+  "settings": [
+    {
+      "type": "checkbox",
+      "id": "enable_popup",
+      "label": "Enable popup",
+      "default": true
+    },
+    {
+      "type": "text",
+      "id": "badge_text",
+      "label": "Badge text",
+      "default": "CYBER EN CHILE"
+    },
+    {
+      "type": "text",
+      "id": "heading",
+      "label": "Heading",
+      "default": "20% OFF en GETCH® por el Cyber"
+    },
+    {
+      "type": "richtext",
+      "id": "message",
+      "label": "Message",
+      "default": "<p>Aprovecha el 20% de descuento en toda la tienda durante el Cyber en Chile. Cupos limitados.</p>"
+    },
+    {
+      "type": "text",
+      "id": "button_label",
+      "label": "Button label",
+      "default": "Ver ofertas"
+    },
+    {
+      "type": "url",
+      "id": "button_link",
+      "label": "Button link",
+      "default": "/collections/all"
+    },
+    {
+      "type": "text",
+      "id": "popup_identifier",
+      "label": "Popup identifier",
+      "default": "cyber-2024",
+      "info": "Used for session storage so the popup only appears once per visit. Change this value to show again."
+    },
+    {
+      "type": "number",
+      "id": "delay_ms",
+      "label": "Delay before showing (ms)",
+      "default": 800
+    }
+  ],
+  "presets": [
+    {
+      "name": "Cyber promo popup"
+    }
+  ]
+}
+{% endschema %}

--- a/sections/home-cta-banner.liquid
+++ b/sections/home-cta-banner.liquid
@@ -1,0 +1,79 @@
+<section class="home-cta-banner color-{{ section.settings.color_scheme }} gradient">
+  <div class="page-width">
+    <div class="home-cta-banner__inner">
+      {% if section.settings.heading != blank %}
+        <h2 class="home-cta-banner__heading">{{ section.settings.heading }}</h2>
+      {% endif %}
+      {% if section.settings.description != blank %}
+        <div class="home-cta-banner__description rte">{{ section.settings.description }}</div>
+      {% endif %}
+      {% if section.settings.button_label != blank %}
+        <a
+          {% if section.settings.button_link == blank %}
+            role="link" aria-disabled="true"
+          {% else %}
+            href="{{ section.settings.button_link }}"
+          {% endif %}
+          class="button button--{{ section.settings.button_style }}"
+        >
+          {{ section.settings.button_label | escape }}
+        </a>
+      {% endif %}
+    </div>
+  </div>
+</section>
+
+{% schema %}
+{
+  "name": "Home CTA banner",
+  "tag": "section",
+  "class": "section",
+  "settings": [
+    {
+      "type": "inline_richtext",
+      "id": "heading",
+      "label": "Heading",
+      "default": "Descarga la app GETCH"
+    },
+    {
+      "type": "richtext",
+      "id": "description",
+      "label": "Descripción",
+      "default": "<p>Ten la libertad de generar patentes desde cualquier dispositivo móvil sin límites.</p>"
+    },
+    {
+      "type": "text",
+      "id": "button_label",
+      "label": "Etiqueta del botón",
+      "default": "Descargar app"
+    },
+    {
+      "type": "select",
+      "id": "button_style",
+      "label": "Estilo del botón",
+      "options": [
+        {"value": "primary", "label": "Primario"},
+        {"value": "secondary", "label": "Secundario"}
+      ],
+      "default": "primary"
+    },
+    {
+      "type": "url",
+      "id": "button_link",
+      "label": "Enlace del botón"
+    },
+    {
+      "type": "color_scheme",
+      "id": "color_scheme",
+      "label": "Esquema de color",
+      "default": "scheme-3"
+    }
+  ],
+  "presets": [
+    {
+      "name": "Home CTA banner",
+      "category": "GETCH"
+    }
+  ]
+}
+{% endschema %}

--- a/sections/home-feature-grid.liquid
+++ b/sections/home-feature-grid.liquid
@@ -1,0 +1,167 @@
+{% comment %}
+  Generic feature grid with optional icons. Used for highlights like "Fácil, Simple, Rápido".
+{% endcomment %}
+<section class="home-feature-grid color-{{ section.settings.color_scheme }} gradient">
+  <div class="page-width">
+    <div class="home-feature-grid__header">
+      {% if section.settings.preheading != blank %}
+        <p class="home-feature-grid__eyebrow">{{ section.settings.preheading }}</p>
+      {% endif %}
+      {% if section.settings.heading != blank %}
+        <h2 class="home-feature-grid__heading">{{ section.settings.heading }}</h2>
+      {% endif %}
+      {% if section.settings.description != blank %}
+        <div class="home-feature-grid__description rte">{{ section.settings.description }}</div>
+      {% endif %}
+      {% if section.settings.button_label != blank %}
+        <div class="home-feature-grid__actions">
+          <a
+            {% if section.settings.button_link == blank %}
+              role="link" aria-disabled="true"
+            {% else %}
+              href="{{ section.settings.button_link }}"
+            {% endif %}
+            class="button button--{{ section.settings.button_style }}"
+          >
+            {{ section.settings.button_label | escape }}
+          </a>
+        </div>
+      {% endif %}
+    </div>
+    {% if section.blocks.size > 0 %}
+      <div class="home-feature-grid__items">
+        {% for block in section.blocks %}
+          <article class="home-feature-grid__item" {{ block.shopify_attributes }}>
+            {% if block.settings.icon != blank %}
+              {{
+                block.settings.icon
+                | image_url: width: 120
+                | image_tag:
+                    class: 'home-feature-grid__icon',
+                    loading: 'lazy',
+                    alt: block.settings.icon_alt | default: block.settings.title
+              }}
+            {% endif %}
+            {% if block.settings.title != blank %}
+              <h3 class="home-feature-grid__item-title">{{ block.settings.title }}</h3>
+            {% endif %}
+            {% if block.settings.text != blank %}
+              <div class="home-feature-grid__item-text rte">{{ block.settings.text }}</div>
+            {% endif %}
+            {% if block.settings.link_label != blank %}
+              <a
+                {% if block.settings.link == blank %}
+                  role="link" aria-disabled="true"
+                {% else %}
+                  href="{{ block.settings.link }}"
+                {% endif %}
+                class="home-feature-grid__item-link"
+              >
+                {{ block.settings.link_label | escape }}
+              </a>
+            {% endif %}
+          </article>
+        {% endfor %}
+      </div>
+    {% endif %}
+  </div>
+</section>
+
+{% schema %}
+{
+  "name": "Home feature grid",
+  "tag": "section",
+  "class": "section",
+  "settings": [
+    {
+      "type": "inline_richtext",
+      "id": "preheading",
+      "label": "Pre heading"
+    },
+    {
+      "type": "inline_richtext",
+      "id": "heading",
+      "label": "Heading",
+      "default": "Sistema digital"
+    },
+    {
+      "type": "richtext",
+      "id": "description",
+      "label": "Descripción"
+    },
+    {
+      "type": "text",
+      "id": "button_label",
+      "label": "Etiqueta botón"
+    },
+    {
+      "type": "select",
+      "id": "button_style",
+      "label": "Estilo del botón",
+      "options": [
+        {"value": "primary", "label": "Primario"},
+        {"value": "secondary", "label": "Secundario"}
+      ],
+      "default": "secondary"
+    },
+    {
+      "type": "url",
+      "id": "button_link",
+      "label": "Enlace botón"
+    },
+    {
+      "type": "color_scheme",
+      "id": "color_scheme",
+      "label": "Esquema de color",
+      "default": "scheme-2"
+    }
+  ],
+  "blocks": [
+    {
+      "type": "feature",
+      "name": "Característica",
+      "settings": [
+        {
+          "type": "image_picker",
+          "id": "icon",
+          "label": "Icono"
+        },
+        {
+          "type": "text",
+          "id": "icon_alt",
+          "label": "Texto alternativo icono"
+        },
+        {
+          "type": "inline_richtext",
+          "id": "title",
+          "label": "Título",
+          "default": "Fácil"
+        },
+        {
+          "type": "richtext",
+          "id": "text",
+          "label": "Descripción",
+          "default": "<p>Describe brevemente la ventaja que ofreces.</p>"
+        },
+        {
+          "type": "text",
+          "id": "link_label",
+          "label": "Etiqueta enlace"
+        },
+        {
+          "type": "url",
+          "id": "link",
+          "label": "Enlace"
+        }
+      ]
+    }
+  ],
+  "max_blocks": 6,
+  "presets": [
+    {
+      "name": "Home feature grid",
+      "category": "GETCH"
+    }
+  ]
+}
+{% endschema %}

--- a/sections/home-hero.liquid
+++ b/sections/home-hero.liquid
@@ -1,0 +1,212 @@
+{% comment %}
+  Custom hero section inspired by GETCH landing hero: supports background image, overlay,
+  main headline and list of highlight bullet points.
+{% endcomment %}
+
+{% liquid
+  assign bg_image = section.settings.background_image
+  assign overlay_color = section.settings.overlay_color | default: '#000000'
+  assign overlay_opacity = section.settings.overlay_opacity | divided_by: 100.0
+%}
+
+<section class="home-hero color-{{ section.settings.color_scheme }} gradient">
+  <div class="home-hero__media">
+    {% if bg_image != blank %}
+      {%- capture sizes -%}
+        (min-width: 1200px) 1200px, 100vw
+      {%- endcapture -%}
+      {{
+        bg_image
+        | image_url: width: 2400
+        | image_tag:
+            class: 'home-hero__image',
+            sizes: sizes,
+            widths: '750, 1100, 1500, 1800, 2100, 2400',
+            loading: 'lazy'
+      }}
+    {% else %}
+      <div class="home-hero__image-placeholder"></div>
+    {% endif %}
+    <div class="home-hero__overlay" style="background-color: {{ overlay_color }}; opacity: {{ overlay_opacity }};"></div>
+  </div>
+  <div class="home-hero__content">
+    <div class="home-hero__inner">
+      {% if section.settings.preheading != blank %}
+        <p class="home-hero__eyebrow">{{ section.settings.preheading }}</p>
+      {% endif %}
+      {% if section.settings.heading != blank %}
+        <h1 class="home-hero__heading">{{ section.settings.heading }}</h1>
+      {% endif %}
+      {% if section.settings.description != blank %}
+        <div class="home-hero__description rte">{{ section.settings.description }}</div>
+      {% endif %}
+      {% if section.settings.primary_button_label != blank or section.settings.secondary_button_label != blank %}
+        <div class="home-hero__actions">
+          {% if section.settings.primary_button_label != blank %}
+            <a
+              {% if section.settings.primary_button_link == blank %}
+                role="link" aria-disabled="true"
+              {% else %}
+                href="{{ section.settings.primary_button_link }}"
+              {% endif %}
+              class="button button--primary"
+            >
+              {{ section.settings.primary_button_label | escape }}
+            </a>
+          {% endif %}
+          {% if section.settings.secondary_button_label != blank %}
+            <a
+              {% if section.settings.secondary_button_link == blank %}
+                role="link" aria-disabled="true"
+              {% else %}
+                href="{{ section.settings.secondary_button_link }}"
+              {% endif %}
+              class="button button--secondary"
+            >
+              {{ section.settings.secondary_button_label | escape }}
+            </a>
+          {% endif %}
+        </div>
+      {% endif %}
+      {% if section.blocks.size > 0 %}
+        <div class="home-hero__highlights" role="list">
+          {% for block in section.blocks %}
+            {% if block.type == 'highlight' %}
+              <div class="home-hero__highlight" role="listitem" {{ block.shopify_attributes }}>
+                {% if block.settings.icon != blank %}
+                  {{
+                    block.settings.icon
+                    | image_url: width: 80
+                    | image_tag:
+                        class: 'home-hero__highlight-icon',
+                        loading: 'lazy',
+                        alt: block.settings.icon_alt | default: block.settings.title
+                  }}
+                {% endif %}
+                <div class="home-hero__highlight-text">
+                  {% if block.settings.title != blank %}
+                    <p class="home-hero__highlight-title">{{ block.settings.title }}</p>
+                  {% endif %}
+                  {% if block.settings.text != blank %}
+                    <p class="home-hero__highlight-subtext">{{ block.settings.text }}</p>
+                  {% endif %}
+                </div>
+              </div>
+            {% endif %}
+          {% endfor %}
+        </div>
+      {% endif %}
+    </div>
+  </div>
+</section>
+
+{% schema %}
+{
+  "name": "Home hero",
+  "tag": "section",
+  "class": "section",
+  "settings": [
+    {
+      "type": "inline_richtext",
+      "id": "preheading",
+      "label": "Pre heading",
+      "default": "Sistema digital"
+    },
+    {
+      "type": "inline_richtext",
+      "id": "heading",
+      "label": "Heading",
+      "default": "Únicos proveedores de insumos premium para grabar patentes"
+    },
+    {
+      "type": "richtext",
+      "id": "description",
+      "label": "Descripción",
+      "default": "<p>Automatiza el grabado de patentes con nuestra plataforma GETCH® y entrega resultados consistentes en minutos.</p>"
+    },
+    {
+      "type": "text",
+      "id": "primary_button_label",
+      "label": "Etiqueta botón principal",
+      "default": "Ver planes"
+    },
+    {
+      "type": "url",
+      "id": "primary_button_link",
+      "label": "Enlace botón principal"
+    },
+    {
+      "type": "text",
+      "id": "secondary_button_label",
+      "label": "Etiqueta botón secundario"
+    },
+    {
+      "type": "url",
+      "id": "secondary_button_link",
+      "label": "Enlace botón secundario"
+    },
+    {
+      "type": "image_picker",
+      "id": "background_image",
+      "label": "Imagen de fondo"
+    },
+    {
+      "type": "color",
+      "id": "overlay_color",
+      "label": "Color de overlay",
+      "default": "#141414"
+    },
+    {
+      "type": "range",
+      "id": "overlay_opacity",
+      "label": "Opacidad del overlay",
+      "min": 0,
+      "max": 90,
+      "step": 5,
+      "default": 60
+    },
+    {
+      "type": "color_scheme",
+      "id": "color_scheme",
+      "label": "Esquema de color",
+      "default": "scheme-3"
+    }
+  ],
+  "blocks": [
+    {
+      "type": "highlight",
+      "name": "Resaltado",
+      "settings": [
+        {
+          "type": "image_picker",
+          "id": "icon",
+          "label": "Icono"
+        },
+        {
+          "type": "text",
+          "id": "icon_alt",
+          "label": "Texto alternativo icono"
+        },
+        {
+          "type": "text",
+          "id": "title",
+          "label": "Título",
+          "default": "Envíos a todo Chile"
+        },
+        {
+          "type": "text",
+          "id": "text",
+          "label": "Texto complementario"
+        }
+      ]
+    }
+  ],
+  "max_blocks": 5,
+  "presets": [
+    {
+      "name": "Home hero",
+      "category": "GETCH"
+    }
+  ]
+}
+{% endschema %}

--- a/sections/home-plan-grid.liquid
+++ b/sections/home-plan-grid.liquid
@@ -1,0 +1,165 @@
+{% comment %}
+  Pricing grid for GETCH plans.
+{% endcomment %}
+<section class="home-plan-grid color-{{ section.settings.color_scheme }} gradient">
+  <div class="page-width">
+    <div class="home-plan-grid__header">
+      {% if section.settings.preheading != blank %}
+        <p class="home-plan-grid__eyebrow">{{ section.settings.preheading }}</p>
+      {% endif %}
+      {% if section.settings.heading != blank %}
+        <h2 class="home-plan-grid__heading">{{ section.settings.heading }}</h2>
+      {% endif %}
+      {% if section.settings.description != blank %}
+        <div class="home-plan-grid__description rte">{{ section.settings.description }}</div>
+      {% endif %}
+    </div>
+    {% if section.blocks.size > 0 %}
+      <div class="home-plan-grid__items">
+        {% for block in section.blocks %}
+          {% assign features = block.settings.features | newline_to_br | split: '<br />' %}
+          <article class="home-plan-card" {{ block.shopify_attributes }}>
+            {% if block.settings.badge != blank %}
+              <span class="home-plan-card__badge">{{ block.settings.badge }}</span>
+            {% endif %}
+            {% if block.settings.title != blank %}
+              <h3 class="home-plan-card__title">{{ block.settings.title }}</h3>
+            {% endif %}
+            {% if block.settings.price != blank %}
+              <div class="home-plan-card__price">
+                <span class="home-plan-card__price-amount">{{ block.settings.price }}</span>
+                {% if block.settings.price_suffix != blank %}
+                  <span class="home-plan-card__price-suffix">{{ block.settings.price_suffix }}</span>
+                {% endif %}
+              </div>
+            {% endif %}
+            {% if features.size > 0 %}
+              <ul class="home-plan-card__features">
+                {% for feature in features %}
+                  {% assign feature_text = feature | strip %}
+                  {% if feature_text != '' %}
+                    <li>{{ feature_text }}</li>
+                  {% endif %}
+                {% endfor %}
+              </ul>
+            {% endif %}
+            {% if block.settings.button_label != blank %}
+              <div class="home-plan-card__actions">
+                <a
+                  {% if block.settings.button_link == blank %}
+                    role="link" aria-disabled="true"
+                  {% else %}
+                    href="{{ block.settings.button_link }}"
+                  {% endif %}
+                  class="button button--primary"
+                >
+                  {{ block.settings.button_label | escape }}
+                </a>
+              </div>
+            {% endif %}
+          </article>
+        {% endfor %}
+      </div>
+    {% endif %}
+  </div>
+</section>
+
+{% schema %}
+{
+  "name": "Home pricing grid",
+  "tag": "section",
+  "class": "section",
+  "settings": [
+    {
+      "type": "inline_richtext",
+      "id": "preheading",
+      "label": "Pre heading",
+      "default": "#Precios"
+    },
+    {
+      "type": "inline_richtext",
+      "id": "heading",
+      "label": "Heading",
+      "default": "Lo que necesitas grabar, a un precio que puedas pagar"
+    },
+    {
+      "type": "richtext",
+      "id": "description",
+      "label": "Descripción",
+      "default": "<p>Potencia tu negocio de grabado de patente desde $30.000 por plan.</p>"
+    },
+    {
+      "type": "color_scheme",
+      "id": "color_scheme",
+      "label": "Esquema de color",
+      "default": "scheme-2"
+    }
+  ],
+  "blocks": [
+    {
+      "type": "plan",
+      "name": "Plan",
+      "settings": [
+        {
+          "type": "text",
+          "id": "badge",
+          "label": "Etiqueta destacada"
+        },
+        {
+          "type": "inline_richtext",
+          "id": "title",
+          "label": "Nombre del plan",
+          "default": "Plan base"
+        },
+        {
+          "type": "text",
+          "id": "price",
+          "label": "Precio",
+          "default": "$30.000 + IVA"
+        },
+        {
+          "type": "text",
+          "id": "price_suffix",
+          "label": "Sufijo precio",
+          "default": "Mensual"
+        },
+        {
+          "type": "textarea",
+          "id": "features",
+          "label": "Características (una por línea)",
+          "default": "Hasta 15 plantillas (PATENTES).\n1 Usuario\nImpresión ilimitada\n+100 logos de marcas"
+        },
+        {
+          "type": "text",
+          "id": "button_label",
+          "label": "Etiqueta botón",
+          "default": "¡La quiero!"
+        },
+        {
+          "type": "url",
+          "id": "button_link",
+          "label": "Enlace botón"
+        }
+      ]
+    }
+  ],
+  "max_blocks": 4,
+  "presets": [
+    {
+      "name": "Home pricing grid",
+      "category": "GETCH",
+      "blocks": [
+        {
+          "type": "plan"
+        },
+        {
+          "type": "plan"
+        },
+        {
+          "type": "plan"
+        }
+      ]
+    }
+  ]
+}
+{% endschema %}

--- a/sections/main-product.liquid
+++ b/sections/main-product.liquid
@@ -76,6 +76,8 @@
   <div class="page-width">
     <div class="product product--{{ section.settings.media_size }} product--{{ section.settings.media_position }} product--{{ section.settings.gallery_layout }} product--mobile-{{ section.settings.mobile_thumbnails }} grid grid--1-col {% if product.media.size > 0 %}grid--2-col-tablet{% else %}product--no-media{% endif %}">
       <div class="grid__item product__media-wrapper">
+        <span class="product-promo-ribbon product-promo-ribbon--product" aria-hidden="true">-20%</span>
+        <span class="visually-hidden">Promoción Cyber 20 por ciento menos en este producto</span>
         {% render 'product-media-gallery', variant_images: variant_images %}
       </div>
       <div class="product__info-wrapper grid__item{% if settings.page_width > 1400 and section.settings.media_size == "small" %} product__info-wrapper--extra-padding{% endif %}{% if settings.animations_reveal_on_scroll %} scroll-trigger animate--slide-in{% endif %}">

--- a/snippets/card-product.liquid
+++ b/snippets/card-product.liquid
@@ -57,6 +57,8 @@
         class="card__inner {% if settings.card_style == 'standard' %}color-{{ settings.card_color_scheme }} gradient{% endif %}{% if card_product.featured_media or settings.card_style == 'standard' %} ratio{% endif %}"
         style="--ratio-percent: {{ 1 | divided_by: ratio | times: 100 }}%;"
       >
+        <span class="product-promo-ribbon" aria-hidden="true">-20%</span>
+        <span class="visually-hidden">Promoción Cyber 20 por ciento menos</span>
         {%- if card_product.featured_media -%}
           <div class="card__media{% if image_shape and image_shape != 'default' %} shape--{{ image_shape }} color-{{ settings.card_color_scheme }} gradient{% endif %}">
             <div class="media media--transparent media--hover-effect">

--- a/templates/index.json
+++ b/templates/index.json
@@ -1,210 +1,447 @@
 {
   "sections": {
-    "image_banner": {
-      "type": "image-banner",
+    "cyber_popup": {
+      "type": "cyber-promo-popup",
+      "settings": {
+        "enable_popup": true,
+        "badge_text": "CYBER EN CHILE",
+        "heading": "20% OFF en GETCH® por el Cyber",
+        "message": "<p>Aprovecha el 20% de descuento en toda la tienda durante el Cyber en Chile. Cupos limitados.</p>",
+        "button_label": "Ver ofertas",
+        "button_link": "shopify://collections/all",
+        "popup_identifier": "cyber-2024",
+        "delay_ms": 800
+      }
+    },
+    "home_hero": {
+      "type": "home-hero",
+      "settings": {
+        "preheading": "Sistema digital",
+        "heading": "Únicos proveedores de insumos premium para grabado de patentes en Chile",
+        "description": "<p>Automatiza el grabado de patentes con nuestra plataforma GETCH® y entrega resultados consistentes en minutos.</p>",
+        "primary_button_label": "Ver planes",
+        "primary_button_link": "/collections/all",
+        "secondary_button_label": "Comunícate con ventas",
+        "secondary_button_link": "/pages/contacto",
+        "background_image": "",
+        "overlay_color": "#141414",
+        "overlay_opacity": 55,
+        "color_scheme": "scheme-3"
+      },
       "blocks": {
-        "heading": {
-          "type": "heading",
+        "highlight_1": {
+          "type": "highlight",
           "settings": {
-            "heading": "Image banner",
-            "heading_size": "h0"
+            "icon": "",
+            "icon_alt": "",
+            "title": "Enviamos a todo Chile",
+            "text": "Logística express y seguimiento en cada despacho."
           }
         },
-        "text": {
-          "type": "text",
+        "highlight_2": {
+          "type": "highlight",
           "settings": {
-            "text": "Give customers details about the banner image(s) or content on the template.",
-            "text_style": "body"
+            "icon": "",
+            "icon_alt": "",
+            "title": "Soporte experto",
+            "text": "Acompañamiento de lunes a domingo para tu operación."
           }
         },
-        "button": {
-          "type": "buttons",
+        "highlight_3": {
+          "type": "highlight",
           "settings": {
-            "button_label_1": "Shop all",
-            "button_link_1": "shopify://collections/all",
-            "button_style_secondary_1": true,
-            "button_label_2": "",
-            "button_link_2": "",
-            "button_style_secondary_2": false
+            "icon": "",
+            "icon_alt": "",
+            "title": "App GETCH® incluida",
+            "text": "Genera plantillas precisas desde cualquier dispositivo."
           }
         }
       },
       "block_order": [
-        "heading",
-        "text",
-        "button"
-      ],
-      "settings": {
-        "image_overlay_opacity": 40,
-        "image_height": "large",
-        "desktop_content_position": "bottom-center",
-        "show_text_box": false,
-        "desktop_content_alignment": "center",
-        "color_scheme": "scheme-3",
-        "mobile_content_alignment": "center",
-        "stack_images_on_mobile": false,
-        "show_text_below": false
-      }
+        "highlight_1",
+        "highlight_2",
+        "highlight_3"
+      ]
     },
-    "rich_text": {
-      "type": "rich-text",
+    "feature_strip": {
+      "type": "home-feature-grid",
+      "settings": {
+        "preheading": "Sistema digital",
+        "heading": "Ahorra tiempo valioso generando plantillas exactas",
+        "description": "<p>Deja atrás procesos manuales y centraliza toda la operación en una experiencia pensada para grabadores profesionales.</p>",
+        "button_label": "",
+        "button_style": "secondary",
+        "button_link": "",
+        "color_scheme": "scheme-2"
+      },
       "blocks": {
-        "heading": {
+        "feature_1": {
+          "type": "feature",
+          "settings": {
+            "icon": "",
+            "icon_alt": "",
+            "title": "Fácil",
+            "text": "<p>Interfaz intuitiva para crear etiquetas en segundos.</p>",
+            "link_label": "",
+            "link": ""
+          }
+        },
+        "feature_2": {
+          "type": "feature",
+          "settings": {
+            "icon": "",
+            "icon_alt": "",
+            "title": "Simple",
+            "text": "<p>Conectada a tu impresora térmica sin configuraciones complejas.</p>",
+            "link_label": "",
+            "link": ""
+          }
+        },
+        "feature_3": {
+          "type": "feature",
+          "settings": {
+            "icon": "",
+            "icon_alt": "",
+            "title": "Rápido",
+            "text": "<p>Resultados consistentes listos para instalar en cada vehículo.</p>",
+            "link_label": "",
+            "link": ""
+          }
+        }
+      },
+      "block_order": [
+        "feature_1",
+        "feature_2",
+        "feature_3"
+      ]
+    },
+    "welcome_block": {
+      "type": "image-with-text",
+      "settings": {
+        "image": "",
+        "image_overlay_opacity": 0,
+        "image_behavior": "none",
+        "desktop_image_width": "medium",
+        "content_position": "middle",
+        "desktop_content_alignment": "left",
+        "mobile_content_alignment": "left",
+        "section_color_scheme": "scheme-1",
+        "color_scheme": "scheme-2",
+        "padding_top": 32,
+        "padding_bottom": 32
+      },
+      "blocks": {
+        "welcome_heading": {
           "type": "heading",
           "settings": {
-            "heading": "Talk about your brand",
+            "heading": "Bienvenido a GETCH.cl",
             "heading_size": "h1"
           }
         },
-        "text": {
+        "welcome_text": {
           "type": "text",
           "settings": {
-            "text": "<p>Share information about your brand with your customers. Describe a product, make announcements, or welcome customers to your store.<\/p>"
+            "text": "<p>Tu aplicación móvil para generar plantillas digitales de grabado de patentes en vidrios y espejos. Personaliza y protege cada vehículo con un proceso confiable, rápido y repetible.</p>"
+          }
+        },
+        "welcome_button": {
+          "type": "button",
+          "settings": {
+            "button_label": "Solicitar demo",
+            "button_link": "/pages/contacto",
+            "button_style_secondary": false
           }
         }
       },
       "block_order": [
-        "heading",
-        "text"
-      ],
-      "settings": {
-        "color_scheme": "scheme-1",
-        "full_width": true,
-        "padding_top": 40,
-        "padding_bottom": 0
-      }
+        "welcome_heading",
+        "welcome_text",
+        "welcome_button"
+      ]
     },
-    "featured_collection": {
+    "product_showcase": {
       "type": "featured-collection",
       "settings": {
-        "title": "Featured products",
-        "heading_size": "h2",
+        "title": "Nuestros productos",
+        "heading_size": "h1",
         "collection": "all",
-        "products_to_show": 8,
+        "products_to_show": 4,
         "columns_desktop": 4,
         "color_scheme": "scheme-1",
-        "show_view_all": false,
-        "swipe_on_mobile": false,
+        "show_view_all": true,
+        "swipe_on_mobile": true,
         "image_ratio": "adapt",
         "show_secondary_image": true,
         "show_vendor": false,
         "show_rating": false,
         "columns_mobile": "2",
-        "padding_top": 28,
-        "padding_bottom": 36
-      }
-    },
-    "collage": {
-      "type": "collage",
-      "blocks": {
-        "collection-0": {
-          "type": "collection",
-          "settings": {
-            "collection": ""
-          }
-        },
-        "product": {
-          "type": "product",
-          "settings": {
-            "product": "",
-            "second_image": false
-          }
-        },
-        "collection-1": {
-          "type": "collection",
-          "settings": {
-            "collection": ""
-          }
-        }
-      },
-      "block_order": [
-        "collection-0",
-        "product",
-        "collection-1"
-      ],
-      "settings": {
-        "heading": "Multimedia collage",
-        "heading_size": "h2",
-        "desktop_layout": "left",
-        "mobile_layout": "collage",
-        "color_scheme": "scheme-1",
         "padding_top": 36,
         "padding_bottom": 36
       }
     },
-    "video": {
-      "type": "video",
+    "differentials": {
+      "type": "home-feature-grid",
       "settings": {
-        "heading": "",
-        "video_url": "https://www.youtube.com/watch?v=_9VUPq3SxOc",
-        "heading_size": "h1",
+        "preheading": "Diferenciales",
+        "heading": "Impulsa tu negocio de grabado",
         "description": "",
-        "full_width": false,
-        "color_scheme": "scheme-1",
-        "padding_top": 36,
-        "padding_bottom": 36
-      }
-    },
-    "multicolumn": {
-      "type": "multicolumn",
+        "button_label": "Compra un plan",
+        "button_style": "primary",
+        "button_link": "/collections/all",
+        "color_scheme": "scheme-2"
+      },
       "blocks": {
-        "column1": {
-          "type": "column",
+        "diff_1": {
+          "type": "feature",
           "settings": {
-            "title": "Column",
-            "text": "<p>Pair text with an image to focus on your chosen product, collection, or blog post. Add details on availability, style, or even provide a review.<\/p>",
+            "icon": "",
+            "icon_alt": "",
+            "title": "Patentes más logo",
+            "text": "<p>Profesionales y de calidad para cada entrega.</p>",
             "link_label": "",
             "link": ""
           }
         },
-        "column2": {
-          "type": "column",
+        "diff_2": {
+          "type": "feature",
           "settings": {
-            "title": "Column",
-            "text": "<p>Pair text with an image to focus on your chosen product, collection, or blog post. Add details on availability, style, or even provide a review.<\/p>",
+            "icon": "",
+            "icon_alt": "",
+            "title": "Súmate a los expertos",
+            "text": "<p>La herramienta digital que usan los grabadores líderes del país.</p>",
             "link_label": "",
             "link": ""
           }
         },
-        "column3": {
-          "type": "column",
+        "diff_3": {
+          "type": "feature",
           "settings": {
-            "title": "Column",
-            "text": "<p>Pair text with an image to focus on your chosen product, collection, or blog post. Add details on availability, style, or even provide a review.<\/p>",
+            "icon": "",
+            "icon_alt": "",
+            "title": "Sé libre de grabar",
+            "text": "<p>Producción ágil con plantillas ilimitadas disponibles 24/7.</p>",
             "link_label": "",
             "link": ""
           }
         }
       },
       "block_order": [
-        "column1",
-        "column2",
-        "column3"
-      ],
+        "diff_1",
+        "diff_2",
+        "diff_3"
+      ]
+    },
+    "cta_banner": {
+      "type": "home-cta-banner",
       "settings": {
-        "title": "",
-        "heading_size": "h1",
-        "image_width": "third",
-        "image_ratio": "adapt",
-        "columns_desktop": 3,
-        "column_alignment": "center",
-        "background_style": "none",
-        "button_label": "",
-        "button_link": "",
-        "swipe_on_mobile": false,
-        "color_scheme": "scheme-1",
-        "columns_mobile": "1",
-        "padding_top": 36,
-        "padding_bottom": 36
+        "heading": "Imprime sin límites desde cualquier dispositivo móvil",
+        "description": "<p>Ten la libertad de generar patentes donde estés y con la cantidad de etiquetas que necesites.</p>",
+        "button_label": "Descargar app",
+        "button_style": "secondary",
+        "button_link": "/pages/app-gbdx",
+        "color_scheme": "scheme-3"
       }
+    },
+    "pricing": {
+      "type": "home-plan-grid",
+      "settings": {
+        "preheading": "#Precios",
+        "heading": "Lo que necesitas grabar, a un precio que puedas pagar",
+        "description": "<p>Potencia tu negocio desde $30.000 por plan y escala tu capacidad con créditos adicionales.</p>",
+        "color_scheme": "scheme-2"
+      },
+      "blocks": {
+        "plan_base": {
+          "type": "plan",
+          "settings": {
+            "badge": "Popular",
+            "title": "PLAN BASE",
+            "price": "$30.000 + IVA",
+            "price_suffix": "Hasta 15 patentes",
+            "features": "1 Usuario\nImpresión ilimitada\n+100 logos de marcas",
+            "button_label": "¡La quiero!",
+            "button_link": "/collections/all"
+          }
+        },
+        "plan_estandar": {
+          "type": "plan",
+          "settings": {
+            "badge": "",
+            "title": "PLAN ESTÁNDAR",
+            "price": "$45.000 + IVA",
+            "price_suffix": "Hasta 25 patentes",
+            "features": "1 Usuario\nImpresión ilimitada\n+100 logos de marcas",
+            "button_label": "¡La quiero!",
+            "button_link": "/collections/all"
+          }
+        },
+        "plan_pro": {
+          "type": "plan",
+          "settings": {
+            "badge": "",
+            "title": "PLAN PRO",
+            "price": "$75.000 + IVA",
+            "price_suffix": "Hasta 50 patentes",
+            "features": "1 Usuario\nImpresión ilimitada\n+150 logos de marcas",
+            "button_label": "¡La quiero!",
+            "button_link": "/collections/all"
+          }
+        },
+        "plan_full": {
+          "type": "plan",
+          "settings": {
+            "badge": "",
+            "title": "PLAN FULL",
+            "price": "$100.000 + IVA",
+            "price_suffix": "Hasta 100 patentes",
+            "features": "2 Usuarios\nImpresión ilimitada\n+200 logos de marcas",
+            "button_label": "¡La quiero!",
+            "button_link": "/collections/all"
+          }
+        }
+      },
+      "block_order": [
+        "plan_base",
+        "plan_estandar",
+        "plan_pro",
+        "plan_full"
+      ]
+    },
+    "pricing_note": {
+      "type": "rich-text",
+      "settings": {
+        "color_scheme": "scheme-2",
+        "full_width": false,
+        "padding_top": 16,
+        "padding_bottom": 24,
+        "desktop_content_position": "left",
+        "content_alignment": "center"
+      },
+      "blocks": {
+        "pricing_heading": {
+          "type": "heading",
+          "settings": {
+            "heading": "¡Todos nuestros planes permiten imprimir ilimitadamente las plantillas generadas!",
+            "heading_size": "h2"
+          }
+        },
+        "pricing_text": {
+          "type": "text",
+          "settings": {
+            "text": "<p>Comunícate con ventas y elige el plan que mejor se adapte a tus metas.</p>"
+          }
+        },
+        "pricing_cta": {
+          "type": "button",
+          "settings": {
+            "button_label": "Hablar con ventas",
+            "button_link": "mailto:hablemos@GETCH.cl",
+            "button_style_secondary": false,
+            "button_label_2": "",
+            "button_link_2": "",
+            "button_style_secondary_2": true
+          }
+        }
+      },
+      "block_order": [
+        "pricing_heading",
+        "pricing_text",
+        "pricing_cta"
+      ]
+    },
+    "faq": {
+      "type": "collapsible-content",
+      "settings": {
+        "caption": "Preguntas frecuentes",
+        "heading": "Resolvemos tus dudas",
+        "heading_size": "h1",
+        "heading_alignment": "center",
+        "layout": "none",
+        "container_color_scheme": "scheme-2",
+        "color_scheme": "scheme-1",
+        "open_first_collapsible_row": true,
+        "image": "",
+        "image_ratio": "adapt",
+        "desktop_layout": "image_first",
+        "padding_top": 36,
+        "padding_bottom": 48
+      },
+      "blocks": {
+        "faq_1": {
+          "type": "collapsible_row",
+          "settings": {
+            "heading": "¿Qué es GETCH?",
+            "icon": "none",
+            "row_content": "<p>Es una aplicación móvil que genera e imprime plantillas de grabado para vidrios y espejos de vehículos. Solo descarga la app, ingresa con tus credenciales y comienza a producir.</p>",
+            "page": ""
+          }
+        },
+        "faq_2": {
+          "type": "collapsible_row",
+          "settings": {
+            "heading": "¿Cómo hago para usar GETCH?",
+            "icon": "none",
+            "row_content": "<p>Necesitas una computadora o dispositivo móvil con acceso a Internet. Contrata un plan y prueba todas las funcionalidades de inmediato.</p>",
+            "page": ""
+          }
+        },
+        "faq_3": {
+          "type": "collapsible_row",
+          "settings": {
+            "heading": "¿Qué es un crédito?",
+            "icon": "none",
+            "row_content": "<p>Cada crédito equivale a una patente. Generar una nueva patente descuenta un crédito del total contratado.</p>",
+            "page": ""
+          }
+        },
+        "faq_4": {
+          "type": "collapsible_row",
+          "settings": {
+            "heading": "¿Cuento con soporte?",
+            "icon": "none",
+            "row_content": "<p>Sí. Nuestro equipo está disponible de lunes a domingo para ayudarte en hablemos@GETCH.cl.</p>",
+            "page": ""
+          }
+        },
+        "faq_5": {
+          "type": "collapsible_row",
+          "settings": {
+            "heading": "¿Se puede imprimir ilimitadamente?",
+            "icon": "none",
+            "row_content": "<p>Sí, puedes imprimir tantas veces quieras la plantilla generada para cada patente.</p>",
+            "page": ""
+          }
+        },
+        "faq_6": {
+          "type": "collapsible_row",
+          "settings": {
+            "heading": "¿Funciona en cualquier dispositivo?",
+            "icon": "none",
+            "row_content": "<p>GETCH opera en navegadores y dispositivos como computadores, teléfonos y tabletas con conexión a Internet.</p>",
+            "page": ""
+          }
+        }
+      },
+      "block_order": [
+        "faq_1",
+        "faq_2",
+        "faq_3",
+        "faq_4",
+        "faq_5",
+        "faq_6"
+      ]
     }
   },
   "order": [
-    "image_banner",
-    "rich_text",
-    "featured_collection",
-    "collage",
-    "video",
-    "multicolumn"
+    "cyber_popup",
+    "home_hero",
+    "feature_strip",
+    "welcome_block",
+    "product_showcase",
+    "differentials",
+    "cta_banner",
+    "pricing",
+    "pricing_note",
+    "faq"
   ]
 }


### PR DESCRIPTION
**Changes**
- Introduced GETCH-based home layout sections (hero, feature grid, pricing grid, CTA) with updated copy and styling overrides in `assets/theme-grabad.css`.
- Added a Cyber Monday popup section showing a single-session 20% promo banner and the necessary CSS/JS hooks.
- Applied a global `-20%` orange ribbon to product cards and product pages for the Cyber sale.
- Synced `templates/index.json` to include the new sections and popup while updating product page markup for the promo ribbon.
