### PR TITLE
Fix assignment in render tag

### DIFF
--- a/snippets/product-variant-options.liquid
+++ b/snippets/product-variant-options.liquid
@@ -58,16 +58,19 @@
     </span>
   {%- endcapture -%}
 
+  {% assign escaped_value = value | escape %}
+
   {%- if picker_type == 'swatch' -%}
     {%- capture help_text -%}
-      <span class="visually-hidden">{{ value | escape }}</span>
+      <span class="visually-hidden">{{ escaped_value }}</span>
       {{ label_unavailable }}
     {%- endcapture -%}
+
     {%
       render 'swatch-input',
       id: input_id,
       name: input_name,
-      value: value | escape,
+      value: escaped_value,
       swatch: value.swatch,
       product_form_id: product_form_id,
       checked: value.selected,
@@ -81,7 +84,7 @@
       type="radio"
       id="{{ input_id }}"
       name="{{ input_name | escape }}"
-      value="{{ value | escape }}"
+      value="{{ escaped_value }}"
       form="{{ product_form_id }}"
       {% if value.selected %}
         checked
@@ -98,7 +101,7 @@
   {%- elsif picker_type == 'dropdown' or picker_type == 'swatch_dropdown' -%}
     <option
       id="{{ input_id }}"
-      value="{{ value | escape }}"
+      value="{{ escaped_value }}"
       {% if value.selected %}
         selected="selected"
       {% endif %}


### PR DESCRIPTION
The only required change here is inside the render tag for `render 'swatch-input'` where we previously defined `value: value | escape`. This will throw a syntax error in v5.9.0 of Liquid using the new rigid parser.