### PR TITLE
Add Wishlist Feature to Product Cards

### DIFF
--- a/assets/base.css
+++ b/assets/base.css
@@ -3595,3 +3595,42 @@ details-disclosure > details {
     transform: translateX(100%) scaleX(0);
   }
 }
+.wishlist-btn {
+  position: absolute;
+  top: 10px;
+  right: 10px;
+  z-index: 100;
+  font-size: 20px;
+  cursor: pointer;
+  background: none;
+  border: none;
+  opacity: 0.8;
+}
+
+.wishlist-btn.active {
+  color: red;
+  opacity: 1;
+}
+.card__wishlist {
+  position: absolute;
+  top: 8px;      /* distance from top of card */
+  right: 8px;    /* distance from right of card */
+  z-index: 10;
+  pointer-events: auto; /* make sure it’s clickable */
+}
+
+.card__wishlist button {
+  background: none;
+  border: none;
+  font-size: 20px;   /* adjust size of the heart */
+  cursor: pointer;
+  color: #333;       /* normal color */
+  transition: color 0.2s;
+}
+
+.card__wishlist button.active {
+  color: red;        /* filled heart */
+}
+
+
+

--- a/assets/global.js
+++ b/assets/global.js
@@ -1330,3 +1330,39 @@ class CartPerformance {
     );
   }
 }
+// Wishlist Feature
+function loadWishlist() {
+  return JSON.parse(localStorage.getItem("wishlist")) || [];
+}
+
+function saveWishlist(list) {
+  localStorage.setItem("wishlist", JSON.stringify(list));
+}
+
+document.addEventListener("click", function (e) {
+  if (e.target.classList.contains("wishlist-btn")) {
+    const id = e.target.dataset.productId;
+    let wishlist = loadWishlist();
+
+    if (wishlist.includes(id)) {
+      wishlist = wishlist.filter(w => w != id);
+      e.target.classList.remove("active");
+    } else {
+      wishlist.push(id);
+      e.target.classList.add("active");
+    }
+
+    saveWishlist(wishlist);
+  }
+});
+
+// Highlight active items on page load
+document.addEventListener("DOMContentLoaded", () => {
+  const wishlist = loadWishlist();
+  document.querySelectorAll(".wishlist-btn").forEach(btn => {
+    if (wishlist.includes(btn.dataset.productId)) {
+      btn.classList.add("active");
+    }
+  });
+});
+

--- a/snippets/card-product.liquid
+++ b/snippets/card-product.liquid
@@ -160,6 +160,8 @@
               {{ card_product.title | escape }}
             </a>
           </h3>
+        
+
           <div class="card-information">
             {%- if show_vendor -%}
               <span class="visually-hidden">{{ 'accessibility.vendor' | t }}</span>
@@ -586,6 +588,20 @@
       "
       style="--ratio-percent: {{ 1 | divided_by: ratio | times: 100 }}%;"
     >
+        <div class="card-wrapper product-card-wrapper underline-links-hover">
+  <div class="card card--{{ settings.card_style }} ...">
+    
+    {% render 'product-wishlist', product: card_product %}   <!-- Add this line -->
+
+    <div class="card__inner {% if settings.card_style == 'standard' %}color-{{ settings.card_color_scheme }} gradient{% endif %}{% if card_product.featured_media or settings.card_style == 'standard' %} ratio{% endif %}"
+      style="--ratio-percent: {{ 1 | divided_by: ratio | times: 100 }}%;">
+      
+      <!-- existing content inside card__inner -->
+
+    </div>
+  </div>
+</div>
+
       <div
         class="card__inner{% if settings.card_style == 'standard' %} color-{{ settings.card_color_scheme }} gradient{% endif %} ratio"
       >

--- a/snippets/product-wishlist.liquid
+++ b/snippets/product-wishlist.liquid
@@ -1,0 +1,6 @@
+<button
+  class="wishlist-btn"
+  data-product-id="{{ product.id }}"
+>
+  ❤️
+</button>


### PR DESCRIPTION
This PR adds a wishlist feature to the Dawn theme. It includes:

- Heart (❤️) button on product cards
- Wishlist state stored in localStorage
- JavaScript toggle logic
- Active state persistence on reload
- CSS positioning for the button
- Wishlist snippet integrated into card-product.liquid

This feature is beginner-friendly and works completely on the frontend.

