### PR TITLE
Fix typo in product-variant-options snippet

### DIFF
--- a/snippets/product-variant-options.liquid
+++ b/snippets/product-variant-options.liquid
@@ -5,7 +5,7 @@
   - product: {Object} product object.
   - option: {Object} current product_option object.
   - block: {Object} block object.
-  - picker_type: {String} type of picker to dispay
+  - picker_type: {String} type of picker to display.
 
 
   Usage:


### PR DESCRIPTION
Fixes a minor typo on line 8 of the **product-variant-options.liquid** file.

<img width="1100" height="316" alt="screenshot_07_02_22@2x" src="https://github.com/user-attachments/assets/e22845f8-e29f-49a1-9780-b9399e1917aa" />
