### PR TITLE
fix: white space handling in product-variant-options snippet

### DIFF
--- a/snippets/product-variant-options.liquid
+++ b/snippets/product-variant-options.liquid
@@ -95,7 +95,7 @@
       {{ input_dataset }}
     >
     <label for="{{ input_id }}">
-      {{ value -}}
+      {{ value }}
       {{ label_unavailable }}
     </label>
   {%- elsif picker_type == 'dropdown' or picker_type == 'swatch_dropdown' -%}
@@ -113,7 +113,7 @@
       {% endif %}
       {{ input_dataset }}
     >
-      {% if option_disabled -%}
+      {%- if option_disabled -%}
         {{- 'products.product.value_unavailable' | t: option_value: value -}}
       {%- else -%}
         {{- value -}}


### PR DESCRIPTION
fix white space handling

<img width="753" height="347" alt="image" src="https://github.com/user-attachments/assets/b52f4c21-f755-48be-82b0-167a4e438e37" />
