### PR TITLE
Fix: Render HTML in email error message on registration form

### DIFF
--- a/sections/main-register.liquid
+++ b/sections/main-register.liquid
@@ -4,7 +4,7 @@
   .section-{{ section.id }}-padding {
     padding-top: {{ section.settings.padding_top | times: 0.75 | round: 0 }}px;
     padding-bottom: {{ section.settings.padding_bottom | times: 0.75 | round: 0 }}px;
-  }
+  
 
   @media screen and (min-width: 750px) {
     .section-{{ section.id }}-padding {
@@ -98,8 +98,7 @@
         <span class="svg-wrapper">
           {{- 'icon-error.svg' | inline_asset_content -}}
         </span>
-        {{ form.errors.translated_fields.email | capitalize }}
-        {{ form.errors.messages.email }}.
+        {{ form.errors.messages.email }}
       </span>
     {%- endif -%}
     <div class="field">


### PR DESCRIPTION
When registering with an already-used email address, Shopify returns an error message that contains an HTML anchor tag (e.g. `<a href="/account/login#recover">reset your password</a>`). The inline error span below the email field was rendering this as plain text because it prepended the field label and appended a hardcoded period, breaking HTML rendering.

**Fix:** Remove the redundant field label prefix (`translated_fields.email`) and the hardcoded trailing period from the inline email error message output so that the full error message — including any HTML links — renders correctly.

Fixes #3891

### PR Summary:

When a customer tries to register with an email address already associated with a legacy account, the error message now correctly renders the "reset your password" link as a clickable anchor, rather than displaying raw HTML as plain text.