### PR TITLE
chore: repo setup retrofit — scaffolding, skills, docs, planning

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,6 @@
+{
+  "enabledPlugins": {
+    "shopify-ai-toolkit@claude-plugins-official": true,
+    "shopify@claude-plugins-official": true
+  }
+}

--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,0 +1,12 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(where python *)",
+      "Bash(where python3 *)",
+      "Bash(where py *)",
+      "Bash(where uv *)",
+      "Bash(uv --version)",
+      "Bash(uv python *)"
+    ]
+  }
+}

--- a/.claude/skills/audit/SKILL.md
+++ b/.claude/skills/audit/SKILL.md
@@ -1,0 +1,206 @@
+---
+name: audit
+description: Run a systematic health check on the Sick Rabbit Shopify theme — catches design-token drift, dead Liquid, stale component registries, schema and translation problems, Dawn-file destruction, and other debt that accumulates quietly between features. Use this skill when the user says "run an audit", "audit the theme", "health check", "check the codebase", "are we clean", "sanity check", "how's the theme looking" — or when a major piece of work just shipped (end of a phase, before a restyle wave, before launch). Also trigger at roadmap checkpoints and proactively suggest running one when a section restyle, token pass, or phase finishes. Before Phase 5 launch this is mandatory. Not for fixing bugs (that's the debug-session skill) or logging a single bug (that's the issue skill) — audits sweep the whole codebase for silent drift and log what they find.
+---
+
+# Audit
+
+A systematic sweep of the theme to catch the things that degrade quietly between features. Every audit runs a standard set of checks, then adds context-aware extras based on what was recently shipped.
+
+The goal is to catch drift before it becomes debt. On a forked Shopify theme, drift is especially expensive: Dawn is `upstream`, and every hardcoded value, destructured file, or stale registry entry makes the next `git merge upstream/main` worse.
+
+## Standard checks (run every audit)
+
+### 1. Snippet / section usage
+
+- Scan `sections/` and `snippets/` for Liquid fragments that duplicate each other. If a chunk of markup shows up in 2+ places, flag it for extraction.
+- Check that `docs/components.md` matches reality — every Sick-Rabbit-custom snippet/section listed; no orphan entries pointing at deleted files.
+- Flag any `{% include %}` calls — should all be `{% render %}`.
+- Flag `.liquid` files in `sections/` that are missing a `{% schema %}` block or missing `presets` (breaks merchant editability).
+- Flag sections with settings defined in the schema that the template never reads (dead settings confuse merchants).
+
+### 2. Design tokens
+
+- Grep `assets/**/*.css`, `sections/**/*.liquid`, `snippets/**/*.liquid`, `layout/**/*.liquid` for hardcoded hex (`#[0-9a-f]{3,8}`), `rgb(`, `rgba(`.
+- Check inline `style=""` attributes in Liquid for colour/size/spacing literals.
+- Flag hardcoded font stacks (e.g. `font-family: 'Pirata One', cursive;` outside the token layer).
+- Flag magic numbers for spacing/padding/margin/radius that aren't coming from tokens.
+- Reference `docs/design/system.md` for the canonical list — if a value isn't there, either it needs to be added first or the usage is wrong.
+- Check `config/settings_data.json` vs. `docs/design/system.md` for drift — is the store actually running the tokens we say it is?
+
+### 3. Locale / translation hygiene
+
+- Scan `sections/` and `snippets/` for English strings that should go through `{{ '...' | t }}` — plain text in `<button>`, `<h1>`, `<p>`, `alt=""`, `placeholder=""`, `title=""`, etc.
+- Check that every `t:` key used in Liquid exists in `locales/en.default.json`.
+- Flag orphan keys in `locales/en.default.json` not referenced anywhere.
+- If other locale files exist, flag keys that are present in `en.default.json` but missing in other locales.
+
+### 4. Money / currency
+
+- Grep for prices formatted manually (`£{{ product.price }}`, concatenated currency symbols, `divided_by: 100`) instead of `| money`, `| money_with_currency`, or `| money_without_trailing_zeros`.
+
+### 5. Dead code
+
+- Orphan snippets (files in `snippets/` never referenced by `{% render %}` or `{% include %}`).
+- Orphan sections (files in `sections/` not present in any `templates/*.json` and with no `"presets"` in the schema — truly unreachable).
+- Orphan CSS files in `assets/` not referenced by any Liquid file.
+- Orphan JS files in `assets/` not referenced by any Liquid file or `script` tag.
+- Commented-out Liquid/HTML/CSS/JS blocks. Git has the history.
+- Unused keys in `config/settings_schema.json` — setting IDs that nothing reads.
+
+### 6. Naming and structure consistency
+
+- Snippets and sections: kebab-case filenames. Flag camelCase or snake_case.
+- JSON templates: kebab-case. Section-scoped CSS: `section-<name>.css` pattern.
+- Liquid variable names: snake_case.
+- Flag files living in the wrong directory (a schema-carrying file in `snippets/`, a schema-less fragment in `sections/`).
+
+### 7. Dawn integrity (upstream friendliness)
+
+- Has any Dawn-originating file been renamed, moved, or deleted? Every such change becomes a permanent merge conflict. Flag and ask whether it was deliberate — if yes, should be logged in `docs/decisions.md`.
+- Count commits behind `upstream/main` (`git fetch upstream && git rev-list --count HEAD..upstream/main`). If the gap is growing, flag for a scheduled merge.
+
+### 8. JSON validity
+
+- Every `templates/*.json`, `config/settings_data.json`, `config/settings_schema.json`, `locales/*.json`, and inline `{% schema %}` block must parse. A trailing comma kills the storefront. (`shopify theme check` catches most of this — run it as part of the audit.)
+
+### 9. Theme check
+
+- Run `shopify theme check`. Record errors (blockers) and warnings (review-and-decide) separately.
+- If any check rule has been disabled in `.theme-check.yml` without a matching `docs/decisions.md` entry, flag it.
+
+## Context-aware extras
+
+After the standard checks, read `planning/roadmap.md` to see what phase is active and what just shipped. Add the relevant extras and tell the user what and why before running them.
+
+| Recent work | Add extras |
+|---|---|
+| Phase 2 (token extraction) | **Token coverage**, **font loading** |
+| Phase 3 (section restyle) — header/nav | **Accessibility (keyboard nav)**, **performance (critical CSS)** |
+| Phase 3 — PDP / variant picker | **Accessibility (ARIA live regions)**, **performance (JS deferral)**, **variant state edge cases** |
+| Phase 3 — cart drawer | **Accessibility (focus trap)**, **performance (JS hydration)**, **edge cases (empty cart, variant swap)** |
+| Phase 4 (products + content) | **Data completeness**, **image alt text**, **metafield coverage** |
+| Phase 5 (launch) | **Pre-launch checklist** (see below) — mandatory, no skipping |
+
+Tell the user: *"Running standard audit + accessibility + performance (cart-drawer restyle just landed). Want to add or skip anything?"*
+
+### Performance (Shopify flavour)
+
+- Images rendered with `image_url: width: X` at a size appropriate for the slot (not 2000px in a 400px thumbnail).
+- Below-fold images using `loading="lazy"` and appropriate `fetchpriority`.
+- Custom fonts declared with `font-display: swap`; preloaded only when above-the-fold.
+- Critical CSS inlined in `<head>`; non-critical loaded asynchronously.
+- JavaScript loaded with `defer` or as `type="module"`; no blocking scripts.
+- No heavy work happening on every page (e.g. a global JS file that loads a carousel lib on pages without carousels).
+- Lighthouse score delta vs. vanilla Dawn — if we've regressed performance, flag it.
+
+### Accessibility (WCAG 2.2 AA)
+
+- Colour contrast — with the Sick Rabbit warm-dark palette this needs real checking, not assumption. Body text on backgrounds: 4.5:1. UI text: 3:1. Use the actual hex values from `docs/design/system.md`.
+- Touch targets ≥ 44×44 CSS pixels (cart icons, variant buttons, nav toggles).
+- Every interactive element keyboard-reachable; focus state visible (and on-brand — don't kill the default outline without replacing it).
+- `aria-live` on cart-update announcements; focus trap on cart drawer and modals; focus restored on close.
+- Product images have meaningful `alt` text (not just the filename).
+- Form inputs have associated `<label>` or `aria-label`.
+- Heading hierarchy per page (one `h1`, no skipped levels).
+
+### Pre-launch checklist (Phase 5 — mandatory)
+
+Run every standard check plus:
+
+- Storefront **password protection removed** (or, if staying protected, that's deliberate).
+- Legal pages present and linked: shipping policy, returns, privacy, terms (policies live in Shopify admin → Settings → Policies).
+- Shipping zones configured for the intended markets (GBP, UK + ROI + EU as applicable).
+- Taxes configured correctly for GBP / UK registration status.
+- Payment gateway active (Shopify Payments or alternative) and tested with a real test transaction.
+- Favicon set; social share meta (`og:image`, `og:title`, `twitter:card`) on home and PDP.
+- 404 template styled and on-brand.
+- Theme editor → all sections still editable (no regressions to schema blocks).
+- Google Analytics / meta pixel / any tracking scripts installed and firing.
+- DNS configuration for `sickrabbit.com` matches Shopify's required records; SSL provisioned.
+- Dawn `upstream/main` merged to within ~1 release.
+- `git log --author="Shopify"` — any merchant-admin auto-commits reviewed and understood before launch.
+
+## Workflow
+
+### 1. Announce the plan
+
+Read `planning/roadmap.md`. List the standard checks plus any extras, and explain why the extras are included. Let the user adjust before you start.
+
+### 2. Run checks systematically
+
+Work through each category in order. Prefer Grep/ripgrep over manual reading for anything mechanical (hex values, `{% include %}`, orphan snippets — write small shell/regex passes instead of eyeballing).
+
+For each finding, assess severity using the issue skill's Shopify-flavoured rubric:
+
+- **High** — breaks the purchase path, shopper-visible error, security/compliance issue, pre-launch blocker.
+- **Medium** — inconsistency, drift from the token system, minor technical debt, something that'll bite in the next restyle.
+- **Low** — cosmetic or trivial.
+
+### 3. Log findings to `planning/issues.md`
+
+Use the `issue` skill's format. Add the audit provenance in Steps:
+
+```
+**Steps:** Found during audit YYYY-MM-DD — [check category]. <reproducer or file:line>
+```
+
+That traceability lets future audits dedupe and lets `git log | grep` find the fix later.
+
+Don't fix things during the audit pass itself. That conflates two workflows and makes the audit less thorough (you'll burn time fixing the first thing you find and forget to finish the sweep). Audit first, fix later in a debug session.
+
+### 4. Produce a summary
+
+Write to chat:
+
+```
+## Audit Summary — YYYY-MM-DD
+
+**Checks:** Snippet/section, Design tokens, Locales, Money, Dead code, Naming, Dawn integrity, JSON, Theme check + Accessibility + Performance
+
+### Results
+- High: 2
+- Medium: 6
+- Low: 3
+
+### Highlights
+- 4 hardcoded hex values in sections/header.liquid and snippets/product-card.liquid (design tokens)
+- `snippets/legacy-hero.liquid` orphaned — no render call in repo (dead code)
+- Cart drawer `aria-live` missing — screen readers don't announce line-item updates (accessibility, high)
+- 47 commits behind upstream/main — schedule a Dawn merge (Dawn integrity)
+
+### Logged
+All findings added to planning/issues.md as ISS-012 through ISS-022.
+```
+
+## Roadmap integration
+
+Audits are checkpoints, not ad-hoc. When building or updating `planning/roadmap.md`, insert an **Audit Checkpoint** between major phases without being asked — it's standard practice on this project:
+
+```markdown
+### Phase 2 — Extract brand tokens
+...
+
+### Audit Checkpoint (post-Phase 2)
+Token-coverage pass before Phase 3 restyle begins.
+
+### Phase 3 — Restyle sections
+...
+
+### Audit Checkpoint (pre-launch, mandatory)
+Full audit including the pre-launch checklist before Phase 5.
+
+### Phase 5 — Launch
+...
+```
+
+The cost of a full audit is small compared to the cost of restyling on top of hidden token drift or launching with a broken 404.
+
+## Rules
+
+- **Sweep, don't fix.** An audit catalogues findings; fixes happen afterwards via debug-session.
+- **Log to `planning/issues.md`** with audit provenance — don't drop findings into chat and forget them.
+- **Run `shopify theme check`** as part of every audit — it catches things grep doesn't.
+- **Read the roadmap** before choosing extras. Context-free audits miss the things most likely to be broken.
+- **Respect Dawn.** Any destructive edit to a Dawn-originating file is a finding unless already logged in `docs/decisions.md`.
+- **Don't skip the pre-launch checklist** before Phase 5.

--- a/.claude/skills/commit/SKILL.md
+++ b/.claude/skills/commit/SKILL.md
@@ -1,0 +1,167 @@
+---
+name: commit
+description: Stage and commit changes to the Sick Rabbit Shopify theme following project conventions. Use this skill whenever the user says "commit", "save changes", "commit this", "let's commit", wants to prepare code for a PR, or has just finished a task and needs to save their work. Also trigger when the user asks to check what's changed before committing, says "what did we change", "ready to commit", or is about to push — this skill runs the pre-commit quality checks that matter for a live Shopify theme.
+---
+
+# Commit
+
+Every commit to `main` on this repo auto-deploys to the live Shopify theme at `sick-rabbit-store.myshopify.com` (and, post-launch, `sickrabbit.com`). There is no staging step. Treat each commit like a production push — sloppy commits go live.
+
+This skill ensures every commit follows the same format, passes the same quality checks, and doesn't break the storefront.
+
+## Context that shapes this skill
+
+- **`main` auto-deploys.** Shopify's GitHub integration syncs `main` → live theme. No CI gate between commit and customers seeing it.
+- **Merchant admin edits auto-commit back.** Expect commits on `main` authored by Shopify's bot when the merchant edits sections or theme settings in admin. Don't be surprised by these; don't revert them without asking.
+- **Dawn is `upstream`.** Periodic `git fetch upstream && git merge upstream/main` merges Shopify's Dawn updates in. Those merge commits are expected and fine.
+- **No bundler, no build step.** What you commit is what Shopify serves. Liquid, CSS, JS all ship as-is.
+
+## Message format
+
+```
+type: concise description
+
+Co-Authored-By: Claude Opus <VERSION> (1M context) <noreply@anthropic.com>
+```
+
+Use the actual model running the session in the co-author line (check your own system prompt — e.g. `Claude Opus 4.7 (1M context)`).
+
+### Types
+
+| Type | When to use | Example |
+|------|-------------|---------|
+| `fix` | Bug fixes | `fix: stop cart drawer from closing on variant change` |
+| `feat` | New sections, snippets, merchant-visible features | `feat: add anachronism collection section` |
+| `restyle` | Visual restyle of existing Dawn sections/snippets (Phase 3 work) | `restyle: header nav to match brand type scale` |
+| `refactor` | Structural changes without visual or behaviour change | `refactor: extract product-card media into snippet` |
+| `tokens` | Design token / theme settings changes | `tokens: wire burnt rose into primary button scheme` |
+| `docs` | Documentation only (`docs/`, `planning/`, `CLAUDE.md`) | `docs: log decision to defer bespoke PDP` |
+| `chore` | Tooling, config, deps, `.greptile/` changes | `chore: tighten theme-check rules for schema blocks` |
+| `content` | Locale / translation / copy-only changes | `content: update en.default cart empty-state copy` |
+
+`restyle` and `tokens` are Shopify-theme-specific additions to the usual Conventional Commits set — they make Phase 3 history grep-able.
+
+### Style
+
+- **Lowercase after the prefix** — `fix: resolve cart bug` not `fix: Resolve Cart Bug`
+- **Imperative mood** — "add", "fix", "remove" (not "added", "fixes", "removed")
+- **Under 72 characters** for the subject line
+- Use the body for the "why" if the subject alone doesn't tell the full story
+- Reference the section/snippet/template path when it narrows the subject usefully — e.g. `restyle(sections/header): ...`
+
+## Branch naming
+
+- `fix/<short-description>` — bug fixes
+- `feat/<short-description>` — new features
+- `restyle/<section>` — visual restyle of a specific section/snippet
+- `refactor/<short-description>` — structural changes
+- `tokens/<short-description>` — token or theme-setting changes
+- `docs/<short-description>` — docs only
+- `chore/<short-description>` — tooling
+
+## Workflow
+
+### 0. Refuse if on `main`
+
+Before anything else, check the current branch:
+
+```bash
+git branch --show-current
+```
+
+If it's `main`, stop. Tell the user:
+
+> You're on `main`, which is connected to the live Shopify theme — commits here auto-deploy. Create a branch first:
+>
+> ```
+> git checkout -b <type>/<short-description>
+> ```
+>
+> Types: `fix`, `feat`, `restyle`, `tokens`, `refactor`, `docs`, `chore`, `content`.
+
+The `.githooks/pre-commit` hook also refuses this at the git level if it's enabled. This skill-level check is the earlier, friendlier version.
+
+### 1. Review what changed
+
+```bash
+git status
+git diff
+```
+
+Read through the diff. This catches accidental changes, leftover debug code, files that shouldn't be committed, and — importantly for this repo — merchant-admin auto-commits that may have landed in your working tree during a `git pull`.
+
+### 2. Quality check
+
+Scan the diff for these common issues before staging.
+
+**Universal**
+
+- **Debug code left in** — `console.log`, `debugger`, commented-out blocks with no explanation.
+- **Staged secrets** — `.env`-style values, API keys, tokens, the real Greptile key in `.greptile/mcp-proxy.mjs`. Credential leaks are irreversible. (`.greptile/mcp-proxy.mjs` is gitignored — confirm it's still not staged.)
+- **Orphaned imports / unused JS** — leftovers from refactoring clutter the file.
+- **Files that shouldn't be tracked** — `.shopify/`, node_modules, personal editor files.
+
+**Shopify / Liquid**
+
+- **Hardcoded colours, hex, spacing, radii** in CSS or inline `style=""` attributes. Everything visual goes through Dawn's CSS custom properties or Sick Rabbit tokens in `assets/base.css` / `config/settings_data.json`. If a value isn't in the token system, it should be added to `docs/design/system.md` and `assets/base.css` first.
+- **`{% include %}` instead of `{% render %}`.** `{% include %}` is deprecated and leaks scope — always `{% render 'name' %}`.
+- **Missing `{% schema %}` on section files.** Every file in `sections/` needs a schema block with `settings` and `presets` so merchants can still edit it.
+- **Hardcoded English copy.** User-facing strings should go through `{{ 'key.path' | t }}` with the text in `locales/en.default.json`.
+- **Manual currency formatting.** Prices go through `| money`, `| money_with_currency`, or `| money_without_trailing_zeros` — never `£{{ price }}` or `{{ price | divided_by: 100 }}`.
+- **Destructive changes to Dawn originals.** Renaming, deleting, or restructuring Dawn's files turns every future `git merge upstream/main` into a conflict festival. Prefer additive changes (new snippet/section, CSS override) where possible.
+- **Stale `docs/components.md`.** If a snippet or section was added or renamed, the registry should be updated in the same commit.
+- **Broken JSON.** `templates/*.json`, `config/settings_data.json`, `config/settings_schema.json`, `locales/*.json`, and any `{% schema %}` blocks must be valid JSON. A trailing comma kills the theme.
+
+If any of these come up, fix before staging. Call it out to the user — don't silently patch it over and commit, since some of these (e.g. hardcoded hex) might represent a deliberate exception worth discussing.
+
+### 3. Run theme check
+
+```bash
+shopify theme check
+```
+
+If the user has the [Shopify Liquid VS Code extension](https://shopify.dev/docs/storefronts/themes/tools/shopify-liquid-vscode) running, most of this is already flagged live in the editor (wavy red/yellow lines, Prettier formatting on save). Running it from the terminal is the belt-and-braces gate before pushing — it catches anything the editor missed and is the same check that'll run in CI.
+
+Any new errors block the commit until resolved. Warnings are judgement calls — don't suppress check rules without logging it in `docs/decisions.md`.
+
+### 4. Stage and commit
+
+Stage specific files by name. Avoid `git add -A` or `git add .` — those sweep in unrelated changes, untracked editor files, or an accidental `.greptile/mcp-proxy.mjs` if the gitignore hasn't been respected.
+
+```bash
+git add <file1> <file2> ...
+git commit -m "$(cat <<'EOF'
+type: description here
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+Replace `Claude Opus 4.7` with the actual model running the session.
+
+### 5. Verify
+
+```bash
+git status
+git log --oneline -n 3
+```
+
+Confirm the commit landed, nothing unintended was left out, and the message reads correctly.
+
+## One logical change per commit
+
+A bug fix and an unrelated restyle are two commits. This makes `git bisect` and `git revert` work correctly — important on a live-deploying repo where "revert just the broken bit" is sometimes the fastest route back to a working store.
+
+If the working tree has mixed changes, stage and commit them separately rather than squashing into one.
+
+## Safety
+
+- **Never force push to `main`** — it rewrites the deployed theme history and can trigger a confusing re-sync. If you genuinely need to rewrite history on a feature branch, confirm with the user first.
+- **Never amend a commit that's already been pushed** — treat amending as a local-only tool.
+- **Never skip hooks** (`--no-verify`) unless the user explicitly asks. Hooks exist because something went wrong before; bypassing them repeats the mistake.
+- **Don't commit while `shopify theme dev` is running on the wrong store or wrong theme** — check `shopify theme list` if unsure.
+
+## Shopify admin auto-commits — do not "clean up"
+
+Commits authored by something like `Shopify <theme-kit@shopify.com>` on `config/settings_data.json` or `templates/*.json` are merchant edits flowing back from the admin. They're legitimate and must not be reverted casually. If you see one that looks wrong, ask the user before touching it.

--- a/.claude/skills/debug-session/SKILL.md
+++ b/.claude/skills/debug-session/SKILL.md
@@ -1,0 +1,142 @@
+---
+name: debug-session
+description: Run a structured debugging session on the Sick Rabbit Shopify theme — triaging and working through multiple bugs in one sitting. Use this skill when the user wants to "debug", "fix things", "work through a list of issues", enter "debug mode", says "let's debug", or has multiple storefront problems to triage at once ("the PDP is broken AND the cart flickers AND the header nav disappears on mobile"). Also use when the user pastes in a batch of bug reports, returns from QA with a list, or shares Greptile findings they want to work through systematically. Not for single isolated fixes — those can go straight through the issue skill. This skill is the "sit down and work through everything that's wrong" workflow.
+---
+
+# Debug Session
+
+A structured workflow for working through multiple storefront bugs in one sitting. List first, fix one at a time, verify each one before moving on, record as you go.
+
+The core principle: a debug session on a live-deploying Shopify theme goes sideways fast if you skip the triage step. Fixing one thing can mask another, and chasing a "bug" that turns out to be a merchant admin setting wastes an hour. Get the full picture first.
+
+## Before touching any code
+
+### 0. Check the branch
+
+```bash
+git branch --show-current
+```
+
+If it's `main`, stop. Tell the user:
+
+> You're on `main`, which auto-deploys to the live Shopify theme. Debug fixes need a branch so Greptile can review them before they ship:
+>
+> ```
+> git checkout -b fix/debug-YYYY-MM-DD
+> ```
+
+Don't start triaging on `main` — the session will want to commit fixes eventually, and the `commit` skill will refuse anyway.
+
+### 1. Read the existing issues
+
+Read `planning/issues.md` and note everything in Open. Present to the user:
+
+> You have 3 open issues. Want to work through these, start with new ones you're seeing now, or mix?
+
+### 2. Collect new issues
+
+Ask for everything that's wrong before writing a single fix. For each new issue, use the `issue` skill to log it in `planning/issues.md` (ID, severity, Where, Steps). Log them all before investigating.
+
+On a Shopify theme, "Steps" needs more than usual:
+
+- **Page / URL** — homepage, PDP for which product, collection X, checkout
+- **Device and viewport** — mobile Safari 414px, desktop Chrome 1440px, etc.
+- **Variant / customer state** — logged-in vs. guest, which variant selected, empty cart vs. populated, currency
+- **Live vs. theme editor vs. local dev** — the three render slightly differently; bugs that only appear in the theme editor often aren't bugs
+
+### 3. Triage: is this actually a code bug?
+
+Before code-chasing, check the common "not a bug" paths. A couple of minutes here saves long investigations:
+
+- **Merchant admin setting** — section hidden, block removed, setting misconfigured via the theme editor. Ask the user to check Online Store → Themes → Customize for the affected page. If the misconfiguration is in `config/settings_data.json`, it came from admin and should be resolved there, not in code.
+- **Product data** — missing image, wrong price/tax, variant not in stock, inventory tracking off. Check the product in the Shopify admin.
+- **Shopify platform issue** — [shopifystatus.com](https://www.shopifystatus.com/). If something store-wide just broke in the last hour and you changed nothing, check there first.
+- **App block interference** — a third-party app can inject a block into a section. If a bug appears only where an app block sits, start there.
+- **Browser cache / CDN** — a hard refresh sometimes fixes what isn't broken. Don't waste a session if the user hasn't refreshed.
+- **Merchant auto-commit** — `git log` might show a recent commit from the Shopify bot changing `settings_data.json` or a JSON template; that can explain sudden behaviour changes.
+
+If one of these is the cause, say so, close out the "issue" without a code fix, and move on.
+
+### 4. Prioritise and decide the branching strategy
+
+Once everything real is logged, suggest an order:
+
+- **Severity first**: High → Medium → Low
+- **Within severity, broken-before-polish**: a shopper-visible Liquid error before a rogue 2px margin
+- **Dependencies**: if fix A likely affects the area fix B is in, do A first
+
+Then decide *where* fixes will land:
+
+- **Single quick fix, confident in it** — fix directly on `main`. Remember: `main` deploys live.
+- **Multi-fix session, or anything non-trivial** — cut a branch `fix/debug-YYYY-MM-DD` or similar. Let Greptile review before merging. For this project, branches-to-PR is the default for anything beyond a one-line fix.
+
+Confirm the order and branching with the user before investigating.
+
+## Working through issues
+
+Work sequentially, one issue at a time.
+
+### For each issue
+
+1. **Reproduce first.** Get `shopify theme dev --store=sick-rabbit-store.myshopify.com` running and reproduce the bug at `127.0.0.1:9292` on the same page/device/variant/state the user reported. If you can't reproduce, say so before investigating — a bug that doesn't reproduce needs more info, not more code reading.
+
+2. **Investigate.** Read the relevant section/snippet/template. Trace through the Liquid execution. For JS bugs, open browser devtools; for layout bugs, use the element inspector with the live dev server. Find the actual root cause, don't guess and patch.
+
+3. **Fix.** Keep the fix minimal. A debug session is about fixing, not improving. If you notice *other* things that should change while you're in the file, mention them — don't silently refactor. Prefer additive changes over restructuring Dawn's originals (see `CLAUDE.md`), so `upstream/main` merges stay tractable.
+
+4. **Re-check in the browser.** The Shopify Liquid VS Code extension catches syntax issues live, but runtime behaviour only shows up when you view the page. Check the specific scenario the user reported (right page, right variant, right viewport, right logged-in state). For visual/layout bugs, eyeball on the actual breakpoint, not just by reading CSS.
+
+5. **Record.** Update the issue in `planning/issues.md` immediately:
+   - Set `Fixed:` to today's date
+   - Write a clear `Fix:` sentence — root cause and what changed
+   - Leave `Commit:` empty for now (fill in after the commit lands)
+
+6. **Have the user verify.** Not fixed until the user says so. If the fix doesn't hold up, go back to step 2 — don't move on.
+
+7. **Move the entry** from Open to Fixed.
+
+### If a fix is too complex or blocked
+
+Mark it `**Severity:** deferred` and add a note in Steps: what's known so far, what's blocking, what to try next. Deferred issues are useful context for the next session. Don't burn a whole session stuck on one when others are waiting.
+
+### If you notice something unreported
+
+Mention it to the user. They decide whether to log it as a new issue or ignore it. Silently fixing unreported problems creates invisible diffs that are hard to trace when something regresses.
+
+## Closing the session
+
+When the list is worked through:
+
+1. **Summarise in chat:**
+   ```
+   ## Session Summary
+   - ISS-004: Fixed (cart drawer closed on variant change — stale event listener)
+   - ISS-005: Fixed (header nav disappeared on mobile — missing `display: flex` at 414px)
+   - ISS-006: Deferred (PDP price flicker — needs variant JS deep-dive)
+   - ISS-007: New — logged during session (footer newsletter input has hardcoded hex)
+   ```
+
+2. **Commit.** Use the `commit` skill. One logical change per commit — group fixes only if they genuinely belong to one change. Reference issue IDs in messages so `git log | grep ISS-` stays useful:
+   ```
+   fix: stop cart drawer closing on variant change (ISS-004)
+   ```
+
+3. **Fill the `Commit:` field** on each fixed issue with the actual hash after the commit lands (`git log -1 --format=%h`).
+
+4. **If you branched** — push the branch, let Greptile review, and merge to `main` once green. Merging to `main` deploys live.
+
+5. **Update `docs/components.md`** if any snippet or section was added, renamed, or significantly changed during fixes.
+
+## Rules
+
+- **List first, fix second** — get everything logged before writing any fix
+- **Triage for not-a-code-bug first** — admin config, product data, platform status, app blocks
+- **Reproduce before investigating** — if you can't reproduce, gather more info; don't read code blindly
+- **One at a time** — sequential, not batched; debugging-while-context-switching misses things
+- **Minimal fixes** — don't refactor during debug; log improvements separately
+- **Verify in the browser on the right scenario** — the user's device/page/variant, not a guess
+- **User confirms** — not fixed until they say so
+- **Record immediately** — update the tracker after each fix, not at the end
+- **Don't silently fix unreported things** — mention, let the user decide
+- **Deferred is OK** — better than burning the session on one stubborn bug
+- **Remember `main` deploys live** — branch for anything non-trivial

--- a/.claude/skills/frontend-design/SKILL.md
+++ b/.claude/skills/frontend-design/SKILL.md
@@ -1,0 +1,274 @@
+---
+name: frontend-design
+description: Design and restyle UI for the Sick Rabbit Shopify theme — sections, snippets, layouts, components, colour/type/spacing decisions. Use this skill whenever the user is doing visual work on the theme: restyling a Dawn section (header, hero, PDP, cart drawer, footer), creating a new section or snippet, adjusting typography, applying brand colours, designing a module, reviewing how something looks, or asking things like "make this feel more Sick Rabbit", "restyle this", "design the header", "what should this look like", "fix the spacing", "typography pass", "does this match the brand". This is the authority on what Sick Rabbit looks and feels like — consult it for any design decision no matter how small, because "just this once hardcode a hex" is how drift starts. Not for architectural decisions about sections vs. snippets or OS 2.0 schemas (that's the architecture doc); not for logging design bugs (that's the issue skill). This skill answers "how should it look?" and "is that on-brand?". The Phase 3 restyle is the heart of this project — expect this skill to be invoked constantly.
+---
+
+# Frontend Design — Sick Rabbit
+
+This is the visual authority for the Sick Rabbit theme. Whenever you're making something look a certain way, consult this.
+
+## Two skills, one stack
+
+Claude Code has a general `frontend-design` skill from the marketplace that teaches how to build **creative, production-grade frontend that doesn't look AI-generated**. Use that one for general design craft — layout instincts, avoiding slop aesthetics, pushing past the default.
+
+**This skill layers Sick Rabbit on top of that craft.** It answers: *what does "Sick Rabbit" actually look like and how do I express it in Dawn + Liquid + CSS without breaking OS 2.0 or the upstream merge path?* Consult both.
+
+## Brand identity, distilled
+
+Sick Rabbit is a streetwear-adjacent apparel brand with a peculiar combination of references — **archaic / literary-occult typography**, **analogue music-gear physicality** (pedal boards, mixing desks, hardware synths), and a **playful, irreverent** tone that refuses to take itself too seriously. Collection themes — Anachronism, Norse Poets Society, Digital Occult, Major Arcana — are the permission slip. The storefront should feel like a small label run by someone with weird taste, not a generic Shopify fit-any-brand template.
+
+The three ingredients sit together on purpose:
+- Archaic blackletter + monospace is the "text-as-artefact" side
+- Knobs, bevels, dials, meters is the "object-you-touch" side
+- Playful irreverence is what keeps it from becoming cosplay-goth or tech-bro
+
+### The six principles
+
+1. **Warm-dark, not goth-dark.** The palette is earthy (graphite, burnt rose, dark slate, sand-dune cream). No pure black, no pure white, no cold greys. A hex that looks "just fine" in isolation will feel wrong next to the real tokens — always place a new value against the existing palette before committing.
+2. **Typography-led.** Blackletter display faces (UnifrakturMaguntia, Pirata One, UnifrakturCook) carry the brand. A monospace (Anonymous Pro) carries the UI. The tension between those two is the signature — don't soften it with a neutral sans-serif for body text.
+3. **Analogue-physical, not flat-digital.** UI elements can feel like hardware — pedal-board buttons, pots/knobs, meters, LED indicators, labelled panels. The `--shadow-bevel-raised`, `--shadow-bevel-pressed`, `--shadow-bevel-hover` tokens exist for this reason. Interactive controls (CTAs, variant pickers, add-to-cart, filters) can lean into this vocabulary. Purely editorial surfaces (long copy, hero) can stay flat. The goal isn't skeuomorphism cosplay — it's *one leg in the physical world* as a brand signal.
+4. **Playful and irreverent, not precious.** The brand isn't serious about itself. Microcopy can be funny. Empty states can have personality. A 404 can be on-brand and dumb in a good way. "Slightly strange" shouldn't read as "strained cool" — it reads as a label having fun.
+5. **Product-first once you're on the PDP.** Photography and the variant picker are the centre of gravity. Everything else steps back. Chrome stays minimal. The analogue vocabulary helps here — variant pickers as hardware selectors, quantity as a dial, add-to-cart as a chunky pedal button.
+6. **Deliberate over polished.** The aim isn't SaaS polish — rounded-everything, airy gradients, feel-good micro-interactions. Hard edges, confident type, restrained animation, small tactile details. If it looks like a Stripe clone, it's wrong.
+
+### The anti-patterns — things that would kill it
+
+- **Bright primary CTAs** that fight the warm-dark palette (electric blue, neon green)
+- **SaaS aesthetics**: soft gradients, glass-morphism, big drop shadows, rounded-everything, feel-good animation
+- **Corporate sans-serif body text** (Inter, SF Pro, Helvetica, system-ui default) — neutralises the blackletter tension
+- **Pastel "friendly" accent colours**
+- **Generic Shopify hover**: scale-up-on-hover product card, fade-in-everything, the usual
+- **Excessive animation** — a page should feel still until a shopper does something
+- **Stock-photo hero composition**: centred text + "shop now" + lifestyle photo
+- **Default Dawn leaking through**: neutral greys, sans-serif headings, generic blue focus rings, system button chrome
+- **Cosplay goth**: skulls, pentagrams, blood-red, mall-Hot-Topic energy. The brand is literary-occult, not costume-goth.
+- **Earnest "curated brand" voice** — the one that says "discover our collection of thoughtfully designed pieces." This brand doesn't talk like that. See principle 4.
+- **Skeuomorphism cosplay** — a product card rendered as a literal polaroid, drop-shadowed and rotated. The analogue vocabulary is *selective* (interactive controls), not a wholesale retro theme.
+
+If a choice drifts toward any of those, push back. The brand is specific; generic defaults aren't "safe," they're wrong.
+
+## Tokens are the source of truth
+
+The canonical token list lives at **`docs/design/system.md`**. That file is the contract. This skill gives you taste; that file gives you values.
+
+Rules:
+
+- Never hardcode hex, rgb, spacing pixels, radii, or font-families in CSS or inline Liquid `style=""`. Use CSS custom properties from `assets/base.css` or Dawn's colour scheme system.
+- If the value you need isn't in `docs/design/system.md`, **add it there and in `assets/base.css` first**, then use it. Adding to the system is a lightweight decision, not a heavy one — the heavy decision is letting hardcoded values creep in.
+- Dawn's own CSS custom properties (set from `config/settings_data.json`) are part of the system. When you're styling, reach for `var(--color-foreground)`, `var(--color-background)`, etc., wired to our palette via the scheme settings. Don't bypass them by defining parallel CSS vars with the same name.
+- Merchant-editable surfaces (section settings, colour schemes) are the preferred way to expose design decisions. If a merchant should be able to pick a colour for a section, surface it via a `color_scheme` setting in the section's schema, not a hardcoded `background:`.
+
+## Colour, applied
+
+The palette is in `docs/design/system.md`. Here's when to use each:
+
+| Colour | Typical role | Don't use for |
+|---|---|---|
+| `--color-sand-dune` (#e5dcc5) | Default page background, header/footer, hero background on light sections | CTA, body text on dark (too low contrast) |
+| `--color-graphite` (#2d2d2a) | Body text on sand-dune; dark surfaces (footer, feature sections); primary heading colour | CTAs (too quiet) |
+| `--color-dark-slate-grey` (#1c4d4f) | Secondary/elevated surfaces, tag/badge backgrounds, secondary CTAs | Body text on sand-dune (contrast is borderline) |
+| `--color-burnt-rose` (#903636) | Primary CTA, accent, in-brand highlight. Use sparingly for emphasis to keep its impact | Background fills, body text |
+| `--color-faded-copper` (#a77b5f) | Reserved — special one-off uses (collection-specific highlights, seasonal accents) | Anything recurring |
+
+Rules of thumb:
+- Two colours at a time usually feels right; three colours in a section requires a *reason*. Four colours is almost always wrong.
+- The burnt-rose CTA is the brand's punctuation mark — if every button is burnt rose, nothing is emphasised. Reserve it for the primary action.
+- On dark surfaces (graphite, dark slate), use sand-dune or a slightly warmer off-white for text. Never pure `#fff`.
+- Body text hierarchy is carried by **weight and family**, not colour. Don't use five greys for five heading levels.
+
+## Typography, applied
+
+Six families, each with a role (full list in `docs/design/system.md`):
+
+- **UnifrakturMaguntia** — H1, primary display. Use big, use once per page. Never set it under 2rem — blackletter at small sizes is unreadable and looks cosplay.
+- **Pirata One** — H2, secondary display. Slightly more functional than UnifrakturMaguntia; good for section headings.
+- **UnifrakturCook** — logo only. Don't repurpose.
+- **Nordica Plus** — collection names, poster-style displays. The brand's "poster type."
+- **Outfit** — hero wordmark ("Sick Rabbit"). Used where blackletter would be too hard to read (hero titles, some landing-page moments). Limited use — this is the "readable" face, don't let it take over.
+- **Anonymous Pro (monospace)** — body, labels, UI, microcopy. This is where most text lives. The monospace tension against the blackletter displays is the signature.
+
+Rules of thumb:
+- **One display face per section**, ideally per page. Multiple blackletter faces at once = ransom note.
+- **Headings can be big**. The scale in `docs/design/system.md` goes up to 84px for the logo. Use the scale — don't timidly default to 24px for every heading.
+- **Tight line-heights on display type** (`--leading-tight: 1`), generous on body (`--leading-normal: 1.5`, `--leading-relaxed: 1.8` for long-form).
+- **Don't italicise blackletter.** Never.
+- **Kerning and spacing matter more at large sizes** than small. For the 64–84px display sizes, inspect the letterforms — blackletter has weird default kerning that often needs a `letter-spacing: -0.02em` or similar tuning.
+
+## The analogue-hardware vocabulary
+
+This is what "principle 3" looks like in practice. These are design moves — use them where they fit, don't force them everywhere.
+
+**Vocabulary bank**:
+- **Bevelled buttons** — depress on click. `--shadow-bevel-raised` for default, `--shadow-bevel-pressed` for `:active`, `--shadow-bevel-hover` on hover. The change should feel *mechanical* (instant, discrete), not CSS-easing smooth.
+- **Knobs / dials** — quantity control, sort-by, variant size. A circular control with a notch is on-brand; a vanilla `<select>` is not.
+- **Toggle switches** — filters, on/off states. Chunky, labelled, with a satisfying on/off position (think guitar-pedal toggle, not iOS switch).
+- **Meters / LEDs** — stock indicators, progress, cart-item counter. A segmented LED read-out ("3 in stock" as three lit bars) reads more Sick-Rabbit than a plain number.
+- **Labelled panels** — section headings can look like hardware labels: uppercase monospace, small, on a separator line or bordered box. Think guitar-amp front panel.
+- **Patch-cable / wiring motifs** — decorative, for transitions, dividers, hero ornaments. Subtle, not everywhere.
+- **Tactile type** — display type can feel embossed, die-cut, engraved. Don't go full steampunk, but a slight depth cue on the wordmark or a big heading is on-brand.
+
+**Where to apply**:
+- **Lean in**: CTAs (add-to-cart, checkout, submit), variant pickers, filter/sort UI, cart drawer controls, quantity adjusters, search button, newsletter form submit.
+- **Stay flat**: editorial hero copy, collection grids, product photography frames, long-form copy, policy pages. Don't bevel a paragraph.
+
+**Where it usually fails**:
+- **Over-applied** — every element bevelled and clickable-looking. Reads as Fisher-Price, not pedal-board. Pick the interactive elements, leave the rest alone.
+- **Too literal** — a product card rendered as a cassette tape label with tape-reels. That's costume, not design. The vocabulary is *inspired by* hardware, not *a theme of* it.
+- **Inconsistent metaphor** — one button is a pedal, another is a chrome light-switch, another is flat. Pick the vocabulary and use it consistently across interactive controls.
+
+## How to restyle a Dawn section (Phase 3 workflow)
+
+Phase 3 is a section-by-section restyle (priority: header → homepage → collection → PDP → cart drawer → footer). For each section:
+
+### 1. Read Dawn's original first
+
+Open the section file (`sections/<name>.liquid`) and its associated CSS (`assets/section-<name>.css` or `assets/component-*.css`). Note what merchant-editable settings already exist — the schema must stay intact so theme-editor behaviour is preserved.
+
+### 2. Look at a brand reference
+
+Before touching code, look at the old Astro repo (`C:\Users\redpo\repos\sickrabbit-website\src\pages/` and `src/content/`) for how this thing has been expressed in the brand's voice before. It's not a codebase to port; it's a mood board. Especially valuable for copy tone and hero typography treatments.
+
+### 3. Plan additive, not destructive
+
+Dawn is `upstream`. Every structural rewrite is a future merge conflict. Prefer these in order:
+1. **CSS custom property overrides** in `assets/base.css` — change the look without touching the Liquid at all
+2. **Section-scoped CSS** in `assets/section-<name>.css` — override Dawn's defaults with class selectors
+3. **Schema settings** — expose merchant-editable knobs so design choices aren't hardcoded
+4. **New snippets** you `{% render %}` into the section — when you need new markup
+5. **Direct Liquid edits to Dawn's section file** — last resort, only when the above can't express the change
+
+### 4. Build the variant in isolation
+
+Run `shopify theme dev` at `127.0.0.1:9292`. Navigate to the page with the section. Open devtools, tune CSS custom properties live in the inspector before committing to values in code.
+
+### 5. Verify across the scenarios
+
+Design only holds up if it holds up in reality:
+- **Breakpoints** — 414px (mobile Safari), 768px (tablet), 1024px (small desktop), 1440px (desktop). Design once, check four times.
+- **Content states** — empty (no products, empty cart), short content, very long content (paragraph of 3 sentences vs. paragraph of 15)
+- **Dark content areas** — some sections have the palette inverted; make sure the type still reads
+
+### 6. Update `docs/components.md` if you added anything
+
+New snippets and significantly-modified sections go in the registry.
+
+### 7. Log the decision if it's material
+
+If the restyle made a non-obvious choice (e.g. "we override Dawn's button entirely instead of extending it"), add a short entry to `docs/decisions.md`. Future you will want to know why.
+
+## Section-specific notes (growing document)
+
+Populate this section as Phase 3 progresses. Each section gets a paragraph on the key design move, the failure modes encountered, and the token choices that worked.
+
+- **Header** — _TBD (Phase 3 first pass)._ Key decisions: logo treatment (UnifrakturCook), nav font, cart icon style, announcement bar behaviour.
+- **Hero / homepage** — _TBD._ Key decisions: hero wordmark, featured-collection presentation, density of the page.
+- **Collection grid** — _TBD._ Key decisions: product card, hover state, filter/sort UI, empty state.
+- **PDP** — _TBD._ Key decisions: gallery layout, variant picker, add-to-cart button, description typography, related products.
+- **Cart drawer** — _TBD._ Key decisions: line item layout, quantity control, empty-cart moment, checkout CTA treatment.
+- **Footer** — _TBD._ Key decisions: newsletter form, link grouping, social icons, "slightly strange" moment.
+
+When you finish a section, write the paragraph. These notes compound.
+
+## Accessibility, specific to this palette
+
+The warm-dark palette needs real contrast checking — eyeballing lies. WCAG 2.2 AA: **4.5:1** for body text, **3:1** for large text (≥ 18px bold or ≥ 24px regular) and UI components.
+
+Known-good combinations (check with a tool before relying):
+
+- `--color-graphite` on `--color-sand-dune` — safe for body text
+- `--color-sand-dune` on `--color-graphite` — safe for body text
+- `--color-sand-dune` on `--color-dark-slate-grey` — safe for body text
+- `--color-burnt-rose` on `--color-sand-dune` — **marginal for body text**; fine for large headings and CTA buttons
+- `--color-dark-slate-grey` on `--color-sand-dune` — **marginal for body text**; verify before use
+
+Other accessibility rules:
+
+- **Focus states must be visible and on-brand.** Don't `outline: none` without replacing with a custom style — the default browser outline is ugly but it's there for a reason. A 2px burnt-rose outline with a 2px offset reads as intentional and on-brand.
+- **Touch targets ≥ 44×44 CSS pixels.** Nav links, cart buttons, variant swatches. Decorative elements can be smaller.
+- **Blackletter is hard to read.** Use it for display sizes, not for body copy or critical labels. Anything a shopper needs to understand at a glance (prices, "Add to cart", checkout steps) goes in Anonymous Pro.
+- **Alt text on product images** should describe the product, not be empty or the filename.
+- **Announce cart updates** with `aria-live="polite"` on the cart line-item region.
+
+## Shopify / OS 2.0 hooks
+
+- **Colour schemes** (`config/settings_data.json` → `color_schemes`) are how a merchant can change a section's palette. Map the brand tokens onto Dawn's scheme slots (background, foreground, button, button-label, secondary-button, etc.) so schemes work out of the box.
+- **Section settings** are where design choices become merchant-editable. If the user wants to pick a hero image, a heading, or a background colour per-section, it belongs in the schema.
+- **App blocks** — some sections may accept merchant-installed app blocks (e.g. reviews). Design the section so an app block drop-in doesn't break the layout.
+- **Responsive images** — use `{{ image | image_url: width: X }}` with sensible widths and `srcset`, not a fixed-size image in markup.
+
+## Common patterns (seed)
+
+These grow into a `references/examples.md` when there are enough of them to warrant splitting.
+
+### Section CSS skeleton
+
+```liquid
+<!-- sections/sick-rabbit-example.liquid -->
+<div class="sr-example color-{{ section.settings.color_scheme }}">
+  <h2 class="sr-example__heading">{{ section.settings.heading }}</h2>
+</div>
+
+{% stylesheet %}
+  .sr-example {
+    padding-block: var(--space-10);
+    padding-inline: var(--space-4);
+  }
+  .sr-example__heading {
+    font-family: var(--font-heading);
+    font-size: var(--text-h1);
+    line-height: var(--leading-tight);
+    color: rgb(var(--color-foreground));
+  }
+{% endstylesheet %}
+
+{% schema %}
+{
+  "name": "Sick Rabbit Example",
+  "settings": [
+    { "type": "color_scheme", "id": "color_scheme", "label": "Colour scheme", "default": "scheme-1" },
+    { "type": "text", "id": "heading", "label": "Heading", "default": "Example" }
+  ],
+  "presets": [{ "name": "Sick Rabbit Example" }]
+}
+{% endschema %}
+```
+
+### Do / don't
+
+```css
+/* ✓ */
+.product-card__title {
+  font-family: var(--font-heading);
+  color: rgb(var(--color-foreground));
+  padding: var(--space-3);
+}
+
+/* ✗ */
+.product-card__title {
+  font-family: 'Pirata One', cursive;
+  color: #2d2d2a;
+  padding: 24px;
+}
+```
+
+## When in doubt
+
+- **When in doubt about a value**, check `docs/design/system.md`.
+- **When in doubt about a pattern**, look at how the old Astro repo expressed it — it doesn't have to match, but it's a strong hint.
+- **When in doubt about the brand**, re-read the five principles above. If a choice fights them, it's probably wrong.
+- **When in doubt about a Shopify constraint**, consult the Shopify AI Toolkit skill or `docs/architecture.md`.
+- **When in doubt whether the user will like it**, show them at `127.0.0.1:9292` before committing. Design opinions are cheap; a live preview is fast.
+
+## Reference
+
+- **Tokens (source of truth)** — `docs/design/system.md`
+- **Brand mood board (old Astro repo)** — `C:\Users\redpo\repos\sickrabbit-website\src\styles/`, `src/pages/`, `src/content/`
+- **Architecture** — `docs/architecture.md`
+- **Decisions** — `docs/decisions.md`
+- **Generic design craft** — the `frontend-design:frontend-design` skill from the Claude Code marketplace (complements this one)
+
+Populate sibling files as the design grows:
+- `components/README.md` — shared snippet/section UI inventory
+- `references/brand-voice.md` — copy voice, tone, microcopy examples from the old repo
+- `references/dawn-overrides.md` — patterns for overriding Dawn defaults cleanly
+- `references/section-notes.md` — per-section design log (or keep inline above until it splits)

--- a/.claude/skills/issue/SKILL.md
+++ b/.claude/skills/issue/SKILL.md
@@ -1,0 +1,117 @@
+---
+name: issue
+description: Log bugs and regressions for the Sick Rabbit theme to planning/issues.md. Use this skill when the user reports something broken on the storefront — crashes, wrong behaviour, checkout or cart problems, layout that breaks, wrong prices, variants not switching, sections disappearing, accessibility regressions, translations missing, or anything working one way and now working another. Trigger on "that's broken", "this is a bug", "this doesn't work", "it's glitching", "look at the site — X is wrong", "did we regress X", "prod is broken", "what issues do we have", "what's open", "show me the bugs", "is there a bug for X". Also trigger when the user wants to mark an issue fixed or asks to show the current bug list. For features, new sections, or things to build, route to planning/ideas.md or planning/roadmap.md instead — this skill is strictly for things that need fixing.
+---
+
+# Issue
+
+Issues for the Sick Rabbit theme live in `planning/issues.md`. This is the single source of truth for what's broken. Features, new sections, and things to build go in `planning/ideas.md` (not yet committed) or `planning/roadmap.md` (committed) — not here.
+
+## Issue vs. task vs. idea vs. roadmap item
+
+- **Issue** → "the variant picker doesn't update the price on mobile" → something's broken → log here
+- **Task** → "add a size filter to the collection page" → something to build inside the current/next phase → use the `task` skill (`TSK-NNN` in `planning/roadmap.md`)
+- **Idea** → "we should build a lookbook page" → something new not yet decided → `planning/ideas.md`
+- **Phase / roadmap item** → "Phase 3 — Restyle sections" → a whole chunk of work → use the `plan` skill
+
+If the user describes something that isn't broken, route it:
+- Concrete and ready to build → `task`
+- Not yet committed → `ideas.md`
+- A whole phase → `plan`
+
+## Why this matters for a Shopify theme
+
+`main` auto-deploys to the live theme. "It's broken" on this project usually means a customer is seeing it right now. Severity is less about cosmetics and more about whether a shopper can find, understand, or complete a purchase.
+
+## File format
+
+`planning/issues.md` has two sections — Open and Fixed. New issues go in Open. When resolved, they move to Fixed with the fix summary and commit hash.
+
+```markdown
+# Issues
+
+## Open
+
+### ISS-003: Description of the issue
+**Found:** YYYY-MM-DD
+**Severity:** High | Medium | Low
+**Where:** Section/snippet/template path or page type (e.g. `sections/header.liquid`, PDP, cart drawer)
+**Steps:** How to reproduce — include device/browser if relevant
+**Screenshot/URL:** optional but helpful for visual bugs
+
+## Fixed
+
+### ISS-001: Cart drawer closes on variant change
+**Found:** 2026-04-22
+**Severity:** High
+**Fixed:** 2026-04-23
+**Fix:** Removed stray event listener that re-initialised drawer on DOM mutation
+**Commit:** abc1234
+```
+
+The `Where` line is an addition to the playbook template — it's always useful on a Shopify theme because the first thing anyone does when reopening an issue is find the relevant section/snippet.
+
+### Issue IDs
+
+Format: `ISS-NNN`. Increment from the highest existing ID. Read `planning/issues.md` first to find it — don't guess.
+
+## Severity, Shopify-flavoured
+
+Severity in a live-selling theme is mostly about: *does this prevent a sale or make a customer see something wrong*.
+
+- **High** — blocks or breaks the purchase path. Checkout broken; cart broken; wrong price shown; currency/tax wrong; product variants not selecting; product pages 404ing; page crashing / white-screening; storefront password or unintended redirects; severe accessibility regression (can't add to cart by keyboard); Liquid error rendering a shopper-visible "Liquid error" string.
+- **Medium** — visible problem with a workaround or limited blast radius. Visual glitch in one section, layout breaking at a specific viewport, an animation that jitters, a translation key missing, a setting that isn't wiring through to the CSS, a broken link in the footer, a Greptile-flagged regression that hasn't bitten customers yet.
+- **Low** — minor, edge case, or internal-only. Copy typo, slight spacing inconsistency, admin-only annoyance, console warning with no user-visible impact.
+
+When in doubt, ask the user — don't downgrade something that could be High.
+
+## Workflow
+
+### Logging an issue
+
+1. Read `planning/issues.md` to find the current highest `ISS-NNN`.
+2. Assess severity using the rules above. If you're unsure, ask.
+3. Add an entry to the Open section with the next ID.
+4. Fill every field: Found, Severity, Where, Steps. Skip Screenshot/URL if not provided.
+5. Confirm in chat with the ID and one-line summary: e.g. *"Logged ISS-004 (high): cart drawer closes on variant change on mobile Safari."*
+
+If the user reports several issues at once, log them all first, then confirm.
+
+### Marking an issue fixed
+
+When a fix has landed:
+
+1. Move the entry from Open to Fixed.
+2. Add `Fixed:` (date), `Fix:` (one or two sentences on the root cause and what changed), `Commit:` (hash).
+3. Keep the body of the entry intact so the "what was broken" record survives.
+
+If you're logging the fix as part of the same conversation that fixed it, reference the most recent commit hash from `git log -1 --format=%h`.
+
+### Showing open issues
+
+When asked "what's open" or "show the issues":
+
+1. Read `planning/issues.md`.
+2. Summarise the Open section in chat, grouped by severity (High → Medium → Low), newest first within each group.
+3. If there's nothing open, say so — don't invent entries to pad.
+
+## Connecting to commits
+
+Reference the issue ID in commit messages so `git log | grep ISS-` stays useful:
+
+```
+fix: stop cart drawer closing on variant change (ISS-004)
+```
+
+The `commit` skill's `fix` type pairs naturally with issues.
+
+## Connecting to Greptile and audits
+
+- **Greptile review comments** that surface real regressions can be logged as issues with a note like "Found by Greptile on PR #N" in the Steps field. Style-only Greptile nits (naming, token tidy-ups) usually don't warrant an issue — address them in the PR.
+- **Audit findings** (from the `audit` skill, when it exists) land here too, with "Found during audit — [check category]" in the Steps field. That traceability helps future audits dedupe.
+
+## What not to log as an issue
+
+- Things that are working as intended but the user doesn't like — that's a design change, go to `planning/ideas.md` or discuss a decision in `docs/decisions.md`.
+- Merchant-admin configuration mistakes (e.g. a section hidden via admin toggles) — this is store config, not a theme bug. Tell the user what to flip in admin instead.
+- Shopify platform outages — not ours to fix. Point at [shopify.status.com](https://www.shopifystatus.com/) and don't log.

--- a/.claude/skills/plan/SKILL.md
+++ b/.claude/skills/plan/SKILL.md
@@ -1,0 +1,188 @@
+---
+name: plan
+description: Manage the Sick Rabbit theme roadmap and ideas backlog. Use this skill when the user says "what are we working on", "what's next", "status", "show the plan", "what's the roadmap", "what phase are we in", "add to the roadmap", "mark Phase X as shipped", "move this to in progress", "add an idea", "evaluate this feature", "prioritise", or anything else about what to build next and in what order. Also trigger when a section restyle or phase finishes and the roadmap needs updating, when the user wants to promote an idea from ideas.md to the roadmap, or when they're weighing whether a post-launch feature idea is worth committing to. Not for logging bugs (that's the issue skill) — this skill is strictly about what to build and in what order.
+---
+
+# Plan
+
+This skill manages the two files that define what the Sick Rabbit theme is building:
+
+- **`planning/roadmap.md`** — what's shipped, what's in progress, what's next. The committed plan. Mirrors the phased build plan in Kiro at `Projects/Sick Rabbit/Documentation/Website/Development/Shopify Build Plan.md`.
+- **`planning/ideas.md`** — features being considered but not yet committed. The "maybe" list, mostly post-launch stuff.
+
+The separation matters: half-formed ideas shouldn't clutter the committed plan. Ideas get evaluated on their own merits and only graduate to the roadmap when there's a clear decision to build them.
+
+## Kiro linkage
+
+The Shopify Build Plan in Kiro is the narrative source of truth — it has the rationale for each phase, tech decisions, and timeline. `planning/roadmap.md` in the repo is the status-tracking summary. When a phase ships or scope changes materially, update both: the Kiro doc gets the prose update, the repo roadmap gets the checkbox tick / shipped-row addition. If the user asks "what's the plan" without context, the repo roadmap is the fast answer; if they want the *why*, point them at the Kiro doc.
+
+## Roadmap format
+
+The project follows the five-phase build plan. Each phase already has a structure; keep it.
+
+```markdown
+# Roadmap
+
+Mirrors Projects/Sick Rabbit/Documentation/Website/Development/Shopify Build Plan.md in Kiro.
+
+## Shipped
+
+| Version | What | Date |
+|---|---|---|
+| — | Dawn forked as base theme | 2026-04-19 |
+| — | Repo setup retrofit | 2026-04-19 |
+| Phase 1 | Setup complete (CLI, Greptile, AI Toolkit, skills) | 2026-04-20 |
+
+## In Progress
+
+### Phase 2 — Extract brand tokens
+Pull colours, fonts, type scale from the old Astro repo; apply to Dawn's colour schemes and CSS custom properties.
+- [x] Source tokens documented in `docs/design/system.md`
+- [ ] Map onto Dawn colour schemes in `config/settings_data.json`
+- [ ] Add CSS custom properties to `assets/base.css`
+- [ ] Wire webfonts (UnifrakturMaguntia, Pirata One, Anonymous Pro, Nordica Plus, UnifrakturCook, Outfit)
+
+## Next
+
+### Audit Checkpoint (post-Phase 2)
+Token-coverage audit before Phase 3 restyle begins.
+
+### Phase 3 — Restyle sections
+Section-by-section restyle in priority order:
+- [ ] Header (logo, nav, cart icon, announcement bar)
+- [ ] Homepage (hero, featured collections, content modules)
+- [ ] Collection page
+- [ ] Product page / PDP
+- [ ] Cart drawer
+- [ ] Footer
+
+### Phase 4 — Content + products (parallel with Phase 3)
+- [ ] Tapstitch integration
+- [ ] Product creation + tagging
+- [ ] Rule-based collections (Anachronism, Norse Poets Society, Digital Occult, Major Arcana)
+- [ ] Copy from old Astro repo
+- [ ] Shipping zones, payment gateways, taxes (GBP)
+
+### Audit Checkpoint (pre-launch, mandatory)
+Full audit including the pre-launch checklist before Phase 5.
+
+### Phase 5 — Launch
+- [ ] Connect GitHub integration — `main` → live theme
+- [ ] Point `sickrabbit.com` DNS at Shopify
+- [ ] SSL auto-provision
+- [ ] Password-protect for QA
+- [ ] Remove password → live
+```
+
+### Sections
+
+- **Shipped** — completed phases/pieces, one row each, dated. This is the project's history.
+- **In Progress** — what's actively being built. Checklist of concrete sub-steps. Ideally one phase active at a time.
+- **Next** — what's coming after, in priority order. Enough detail to understand scope, not a full spec.
+
+### Sub-phases / tasks
+
+Phase 1 is broken into `1a → 1e` because it's multi-session. Phase 3 is a list of sections rather than sub-phases because each section restyle is roughly one session. Use whichever shape fits the phase.
+
+For **item-level work inside a phase** — adding a concrete thing to build, ticking it off, listing what's open — hand off to the `task` skill. It owns `TSK-NNN` IDs and the bullet-level operations. This skill (`plan`) owns the phase-level structure: shipped/in-progress/next, transitions between sections, audit-checkpoint placement.
+
+The quick split:
+- "What phase are we in, and what's shipped?" → `plan`
+- "Add TSK-NNN for X", "mark TSK-NNN done", "what tasks are open in Phase 3?" → `task`
+
+If a phase just needs a short flat checklist (one session's work, no cross-session tracking), plain bullets are fine and `task` IDs are optional. Introduce TSK-NNN when multi-session work benefits from commit traceability (`feat: … (TSK-009)`).
+
+## Ideas format
+
+```markdown
+# Ideas
+
+Features being considered but not committed. Mostly post-launch — anything worth weighing goes here before graduating to the roadmap.
+
+| Idea | Complexity | Feasibility | Demand | Usefulness | Notes |
+|------|-----------|-------------|--------|------------|-------|
+| Bespoke PDP layout | High | High | Medium | High | Post-launch iteration on Dawn's default PDP |
+| Lookbook section | Medium | High | Medium | High | Reusable OS 2.0 section for Anachronism / Norse Poets / etc. |
+| Custom 404 | Low | High | Low | Medium | On-brand + irreverent |
+| Loyalty / referral | Medium | High | Low | Low | Shopify app if volume warrants |
+```
+
+### Evaluation columns
+
+- **Complexity** — how hard to build? (Low / Medium / High)
+- **Feasibility** — can it actually be done with Dawn + Shopify + the current plan? (Low / Medium / High)
+- **Demand** — how much does the brand/audience want this? (Low / Medium / High). Pre-launch this is a judgement call based on the brand direction.
+- **Usefulness** — how much value does it add? (Low / Medium / High). Novelty features can be high-demand but low-usefulness; infrastructure can be the opposite.
+- **Notes** — one-line context: constraint, dependency, or direction.
+
+## Operations
+
+### Show status
+
+Read `planning/roadmap.md` and summarise: what's shipped, what's in progress (with sub-step progress), what's next. If asked for a one-line answer, say the current phase and the immediate next step. If asked for *why* a phase is scoped the way it is, read the Shopify Build Plan in Kiro.
+
+### Add to the roadmap
+
+1. Decide which section it belongs in (usually **Next**).
+2. Ask about priority relative to existing Next items if the list isn't empty.
+3. Add with a brief description and a checklist if it's multi-step.
+4. If it's a major feature (new template, new integration, new section family), insert an **Audit Checkpoint** right after it — audits between major features prevent drift from one contaminating the next.
+5. Mirror the change in the Kiro Shopify Build Plan when the scope or phase structure is materially different from what the plan currently says.
+
+### Move between sections
+
+- **Starting work**: move from Next to In Progress. Break into a checklist of concrete sub-steps. If the phase is session-long, plain bullets are fine; if multi-session, use `TSK-NNN` IDs.
+- **Shipping**: move from In Progress to Shipped. Add a row to the Shipped table with today's date (absolute, not "today"). Clear the checklist — the detail is in git history.
+- **Pausing**: move from In Progress back to Next with a note about why it was paused and what state it's in.
+
+Dates: always convert relative references ("today", "this week", "Thursday") to absolute `YYYY-MM-DD`. Relative dates rot quickly.
+
+### Add an idea
+
+1. Read `planning/ideas.md` first to avoid duplicates.
+2. Evaluate across the four columns. Ask the user if you're unsure about any rating.
+3. Add to the table with a one-line Notes entry.
+4. Confirm in chat: *"Added to ideas: Lookbook section (Medium complexity, High feasibility, Medium demand, High usefulness)."*
+
+### Promote an idea
+
+When an idea graduates to the roadmap:
+
+1. Remove from the ideas table.
+2. Add to **Next** in `planning/roadmap.md` with a description and a preliminary checklist.
+3. Ask about priority relative to other Next items.
+4. Insert an **Audit Checkpoint** after it if it's a major feature.
+5. If the promotion materially changes the build plan, sketch the change and update Kiro's Shopify Build Plan — don't let repo and vault drift.
+
+### Evaluate ideas
+
+When the user asks to review or prioritise `planning/ideas.md`:
+
+- Which ideas score highest across all four columns?
+- Any dependencies (idea X needs idea Y first)?
+- Does anything on the ideas list unlock or block something already on the roadmap?
+- Is anything actually post-Phase-5 only (don't pollute Next with "after launch" ideas)?
+
+Present a recommendation but let the user decide.
+
+## Audit checkpoints
+
+After every major feature, insert an audit checkpoint. Build this into roadmap updates automatically:
+
+```markdown
+### Audit Checkpoint (post-Phase 2)
+Token-coverage audit before Phase 3 restyle begins.
+```
+
+A "major feature" on this project means: a phase transition, a new template type, a new third-party integration, a big section restyle. Minor token tweaks and copy edits don't need checkpoints between them.
+
+The `audit` skill handles what happens at the checkpoint; this skill just makes sure it gets scheduled. The **pre-launch checkpoint before Phase 5 is mandatory** — don't let the user launch without it.
+
+## Principles
+
+- **The roadmap is a living document.** Update it honestly as priorities shift. An out-of-date plan is worse than no plan.
+- **Ideas are cheap, commitments are expensive.** Keep `ideas.md` generous; keep `roadmap.md` honest. The gap between "that sounds cool" and "we're building that next" should require a conscious decision.
+- **One phase at a time.** If In Progress has three phases open, nothing is actually in progress. Finish the restyle before starting the next.
+- **Absolute dates, always.** "Next week" becomes `2026-04-27`. Relative dates rot.
+- **Kiro = narrative, repo = status.** Keep both coherent; if they diverge, reconcile.
+- **Don't skip the pre-launch audit.** Phase 5 is the one checkpoint that's non-negotiable.

--- a/.claude/skills/pr-comments/SKILL.md
+++ b/.claude/skills/pr-comments/SKILL.md
@@ -1,0 +1,267 @@
+---
+name: pr-comments
+description: Fetch, triage, and resolve PR review comments on the Sick Rabbit theme — then commit, push, and schedule a re-check so Greptile's next review round gets handled hands-free. Use this skill whenever the user mentions PR comments, review feedback, Greptile comments, "check the PR", "resolve comments", "what did the reviewer say", "fix the review", "address feedback", "go through the comments", "are there new comments", "what's Greptile saying", or any variation of reading and acting on PR review feedback. Also trigger right after the user has pushed a PR and wants to see if feedback has arrived, or says "let's close out this PR" / "let's merge this once it's clean". This skill runs the review loop; it pairs with pr-commit (which creates the PR). Not for creating PRs from scratch — that's pr-commit.
+---
+
+# PR Comments — Fetch, Triage, Resolve, Commit, Push, Watch
+
+Automates the entire review-response loop on a PR: pull down every unresolved comment, make the fixes, commit, push, and **schedule a re-check** so Greptile's next round gets handled too — hands-free until the PR is clean.
+
+Every merge to `main` deploys to the live Shopify theme, so the review gate matters. This skill is how the gate actually works.
+
+## Default behaviour
+
+When invoked with no arguments (`/pr-comments`), run the full workflow automatically:
+
+1. Detect the PR for the current branch
+2. Fetch all comments
+3. Show the triage summary
+4. Resolve all comments (P1 → P2 → P3)
+5. Commit and push
+6. Schedule a re-check in 8 minutes to catch Greptile's next review
+
+No confirmation needed — the user invoked the skill because they want comments resolved. Only pause if something is genuinely ambiguous or conflicting (e.g. two comments contradict each other, or a comment is about a file that has changed significantly since the review).
+
+If the user passes arguments (a PR number, "just P1s", "only check don't fix"), respect those.
+
+## Workflow
+
+### 1. Identify the PR
+
+```bash
+git branch --show-current
+gh pr view --json number,title,url,headRefName,state
+```
+
+- If the current branch is `main`, the user ran this in the wrong place. Tell them: *"You're on `main`. This skill operates on a PR branch. Check out the PR branch first (`gh pr checkout <number>`) and rerun."* Stop.
+- If the user gave a PR number or URL, use that.
+- If `state` is `MERGED` or `CLOSED`, report *"PR #N is already merged/closed — nothing to do"* and **cancel any scheduled re-check** (CronDelete). Stop.
+- If no PR exists for the current branch, tell the user and stop.
+
+### 2. Fetch all review comments
+
+Inline code comments:
+
+```bash
+gh api repos/{owner}/{repo}/pulls/{number}/comments --paginate \
+  --jq '.[] | {id, path, original_line, line, body, diff_hunk, in_reply_to_id, created_at, user: .user.login}'
+```
+
+Top-level PR comments (not attached to a line):
+
+```bash
+gh api repos/{owner}/{repo}/issues/{number}/comments \
+  --jq '.[] | {id, body: (.body | .[0:500]), user: .user.login, created_at}'
+```
+
+If the Greptile MCP is available (`greptile-api` server), also call `list_merge_request_comments` with `greptileGenerated=true` and `addressed=false` to get the structured Greptile data directly — easier than parsing HTML badges.
+
+### 3. Filter and group
+
+- **Skip reply threads** — comments where `in_reply_to_id` is set are replies. Group them with the parent; act on the root.
+- **Group by file** — batch fixes per file.
+- **Extract priority** — Greptile tags comments P1 / P2 / P3 in the body. P1 = critical, P2 = important, P3 = suggestion.
+- **Extract suggestions** — look for ` ```suggestion ` blocks. These are ready-to-apply code replacements.
+
+### 4. Show the triage summary
+
+```
+PR #2: restyle: header nav to match brand type scale
+14 comments across 6 files
+
+P1 (2):
+  - sections/header.liquid:45 — hardcoded #2d2d2a instead of var(--color-graphite)
+  - snippets/header-nav.liquid:12 — {% include %} should be {% render %}
+
+P2 (4):
+  - assets/section-header.css:28 — magic number 24px should use --space-3
+  - sections/header.liquid:67 — English string not going through t: filter
+  - ...
+
+P3 (8):
+  - ...
+
+Resolving all...
+```
+
+This is informational, not a gate. Proceed to fixing.
+
+### 5. Resolve comments
+
+Work file-by-file, highest priority first.
+
+For each file:
+
+1. **Read the current file** — always, before editing. The comment was made against the review state; the file may have moved since.
+2. **Apply suggestions directly** when the comment has a ` ```suggestion ` block, but only after verifying the suggestion still applies (if the diff hunk context no longer matches, the suggestion is stale).
+3. **Reason through non-suggestion comments** — read the surrounding code, understand what the reviewer is asking for, implement the minimal change. No scope creep.
+4. **Verify the edit** — re-read the changed region to confirm the fix is correct and doesn't break adjacent code.
+
+**When to push back on a Greptile comment rather than accepting it**:
+
+- The comment is asking for something that conflicts with a decision already logged in `docs/decisions.md` (e.g. Greptile wants to restructure a Dawn file we deliberately left alone). Reply to the comment citing the decision and mark it as not-a-fix.
+- The comment is asking for something that would break merchant admin editability (e.g. removing a section's `{% schema %}` block). Reject with a reply explaining why.
+- The comment is stylistic and contradicts a more important rule elsewhere (e.g. asking for a hardcoded hex "for simplicity" when the token system is the whole point). Reject with a reply.
+- The comment is about Dawn's original code that we haven't touched. Reply: *"This is Dawn's original code; left deliberately per upstream-merge policy in docs/decisions.md."*
+
+When in doubt, flag for the user rather than silently applying or silently ignoring.
+
+### 6. Commit and push
+
+Use the project's commit conventions (see the `commit` skill). For review responses:
+
+- Prefix depends on what changed. Usually `fix:` (if the fix was a bug) or the matching type of the original PR (e.g. `restyle:` if the PR was a restyle and the fix is tightening a style).
+- One commit for all review fixes is usually fine — these are review responses, not independent features. Exception: if the review surfaced two unrelated bugs in the same PR, split into two commits.
+- Stage only the files you changed.
+- Push immediately after committing — the whole point is to get the changes back up for re-review quickly.
+
+```bash
+git add <file1> <file2>
+git commit -m "$(cat <<'EOF'
+fix: address PR review comments
+
+Co-Authored-By: Claude Opus <VERSION> (1M context) <noreply@anthropic.com>
+EOF
+)"
+git push
+```
+
+Replace `<VERSION>` with the actual model version.
+
+### 7. Report
+
+```
+Committed and pushed abc1234: fix: address PR review comments
+
+Resolved 11/14 comments:
+  - sections/header.liquid — replaced hardcoded hex with --color-graphite (P1)
+  - snippets/header-nav.liquid — {% include %} → {% render %} (P1)
+  - assets/section-header.css — 24px → var(--space-3) (P2)
+  - ...
+
+Flagged 3 comments for your review:
+  - sections/header.liquid:92 — Greptile wants to restructure this block, but it's Dawn's original. Replied on the thread citing docs/decisions.md.
+  - ...
+```
+
+### 8. Schedule the automatic re-check
+
+Use CronCreate to fire `/pr-comments` every 8 minutes:
+
+```
+CronCreate:
+  cron: "*/8 * * * *"
+  prompt: "/pr-comments"
+  recurring: true
+```
+
+Before creating: **check with CronList**. Only one `/pr-comments` cron at a time per session. If one already exists, leave it.
+
+Tell the user: *"Scheduled re-check every 8 minutes. I'll pick up Greptile's next review automatically."*
+
+**Connectivity precheck** — before scheduling, verify Greptile actually sees the PR. If the Greptile MCP is available:
+
+```
+mcp__greptile-api__list_code_reviews(prNumber, repository)
+```
+
+If it returns "merge request not found" or zero code reviews, Greptile isn't seeing the PR. Do **not** schedule the cron. Report:
+
+```
+Greptile doesn't see PR #N yet. Check app.greptile.com — verify
+redpotatoe07/sickrabbit-theme is connected and indexing finished.
+Re-run pr-comments once it shows the PR. No cron scheduled —
+would just burn cycles.
+```
+
+### 9. On re-check fires: abort and loop-backoff logic
+
+When this skill runs from a scheduled cron fire, check abort conditions in order **before** processing comments:
+
+**9a. PR closed or merged** — detected at step 1. CronDelete the loop. Stop.
+
+**9b. Greptile still can't see the PR** — if the connectivity check still fails and the PR has been open 15+ minutes, cancel the cron and report the connectivity issue (as in step 8).
+
+**9c. Consecutive empty fires** — maintain a counter in `.claude/.pr-comments-state.json`:
+
+```json
+{ "pr_number": 2, "empty_fires": 0, "last_checked_at": "2026-04-20T12:30:00Z" }
+```
+
+- Any fire with zero new comments/reviews since the last push: `empty_fires += 1`.
+- Any fire with new activity: `empty_fires = 0`.
+- When `empty_fires == 3`, cancel the cron and report: *"3 empty checks in a row — cancelling auto-recheck. Re-run pr-comments manually once a review arrives."*
+
+Add `.claude/.pr-comments-state.json` to `.gitignore`. Session state, not a tracked artifact.
+
+**9d. Stale-comment detection** — get last push time (`git log --format='%ci' -1`). If ALL comments predate the last push, treat as empty and apply 9c. Don't offer merge on a stale-comments run — let 9c drive the cancel.
+
+If there *are* new comments, reset `empty_fires` to 0 and run the full resolve workflow (3–7). The cron fires again in 8 minutes.
+
+### 10. PR is clean — offer to merge (with live-deploy reminder)
+
+Triggered only when the cron is cancelled for a **positive** reason: all comments resolved, review posted, no open review items. Not triggered when 9b or 9c cancels.
+
+**Cancel the re-check** (CronDelete) and offer:
+
+```
+No new comments on PR #2 — PR is clean.
+(Cancelled automatic re-check.)
+
+Reminder: merging to main deploys immediately to the live theme
+at sick-rabbit-store.myshopify.com (and sickrabbit.com post-launch).
+
+Ready to merge? I can:
+  1. Squash and merge into main  ← ships live
+  2. Leave it open for now
+```
+
+The live-deploy reminder is intentional on this project — the user should have a beat to confirm before the PR hits production.
+
+If the user says yes / merge / ship:
+
+1. **Squash and merge**:
+   ```bash
+   gh pr merge {number} --squash --delete-branch
+   ```
+2. **Ask which roadmap item(s) this shipped.** Parsing the PR title is unreliable on this project — Phase 3 has six section-restyles and `restyle: header nav` could tick "Header" in Phase 3 or, if the PR was bigger than expected, close out multiple sub-items. Ask:
+
+   > PR #N is merged. Which roadmap item(s) did it ship? I'll mark them in `planning/roadmap.md`:
+   >
+   > Options (from current In Progress + Next):
+   > - Phase 3 → Header
+   > - Phase 3 → Homepage
+   > - (…)
+   >
+   > Or tell me something else.
+
+   Then invoke the `plan` skill with the user's answer to update `planning/roadmap.md` (tick the checkbox / move to Shipped) with today's date. If the PR accomplished more than a single item, mark all of them.
+
+3. **Pull `main` locally** so the working tree matches:
+   ```bash
+   git checkout main && git pull
+   ```
+
+If the user says no, acknowledge and stop. Leave the PR open.
+
+## Edge cases
+
+- **PR already merged/closed** — step 1 catches it, cancel any existing re-check.
+- **Greptile can't see the PR (first run)** — step 8 connectivity precheck skips the cron and surfaces the issue.
+- **Greptile can't see the PR (subsequent run)** — step 9b cancels the cron.
+- **3 consecutive empty fires** — step 9c cancels. User re-runs manually when a review is expected.
+- **No review comments yet legitimately** — don't auto-merge a fresh PR with zero comments. The empty-fire counter handles the "reviewer hasn't posted yet" case.
+- **All comments stale** — 9d + 9c. Does not auto-merge.
+- **PR on a different branch than current** — user specifies PR number; don't assume.
+- **Merge conflicts on `gh pr merge`** — report the error, suggest the user pull `main` and rebase locally.
+- **Greptile flags something that's genuinely Dawn-original** — reply on the thread citing the decisions log; don't silently fix.
+- **Greptile flags a hardcoded value we consciously accepted** — same approach: reply with the justification; don't silently fix.
+- **Session ends mid-loop** — the cron disappears with the session. State file persists but is harmless — it gets overwritten on next run.
+
+## Interaction with other skills
+
+- **`pr-commit`** — creates the PR and kicks off the first re-check schedule. This skill takes over from there.
+- **`commit`** — follows the same commit conventions for review-response commits (prefix, co-author, specific file staging).
+- **`issue`** — if a reviewer surfaces a genuine bug that won't be fixed in this PR, log it as an issue with the `issue` skill rather than rolling it into a sprawling PR.
+- **`plan`** — post-merge, this skill invokes `plan` to mark the roadmap item shipped.
+- **`audit`** — if a PR gets an unusually high volume of Greptile comments, that's a signal we've drifted from standards. Consider running an audit as a follow-up.

--- a/.claude/skills/pr-commit/SKILL.md
+++ b/.claude/skills/pr-commit/SKILL.md
@@ -1,0 +1,304 @@
+---
+name: pr-commit
+description: Open a pull request for the Sick Rabbit theme — analyses the branch, updates planning docs, commits doc changes, pushes, and creates the PR with a title/body that matches the project's conventions. Also schedules an automatic Greptile review check. Use this skill whenever the user says "create a PR", "open a PR", "make a PR", "push and PR", "ready for review", "send this up", "ship this branch", "let's get this reviewed", "submit for review", "PR this", or has finished a block of work on a feature/fix/restyle branch and wants to get it reviewed. Also trigger on "we're done with this branch", "that's everything", or "let's push this up". Not for committing uncommitted work — that's the commit skill. Not for responding to review feedback on an existing PR — that's the pr-comments skill. This skill creates the PR; pr-comments closes the loop.
+---
+
+# PR Commit
+
+Opens a PR with the right title, body, and doc updates baked in, then hands off to Greptile's review loop. The goal: doc maintenance (roadmap, issues, components) happens as part of PR creation, not as a separate step that gets forgotten.
+
+Every PR merged to `main` auto-deploys to the live Shopify theme. The review gate is load-bearing — this skill treats PR creation as a checkpoint, not a formality.
+
+## Workflow
+
+### 1. Validate preconditions
+
+```bash
+git branch --show-current
+git status
+git log main..HEAD --oneline
+```
+
+- **On main?** Stop: *"You're on main — create a feature branch first with `git checkout -b <type>/<short-description>`."*
+- **Uncommitted changes?** Stop: *"You have uncommitted changes. Use the `commit` skill first, then we can open the PR."*
+- **No commits ahead of main?** Stop: *"No commits ahead of main — nothing to PR."*
+
+### 2. Analyse the branch
+
+```bash
+git log main..HEAD --oneline
+git log main..HEAD --format="%s%n%b"
+git diff main --stat
+git diff main --name-only
+```
+
+Also check whether `main` has advanced since the branch was cut (merchant auto-commits or other merged PRs can land on `main` while you're working):
+
+```bash
+git fetch origin
+git rev-list --count HEAD..origin/main
+```
+
+If the count is non-zero, warn the user:
+
+> `main` is N commits ahead of this branch. Consider rebasing before opening the PR so the review is against a current base:
+>
+> ```
+> git fetch origin
+> git rebase origin/main
+> ```
+>
+> Continue anyway? (The PR will still work, but conflicts may need resolution during merge.)
+
+This is a soft warning, not a block — sometimes the user knowingly wants to open the PR against the branch-point state.
+
+From this, build an understanding of:
+
+- **Feature/fix/restyle nature** — from commit messages and their types (`feat:`, `fix:`, `restyle:`, `tokens:`, `refactor:`, `docs:`, `chore:`, `content:`)
+- **Which section/snippet/template files changed** (`sections/**`, `snippets/**`, `templates/**`, `layout/**`)
+- **Which assets changed** (`assets/**/*.css`, `assets/**/*.js`)
+- **Which config/locale files changed** (`config/settings_*.json`, `locales/*.json`)
+- **Which issue IDs appear** in commit messages (pattern: `ISS-\d+`)
+- **Whether Dawn originals were touched** (Dawn files being edited needs a decision log entry — flag if missing)
+
+### 3. Determine which docs need updating
+
+Use cheap checks first — don't read a file you don't need to touch.
+
+#### `planning/issues.md`
+
+**Cheap check:** Parse all commit messages for `ISS-\d+`.
+**Update if:** Any issue IDs found. Read the file, find those IDs in Open, move to Fixed with:
+- `**Fixed:** <today's date>`
+- `**Fix:** <one-line description derived from the commit message>`
+- `**Commit:** <short hash>`
+
+#### `planning/roadmap.md`
+
+**Cheap check:** Always read — it's short and the skill needs to know the current phase.
+**Update if:** The branch completes or advances roadmap items:
+- An "In Progress" item finished → move to Shipped with today's date
+- A "Next" item started → move to In Progress
+- Mark completed sub-items `[x]` (Phase 3 section-by-section checklist especially)
+- If nothing matches, don't touch it
+
+#### `planning/ideas.md`
+
+**Cheap check:** Only check if roadmap moved something to Shipped.
+**Update if:** A shipped item matches an idea — remove it, it graduated.
+
+#### `docs/components.md`
+
+**Cheap check:** Did any `snippets/*.liquid` or `sections/*.liquid` files get added, renamed, or materially modified?
+
+```bash
+git diff main --name-status -- snippets/ sections/
+```
+
+The `--name-status` flag surfaces adds (`A`), deletes (`D`), modifies (`M`), and renames (`R100` etc.) distinctly. Handle each differently:
+
+- **Add (`A`)** — new snippet/section, add a row to the registry
+- **Delete (`D`)** — remove the row (unless it's being replaced by an Add, in which case it's a rename)
+- **Rename (`R`)** — git reports this as `R<score>` with the old and new paths; update the existing row's path, don't add a new row
+- **Modify (`M`)** — only touch the registry if the purpose or rendered-by changed materially; cosmetic edits don't need a registry bump
+
+**Update if:** Yes — add, update, or remove rows in the custom snippets/sections tables. Keep it minimal: name, path, purpose, where rendered.
+
+#### `docs/design/system.md`
+
+**Cheap check:** Did `assets/base.css` or `config/settings_data.json` change?
+**Update if:** A new CSS custom property was added that isn't already in the system doc, or a colour scheme was changed materially.
+
+#### `docs/decisions.md`
+
+**Cheap check:** Did any Dawn-originating file get renamed, moved, or deleted? (Check against Dawn upstream — `git log upstream/main -- <path>` existing means it's Dawn's.)
+
+**Update if:** Yes — and if no corresponding entry exists in `decisions.md`, **stop and offer to draft one with the user** before continuing. Destructive edits to Dawn need a logged decision; silently merging them violates the upstream-merge policy.
+
+The prompt flow:
+
+> This branch modifies or deletes Dawn-originating files: `<paths>`. Per the upstream-merge policy, destructive Dawn edits need a logged decision in `docs/decisions.md`. Want me to draft an entry now? I'll ask:
+>
+> - What was decided (what changes and why this shape)
+> - Why (what problem it solves, what constraint forces this over an additive alternative)
+> - What was rejected (the additive alternative considered and why it didn't work)
+>
+> Then I'll write it to `docs/decisions.md` and include it in the `docs:` commit. Otherwise I'll stop here and you can add the entry manually.
+
+If the user says yes, interview briefly and write the entry using the existing `decisions.md` format (see existing entries for reference). If no, stop — don't create the PR without the decision logged.
+
+### 4. Update the docs
+
+For each doc that needs updating:
+1. Read the current file
+2. Make surgical, minimal changes — don't rewrite sections unrelated to the branch
+3. Show the user what was updated:
+
+```
+Updated planning docs:
+  - planning/roadmap.md — moved Phase 3 header to Shipped
+  - planning/issues.md — moved ISS-004 to Fixed
+  - docs/components.md — added sick-rabbit-header-nav snippet
+```
+
+This is informational, not a gate. Proceed.
+
+### 5. Commit the doc updates
+
+If any docs changed, commit them separately with `docs:` prefix so doc housekeeping doesn't pollute the feature diff.
+
+```bash
+git add planning/roadmap.md planning/issues.md docs/components.md
+git commit -m "$(cat <<'EOF'
+docs: update planning docs for PR
+
+Co-Authored-By: Claude Opus <VERSION> (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+Replace `<VERSION>` with the actual model version running the session (e.g. `4.7`). Only stage files that were actually modified — never `git add -A`.
+
+If no docs needed updating, skip this step. Don't create an empty commit.
+
+### 6. Run theme-check as a branch-level gate
+
+```bash
+shopify theme check
+```
+
+The `commit` skill runs this per-commit, but a branch-as-a-whole gate catches the case where two commits compose into a broken state (one adds a CSS variable, another removes it; one renames a snippet, another still `{% render %}`s the old name). The VS Code extension's live diagnostics usually surface these during development — this is the pre-push belt-and-braces version.
+
+If any new errors appear (not warnings), stop and tell the user. Don't push a broken branch up for review.
+
+### 7. Push and create PR
+
+#### Check for existing PR
+
+```bash
+gh pr view --json number,url,state 2>/dev/null
+```
+
+If a PR already exists and is `OPEN`, report: *"PR #N already exists: <url>. Use the `pr-comments` skill to check for review feedback."* Stop here.
+
+If the PR exists but is `CLOSED` or `MERGED`, note it and proceed — the user is clearly starting a new PR on the same branch name (rare but valid).
+
+#### Push the branch
+
+```bash
+git push -u origin <branch-name>
+```
+
+If the branch already tracks a remote, just `git push`.
+
+#### Derive the PR title
+
+Parse the branch name prefix for the type and humanise the description:
+
+| Branch | Title |
+|---|---|
+| `fix/cart-drawer-variant-reset` | `fix: cart drawer resets on variant change` |
+| `feat/anachronism-collection-template` | `feat: anachronism collection template` |
+| `restyle/header-nav` | `restyle: header nav to match brand type scale` |
+| `tokens/burnt-rose-primary-cta` | `tokens: wire burnt rose as primary CTA colour` |
+| `refactor/extract-product-card-media` | `refactor: extract product-card media into snippet` |
+| `docs/decisions-phase-3-pdp` | `docs: log phase 3 PDP design decisions` |
+| `content/en-default-cart-empty` | `content: update cart empty-state copy` |
+
+For `content/*` branches, add a dedicated test-plan bullet: *"Verify the affected copy renders correctly on the page(s) where the translation key is used — check both desktop and mobile to catch any truncation or layout overflow."*
+
+Keep under 70 characters. Details go in the body.
+
+#### Structure the PR body
+
+```markdown
+## Summary
+
+<1–2 sentence overview of what the branch accomplishes>
+
+- **Change/fix name** (ISS-NNN if applicable): one-line description
+- **Change/fix name**: one-line description
+- ...
+
+## What changed in the theme
+
+- Sections: `sections/foo.liquid`, `sections/bar.liquid`
+- Snippets: `snippets/baz.liquid`
+- CSS: `assets/section-foo.css`
+- Config/locale: `config/settings_data.json`, `locales/en.default.json`
+
+(Only include the bullets that actually apply — drop ones that don't.)
+
+## Test plan
+
+- [ ] Visit `127.0.0.1:9292` (or the preview theme) and confirm the affected page renders correctly on desktop
+- [ ] Re-check at 414px mobile viewport
+- [ ] If the change involves a section: verify the schema still works in the theme editor (no merchant-editing regressions)
+- [ ] `shopify theme check` passes clean
+- [ ] Any issue IDs referenced (ISS-NNN) are fixed
+
+## Upstream / Dawn notes
+
+(If any Dawn-originating files were edited: link to the `docs/decisions.md` entry that authorised it. Otherwise: "Additive changes only — no Dawn files renamed or removed.")
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+```
+
+Summary bullets are derived from commit messages grouped by feature, not one-per-commit. Test plan items are user-facing verification steps for a theme — page loads, visual checks, theme editor, `theme check`. Not abstract unit-test things.
+
+The **Upstream / Dawn notes** section is specific to this project — it forces the PR author (and reviewer) to acknowledge the upstream-merge implication of any Dawn-file edits.
+
+#### Create the PR
+
+```bash
+gh pr create --title "<title>" --body "$(cat <<'EOF'
+<body>
+EOF
+)"
+```
+
+### 8. Report
+
+```
+Created PR #N: restyle: header nav to match brand type scale
+https://github.com/redpotatoe07/sickrabbit-theme/pull/N
+
+Doc updates: planning/roadmap.md, docs/components.md
+Scheduled Greptile review check every 8 minutes — pr-comments will pick up feedback automatically.
+```
+
+### 9. Schedule the review check
+
+After creating the PR, schedule `/pr-comments` to run every 8 minutes so Greptile's review gets picked up without you having to remember. Use CronCreate:
+
+```
+CronCreate:
+  cron: "*/8 * * * *"
+  prompt: "/pr-comments"
+  recurring: true
+```
+
+Before creating, **check with CronList** — only one pr-comments cron at a time; don't stack duplicates if one is already running from an earlier PR.
+
+Tell the user: *"Scheduled review check every 8 minutes. Review comments will be picked up and resolved automatically via the pr-comments skill."*
+
+The pr-comments skill handles the rest of the loop: fetch comments, resolve them, commit, push, re-check until clean, then offer to merge (which ships live).
+
+## Edge cases
+
+- **No docs need updating** — skip the doc commit, still push and create the PR. Common for pure refactors or content-only changes.
+- **PR already exists** — report the URL and stop. The user probably wants `pr-comments`.
+- **Uncommitted changes** — don't proceed. Redirect to the `commit` skill.
+- **No commits ahead of main** — nothing to PR. Stop.
+- **Branch has only doc commits** — still valid. The PR is a doc-only PR; analyse accordingly.
+- **Dawn files edited without `docs/decisions.md` entry** — stop and ask the user. This is the load-bearing check that keeps upstream merges tractable.
+- **Merge conflicts** — this skill does not handle rebasing. Suggest the user rebase or merge `main` in first.
+- **User is on an old-style branch name** (no type prefix) — derive the best type from the commit-message analysis and ask before using it.
+
+## Interaction with other skills
+
+- **`commit`** — pr-commit follows the same commit message conventions (prefix types, co-author line, specific file staging) but writes the `docs:` commit inline rather than invoking the skill.
+- **`issue`** — pr-commit moves `ISS-NNN` entries from Open to Fixed using the same format.
+- **`plan`** — pr-commit updates `roadmap.md` and `ideas.md` using the same format.
+- **`pr-comments`** — the natural follow-up. Scheduled automatically at step 8. Handles review feedback end-to-end.
+- **`audit`** — if a big chunk of work just shipped (a phase, a major restyle), the user may want to run an audit before or after the PR. This skill doesn't automate that — but mention it if the branch is phase-sized.

--- a/.claude/skills/refactor/SKILL.md
+++ b/.claude/skills/refactor/SKILL.md
@@ -1,0 +1,108 @@
+---
+name: refactor
+description: Extract repeated Liquid, CSS, or design-token patterns into shared snippets, sections, or token layers in the Sick Rabbit Shopify theme. Use this skill when the user says "refactor", "deduplicate", "DRY this up", "clean up", "extract", "this is copy-pasted everywhere", "turn this into a snippet/section", "move this to a token", or has just finished a restyle and wants to pull shared patterns out. Also trigger when an audit has flagged duplication across sections/snippets, or when a hardcoded value is showing up in 2+ places and should move into the token system. Not for fixing bugs (that's debug-session), not for adding new features (that's just building), and not for destructively rewriting Dawn's originals — refactor here means additive extraction that respects the upstream-merge path.
+---
+
+# Refactor
+
+The #1 source of inconsistency in a restyled Dawn theme is the same Liquid fragment, CSS declaration, or hardcoded value copy-pasted across sections and snippets. Each duplicate is a place where a future change gets applied once and missed elsewhere. This skill is the disciplined process for pulling the shared thing out.
+
+## What "refactor" means on this project
+
+A refactor here is **additive extraction** that doesn't change rendered output. Three shapes:
+
+1. **Liquid duplication → a new snippet.** A block of markup rendered in two or more places gets pulled into `snippets/` and replaced with `{% render 'name' %}` calls.
+2. **CSS duplication → a shared token or utility.** A hardcoded value (colour, spacing, radius, font-family) showing up in multiple files gets promoted to `assets/base.css` as a CSS custom property, and registered in `docs/design/system.md`.
+3. **Settings duplication → a new section.** When the same "configurable block" keeps getting inlined into sections with its own settings, it wants to become its own section (with schema) or a block within an existing section.
+
+Three shapes it **isn't**:
+
+- **Not** restructuring Dawn's original files. Dawn is `upstream`; rewriting Dawn's sections into a "tidier" structure creates permanent merge conflicts. Additive refactor (new snippet, new token, new utility class) is fine. Deleting or renaming a Dawn file is a decision that needs `docs/decisions.md`.
+- **Not** a behaviour change. If you're mid-refactor and notice a bug, log it with the `issue` skill and keep going — don't mix a fix into the refactor commit.
+- **Not** premature abstraction. Two similar blocks of Liquid can stay duplicated. Three-line repetitions don't justify a snippet. Extract when the duplication is *substantial* (10+ lines, or real complexity like a product card, a labelled input, a bevel-button wrapper).
+
+## Before changing anything
+
+0. **Check the branch.** `git branch --show-current`. If it's `main`, stop — create a `refactor/<desc>` branch first. Refactors go through PR review before hitting `main` like every other change, because `main` is live.
+1. **Read `docs/components.md`.** The thing you're about to extract may already exist as a snippet.
+2. **Scan `snippets/` and `sections/`.** A Dawn snippet may cover the need with a parameter you hadn't considered.
+3. **Confirm real duplication.** At least two actual consumers. Hypothetical future duplication isn't duplication yet.
+4. **Check the registry rule**: if the pattern you're extracting doesn't fit a clean name, you probably haven't found the right abstraction yet. Name first, extract second — if the name is forced, the extraction will be too.
+
+## The three extraction shapes
+
+### Shape A — Liquid fragment to snippet
+
+When a chunk of markup renders in 2+ places (e.g. a product card, a labelled form field, a collection tile).
+
+1. **Find every instance.** Search for distinctive markers — a class name, an `{% assign %}`, a settings key. Document every location. A missed instance is worse than no refactor — the old pattern survives in parallel.
+2. **Separate identical from varying.**
+   - What's the same in every instance → lives in the snippet.
+   - What differs → becomes parameters passed via `{% render 'name', key: value %}`.
+   - What's unique to one consumer → stays in the consumer.
+3. **Keep the parameter list minimal.** Only parameterise variations that exist now, not imagined future ones. Two parameters is usually fine; six is a smell.
+4. **Create `snippets/<name>.liquid`.** Kebab-case filename. Use `{% doc %}` / `{% enddoc %}` at the top to document the expected parameters (Shopify's LiquidDoc, supported by the VS Code extension). Use tokens from `docs/design/system.md` for any visual values.
+5. **Replace all call sites.** Always `{% render %}`, never the deprecated `{% include %}`. After each replacement, diff the rendered HTML (view the page at `127.0.0.1:9292` and inspect) to make sure output is identical.
+6. **Remove the old inline code** and any imports/variables that became unused.
+7. **Add to `docs/components.md`.** Name, path, parameters, where it's rendered, one-line purpose.
+
+### Shape B — Hardcoded value to token
+
+When a hex/rgb/spacing/radius value appears in 2+ files.
+
+1. **Find every instance.** Grep the exact value across `assets/`, `sections/`, `snippets/`, `layout/`. Include Liquid inline `style=""` attributes.
+2. **Name the token.** Semantic (`--color-surface-elevated`) beats literal (`--color-1c4d4f`). The name should survive the brand palette drifting slightly.
+3. **Add to `assets/base.css`** as a CSS custom property, grouped with related tokens.
+4. **Document in `docs/design/system.md`** — add a row to the relevant table so future sessions can find it.
+5. **Replace every call site** with `var(--token-name)`. After each replacement, eyeball the page at `127.0.0.1:9292` — a token swap should be pixel-identical.
+6. **Run `shopify theme check`** — catches orphaned references or typos.
+
+### Shape C — Inlined configurable block to section or block
+
+When the same "a merchant can configure this" pattern keeps appearing inside other sections (e.g. an image-with-caption block that three different sections each reimplement).
+
+This is the biggest-blast-radius refactor. Only do it when the duplication is clear and the new section/block has obvious merchant value.
+
+1. **Audit the current usage.** What settings does each inlined version expose? What's actually different between them vs. cosmetically different?
+2. **Decide: standalone section or block-within-section?**
+   - Standalone section: merchant can drop it anywhere in any template.
+   - Block: merchant adds it as a child of a parent section.
+   - If the thing only ever lives inside one kind of parent, it's a block. If it's independent, it's a section.
+3. **Write the schema first.** Define settings, blocks, presets. Keep setting IDs stable — if merchants have saved values against the old inlined versions, renaming an ID loses their data.
+4. **Implement the Liquid.** Use tokens, follow the standard section pattern in `docs/architecture.md`.
+5. **Migrate the old inlined versions.** For each consumer, remove the inlined block and either (a) tell the merchant to re-add it from the theme editor, or (b) rewrite the relevant `templates/*.json` to include the new section with matching settings. Merchant state is at risk here — confirm with the user before touching production-facing templates.
+6. **Add to `docs/components.md`** with schema summary.
+
+## The non-negotiables
+
+- **Behaviour stays identical.** A refactor produces the same rendered output as before — same HTML, same CSS, same behaviour. If `git diff` on the rendered page shows unexpected changes, you haven't refactored, you've rewritten.
+- **One extraction per commit.** Extract the thing, replace every call site, verify, commit with `refactor:` prefix. Start the next extraction on a fresh working tree.
+- **Don't break consumers.** If an existing snippet already has call sites, don't change its parameter signature without migrating every call site in the same commit. Silent interface drift = silent breakage.
+- **Don't rename merchant-visible setting IDs.** Those IDs are the key to the merchant's saved values in `config/settings_data.json` (and on the live store). Renaming a setting ID is a data-loss event for that setting, not a refactor.
+- **Respect Dawn.** Additive snippets, additive tokens, additive utilities are fine. Restructuring Dawn's files is a decision, not a refactor. If you must, log it in `docs/decisions.md` and prepare for merge conflicts.
+- **Don't over-extract.** Three similar lines of Liquid can stay. The right amount of abstraction is the minimum that eliminates meaningful duplication — fewer parameters, smaller snippets, narrower tokens.
+
+## Verify before commit
+
+- **`shopify theme check`** — passes clean (the VS Code extension catches most of this live, terminal run is the pre-push gate)
+- **`127.0.0.1:9292`** — visit every page where the refactor landed, at mobile + desktop breakpoints, and confirm visually identical output
+- **`git diff --stat`** — the diff should be mostly deletions from call sites plus one new file. If it's sprawling, you're doing too many things in one commit.
+- **`docs/components.md`** — updated if a snippet was added or renamed
+- **`docs/design/system.md`** — updated if a token was added or renamed
+
+## Commit with `refactor:` prefix
+
+Use the `commit` skill. The `refactor:` type exists specifically so refactor commits don't get mixed up with `fix:` or `feat:` in `git log`. Reference the extracted thing in the subject:
+
+```
+refactor: extract product-card media into shared snippet
+refactor: promote repeated --color-#1c4d4f usages to --color-surface-elevated token
+refactor: consolidate image-with-caption block into reusable section
+```
+
+## When to say no
+
+- **"Let's refactor this into a utility for later reuse"** — no. Extract when there's real duplication, not speculative reuse.
+- **"While I'm in here, let me also fix this bug"** — no. Log the bug with the `issue` skill, finish the refactor, then fix the bug as a separate commit.
+- **"Let me also rename this to something tidier"** — unless the new name is meaningfully better, no. Pure rename commits are their own thing, not a refactor.
+- **"This Dawn file is messy, let me restructure it"** — no. Dawn is upstream. If there's a genuine problem, discuss and log in `docs/decisions.md` before touching it.

--- a/.claude/skills/skill-creator/LICENSE.txt
+++ b/.claude/skills/skill-creator/LICENSE.txt
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/.claude/skills/skill-creator/SKILL.md
+++ b/.claude/skills/skill-creator/SKILL.md
@@ -1,0 +1,479 @@
+---
+name: skill-creator
+description: Create new skills, modify and improve existing skills, and measure skill performance. Use when users want to create a skill from scratch, update or optimize an existing skill, run evals to test a skill, benchmark skill performance with variance analysis, or optimize a skill's description for better triggering accuracy.
+---
+
+# Skill Creator
+
+A skill for creating new skills and iteratively improving them.
+
+At a high level, the process of creating a skill goes like this:
+
+- Decide what you want the skill to do and roughly how it should do it
+- Write a draft of the skill
+- Create a few test prompts and run claude-with-access-to-the-skill on them
+- Help the user evaluate the results both qualitatively and quantitatively
+  - While the runs happen in the background, draft some quantitative evals if there aren't any (if there are some, you can either use as is or modify if you feel something needs to change about them). Then explain them to the user (or if they already existed, explain the ones that already exist)
+  - Use the `eval-viewer/generate_review.py` script to show the user the results for them to look at, and also let them look at the quantitative metrics
+- Rewrite the skill based on feedback from the user's evaluation of the results (and also if there are any glaring flaws that become apparent from the quantitative benchmarks)
+- Repeat until you're satisfied
+- Expand the test set and try again at larger scale
+
+Your job when using this skill is to figure out where the user is in this process and then jump in and help them progress through these stages. So for instance, maybe they're like "I want to make a skill for X". You can help narrow down what they mean, write a draft, write the test cases, figure out how they want to evaluate, run all the prompts, and repeat.
+
+On the other hand, maybe they already have a draft of the skill. In this case you can go straight to the eval/iterate part of the loop.
+
+Of course, you should always be flexible and if the user is like "I don't need to run a bunch of evaluations, just vibe with me", you can do that instead.
+
+Then after the skill is done (but again, the order is flexible), you can also run the skill description improver, which we have a whole separate script for, to optimize the triggering of the skill.
+
+Cool? Cool.
+
+## Communicating with the user
+
+The skill creator is liable to be used by people across a wide range of familiarity with coding jargon. If you haven't heard (and how could you, it's only very recently that it started), there's a trend now where the power of Claude is inspiring plumbers to open up their terminals, parents and grandparents to google "how to install npm". On the other hand, the bulk of users are probably fairly computer-literate.
+
+So please pay attention to context cues to understand how to phrase your communication! In the default case, just to give you some idea:
+
+- "evaluation" and "benchmark" are borderline, but OK
+- for "JSON" and "assertion" you want to see serious cues from the user that they know what those things are before using them without explaining them
+
+It's OK to briefly explain terms if you're in doubt, and feel free to clarify terms with a short definition if you're unsure if the user will get it.
+
+---
+
+## Creating a skill
+
+### Capture Intent
+
+Start by understanding the user's intent. The current conversation might already contain a workflow the user wants to capture (e.g., they say "turn this into a skill"). If so, extract answers from the conversation history first — the tools used, the sequence of steps, corrections the user made, input/output formats observed. The user may need to fill the gaps, and should confirm before proceeding to the next step.
+
+1. What should this skill enable Claude to do?
+2. When should this skill trigger? (what user phrases/contexts)
+3. What's the expected output format?
+4. Should we set up test cases to verify the skill works? Skills with objectively verifiable outputs (file transforms, data extraction, code generation, fixed workflow steps) benefit from test cases. Skills with subjective outputs (writing style, art) often don't need them. Suggest the appropriate default based on the skill type, but let the user decide.
+
+### Interview and Research
+
+Proactively ask questions about edge cases, input/output formats, example files, success criteria, and dependencies. Wait to write test prompts until you've got this part ironed out.
+
+Check available MCPs - if useful for research (searching docs, finding similar skills, looking up best practices), research in parallel via subagents if available, otherwise inline. Come prepared with context to reduce burden on the user.
+
+### Write the SKILL.md
+
+Based on the user interview, fill in these components:
+
+- **name**: Skill identifier
+- **description**: When to trigger, what it does. This is the primary triggering mechanism - include both what the skill does AND specific contexts for when to use it. All "when to use" info goes here, not in the body. Note: currently Claude has a tendency to "undertrigger" skills -- to not use them when they'd be useful. To combat this, please make the skill descriptions a little bit "pushy". So for instance, instead of "How to build a simple fast dashboard to display internal Anthropic data.", you might write "How to build a simple fast dashboard to display internal Anthropic data. Make sure to use this skill whenever the user mentions dashboards, data visualization, internal metrics, or wants to display any kind of company data, even if they don't explicitly ask for a 'dashboard.'"
+- **compatibility**: Required tools, dependencies (optional, rarely needed)
+- **the rest of the skill :)**
+
+### Skill Writing Guide
+
+#### Anatomy of a Skill
+
+```
+skill-name/
+├── SKILL.md (required)
+│   ├── YAML frontmatter (name, description required)
+│   └── Markdown instructions
+└── Bundled Resources (optional)
+    ├── scripts/    - Executable code for deterministic/repetitive tasks
+    ├── references/ - Docs loaded into context as needed
+    └── assets/     - Files used in output (templates, icons, fonts)
+```
+
+#### Progressive Disclosure
+
+Skills use a three-level loading system:
+1. **Metadata** (name + description) - Always in context (~100 words)
+2. **SKILL.md body** - In context whenever skill triggers (<500 lines ideal)
+3. **Bundled resources** - As needed (unlimited, scripts can execute without loading)
+
+These word counts are approximate and you can feel free to go longer if needed.
+
+**Key patterns:**
+- Keep SKILL.md under 500 lines; if you're approaching this limit, add an additional layer of hierarchy along with clear pointers about where the model using the skill should go next to follow up.
+- Reference files clearly from SKILL.md with guidance on when to read them
+- For large reference files (>300 lines), include a table of contents
+
+**Domain organization**: When a skill supports multiple domains/frameworks, organize by variant:
+```
+cloud-deploy/
+├── SKILL.md (workflow + selection)
+└── references/
+    ├── aws.md
+    ├── gcp.md
+    └── azure.md
+```
+Claude reads only the relevant reference file.
+
+#### Principle of Lack of Surprise
+
+This goes without saying, but skills must not contain malware, exploit code, or any content that could compromise system security. A skill's contents should not surprise the user in their intent if described. Don't go along with requests to create misleading skills or skills designed to facilitate unauthorized access, data exfiltration, or other malicious activities. Things like a "roleplay as an XYZ" are OK though.
+
+#### Writing Patterns
+
+Prefer using the imperative form in instructions.
+
+**Defining output formats** - You can do it like this:
+```markdown
+## Report structure
+ALWAYS use this exact template:
+# [Title]
+## Executive summary
+## Key findings
+## Recommendations
+```
+
+**Examples pattern** - It's useful to include examples. You can format them like this (but if "Input" and "Output" are in the examples you might want to deviate a little):
+```markdown
+## Commit message format
+**Example 1:**
+Input: Added user authentication with JWT tokens
+Output: feat(auth): implement JWT-based authentication
+```
+
+### Writing Style
+
+Try to explain to the model why things are important in lieu of heavy-handed musty MUSTs. Use theory of mind and try to make the skill general and not super-narrow to specific examples. Start by writing a draft and then look at it with fresh eyes and improve it.
+
+### Test Cases
+
+After writing the skill draft, come up with 2-3 realistic test prompts — the kind of thing a real user would actually say. Share them with the user: [you don't have to use this exact language] "Here are a few test cases I'd like to try. Do these look right, or do you want to add more?" Then run them.
+
+Save test cases to `evals/evals.json`. Don't write assertions yet — just the prompts. You'll draft assertions in the next step while the runs are in progress.
+
+```json
+{
+  "skill_name": "example-skill",
+  "evals": [
+    {
+      "id": 1,
+      "prompt": "User's task prompt",
+      "expected_output": "Description of expected result",
+      "files": []
+    }
+  ]
+}
+```
+
+See `references/schemas.md` for the full schema (including the `assertions` field, which you'll add later).
+
+## Running and evaluating test cases
+
+This section is one continuous sequence — don't stop partway through. Do NOT use `/skill-test` or any other testing skill.
+
+Put results in `<skill-name>-workspace/` as a sibling to the skill directory. Within the workspace, organize results by iteration (`iteration-1/`, `iteration-2/`, etc.) and within that, each test case gets a directory (`eval-0/`, `eval-1/`, etc.). Don't create all of this upfront — just create directories as you go.
+
+### Step 1: Spawn all runs (with-skill AND baseline) in the same turn
+
+For each test case, spawn two subagents in the same turn — one with the skill, one without. This is important: don't spawn the with-skill runs first and then come back for baselines later. Launch everything at once so it all finishes around the same time.
+
+**With-skill run:**
+
+```
+Execute this task:
+- Skill path: <path-to-skill>
+- Task: <eval prompt>
+- Input files: <eval files if any, or "none">
+- Save outputs to: <workspace>/iteration-<N>/eval-<ID>/with_skill/outputs/
+- Outputs to save: <what the user cares about — e.g., "the .docx file", "the final CSV">
+```
+
+**Baseline run** (same prompt, but the baseline depends on context):
+- **Creating a new skill**: no skill at all. Same prompt, no skill path, save to `without_skill/outputs/`.
+- **Improving an existing skill**: the old version. Before editing, snapshot the skill (`cp -r <skill-path> <workspace>/skill-snapshot/`), then point the baseline subagent at the snapshot. Save to `old_skill/outputs/`.
+
+Write an `eval_metadata.json` for each test case (assertions can be empty for now). Give each eval a descriptive name based on what it's testing — not just "eval-0". Use this name for the directory too. If this iteration uses new or modified eval prompts, create these files for each new eval directory — don't assume they carry over from previous iterations.
+
+```json
+{
+  "eval_id": 0,
+  "eval_name": "descriptive-name-here",
+  "prompt": "The user's task prompt",
+  "assertions": []
+}
+```
+
+### Step 2: While runs are in progress, draft assertions
+
+Don't just wait for the runs to finish — you can use this time productively. Draft quantitative assertions for each test case and explain them to the user. If assertions already exist in `evals/evals.json`, review them and explain what they check.
+
+Good assertions are objectively verifiable and have descriptive names — they should read clearly in the benchmark viewer so someone glancing at the results immediately understands what each one checks. Subjective skills (writing style, design quality) are better evaluated qualitatively — don't force assertions onto things that need human judgment.
+
+Update the `eval_metadata.json` files and `evals/evals.json` with the assertions once drafted. Also explain to the user what they'll see in the viewer — both the qualitative outputs and the quantitative benchmark.
+
+### Step 3: As runs complete, capture timing data
+
+When each subagent task completes, you receive a notification containing `total_tokens` and `duration_ms`. Save this data immediately to `timing.json` in the run directory:
+
+```json
+{
+  "total_tokens": 84852,
+  "duration_ms": 23332,
+  "total_duration_seconds": 23.3
+}
+```
+
+This is the only opportunity to capture this data — it comes through the task notification and isn't persisted elsewhere. Process each notification as it arrives rather than trying to batch them.
+
+### Step 4: Grade, aggregate, and launch the viewer
+
+Once all runs are done:
+
+1. **Grade each run** — spawn a grader subagent (or grade inline) that reads `agents/grader.md` and evaluates each assertion against the outputs. Save results to `grading.json` in each run directory. The grading.json expectations array must use the fields `text`, `passed`, and `evidence` (not `name`/`met`/`details` or other variants) — the viewer depends on these exact field names. For assertions that can be checked programmatically, write and run a script rather than eyeballing it — scripts are faster, more reliable, and can be reused across iterations.
+
+2. **Aggregate into benchmark** — run the aggregation script from the skill-creator directory:
+   ```bash
+   python -m scripts.aggregate_benchmark <workspace>/iteration-N --skill-name <name>
+   ```
+   This produces `benchmark.json` and `benchmark.md` with pass_rate, time, and tokens for each configuration, with mean ± stddev and the delta. If generating benchmark.json manually, see `references/schemas.md` for the exact schema the viewer expects.
+Put each with_skill version before its baseline counterpart.
+
+3. **Do an analyst pass** — read the benchmark data and surface patterns the aggregate stats might hide. See `agents/analyzer.md` (the "Analyzing Benchmark Results" section) for what to look for — things like assertions that always pass regardless of skill (non-discriminating), high-variance evals (possibly flaky), and time/token tradeoffs.
+
+4. **Launch the viewer** with both qualitative outputs and quantitative data:
+   ```bash
+   nohup python <skill-creator-path>/eval-viewer/generate_review.py \
+     <workspace>/iteration-N \
+     --skill-name "my-skill" \
+     --benchmark <workspace>/iteration-N/benchmark.json \
+     > /dev/null 2>&1 &
+   VIEWER_PID=$!
+   ```
+   For iteration 2+, also pass `--previous-workspace <workspace>/iteration-<N-1>`.
+
+   **Cowork / headless environments:** If `webbrowser.open()` is not available or the environment has no display, use `--static <output_path>` to write a standalone HTML file instead of starting a server. Feedback will be downloaded as a `feedback.json` file when the user clicks "Submit All Reviews". After download, copy `feedback.json` into the workspace directory for the next iteration to pick up.
+
+Note: please use generate_review.py to create the viewer; there's no need to write custom HTML.
+
+5. **Tell the user** something like: "I've opened the results in your browser. There are two tabs — 'Outputs' lets you click through each test case and leave feedback, 'Benchmark' shows the quantitative comparison. When you're done, come back here and let me know."
+
+### What the user sees in the viewer
+
+The "Outputs" tab shows one test case at a time:
+- **Prompt**: the task that was given
+- **Output**: the files the skill produced, rendered inline where possible
+- **Previous Output** (iteration 2+): collapsed section showing last iteration's output
+- **Formal Grades** (if grading was run): collapsed section showing assertion pass/fail
+- **Feedback**: a textbox that auto-saves as they type
+- **Previous Feedback** (iteration 2+): their comments from last time, shown below the textbox
+
+The "Benchmark" tab shows the stats summary: pass rates, timing, and token usage for each configuration, with per-eval breakdowns and analyst observations.
+
+Navigation is via prev/next buttons or arrow keys. When done, they click "Submit All Reviews" which saves all feedback to `feedback.json`.
+
+### Step 5: Read the feedback
+
+When the user tells you they're done, read `feedback.json`:
+
+```json
+{
+  "reviews": [
+    {"run_id": "eval-0-with_skill", "feedback": "the chart is missing axis labels", "timestamp": "..."},
+    {"run_id": "eval-1-with_skill", "feedback": "", "timestamp": "..."},
+    {"run_id": "eval-2-with_skill", "feedback": "perfect, love this", "timestamp": "..."}
+  ],
+  "status": "complete"
+}
+```
+
+Empty feedback means the user thought it was fine. Focus your improvements on the test cases where the user had specific complaints.
+
+Kill the viewer server when you're done with it:
+
+```bash
+kill $VIEWER_PID 2>/dev/null
+```
+
+---
+
+## Improving the skill
+
+This is the heart of the loop. You've run the test cases, the user has reviewed the results, and now you need to make the skill better based on their feedback.
+
+### How to think about improvements
+
+1. **Generalize from the feedback.** The big picture thing that's happening here is that we're trying to create skills that can be used a million times (maybe literally, maybe even more who knows) across many different prompts. Here you and the user are iterating on only a few examples over and over again because it helps move faster. The user knows these examples in and out and it's quick for them to assess new outputs. But if the skill you and the user are codeveloping works only for those examples, it's useless. Rather than put in fiddly overfitty changes, or oppressively constrictive MUSTs, if there's some stubborn issue, you might try branching out and using different metaphors, or recommending different patterns of working. It's relatively cheap to try and maybe you'll land on something great.
+
+2. **Keep the prompt lean.** Remove things that aren't pulling their weight. Make sure to read the transcripts, not just the final outputs — if it looks like the skill is making the model waste a bunch of time doing things that are unproductive, you can try getting rid of the parts of the skill that are making it do that and seeing what happens.
+
+3. **Explain the why.** Try hard to explain the **why** behind everything you're asking the model to do. Today's LLMs are *smart*. They have good theory of mind and when given a good harness can go beyond rote instructions and really make things happen. Even if the feedback from the user is terse or frustrated, try to actually understand the task and why the user is writing what they wrote, and what they actually wrote, and then transmit this understanding into the instructions. If you find yourself writing ALWAYS or NEVER in all caps, or using super rigid structures, that's a yellow flag — if possible, reframe and explain the reasoning so that the model understands why the thing you're asking for is important. That's a more humane, powerful, and effective approach.
+
+4. **Look for repeated work across test cases.** Read the transcripts from the test runs and notice if the subagents all independently wrote similar helper scripts or took the same multi-step approach to something. If all 3 test cases resulted in the subagent writing a `create_docx.py` or a `build_chart.py`, that's a strong signal the skill should bundle that script. Write it once, put it in `scripts/`, and tell the skill to use it. This saves every future invocation from reinventing the wheel.
+
+This task is pretty important (we are trying to create billions a year in economic value here!) and your thinking time is not the blocker; take your time and really mull things over. I'd suggest writing a draft revision and then looking at it anew and making improvements. Really do your best to get into the head of the user and understand what they want and need.
+
+### The iteration loop
+
+After improving the skill:
+
+1. Apply your improvements to the skill
+2. Rerun all test cases into a new `iteration-<N+1>/` directory, including baseline runs. If you're creating a new skill, the baseline is always `without_skill` (no skill) — that stays the same across iterations. If you're improving an existing skill, use your judgment on what makes sense as the baseline: the original version the user came in with, or the previous iteration.
+3. Launch the reviewer with `--previous-workspace` pointing at the previous iteration
+4. Wait for the user to review and tell you they're done
+5. Read the new feedback, improve again, repeat
+
+Keep going until:
+- The user says they're happy
+- The feedback is all empty (everything looks good)
+- You're not making meaningful progress
+
+---
+
+## Advanced: Blind comparison
+
+For situations where you want a more rigorous comparison between two versions of a skill (e.g., the user asks "is the new version actually better?"), there's a blind comparison system. Read `agents/comparator.md` and `agents/analyzer.md` for the details. The basic idea is: give two outputs to an independent agent without telling it which is which, and let it judge quality. Then analyze why the winner won.
+
+This is optional, requires subagents, and most users won't need it. The human review loop is usually sufficient.
+
+---
+
+## Description Optimization
+
+The description field in SKILL.md frontmatter is the primary mechanism that determines whether Claude invokes a skill. After creating or improving a skill, offer to optimize the description for better triggering accuracy.
+
+### Step 1: Generate trigger eval queries
+
+Create 20 eval queries — a mix of should-trigger and should-not-trigger. Save as JSON:
+
+```json
+[
+  {"query": "the user prompt", "should_trigger": true},
+  {"query": "another prompt", "should_trigger": false}
+]
+```
+
+The queries must be realistic and something a Claude Code or Claude.ai user would actually type. Not abstract requests, but requests that are concrete and specific and have a good amount of detail. For instance, file paths, personal context about the user's job or situation, column names and values, company names, URLs. A little bit of backstory. Some might be in lowercase or contain abbreviations or typos or casual speech. Use a mix of different lengths, and focus on edge cases rather than making them clear-cut (the user will get a chance to sign off on them).
+
+Bad: `"Format this data"`, `"Extract text from PDF"`, `"Create a chart"`
+
+Good: `"ok so my boss just sent me this xlsx file (its in my downloads, called something like 'Q4 sales final FINAL v2.xlsx') and she wants me to add a column that shows the profit margin as a percentage. The revenue is in column C and costs are in column D i think"`
+
+For the **should-trigger** queries (8-10), think about coverage. You want different phrasings of the same intent — some formal, some casual. Include cases where the user doesn't explicitly name the skill or file type but clearly needs it. Throw in some uncommon use cases and cases where this skill competes with another but should win.
+
+For the **should-not-trigger** queries (8-10), the most valuable ones are the near-misses — queries that share keywords or concepts with the skill but actually need something different. Think adjacent domains, ambiguous phrasing where a naive keyword match would trigger but shouldn't, and cases where the query touches on something the skill does but in a context where another tool is more appropriate.
+
+The key thing to avoid: don't make should-not-trigger queries obviously irrelevant. "Write a fibonacci function" as a negative test for a PDF skill is too easy — it doesn't test anything. The negative cases should be genuinely tricky.
+
+### Step 2: Review with user
+
+Present the eval set to the user for review using the HTML template:
+
+1. Read the template from `assets/eval_review.html`
+2. Replace the placeholders:
+   - `__EVAL_DATA_PLACEHOLDER__` → the JSON array of eval items (no quotes around it — it's a JS variable assignment)
+   - `__SKILL_NAME_PLACEHOLDER__` → the skill's name
+   - `__SKILL_DESCRIPTION_PLACEHOLDER__` → the skill's current description
+3. Write to a temp file (e.g., `/tmp/eval_review_<skill-name>.html`) and open it: `open /tmp/eval_review_<skill-name>.html`
+4. The user can edit queries, toggle should-trigger, add/remove entries, then click "Export Eval Set"
+5. The file downloads to `~/Downloads/eval_set.json` — check the Downloads folder for the most recent version in case there are multiple (e.g., `eval_set (1).json`)
+
+This step matters — bad eval queries lead to bad descriptions.
+
+### Step 3: Run the optimization loop
+
+Tell the user: "This will take some time — I'll run the optimization loop in the background and check on it periodically."
+
+Save the eval set to the workspace, then run in the background:
+
+```bash
+python -m scripts.run_loop \
+  --eval-set <path-to-trigger-eval.json> \
+  --skill-path <path-to-skill> \
+  --model <model-id-powering-this-session> \
+  --max-iterations 5 \
+  --verbose
+```
+
+Use the model ID from your system prompt (the one powering the current session) so the triggering test matches what the user actually experiences.
+
+While it runs, periodically tail the output to give the user updates on which iteration it's on and what the scores look like.
+
+This handles the full optimization loop automatically. It splits the eval set into 60% train and 40% held-out test, evaluates the current description (running each query 3 times to get a reliable trigger rate), then calls Claude with extended thinking to propose improvements based on what failed. It re-evaluates each new description on both train and test, iterating up to 5 times. When it's done, it opens an HTML report in the browser showing the results per iteration and returns JSON with `best_description` — selected by test score rather than train score to avoid overfitting.
+
+### How skill triggering works
+
+Understanding the triggering mechanism helps design better eval queries. Skills appear in Claude's `available_skills` list with their name + description, and Claude decides whether to consult a skill based on that description. The important thing to know is that Claude only consults skills for tasks it can't easily handle on its own — simple, one-step queries like "read this PDF" may not trigger a skill even if the description matches perfectly, because Claude can handle them directly with basic tools. Complex, multi-step, or specialized queries reliably trigger skills when the description matches.
+
+This means your eval queries should be substantive enough that Claude would actually benefit from consulting a skill. Simple queries like "read file X" are poor test cases — they won't trigger skills regardless of description quality.
+
+### Step 4: Apply the result
+
+Take `best_description` from the JSON output and update the skill's SKILL.md frontmatter. Show the user before/after and report the scores.
+
+---
+
+### Package and Present (only if `present_files` tool is available)
+
+Check whether you have access to the `present_files` tool. If you don't, skip this step. If you do, package the skill and present the .skill file to the user:
+
+```bash
+python -m scripts.package_skill <path/to/skill-folder>
+```
+
+After packaging, direct the user to the resulting `.skill` file path so they can install it.
+
+---
+
+## Claude.ai-specific instructions
+
+In Claude.ai, the core workflow is the same (draft → test → review → improve → repeat), but because Claude.ai doesn't have subagents, some mechanics change. Here's what to adapt:
+
+**Running test cases**: No subagents means no parallel execution. For each test case, read the skill's SKILL.md, then follow its instructions to accomplish the test prompt yourself. Do them one at a time. This is less rigorous than independent subagents (you wrote the skill and you're also running it, so you have full context), but it's a useful sanity check — and the human review step compensates. Skip the baseline runs — just use the skill to complete the task as requested.
+
+**Reviewing results**: If you can't open a browser (e.g., Claude.ai's VM has no display, or you're on a remote server), skip the browser reviewer entirely. Instead, present results directly in the conversation. For each test case, show the prompt and the output. If the output is a file the user needs to see (like a .docx or .xlsx), save it to the filesystem and tell them where it is so they can download and inspect it. Ask for feedback inline: "How does this look? Anything you'd change?"
+
+**Benchmarking**: Skip the quantitative benchmarking — it relies on baseline comparisons which aren't meaningful without subagents. Focus on qualitative feedback from the user.
+
+**The iteration loop**: Same as before — improve the skill, rerun the test cases, ask for feedback — just without the browser reviewer in the middle. You can still organize results into iteration directories on the filesystem if you have one.
+
+**Description optimization**: This section requires the `claude` CLI tool (specifically `claude -p`) which is only available in Claude Code. Skip it if you're on Claude.ai.
+
+**Blind comparison**: Requires subagents. Skip it.
+
+**Packaging**: The `package_skill.py` script works anywhere with Python and a filesystem. On Claude.ai, you can run it and the user can download the resulting `.skill` file.
+
+---
+
+## Cowork-Specific Instructions
+
+If you're in Cowork, the main things to know are:
+
+- You have subagents, so the main workflow (spawn test cases in parallel, run baselines, grade, etc.) all works. (However, if you run into severe problems with timeouts, it's OK to run the test prompts in series rather than parallel.)
+- You don't have a browser or display, so when generating the eval viewer, use `--static <output_path>` to write a standalone HTML file instead of starting a server. Then proffer a link that the user can click to open the HTML in their browser.
+- For whatever reason, the Cowork setup seems to disincline Claude from generating the eval viewer after running the tests, so just to reiterate: whether you're in Cowork or in Claude Code, after running tests, you should always generate the eval viewer for the human to look at examples before revising the skill yourself and trying to make corrections, using `generate_review.py` (not writing your own boutique html code). Sorry in advance but I'm gonna go all caps here: GENERATE THE EVAL VIEWER *BEFORE* evaluating inputs yourself. You want to get them in front of the human ASAP!
+- Feedback works differently: since there's no running server, the viewer's "Submit All Reviews" button will download `feedback.json` as a file. You can then read it from there (you may have to request access first).
+- Packaging works — `package_skill.py` just needs Python and a filesystem.
+- Description optimization (`run_loop.py` / `run_eval.py`) should work in Cowork just fine since it uses `claude -p` via subprocess, not a browser, but please save it until you've fully finished making the skill and the user agrees it's in good shape.
+
+---
+
+## Reference files
+
+The agents/ directory contains instructions for specialized subagents. Read them when you need to spawn the relevant subagent.
+
+- `agents/grader.md` — How to evaluate assertions against outputs
+- `agents/comparator.md` — How to do blind A/B comparison between two outputs
+- `agents/analyzer.md` — How to analyze why one version beat another
+
+The references/ directory has additional documentation:
+- `references/schemas.md` — JSON structures for evals.json, grading.json, etc.
+
+---
+
+Repeating one more time the core loop here for emphasis:
+
+- Figure out what the skill is about
+- Draft or edit the skill
+- Run claude-with-access-to-the-skill on test prompts
+- With the user, evaluate the outputs:
+  - Create benchmark.json and run `eval-viewer/generate_review.py` to help the user review them
+  - Run quantitative evals
+- Repeat until you and the user are satisfied
+- Package the final skill and return it to the user.
+
+Please add steps to your TodoList, if you have such a thing, to make sure you don't forget. If you're in Cowork, please specifically put "Create evals JSON and run `eval-viewer/generate_review.py` so human can review test cases" in your TodoList to make sure it happens.
+
+Good luck!

--- a/.claude/skills/skill-creator/agents/analyzer.md
+++ b/.claude/skills/skill-creator/agents/analyzer.md
@@ -1,0 +1,274 @@
+# Post-hoc Analyzer Agent
+
+Analyze blind comparison results to understand WHY the winner won and generate improvement suggestions.
+
+## Role
+
+After the blind comparator determines a winner, the Post-hoc Analyzer "unblids" the results by examining the skills and transcripts. The goal is to extract actionable insights: what made the winner better, and how can the loser be improved?
+
+## Inputs
+
+You receive these parameters in your prompt:
+
+- **winner**: "A" or "B" (from blind comparison)
+- **winner_skill_path**: Path to the skill that produced the winning output
+- **winner_transcript_path**: Path to the execution transcript for the winner
+- **loser_skill_path**: Path to the skill that produced the losing output
+- **loser_transcript_path**: Path to the execution transcript for the loser
+- **comparison_result_path**: Path to the blind comparator's output JSON
+- **output_path**: Where to save the analysis results
+
+## Process
+
+### Step 1: Read Comparison Result
+
+1. Read the blind comparator's output at comparison_result_path
+2. Note the winning side (A or B), the reasoning, and any scores
+3. Understand what the comparator valued in the winning output
+
+### Step 2: Read Both Skills
+
+1. Read the winner skill's SKILL.md and key referenced files
+2. Read the loser skill's SKILL.md and key referenced files
+3. Identify structural differences:
+   - Instructions clarity and specificity
+   - Script/tool usage patterns
+   - Example coverage
+   - Edge case handling
+
+### Step 3: Read Both Transcripts
+
+1. Read the winner's transcript
+2. Read the loser's transcript
+3. Compare execution patterns:
+   - How closely did each follow their skill's instructions?
+   - What tools were used differently?
+   - Where did the loser diverge from optimal behavior?
+   - Did either encounter errors or make recovery attempts?
+
+### Step 4: Analyze Instruction Following
+
+For each transcript, evaluate:
+- Did the agent follow the skill's explicit instructions?
+- Did the agent use the skill's provided tools/scripts?
+- Were there missed opportunities to leverage skill content?
+- Did the agent add unnecessary steps not in the skill?
+
+Score instruction following 1-10 and note specific issues.
+
+### Step 5: Identify Winner Strengths
+
+Determine what made the winner better:
+- Clearer instructions that led to better behavior?
+- Better scripts/tools that produced better output?
+- More comprehensive examples that guided edge cases?
+- Better error handling guidance?
+
+Be specific. Quote from skills/transcripts where relevant.
+
+### Step 6: Identify Loser Weaknesses
+
+Determine what held the loser back:
+- Ambiguous instructions that led to suboptimal choices?
+- Missing tools/scripts that forced workarounds?
+- Gaps in edge case coverage?
+- Poor error handling that caused failures?
+
+### Step 7: Generate Improvement Suggestions
+
+Based on the analysis, produce actionable suggestions for improving the loser skill:
+- Specific instruction changes to make
+- Tools/scripts to add or modify
+- Examples to include
+- Edge cases to address
+
+Prioritize by impact. Focus on changes that would have changed the outcome.
+
+### Step 8: Write Analysis Results
+
+Save structured analysis to `{output_path}`.
+
+## Output Format
+
+Write a JSON file with this structure:
+
+```json
+{
+  "comparison_summary": {
+    "winner": "A",
+    "winner_skill": "path/to/winner/skill",
+    "loser_skill": "path/to/loser/skill",
+    "comparator_reasoning": "Brief summary of why comparator chose winner"
+  },
+  "winner_strengths": [
+    "Clear step-by-step instructions for handling multi-page documents",
+    "Included validation script that caught formatting errors",
+    "Explicit guidance on fallback behavior when OCR fails"
+  ],
+  "loser_weaknesses": [
+    "Vague instruction 'process the document appropriately' led to inconsistent behavior",
+    "No script for validation, agent had to improvise and made errors",
+    "No guidance on OCR failure, agent gave up instead of trying alternatives"
+  ],
+  "instruction_following": {
+    "winner": {
+      "score": 9,
+      "issues": [
+        "Minor: skipped optional logging step"
+      ]
+    },
+    "loser": {
+      "score": 6,
+      "issues": [
+        "Did not use the skill's formatting template",
+        "Invented own approach instead of following step 3",
+        "Missed the 'always validate output' instruction"
+      ]
+    }
+  },
+  "improvement_suggestions": [
+    {
+      "priority": "high",
+      "category": "instructions",
+      "suggestion": "Replace 'process the document appropriately' with explicit steps: 1) Extract text, 2) Identify sections, 3) Format per template",
+      "expected_impact": "Would eliminate ambiguity that caused inconsistent behavior"
+    },
+    {
+      "priority": "high",
+      "category": "tools",
+      "suggestion": "Add validate_output.py script similar to winner skill's validation approach",
+      "expected_impact": "Would catch formatting errors before final output"
+    },
+    {
+      "priority": "medium",
+      "category": "error_handling",
+      "suggestion": "Add fallback instructions: 'If OCR fails, try: 1) different resolution, 2) image preprocessing, 3) manual extraction'",
+      "expected_impact": "Would prevent early failure on difficult documents"
+    }
+  ],
+  "transcript_insights": {
+    "winner_execution_pattern": "Read skill -> Followed 5-step process -> Used validation script -> Fixed 2 issues -> Produced output",
+    "loser_execution_pattern": "Read skill -> Unclear on approach -> Tried 3 different methods -> No validation -> Output had errors"
+  }
+}
+```
+
+## Guidelines
+
+- **Be specific**: Quote from skills and transcripts, don't just say "instructions were unclear"
+- **Be actionable**: Suggestions should be concrete changes, not vague advice
+- **Focus on skill improvements**: The goal is to improve the losing skill, not critique the agent
+- **Prioritize by impact**: Which changes would most likely have changed the outcome?
+- **Consider causation**: Did the skill weakness actually cause the worse output, or is it incidental?
+- **Stay objective**: Analyze what happened, don't editorialize
+- **Think about generalization**: Would this improvement help on other evals too?
+
+## Categories for Suggestions
+
+Use these categories to organize improvement suggestions:
+
+| Category | Description |
+|----------|-------------|
+| `instructions` | Changes to the skill's prose instructions |
+| `tools` | Scripts, templates, or utilities to add/modify |
+| `examples` | Example inputs/outputs to include |
+| `error_handling` | Guidance for handling failures |
+| `structure` | Reorganization of skill content |
+| `references` | External docs or resources to add |
+
+## Priority Levels
+
+- **high**: Would likely change the outcome of this comparison
+- **medium**: Would improve quality but may not change win/loss
+- **low**: Nice to have, marginal improvement
+
+---
+
+# Analyzing Benchmark Results
+
+When analyzing benchmark results, the analyzer's purpose is to **surface patterns and anomalies** across multiple runs, not suggest skill improvements.
+
+## Role
+
+Review all benchmark run results and generate freeform notes that help the user understand skill performance. Focus on patterns that wouldn't be visible from aggregate metrics alone.
+
+## Inputs
+
+You receive these parameters in your prompt:
+
+- **benchmark_data_path**: Path to the in-progress benchmark.json with all run results
+- **skill_path**: Path to the skill being benchmarked
+- **output_path**: Where to save the notes (as JSON array of strings)
+
+## Process
+
+### Step 1: Read Benchmark Data
+
+1. Read the benchmark.json containing all run results
+2. Note the configurations tested (with_skill, without_skill)
+3. Understand the run_summary aggregates already calculated
+
+### Step 2: Analyze Per-Assertion Patterns
+
+For each expectation across all runs:
+- Does it **always pass** in both configurations? (may not differentiate skill value)
+- Does it **always fail** in both configurations? (may be broken or beyond capability)
+- Does it **always pass with skill but fail without**? (skill clearly adds value here)
+- Does it **always fail with skill but pass without**? (skill may be hurting)
+- Is it **highly variable**? (flaky expectation or non-deterministic behavior)
+
+### Step 3: Analyze Cross-Eval Patterns
+
+Look for patterns across evals:
+- Are certain eval types consistently harder/easier?
+- Do some evals show high variance while others are stable?
+- Are there surprising results that contradict expectations?
+
+### Step 4: Analyze Metrics Patterns
+
+Look at time_seconds, tokens, tool_calls:
+- Does the skill significantly increase execution time?
+- Is there high variance in resource usage?
+- Are there outlier runs that skew the aggregates?
+
+### Step 5: Generate Notes
+
+Write freeform observations as a list of strings. Each note should:
+- State a specific observation
+- Be grounded in the data (not speculation)
+- Help the user understand something the aggregate metrics don't show
+
+Examples:
+- "Assertion 'Output is a PDF file' passes 100% in both configurations - may not differentiate skill value"
+- "Eval 3 shows high variance (50% ± 40%) - run 2 had an unusual failure that may be flaky"
+- "Without-skill runs consistently fail on table extraction expectations (0% pass rate)"
+- "Skill adds 13s average execution time but improves pass rate by 50%"
+- "Token usage is 80% higher with skill, primarily due to script output parsing"
+- "All 3 without-skill runs for eval 1 produced empty output"
+
+### Step 6: Write Notes
+
+Save notes to `{output_path}` as a JSON array of strings:
+
+```json
+[
+  "Assertion 'Output is a PDF file' passes 100% in both configurations - may not differentiate skill value",
+  "Eval 3 shows high variance (50% ± 40%) - run 2 had an unusual failure",
+  "Without-skill runs consistently fail on table extraction expectations",
+  "Skill adds 13s average execution time but improves pass rate by 50%"
+]
+```
+
+## Guidelines
+
+**DO:**
+- Report what you observe in the data
+- Be specific about which evals, expectations, or runs you're referring to
+- Note patterns that aggregate metrics would hide
+- Provide context that helps interpret the numbers
+
+**DO NOT:**
+- Suggest improvements to the skill (that's for the improvement step, not benchmarking)
+- Make subjective quality judgments ("the output was good/bad")
+- Speculate about causes without evidence
+- Repeat information already in the run_summary aggregates

--- a/.claude/skills/skill-creator/agents/comparator.md
+++ b/.claude/skills/skill-creator/agents/comparator.md
@@ -1,0 +1,202 @@
+# Blind Comparator Agent
+
+Compare two outputs WITHOUT knowing which skill produced them.
+
+## Role
+
+The Blind Comparator judges which output better accomplishes the eval task. You receive two outputs labeled A and B, but you do NOT know which skill produced which. This prevents bias toward a particular skill or approach.
+
+Your judgment is based purely on output quality and task completion.
+
+## Inputs
+
+You receive these parameters in your prompt:
+
+- **output_a_path**: Path to the first output file or directory
+- **output_b_path**: Path to the second output file or directory
+- **eval_prompt**: The original task/prompt that was executed
+- **expectations**: List of expectations to check (optional - may be empty)
+
+## Process
+
+### Step 1: Read Both Outputs
+
+1. Examine output A (file or directory)
+2. Examine output B (file or directory)
+3. Note the type, structure, and content of each
+4. If outputs are directories, examine all relevant files inside
+
+### Step 2: Understand the Task
+
+1. Read the eval_prompt carefully
+2. Identify what the task requires:
+   - What should be produced?
+   - What qualities matter (accuracy, completeness, format)?
+   - What would distinguish a good output from a poor one?
+
+### Step 3: Generate Evaluation Rubric
+
+Based on the task, generate a rubric with two dimensions:
+
+**Content Rubric** (what the output contains):
+| Criterion | 1 (Poor) | 3 (Acceptable) | 5 (Excellent) |
+|-----------|----------|----------------|---------------|
+| Correctness | Major errors | Minor errors | Fully correct |
+| Completeness | Missing key elements | Mostly complete | All elements present |
+| Accuracy | Significant inaccuracies | Minor inaccuracies | Accurate throughout |
+
+**Structure Rubric** (how the output is organized):
+| Criterion | 1 (Poor) | 3 (Acceptable) | 5 (Excellent) |
+|-----------|----------|----------------|---------------|
+| Organization | Disorganized | Reasonably organized | Clear, logical structure |
+| Formatting | Inconsistent/broken | Mostly consistent | Professional, polished |
+| Usability | Difficult to use | Usable with effort | Easy to use |
+
+Adapt criteria to the specific task. For example:
+- PDF form → "Field alignment", "Text readability", "Data placement"
+- Document → "Section structure", "Heading hierarchy", "Paragraph flow"
+- Data output → "Schema correctness", "Data types", "Completeness"
+
+### Step 4: Evaluate Each Output Against the Rubric
+
+For each output (A and B):
+
+1. **Score each criterion** on the rubric (1-5 scale)
+2. **Calculate dimension totals**: Content score, Structure score
+3. **Calculate overall score**: Average of dimension scores, scaled to 1-10
+
+### Step 5: Check Assertions (if provided)
+
+If expectations are provided:
+
+1. Check each expectation against output A
+2. Check each expectation against output B
+3. Count pass rates for each output
+4. Use expectation scores as secondary evidence (not the primary decision factor)
+
+### Step 6: Determine the Winner
+
+Compare A and B based on (in priority order):
+
+1. **Primary**: Overall rubric score (content + structure)
+2. **Secondary**: Assertion pass rates (if applicable)
+3. **Tiebreaker**: If truly equal, declare a TIE
+
+Be decisive - ties should be rare. One output is usually better, even if marginally.
+
+### Step 7: Write Comparison Results
+
+Save results to a JSON file at the path specified (or `comparison.json` if not specified).
+
+## Output Format
+
+Write a JSON file with this structure:
+
+```json
+{
+  "winner": "A",
+  "reasoning": "Output A provides a complete solution with proper formatting and all required fields. Output B is missing the date field and has formatting inconsistencies.",
+  "rubric": {
+    "A": {
+      "content": {
+        "correctness": 5,
+        "completeness": 5,
+        "accuracy": 4
+      },
+      "structure": {
+        "organization": 4,
+        "formatting": 5,
+        "usability": 4
+      },
+      "content_score": 4.7,
+      "structure_score": 4.3,
+      "overall_score": 9.0
+    },
+    "B": {
+      "content": {
+        "correctness": 3,
+        "completeness": 2,
+        "accuracy": 3
+      },
+      "structure": {
+        "organization": 3,
+        "formatting": 2,
+        "usability": 3
+      },
+      "content_score": 2.7,
+      "structure_score": 2.7,
+      "overall_score": 5.4
+    }
+  },
+  "output_quality": {
+    "A": {
+      "score": 9,
+      "strengths": ["Complete solution", "Well-formatted", "All fields present"],
+      "weaknesses": ["Minor style inconsistency in header"]
+    },
+    "B": {
+      "score": 5,
+      "strengths": ["Readable output", "Correct basic structure"],
+      "weaknesses": ["Missing date field", "Formatting inconsistencies", "Partial data extraction"]
+    }
+  },
+  "expectation_results": {
+    "A": {
+      "passed": 4,
+      "total": 5,
+      "pass_rate": 0.80,
+      "details": [
+        {"text": "Output includes name", "passed": true},
+        {"text": "Output includes date", "passed": true},
+        {"text": "Format is PDF", "passed": true},
+        {"text": "Contains signature", "passed": false},
+        {"text": "Readable text", "passed": true}
+      ]
+    },
+    "B": {
+      "passed": 3,
+      "total": 5,
+      "pass_rate": 0.60,
+      "details": [
+        {"text": "Output includes name", "passed": true},
+        {"text": "Output includes date", "passed": false},
+        {"text": "Format is PDF", "passed": true},
+        {"text": "Contains signature", "passed": false},
+        {"text": "Readable text", "passed": true}
+      ]
+    }
+  }
+}
+```
+
+If no expectations were provided, omit the `expectation_results` field entirely.
+
+## Field Descriptions
+
+- **winner**: "A", "B", or "TIE"
+- **reasoning**: Clear explanation of why the winner was chosen (or why it's a tie)
+- **rubric**: Structured rubric evaluation for each output
+  - **content**: Scores for content criteria (correctness, completeness, accuracy)
+  - **structure**: Scores for structure criteria (organization, formatting, usability)
+  - **content_score**: Average of content criteria (1-5)
+  - **structure_score**: Average of structure criteria (1-5)
+  - **overall_score**: Combined score scaled to 1-10
+- **output_quality**: Summary quality assessment
+  - **score**: 1-10 rating (should match rubric overall_score)
+  - **strengths**: List of positive aspects
+  - **weaknesses**: List of issues or shortcomings
+- **expectation_results**: (Only if expectations provided)
+  - **passed**: Number of expectations that passed
+  - **total**: Total number of expectations
+  - **pass_rate**: Fraction passed (0.0 to 1.0)
+  - **details**: Individual expectation results
+
+## Guidelines
+
+- **Stay blind**: DO NOT try to infer which skill produced which output. Judge purely on output quality.
+- **Be specific**: Cite specific examples when explaining strengths and weaknesses.
+- **Be decisive**: Choose a winner unless outputs are genuinely equivalent.
+- **Output quality first**: Assertion scores are secondary to overall task completion.
+- **Be objective**: Don't favor outputs based on style preferences; focus on correctness and completeness.
+- **Explain your reasoning**: The reasoning field should make it clear why you chose the winner.
+- **Handle edge cases**: If both outputs fail, pick the one that fails less badly. If both are excellent, pick the one that's marginally better.

--- a/.claude/skills/skill-creator/agents/grader.md
+++ b/.claude/skills/skill-creator/agents/grader.md
@@ -1,0 +1,223 @@
+# Grader Agent
+
+Evaluate expectations against an execution transcript and outputs.
+
+## Role
+
+The Grader reviews a transcript and output files, then determines whether each expectation passes or fails. Provide clear evidence for each judgment.
+
+You have two jobs: grade the outputs, and critique the evals themselves. A passing grade on a weak assertion is worse than useless — it creates false confidence. When you notice an assertion that's trivially satisfied, or an important outcome that no assertion checks, say so.
+
+## Inputs
+
+You receive these parameters in your prompt:
+
+- **expectations**: List of expectations to evaluate (strings)
+- **transcript_path**: Path to the execution transcript (markdown file)
+- **outputs_dir**: Directory containing output files from execution
+
+## Process
+
+### Step 1: Read the Transcript
+
+1. Read the transcript file completely
+2. Note the eval prompt, execution steps, and final result
+3. Identify any issues or errors documented
+
+### Step 2: Examine Output Files
+
+1. List files in outputs_dir
+2. Read/examine each file relevant to the expectations. If outputs aren't plain text, use the inspection tools provided in your prompt — don't rely solely on what the transcript says the executor produced.
+3. Note contents, structure, and quality
+
+### Step 3: Evaluate Each Assertion
+
+For each expectation:
+
+1. **Search for evidence** in the transcript and outputs
+2. **Determine verdict**:
+   - **PASS**: Clear evidence the expectation is true AND the evidence reflects genuine task completion, not just surface-level compliance
+   - **FAIL**: No evidence, or evidence contradicts the expectation, or the evidence is superficial (e.g., correct filename but empty/wrong content)
+3. **Cite the evidence**: Quote the specific text or describe what you found
+
+### Step 4: Extract and Verify Claims
+
+Beyond the predefined expectations, extract implicit claims from the outputs and verify them:
+
+1. **Extract claims** from the transcript and outputs:
+   - Factual statements ("The form has 12 fields")
+   - Process claims ("Used pypdf to fill the form")
+   - Quality claims ("All fields were filled correctly")
+
+2. **Verify each claim**:
+   - **Factual claims**: Can be checked against the outputs or external sources
+   - **Process claims**: Can be verified from the transcript
+   - **Quality claims**: Evaluate whether the claim is justified
+
+3. **Flag unverifiable claims**: Note claims that cannot be verified with available information
+
+This catches issues that predefined expectations might miss.
+
+### Step 5: Read User Notes
+
+If `{outputs_dir}/user_notes.md` exists:
+1. Read it and note any uncertainties or issues flagged by the executor
+2. Include relevant concerns in the grading output
+3. These may reveal problems even when expectations pass
+
+### Step 6: Critique the Evals
+
+After grading, consider whether the evals themselves could be improved. Only surface suggestions when there's a clear gap.
+
+Good suggestions test meaningful outcomes — assertions that are hard to satisfy without actually doing the work correctly. Think about what makes an assertion *discriminating*: it passes when the skill genuinely succeeds and fails when it doesn't.
+
+Suggestions worth raising:
+- An assertion that passed but would also pass for a clearly wrong output (e.g., checking filename existence but not file content)
+- An important outcome you observed — good or bad — that no assertion covers at all
+- An assertion that can't actually be verified from the available outputs
+
+Keep the bar high. The goal is to flag things the eval author would say "good catch" about, not to nitpick every assertion.
+
+### Step 7: Write Grading Results
+
+Save results to `{outputs_dir}/../grading.json` (sibling to outputs_dir).
+
+## Grading Criteria
+
+**PASS when**:
+- The transcript or outputs clearly demonstrate the expectation is true
+- Specific evidence can be cited
+- The evidence reflects genuine substance, not just surface compliance (e.g., a file exists AND contains correct content, not just the right filename)
+
+**FAIL when**:
+- No evidence found for the expectation
+- Evidence contradicts the expectation
+- The expectation cannot be verified from available information
+- The evidence is superficial — the assertion is technically satisfied but the underlying task outcome is wrong or incomplete
+- The output appears to meet the assertion by coincidence rather than by actually doing the work
+
+**When uncertain**: The burden of proof to pass is on the expectation.
+
+### Step 8: Read Executor Metrics and Timing
+
+1. If `{outputs_dir}/metrics.json` exists, read it and include in grading output
+2. If `{outputs_dir}/../timing.json` exists, read it and include timing data
+
+## Output Format
+
+Write a JSON file with this structure:
+
+```json
+{
+  "expectations": [
+    {
+      "text": "The output includes the name 'John Smith'",
+      "passed": true,
+      "evidence": "Found in transcript Step 3: 'Extracted names: John Smith, Sarah Johnson'"
+    },
+    {
+      "text": "The spreadsheet has a SUM formula in cell B10",
+      "passed": false,
+      "evidence": "No spreadsheet was created. The output was a text file."
+    },
+    {
+      "text": "The assistant used the skill's OCR script",
+      "passed": true,
+      "evidence": "Transcript Step 2 shows: 'Tool: Bash - python ocr_script.py image.png'"
+    }
+  ],
+  "summary": {
+    "passed": 2,
+    "failed": 1,
+    "total": 3,
+    "pass_rate": 0.67
+  },
+  "execution_metrics": {
+    "tool_calls": {
+      "Read": 5,
+      "Write": 2,
+      "Bash": 8
+    },
+    "total_tool_calls": 15,
+    "total_steps": 6,
+    "errors_encountered": 0,
+    "output_chars": 12450,
+    "transcript_chars": 3200
+  },
+  "timing": {
+    "executor_duration_seconds": 165.0,
+    "grader_duration_seconds": 26.0,
+    "total_duration_seconds": 191.0
+  },
+  "claims": [
+    {
+      "claim": "The form has 12 fillable fields",
+      "type": "factual",
+      "verified": true,
+      "evidence": "Counted 12 fields in field_info.json"
+    },
+    {
+      "claim": "All required fields were populated",
+      "type": "quality",
+      "verified": false,
+      "evidence": "Reference section was left blank despite data being available"
+    }
+  ],
+  "user_notes_summary": {
+    "uncertainties": ["Used 2023 data, may be stale"],
+    "needs_review": [],
+    "workarounds": ["Fell back to text overlay for non-fillable fields"]
+  },
+  "eval_feedback": {
+    "suggestions": [
+      {
+        "assertion": "The output includes the name 'John Smith'",
+        "reason": "A hallucinated document that mentions the name would also pass — consider checking it appears as the primary contact with matching phone and email from the input"
+      },
+      {
+        "reason": "No assertion checks whether the extracted phone numbers match the input — I observed incorrect numbers in the output that went uncaught"
+      }
+    ],
+    "overall": "Assertions check presence but not correctness. Consider adding content verification."
+  }
+}
+```
+
+## Field Descriptions
+
+- **expectations**: Array of graded expectations
+  - **text**: The original expectation text
+  - **passed**: Boolean - true if expectation passes
+  - **evidence**: Specific quote or description supporting the verdict
+- **summary**: Aggregate statistics
+  - **passed**: Count of passed expectations
+  - **failed**: Count of failed expectations
+  - **total**: Total expectations evaluated
+  - **pass_rate**: Fraction passed (0.0 to 1.0)
+- **execution_metrics**: Copied from executor's metrics.json (if available)
+  - **output_chars**: Total character count of output files (proxy for tokens)
+  - **transcript_chars**: Character count of transcript
+- **timing**: Wall clock timing from timing.json (if available)
+  - **executor_duration_seconds**: Time spent in executor subagent
+  - **total_duration_seconds**: Total elapsed time for the run
+- **claims**: Extracted and verified claims from the output
+  - **claim**: The statement being verified
+  - **type**: "factual", "process", or "quality"
+  - **verified**: Boolean - whether the claim holds
+  - **evidence**: Supporting or contradicting evidence
+- **user_notes_summary**: Issues flagged by the executor
+  - **uncertainties**: Things the executor wasn't sure about
+  - **needs_review**: Items requiring human attention
+  - **workarounds**: Places where the skill didn't work as expected
+- **eval_feedback**: Improvement suggestions for the evals (only when warranted)
+  - **suggestions**: List of concrete suggestions, each with a `reason` and optionally an `assertion` it relates to
+  - **overall**: Brief assessment — can be "No suggestions, evals look solid" if nothing to flag
+
+## Guidelines
+
+- **Be objective**: Base verdicts on evidence, not assumptions
+- **Be specific**: Quote the exact text that supports your verdict
+- **Be thorough**: Check both transcript and output files
+- **Be consistent**: Apply the same standard to each expectation
+- **Explain failures**: Make it clear why evidence was insufficient
+- **No partial credit**: Each expectation is pass or fail, not partial

--- a/.claude/skills/skill-creator/assets/eval_review.html
+++ b/.claude/skills/skill-creator/assets/eval_review.html
@@ -1,0 +1,146 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Eval Set Review - __SKILL_NAME_PLACEHOLDER__</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@500;600&family=Lora:wght@400;500&display=swap" rel="stylesheet">
+  <style>
+    * { box-sizing: border-box; margin: 0; padding: 0; }
+    body { font-family: 'Lora', Georgia, serif; background: #faf9f5; padding: 2rem; color: #141413; }
+    h1 { font-family: 'Poppins', sans-serif; margin-bottom: 0.5rem; font-size: 1.5rem; }
+    .description { color: #b0aea5; margin-bottom: 1.5rem; font-style: italic; max-width: 900px; }
+    .controls { margin-bottom: 1rem; display: flex; gap: 0.5rem; }
+    .btn { font-family: 'Poppins', sans-serif; padding: 0.5rem 1rem; border: none; border-radius: 6px; cursor: pointer; font-size: 0.875rem; font-weight: 500; }
+    .btn-add { background: #6a9bcc; color: white; }
+    .btn-add:hover { background: #5889b8; }
+    .btn-export { background: #d97757; color: white; }
+    .btn-export:hover { background: #c4613f; }
+    table { width: 100%; max-width: 1100px; border-collapse: collapse; background: white; border-radius: 6px; overflow: hidden; box-shadow: 0 1px 3px rgba(0,0,0,0.08); }
+    th { font-family: 'Poppins', sans-serif; background: #141413; color: #faf9f5; padding: 0.75rem 1rem; text-align: left; font-size: 0.875rem; }
+    td { padding: 0.75rem 1rem; border-bottom: 1px solid #e8e6dc; vertical-align: top; }
+    tr:nth-child(even) td { background: #faf9f5; }
+    tr:hover td { background: #f3f1ea; }
+    .section-header td { background: #e8e6dc; font-family: 'Poppins', sans-serif; font-weight: 500; font-size: 0.8rem; color: #141413; text-transform: uppercase; letter-spacing: 0.05em; }
+    .query-input { width: 100%; padding: 0.4rem; border: 1px solid #e8e6dc; border-radius: 4px; font-size: 0.875rem; font-family: 'Lora', Georgia, serif; resize: vertical; min-height: 60px; }
+    .query-input:focus { outline: none; border-color: #d97757; box-shadow: 0 0 0 2px rgba(217,119,87,0.15); }
+    .toggle { position: relative; display: inline-block; width: 44px; height: 24px; }
+    .toggle input { opacity: 0; width: 0; height: 0; }
+    .toggle .slider { position: absolute; inset: 0; background: #b0aea5; border-radius: 24px; cursor: pointer; transition: 0.2s; }
+    .toggle .slider::before { content: ""; position: absolute; width: 18px; height: 18px; left: 3px; bottom: 3px; background: white; border-radius: 50%; transition: 0.2s; }
+    .toggle input:checked + .slider { background: #d97757; }
+    .toggle input:checked + .slider::before { transform: translateX(20px); }
+    .btn-delete { background: #c44; color: white; padding: 0.3rem 0.6rem; border: none; border-radius: 4px; cursor: pointer; font-size: 0.75rem; font-family: 'Poppins', sans-serif; }
+    .btn-delete:hover { background: #a33; }
+    .summary { margin-top: 1rem; color: #b0aea5; font-size: 0.875rem; }
+  </style>
+</head>
+<body>
+  <h1>Eval Set Review: <span id="skill-name">__SKILL_NAME_PLACEHOLDER__</span></h1>
+  <p class="description">Current description: <span id="skill-desc">__SKILL_DESCRIPTION_PLACEHOLDER__</span></p>
+
+  <div class="controls">
+    <button class="btn btn-add" onclick="addRow()">+ Add Query</button>
+    <button class="btn btn-export" onclick="exportEvalSet()">Export Eval Set</button>
+  </div>
+
+  <table>
+    <thead>
+      <tr>
+        <th style="width:65%">Query</th>
+        <th style="width:18%">Should Trigger</th>
+        <th style="width:10%">Actions</th>
+      </tr>
+    </thead>
+    <tbody id="eval-body"></tbody>
+  </table>
+
+  <p class="summary" id="summary"></p>
+
+  <script>
+    const EVAL_DATA = __EVAL_DATA_PLACEHOLDER__;
+
+    let evalItems = [...EVAL_DATA];
+
+    function render() {
+      const tbody = document.getElementById('eval-body');
+      tbody.innerHTML = '';
+
+      // Sort: should-trigger first, then should-not-trigger
+      const sorted = evalItems
+        .map((item, origIdx) => ({ ...item, origIdx }))
+        .sort((a, b) => (b.should_trigger ? 1 : 0) - (a.should_trigger ? 1 : 0));
+
+      let lastGroup = null;
+      sorted.forEach(item => {
+        const group = item.should_trigger ? 'trigger' : 'no-trigger';
+        if (group !== lastGroup) {
+          const headerRow = document.createElement('tr');
+          headerRow.className = 'section-header';
+          headerRow.innerHTML = `<td colspan="3">${item.should_trigger ? 'Should Trigger' : 'Should NOT Trigger'}</td>`;
+          tbody.appendChild(headerRow);
+          lastGroup = group;
+        }
+
+        const idx = item.origIdx;
+        const tr = document.createElement('tr');
+        tr.innerHTML = `
+          <td><textarea class="query-input" onchange="updateQuery(${idx}, this.value)">${escapeHtml(item.query)}</textarea></td>
+          <td>
+            <label class="toggle">
+              <input type="checkbox" ${item.should_trigger ? 'checked' : ''} onchange="updateTrigger(${idx}, this.checked)">
+              <span class="slider"></span>
+            </label>
+            <span style="margin-left:8px;font-size:0.8rem;color:#b0aea5">${item.should_trigger ? 'Yes' : 'No'}</span>
+          </td>
+          <td><button class="btn-delete" onclick="deleteRow(${idx})">Delete</button></td>
+        `;
+        tbody.appendChild(tr);
+      });
+      updateSummary();
+    }
+
+    function escapeHtml(text) {
+      const div = document.createElement('div');
+      div.textContent = text;
+      return div.innerHTML;
+    }
+
+    function updateQuery(idx, value) { evalItems[idx].query = value; updateSummary(); }
+    function updateTrigger(idx, value) { evalItems[idx].should_trigger = value; render(); }
+    function deleteRow(idx) { evalItems.splice(idx, 1); render(); }
+
+    function addRow() {
+      evalItems.push({ query: '', should_trigger: true });
+      render();
+      const inputs = document.querySelectorAll('.query-input');
+      inputs[inputs.length - 1].focus();
+    }
+
+    function updateSummary() {
+      const trigger = evalItems.filter(i => i.should_trigger).length;
+      const noTrigger = evalItems.filter(i => !i.should_trigger).length;
+      document.getElementById('summary').textContent =
+        `${evalItems.length} queries total: ${trigger} should trigger, ${noTrigger} should not trigger`;
+    }
+
+    function exportEvalSet() {
+      const valid = evalItems.filter(i => i.query.trim() !== '');
+      const data = valid.map(i => ({ query: i.query.trim(), should_trigger: i.should_trigger }));
+      const blob = new Blob([JSON.stringify(data, null, 2)], { type: 'application/json' });
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement('a');
+      a.href = url;
+      a.download = 'eval_set.json';
+      document.body.appendChild(a);
+      a.click();
+      document.body.removeChild(a);
+      URL.revokeObjectURL(url);
+    }
+
+    render();
+  </script>
+</body>
+</html>

--- a/.claude/skills/skill-creator/eval-viewer/generate_review.py
+++ b/.claude/skills/skill-creator/eval-viewer/generate_review.py
@@ -1,0 +1,471 @@
+#!/usr/bin/env python3
+"""Generate and serve a review page for eval results.
+
+Reads the workspace directory, discovers runs (directories with outputs/),
+embeds all output data into a self-contained HTML page, and serves it via
+a tiny HTTP server. Feedback auto-saves to feedback.json in the workspace.
+
+Usage:
+    python generate_review.py <workspace-path> [--port PORT] [--skill-name NAME]
+    python generate_review.py <workspace-path> --previous-feedback /path/to/old/feedback.json
+
+No dependencies beyond the Python stdlib are required.
+"""
+
+import argparse
+import base64
+import json
+import mimetypes
+import os
+import re
+import signal
+import subprocess
+import sys
+import time
+import webbrowser
+from functools import partial
+from http.server import HTTPServer, BaseHTTPRequestHandler
+from pathlib import Path
+
+# Files to exclude from output listings
+METADATA_FILES = {"transcript.md", "user_notes.md", "metrics.json"}
+
+# Extensions we render as inline text
+TEXT_EXTENSIONS = {
+    ".txt", ".md", ".json", ".csv", ".py", ".js", ".ts", ".tsx", ".jsx",
+    ".yaml", ".yml", ".xml", ".html", ".css", ".sh", ".rb", ".go", ".rs",
+    ".java", ".c", ".cpp", ".h", ".hpp", ".sql", ".r", ".toml",
+}
+
+# Extensions we render as inline images
+IMAGE_EXTENSIONS = {".png", ".jpg", ".jpeg", ".gif", ".svg", ".webp"}
+
+# MIME type overrides for common types
+MIME_OVERRIDES = {
+    ".svg": "image/svg+xml",
+    ".xlsx": "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+    ".docx": "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+    ".pptx": "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+}
+
+
+def get_mime_type(path: Path) -> str:
+    ext = path.suffix.lower()
+    if ext in MIME_OVERRIDES:
+        return MIME_OVERRIDES[ext]
+    mime, _ = mimetypes.guess_type(str(path))
+    return mime or "application/octet-stream"
+
+
+def find_runs(workspace: Path) -> list[dict]:
+    """Recursively find directories that contain an outputs/ subdirectory."""
+    runs: list[dict] = []
+    _find_runs_recursive(workspace, workspace, runs)
+    runs.sort(key=lambda r: (r.get("eval_id", float("inf")), r["id"]))
+    return runs
+
+
+def _find_runs_recursive(root: Path, current: Path, runs: list[dict]) -> None:
+    if not current.is_dir():
+        return
+
+    outputs_dir = current / "outputs"
+    if outputs_dir.is_dir():
+        run = build_run(root, current)
+        if run:
+            runs.append(run)
+        return
+
+    skip = {"node_modules", ".git", "__pycache__", "skill", "inputs"}
+    for child in sorted(current.iterdir()):
+        if child.is_dir() and child.name not in skip:
+            _find_runs_recursive(root, child, runs)
+
+
+def build_run(root: Path, run_dir: Path) -> dict | None:
+    """Build a run dict with prompt, outputs, and grading data."""
+    prompt = ""
+    eval_id = None
+
+    # Try eval_metadata.json
+    for candidate in [run_dir / "eval_metadata.json", run_dir.parent / "eval_metadata.json"]:
+        if candidate.exists():
+            try:
+                metadata = json.loads(candidate.read_text())
+                prompt = metadata.get("prompt", "")
+                eval_id = metadata.get("eval_id")
+            except (json.JSONDecodeError, OSError):
+                pass
+            if prompt:
+                break
+
+    # Fall back to transcript.md
+    if not prompt:
+        for candidate in [run_dir / "transcript.md", run_dir / "outputs" / "transcript.md"]:
+            if candidate.exists():
+                try:
+                    text = candidate.read_text()
+                    match = re.search(r"## Eval Prompt\n\n([\s\S]*?)(?=\n##|$)", text)
+                    if match:
+                        prompt = match.group(1).strip()
+                except OSError:
+                    pass
+                if prompt:
+                    break
+
+    if not prompt:
+        prompt = "(No prompt found)"
+
+    run_id = str(run_dir.relative_to(root)).replace("/", "-").replace("\\", "-")
+
+    # Collect output files
+    outputs_dir = run_dir / "outputs"
+    output_files: list[dict] = []
+    if outputs_dir.is_dir():
+        for f in sorted(outputs_dir.iterdir()):
+            if f.is_file() and f.name not in METADATA_FILES:
+                output_files.append(embed_file(f))
+
+    # Load grading if present
+    grading = None
+    for candidate in [run_dir / "grading.json", run_dir.parent / "grading.json"]:
+        if candidate.exists():
+            try:
+                grading = json.loads(candidate.read_text())
+            except (json.JSONDecodeError, OSError):
+                pass
+            if grading:
+                break
+
+    return {
+        "id": run_id,
+        "prompt": prompt,
+        "eval_id": eval_id,
+        "outputs": output_files,
+        "grading": grading,
+    }
+
+
+def embed_file(path: Path) -> dict:
+    """Read a file and return an embedded representation."""
+    ext = path.suffix.lower()
+    mime = get_mime_type(path)
+
+    if ext in TEXT_EXTENSIONS:
+        try:
+            content = path.read_text(errors="replace")
+        except OSError:
+            content = "(Error reading file)"
+        return {
+            "name": path.name,
+            "type": "text",
+            "content": content,
+        }
+    elif ext in IMAGE_EXTENSIONS:
+        try:
+            raw = path.read_bytes()
+            b64 = base64.b64encode(raw).decode("ascii")
+        except OSError:
+            return {"name": path.name, "type": "error", "content": "(Error reading file)"}
+        return {
+            "name": path.name,
+            "type": "image",
+            "mime": mime,
+            "data_uri": f"data:{mime};base64,{b64}",
+        }
+    elif ext == ".pdf":
+        try:
+            raw = path.read_bytes()
+            b64 = base64.b64encode(raw).decode("ascii")
+        except OSError:
+            return {"name": path.name, "type": "error", "content": "(Error reading file)"}
+        return {
+            "name": path.name,
+            "type": "pdf",
+            "data_uri": f"data:{mime};base64,{b64}",
+        }
+    elif ext == ".xlsx":
+        try:
+            raw = path.read_bytes()
+            b64 = base64.b64encode(raw).decode("ascii")
+        except OSError:
+            return {"name": path.name, "type": "error", "content": "(Error reading file)"}
+        return {
+            "name": path.name,
+            "type": "xlsx",
+            "data_b64": b64,
+        }
+    else:
+        # Binary / unknown — base64 download link
+        try:
+            raw = path.read_bytes()
+            b64 = base64.b64encode(raw).decode("ascii")
+        except OSError:
+            return {"name": path.name, "type": "error", "content": "(Error reading file)"}
+        return {
+            "name": path.name,
+            "type": "binary",
+            "mime": mime,
+            "data_uri": f"data:{mime};base64,{b64}",
+        }
+
+
+def load_previous_iteration(workspace: Path) -> dict[str, dict]:
+    """Load previous iteration's feedback and outputs.
+
+    Returns a map of run_id -> {"feedback": str, "outputs": list[dict]}.
+    """
+    result: dict[str, dict] = {}
+
+    # Load feedback
+    feedback_map: dict[str, str] = {}
+    feedback_path = workspace / "feedback.json"
+    if feedback_path.exists():
+        try:
+            data = json.loads(feedback_path.read_text())
+            feedback_map = {
+                r["run_id"]: r["feedback"]
+                for r in data.get("reviews", [])
+                if r.get("feedback", "").strip()
+            }
+        except (json.JSONDecodeError, OSError, KeyError):
+            pass
+
+    # Load runs (to get outputs)
+    prev_runs = find_runs(workspace)
+    for run in prev_runs:
+        result[run["id"]] = {
+            "feedback": feedback_map.get(run["id"], ""),
+            "outputs": run.get("outputs", []),
+        }
+
+    # Also add feedback for run_ids that had feedback but no matching run
+    for run_id, fb in feedback_map.items():
+        if run_id not in result:
+            result[run_id] = {"feedback": fb, "outputs": []}
+
+    return result
+
+
+def generate_html(
+    runs: list[dict],
+    skill_name: str,
+    previous: dict[str, dict] | None = None,
+    benchmark: dict | None = None,
+) -> str:
+    """Generate the complete standalone HTML page with embedded data."""
+    template_path = Path(__file__).parent / "viewer.html"
+    template = template_path.read_text()
+
+    # Build previous_feedback and previous_outputs maps for the template
+    previous_feedback: dict[str, str] = {}
+    previous_outputs: dict[str, list[dict]] = {}
+    if previous:
+        for run_id, data in previous.items():
+            if data.get("feedback"):
+                previous_feedback[run_id] = data["feedback"]
+            if data.get("outputs"):
+                previous_outputs[run_id] = data["outputs"]
+
+    embedded = {
+        "skill_name": skill_name,
+        "runs": runs,
+        "previous_feedback": previous_feedback,
+        "previous_outputs": previous_outputs,
+    }
+    if benchmark:
+        embedded["benchmark"] = benchmark
+
+    data_json = json.dumps(embedded)
+
+    return template.replace("/*__EMBEDDED_DATA__*/", f"const EMBEDDED_DATA = {data_json};")
+
+
+# ---------------------------------------------------------------------------
+# HTTP server (stdlib only, zero dependencies)
+# ---------------------------------------------------------------------------
+
+def _kill_port(port: int) -> None:
+    """Kill any process listening on the given port."""
+    try:
+        result = subprocess.run(
+            ["lsof", "-ti", f":{port}"],
+            capture_output=True, text=True, timeout=5,
+        )
+        for pid_str in result.stdout.strip().split("\n"):
+            if pid_str.strip():
+                try:
+                    os.kill(int(pid_str.strip()), signal.SIGTERM)
+                except (ProcessLookupError, ValueError):
+                    pass
+        if result.stdout.strip():
+            time.sleep(0.5)
+    except subprocess.TimeoutExpired:
+        pass
+    except FileNotFoundError:
+        print("Note: lsof not found, cannot check if port is in use", file=sys.stderr)
+
+class ReviewHandler(BaseHTTPRequestHandler):
+    """Serves the review HTML and handles feedback saves.
+
+    Regenerates the HTML on each page load so that refreshing the browser
+    picks up new eval outputs without restarting the server.
+    """
+
+    def __init__(
+        self,
+        workspace: Path,
+        skill_name: str,
+        feedback_path: Path,
+        previous: dict[str, dict],
+        benchmark_path: Path | None,
+        *args,
+        **kwargs,
+    ):
+        self.workspace = workspace
+        self.skill_name = skill_name
+        self.feedback_path = feedback_path
+        self.previous = previous
+        self.benchmark_path = benchmark_path
+        super().__init__(*args, **kwargs)
+
+    def do_GET(self) -> None:
+        if self.path == "/" or self.path == "/index.html":
+            # Regenerate HTML on each request (re-scans workspace for new outputs)
+            runs = find_runs(self.workspace)
+            benchmark = None
+            if self.benchmark_path and self.benchmark_path.exists():
+                try:
+                    benchmark = json.loads(self.benchmark_path.read_text())
+                except (json.JSONDecodeError, OSError):
+                    pass
+            html = generate_html(runs, self.skill_name, self.previous, benchmark)
+            content = html.encode("utf-8")
+            self.send_response(200)
+            self.send_header("Content-Type", "text/html; charset=utf-8")
+            self.send_header("Content-Length", str(len(content)))
+            self.end_headers()
+            self.wfile.write(content)
+        elif self.path == "/api/feedback":
+            data = b"{}"
+            if self.feedback_path.exists():
+                data = self.feedback_path.read_bytes()
+            self.send_response(200)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Content-Length", str(len(data)))
+            self.end_headers()
+            self.wfile.write(data)
+        else:
+            self.send_error(404)
+
+    def do_POST(self) -> None:
+        if self.path == "/api/feedback":
+            length = int(self.headers.get("Content-Length", 0))
+            body = self.rfile.read(length)
+            try:
+                data = json.loads(body)
+                if not isinstance(data, dict) or "reviews" not in data:
+                    raise ValueError("Expected JSON object with 'reviews' key")
+                self.feedback_path.write_text(json.dumps(data, indent=2) + "\n")
+                resp = b'{"ok":true}'
+                self.send_response(200)
+            except (json.JSONDecodeError, OSError, ValueError) as e:
+                resp = json.dumps({"error": str(e)}).encode()
+                self.send_response(500)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Content-Length", str(len(resp)))
+            self.end_headers()
+            self.wfile.write(resp)
+        else:
+            self.send_error(404)
+
+    def log_message(self, format: str, *args: object) -> None:
+        # Suppress request logging to keep terminal clean
+        pass
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Generate and serve eval review")
+    parser.add_argument("workspace", type=Path, help="Path to workspace directory")
+    parser.add_argument("--port", "-p", type=int, default=3117, help="Server port (default: 3117)")
+    parser.add_argument("--skill-name", "-n", type=str, default=None, help="Skill name for header")
+    parser.add_argument(
+        "--previous-workspace", type=Path, default=None,
+        help="Path to previous iteration's workspace (shows old outputs and feedback as context)",
+    )
+    parser.add_argument(
+        "--benchmark", type=Path, default=None,
+        help="Path to benchmark.json to show in the Benchmark tab",
+    )
+    parser.add_argument(
+        "--static", "-s", type=Path, default=None,
+        help="Write standalone HTML to this path instead of starting a server",
+    )
+    args = parser.parse_args()
+
+    workspace = args.workspace.resolve()
+    if not workspace.is_dir():
+        print(f"Error: {workspace} is not a directory", file=sys.stderr)
+        sys.exit(1)
+
+    runs = find_runs(workspace)
+    if not runs:
+        print(f"No runs found in {workspace}", file=sys.stderr)
+        sys.exit(1)
+
+    skill_name = args.skill_name or workspace.name.replace("-workspace", "")
+    feedback_path = workspace / "feedback.json"
+
+    previous: dict[str, dict] = {}
+    if args.previous_workspace:
+        previous = load_previous_iteration(args.previous_workspace.resolve())
+
+    benchmark_path = args.benchmark.resolve() if args.benchmark else None
+    benchmark = None
+    if benchmark_path and benchmark_path.exists():
+        try:
+            benchmark = json.loads(benchmark_path.read_text())
+        except (json.JSONDecodeError, OSError):
+            pass
+
+    if args.static:
+        html = generate_html(runs, skill_name, previous, benchmark)
+        args.static.parent.mkdir(parents=True, exist_ok=True)
+        args.static.write_text(html)
+        print(f"\n  Static viewer written to: {args.static}\n")
+        sys.exit(0)
+
+    # Kill any existing process on the target port
+    port = args.port
+    _kill_port(port)
+    handler = partial(ReviewHandler, workspace, skill_name, feedback_path, previous, benchmark_path)
+    try:
+        server = HTTPServer(("127.0.0.1", port), handler)
+    except OSError:
+        # Port still in use after kill attempt — find a free one
+        server = HTTPServer(("127.0.0.1", 0), handler)
+        port = server.server_address[1]
+
+    url = f"http://localhost:{port}"
+    print(f"\n  Eval Viewer")
+    print(f"  ─────────────────────────────────")
+    print(f"  URL:       {url}")
+    print(f"  Workspace: {workspace}")
+    print(f"  Feedback:  {feedback_path}")
+    if previous:
+        print(f"  Previous:  {args.previous_workspace} ({len(previous)} runs)")
+    if benchmark_path:
+        print(f"  Benchmark: {benchmark_path}")
+    print(f"\n  Press Ctrl+C to stop.\n")
+
+    webbrowser.open(url)
+
+    try:
+        server.serve_forever()
+    except KeyboardInterrupt:
+        print("\nStopped.")
+        server.server_close()
+
+
+if __name__ == "__main__":
+    main()

--- a/.claude/skills/skill-creator/eval-viewer/viewer.html
+++ b/.claude/skills/skill-creator/eval-viewer/viewer.html
@@ -1,0 +1,1325 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Eval Review</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@500;600&family=Lora:wght@400;500&display=swap" rel="stylesheet">
+  <script src="https://cdn.sheetjs.com/xlsx-0.20.3/package/dist/xlsx.full.min.js" integrity="sha384-EnyY0/GSHQGSxSgMwaIPzSESbqoOLSexfnSMN2AP+39Ckmn92stwABZynq1JyzdT" crossorigin="anonymous"></script>
+  <style>
+    :root {
+      --bg: #faf9f5;
+      --surface: #ffffff;
+      --border: #e8e6dc;
+      --text: #141413;
+      --text-muted: #b0aea5;
+      --accent: #d97757;
+      --accent-hover: #c4613f;
+      --green: #788c5d;
+      --green-bg: #eef2e8;
+      --red: #c44;
+      --red-bg: #fceaea;
+      --header-bg: #141413;
+      --header-text: #faf9f5;
+      --radius: 6px;
+    }
+
+    * { box-sizing: border-box; margin: 0; padding: 0; }
+
+    body {
+      font-family: 'Lora', Georgia, serif;
+      background: var(--bg);
+      color: var(--text);
+      height: 100vh;
+      display: flex;
+      flex-direction: column;
+    }
+
+    /* ---- Header ---- */
+    .header {
+      background: var(--header-bg);
+      color: var(--header-text);
+      padding: 1rem 2rem;
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      flex-shrink: 0;
+    }
+    .header h1 {
+      font-family: 'Poppins', sans-serif;
+      font-size: 1.25rem;
+      font-weight: 600;
+    }
+    .header .instructions {
+      font-size: 0.8rem;
+      opacity: 0.7;
+      margin-top: 0.25rem;
+    }
+    .header .progress {
+      font-size: 0.875rem;
+      opacity: 0.8;
+      text-align: right;
+    }
+
+    /* ---- Main content ---- */
+    .main {
+      flex: 1;
+      overflow-y: auto;
+      padding: 1.5rem 2rem;
+      display: flex;
+      flex-direction: column;
+      gap: 1.25rem;
+    }
+
+    /* ---- Sections ---- */
+    .section {
+      background: var(--surface);
+      border: 1px solid var(--border);
+      border-radius: var(--radius);
+      flex-shrink: 0;
+    }
+    .section-header {
+      font-family: 'Poppins', sans-serif;
+      padding: 0.75rem 1rem;
+      font-size: 0.75rem;
+      font-weight: 500;
+      text-transform: uppercase;
+      letter-spacing: 0.05em;
+      color: var(--text-muted);
+      border-bottom: 1px solid var(--border);
+      background: var(--bg);
+    }
+    .section-body {
+      padding: 1rem;
+    }
+
+    /* ---- Config badge ---- */
+    .config-badge {
+      display: inline-block;
+      padding: 0.2rem 0.625rem;
+      border-radius: 9999px;
+      font-family: 'Poppins', sans-serif;
+      font-size: 0.6875rem;
+      font-weight: 600;
+      text-transform: uppercase;
+      letter-spacing: 0.03em;
+      margin-left: 0.75rem;
+      vertical-align: middle;
+    }
+    .config-badge.config-primary {
+      background: rgba(33, 150, 243, 0.12);
+      color: #1976d2;
+    }
+    .config-badge.config-baseline {
+      background: rgba(255, 193, 7, 0.15);
+      color: #f57f17;
+    }
+
+    /* ---- Prompt ---- */
+    .prompt-text {
+      white-space: pre-wrap;
+      font-size: 0.9375rem;
+      line-height: 1.6;
+    }
+
+    /* ---- Outputs ---- */
+    .output-file {
+      border: 1px solid var(--border);
+      border-radius: var(--radius);
+      overflow: hidden;
+    }
+    .output-file + .output-file {
+      margin-top: 1rem;
+    }
+    .output-file-header {
+      padding: 0.5rem 0.75rem;
+      font-size: 0.8rem;
+      font-weight: 600;
+      color: var(--text-muted);
+      background: var(--bg);
+      border-bottom: 1px solid var(--border);
+      font-family: 'SF Mono', SFMono-Regular, Consolas, 'Liberation Mono', Menlo, monospace;
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+    }
+    .output-file-header .dl-btn {
+      font-size: 0.7rem;
+      color: var(--accent);
+      text-decoration: none;
+      cursor: pointer;
+      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+      font-weight: 500;
+      opacity: 0.8;
+    }
+    .output-file-header .dl-btn:hover {
+      opacity: 1;
+      text-decoration: underline;
+    }
+    .output-file-content {
+      padding: 0.75rem;
+      overflow-x: auto;
+    }
+    .output-file-content pre {
+      font-size: 0.8125rem;
+      line-height: 1.5;
+      white-space: pre-wrap;
+      word-break: break-word;
+      font-family: 'SF Mono', SFMono-Regular, Consolas, 'Liberation Mono', Menlo, monospace;
+    }
+    .output-file-content img {
+      max-width: 100%;
+      height: auto;
+      border-radius: 4px;
+    }
+    .output-file-content iframe {
+      width: 100%;
+      height: 600px;
+      border: none;
+    }
+    .output-file-content table {
+      border-collapse: collapse;
+      font-size: 0.8125rem;
+      width: 100%;
+    }
+    .output-file-content table td,
+    .output-file-content table th {
+      border: 1px solid var(--border);
+      padding: 0.375rem 0.5rem;
+      text-align: left;
+    }
+    .output-file-content table th {
+      background: var(--bg);
+      font-weight: 600;
+    }
+    .output-file-content .download-link {
+      display: inline-flex;
+      align-items: center;
+      gap: 0.5rem;
+      padding: 0.5rem 1rem;
+      background: var(--bg);
+      border: 1px solid var(--border);
+      border-radius: 4px;
+      color: var(--accent);
+      text-decoration: none;
+      font-size: 0.875rem;
+      cursor: pointer;
+    }
+    .output-file-content .download-link:hover {
+      background: var(--border);
+    }
+    .empty-state {
+      color: var(--text-muted);
+      font-style: italic;
+      padding: 2rem;
+      text-align: center;
+    }
+
+    /* ---- Feedback ---- */
+    .prev-feedback {
+      background: var(--bg);
+      border: 1px solid var(--border);
+      border-radius: 4px;
+      padding: 0.625rem 0.75rem;
+      margin-top: 0.75rem;
+      font-size: 0.8125rem;
+      color: var(--text-muted);
+      line-height: 1.5;
+    }
+    .prev-feedback-label {
+      font-size: 0.7rem;
+      font-weight: 600;
+      text-transform: uppercase;
+      letter-spacing: 0.04em;
+      margin-bottom: 0.25rem;
+      color: var(--text-muted);
+    }
+    .feedback-textarea {
+      width: 100%;
+      min-height: 100px;
+      padding: 0.75rem;
+      border: 1px solid var(--border);
+      border-radius: 4px;
+      font-family: inherit;
+      font-size: 0.9375rem;
+      line-height: 1.5;
+      resize: vertical;
+      color: var(--text);
+    }
+    .feedback-textarea:focus {
+      outline: none;
+      border-color: var(--accent);
+      box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.1);
+    }
+    .feedback-status {
+      font-size: 0.75rem;
+      color: var(--text-muted);
+      margin-top: 0.5rem;
+      min-height: 1.1em;
+    }
+
+    /* ---- Grades (collapsible) ---- */
+    .grades-toggle {
+      display: flex;
+      align-items: center;
+      cursor: pointer;
+      user-select: none;
+    }
+    .grades-toggle:hover {
+      color: var(--accent);
+    }
+    .grades-toggle .arrow {
+      margin-right: 0.5rem;
+      transition: transform 0.15s;
+      font-size: 0.75rem;
+    }
+    .grades-toggle .arrow.open {
+      transform: rotate(90deg);
+    }
+    .grades-content {
+      display: none;
+      margin-top: 0.75rem;
+    }
+    .grades-content.open {
+      display: block;
+    }
+    .grades-summary {
+      font-size: 0.875rem;
+      margin-bottom: 0.75rem;
+      display: flex;
+      align-items: center;
+      gap: 0.5rem;
+    }
+    .grade-badge {
+      display: inline-block;
+      padding: 0.125rem 0.5rem;
+      border-radius: 9999px;
+      font-size: 0.75rem;
+      font-weight: 600;
+    }
+    .grade-pass { background: var(--green-bg); color: var(--green); }
+    .grade-fail { background: var(--red-bg); color: var(--red); }
+    .assertion-list {
+      list-style: none;
+    }
+    .assertion-item {
+      padding: 0.625rem 0;
+      border-bottom: 1px solid var(--border);
+      font-size: 0.8125rem;
+    }
+    .assertion-item:last-child { border-bottom: none; }
+    .assertion-status {
+      font-weight: 600;
+      margin-right: 0.5rem;
+    }
+    .assertion-status.pass { color: var(--green); }
+    .assertion-status.fail { color: var(--red); }
+    .assertion-evidence {
+      color: var(--text-muted);
+      font-size: 0.75rem;
+      margin-top: 0.25rem;
+      padding-left: 1.5rem;
+    }
+
+    /* ---- View tabs ---- */
+    .view-tabs {
+      display: flex;
+      gap: 0;
+      padding: 0 2rem;
+      background: var(--bg);
+      border-bottom: 1px solid var(--border);
+      flex-shrink: 0;
+    }
+    .view-tab {
+      font-family: 'Poppins', sans-serif;
+      padding: 0.625rem 1.25rem;
+      font-size: 0.8125rem;
+      font-weight: 500;
+      cursor: pointer;
+      border: none;
+      background: none;
+      color: var(--text-muted);
+      border-bottom: 2px solid transparent;
+      transition: all 0.15s;
+    }
+    .view-tab:hover { color: var(--text); }
+    .view-tab.active {
+      color: var(--accent);
+      border-bottom-color: var(--accent);
+    }
+    .view-panel { display: none; }
+    .view-panel.active { display: flex; flex-direction: column; flex: 1; overflow: hidden; }
+
+    /* ---- Benchmark view ---- */
+    .benchmark-view {
+      padding: 1.5rem 2rem;
+      overflow-y: auto;
+      flex: 1;
+    }
+    .benchmark-table {
+      border-collapse: collapse;
+      background: var(--surface);
+      border: 1px solid var(--border);
+      border-radius: var(--radius);
+      font-size: 0.8125rem;
+      width: 100%;
+      margin-bottom: 1.5rem;
+    }
+    .benchmark-table th, .benchmark-table td {
+      padding: 0.625rem 0.75rem;
+      text-align: left;
+      border: 1px solid var(--border);
+    }
+    .benchmark-table th {
+      font-family: 'Poppins', sans-serif;
+      background: var(--header-bg);
+      color: var(--header-text);
+      font-weight: 500;
+      font-size: 0.75rem;
+      text-transform: uppercase;
+      letter-spacing: 0.04em;
+    }
+    .benchmark-table tr:hover { background: var(--bg); }
+    .benchmark-table tr.benchmark-row-with { background: rgba(33, 150, 243, 0.06); }
+    .benchmark-table tr.benchmark-row-without { background: rgba(255, 193, 7, 0.06); }
+    .benchmark-table tr.benchmark-row-with:hover { background: rgba(33, 150, 243, 0.12); }
+    .benchmark-table tr.benchmark-row-without:hover { background: rgba(255, 193, 7, 0.12); }
+    .benchmark-table tr.benchmark-row-avg { font-weight: 600; border-top: 2px solid var(--border); }
+    .benchmark-table tr.benchmark-row-avg.benchmark-row-with { background: rgba(33, 150, 243, 0.12); }
+    .benchmark-table tr.benchmark-row-avg.benchmark-row-without { background: rgba(255, 193, 7, 0.12); }
+    .benchmark-delta-positive { color: var(--green); font-weight: 600; }
+    .benchmark-delta-negative { color: var(--red); font-weight: 600; }
+    .benchmark-notes {
+      background: var(--surface);
+      border: 1px solid var(--border);
+      border-radius: var(--radius);
+      padding: 1rem;
+    }
+    .benchmark-notes h3 {
+      font-family: 'Poppins', sans-serif;
+      font-size: 0.875rem;
+      margin-bottom: 0.75rem;
+    }
+    .benchmark-notes ul {
+      list-style: disc;
+      padding-left: 1.25rem;
+    }
+    .benchmark-notes li {
+      font-size: 0.8125rem;
+      line-height: 1.6;
+      margin-bottom: 0.375rem;
+    }
+    .benchmark-empty {
+      color: var(--text-muted);
+      font-style: italic;
+      text-align: center;
+      padding: 3rem;
+    }
+
+    /* ---- Navigation ---- */
+    .nav {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      padding: 1rem 2rem;
+      border-top: 1px solid var(--border);
+      background: var(--surface);
+      flex-shrink: 0;
+    }
+    .nav-btn {
+      font-family: 'Poppins', sans-serif;
+      padding: 0.5rem 1.25rem;
+      border: 1px solid var(--border);
+      border-radius: var(--radius);
+      background: var(--surface);
+      cursor: pointer;
+      font-size: 0.875rem;
+      font-weight: 500;
+      color: var(--text);
+      transition: all 0.15s;
+    }
+    .nav-btn:hover:not(:disabled) {
+      background: var(--bg);
+      border-color: var(--text-muted);
+    }
+    .nav-btn:disabled {
+      opacity: 0.4;
+      cursor: not-allowed;
+    }
+    .done-btn {
+      font-family: 'Poppins', sans-serif;
+      padding: 0.5rem 1.5rem;
+      border: 1px solid var(--border);
+      border-radius: var(--radius);
+      background: var(--surface);
+      color: var(--text);
+      cursor: pointer;
+      font-size: 0.875rem;
+      font-weight: 500;
+      transition: all 0.15s;
+    }
+    .done-btn:hover {
+      background: var(--bg);
+      border-color: var(--text-muted);
+    }
+    .done-btn.ready {
+      border: none;
+      background: var(--accent);
+      color: white;
+      font-weight: 600;
+    }
+    .done-btn.ready:hover {
+      background: var(--accent-hover);
+    }
+    /* ---- Done overlay ---- */
+    .done-overlay {
+      display: none;
+      position: fixed;
+      inset: 0;
+      background: rgba(0, 0, 0, 0.5);
+      z-index: 100;
+      justify-content: center;
+      align-items: center;
+    }
+    .done-overlay.visible {
+      display: flex;
+    }
+    .done-card {
+      background: var(--surface);
+      border-radius: 12px;
+      padding: 2rem 3rem;
+      text-align: center;
+      box-shadow: 0 20px 60px rgba(0, 0, 0, 0.3);
+      max-width: 500px;
+    }
+    .done-card h2 {
+      font-size: 1.5rem;
+      margin-bottom: 0.5rem;
+    }
+    .done-card p {
+      color: var(--text-muted);
+      margin-bottom: 1.5rem;
+      line-height: 1.5;
+    }
+    .done-card .btn-row {
+      display: flex;
+      gap: 0.5rem;
+      justify-content: center;
+    }
+    .done-card button {
+      padding: 0.5rem 1.25rem;
+      border: 1px solid var(--border);
+      border-radius: var(--radius);
+      background: var(--surface);
+      cursor: pointer;
+      font-size: 0.875rem;
+    }
+    .done-card button:hover {
+      background: var(--bg);
+    }
+    /* ---- Toast ---- */
+    .toast {
+      position: fixed;
+      bottom: 5rem;
+      left: 50%;
+      transform: translateX(-50%);
+      background: var(--header-bg);
+      color: var(--header-text);
+      padding: 0.625rem 1.25rem;
+      border-radius: var(--radius);
+      font-size: 0.875rem;
+      opacity: 0;
+      transition: opacity 0.3s;
+      pointer-events: none;
+      z-index: 200;
+    }
+    .toast.visible {
+      opacity: 1;
+    }
+  </style>
+</head>
+<body>
+  <div id="app" style="height:100vh; display:flex; flex-direction:column;">
+    <div class="header">
+      <div>
+        <h1>Eval Review: <span id="skill-name"></span></h1>
+        <div class="instructions">Review each output and leave feedback below. Navigate with arrow keys or buttons. When done, copy feedback and paste into Claude Code.</div>
+      </div>
+      <div class="progress" id="progress"></div>
+    </div>
+
+    <!-- View tabs (only shown when benchmark data exists) -->
+    <div class="view-tabs" id="view-tabs" style="display:none;">
+      <button class="view-tab active" onclick="switchView('outputs')">Outputs</button>
+      <button class="view-tab" onclick="switchView('benchmark')">Benchmark</button>
+    </div>
+
+    <!-- Outputs panel (qualitative review) -->
+    <div class="view-panel active" id="panel-outputs">
+    <div class="main">
+      <!-- Prompt -->
+      <div class="section">
+        <div class="section-header">Prompt <span class="config-badge" id="config-badge" style="display:none;"></span></div>
+        <div class="section-body">
+          <div class="prompt-text" id="prompt-text"></div>
+        </div>
+      </div>
+
+      <!-- Outputs -->
+      <div class="section">
+        <div class="section-header">Output</div>
+        <div class="section-body" id="outputs-body">
+          <div class="empty-state">No output files found</div>
+        </div>
+      </div>
+
+      <!-- Previous Output (collapsible) -->
+      <div class="section" id="prev-outputs-section" style="display:none;">
+        <div class="section-header">
+          <div class="grades-toggle" onclick="togglePrevOutputs()">
+            <span class="arrow" id="prev-outputs-arrow">&#9654;</span>
+            Previous Output
+          </div>
+        </div>
+        <div class="grades-content" id="prev-outputs-content"></div>
+      </div>
+
+      <!-- Grades (collapsible) -->
+      <div class="section" id="grades-section" style="display:none;">
+        <div class="section-header">
+          <div class="grades-toggle" onclick="toggleGrades()">
+            <span class="arrow" id="grades-arrow">&#9654;</span>
+            Formal Grades
+          </div>
+        </div>
+        <div class="grades-content" id="grades-content"></div>
+      </div>
+
+      <!-- Feedback -->
+      <div class="section">
+        <div class="section-header">Your Feedback</div>
+        <div class="section-body">
+          <textarea
+            class="feedback-textarea"
+            id="feedback"
+            placeholder="What do you think of this output? Any issues, suggestions, or things that look great?"
+          ></textarea>
+          <div class="feedback-status" id="feedback-status"></div>
+          <div class="prev-feedback" id="prev-feedback" style="display:none;">
+            <div class="prev-feedback-label">Previous feedback</div>
+            <div id="prev-feedback-text"></div>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <div class="nav" id="outputs-nav">
+      <button class="nav-btn" id="prev-btn" onclick="navigate(-1)">&#8592; Previous</button>
+      <button class="done-btn" id="done-btn" onclick="showDoneDialog()">Submit All Reviews</button>
+      <button class="nav-btn" id="next-btn" onclick="navigate(1)">Next &#8594;</button>
+    </div>
+    </div><!-- end panel-outputs -->
+
+    <!-- Benchmark panel (quantitative stats) -->
+    <div class="view-panel" id="panel-benchmark">
+      <div class="benchmark-view" id="benchmark-content">
+        <div class="benchmark-empty">No benchmark data available. Run a benchmark to see quantitative results here.</div>
+      </div>
+    </div>
+  </div>
+
+  <!-- Done overlay -->
+  <div class="done-overlay" id="done-overlay">
+    <div class="done-card">
+      <h2>Review Complete</h2>
+      <p>Your feedback has been saved. Go back to your Claude Code session and tell Claude you're done reviewing.</p>
+      <div class="btn-row">
+        <button onclick="closeDoneDialog()">OK</button>
+      </div>
+    </div>
+  </div>
+
+  <!-- Toast -->
+  <div class="toast" id="toast"></div>
+
+  <script>
+    // ---- Embedded data (injected by generate_review.py) ----
+    /*__EMBEDDED_DATA__*/
+
+    // ---- State ----
+    let feedbackMap = {};  // run_id -> feedback text
+    let currentIndex = 0;
+    let visitedRuns = new Set();
+
+    // ---- Init ----
+    async function init() {
+      // Load saved feedback from server — but only if this isn't a fresh
+      // iteration (indicated by previous_feedback being present). When
+      // previous feedback exists, the feedback.json on disk is stale from
+      // the prior iteration and should not pre-fill the textareas.
+      const hasPrevious = Object.keys(EMBEDDED_DATA.previous_feedback || {}).length > 0
+        || Object.keys(EMBEDDED_DATA.previous_outputs || {}).length > 0;
+      if (!hasPrevious) {
+        try {
+          const resp = await fetch("/api/feedback");
+          const data = await resp.json();
+          if (data.reviews) {
+            for (const r of data.reviews) feedbackMap[r.run_id] = r.feedback;
+          }
+        } catch { /* first run, no feedback yet */ }
+      }
+
+      document.getElementById("skill-name").textContent = EMBEDDED_DATA.skill_name;
+      showRun(0);
+
+      // Wire up feedback auto-save
+      const textarea = document.getElementById("feedback");
+      let saveTimeout = null;
+      textarea.addEventListener("input", () => {
+        clearTimeout(saveTimeout);
+        document.getElementById("feedback-status").textContent = "";
+        saveTimeout = setTimeout(() => saveCurrentFeedback(), 800);
+      });
+    }
+
+    // ---- Navigation ----
+    function navigate(delta) {
+      const newIndex = currentIndex + delta;
+      if (newIndex >= 0 && newIndex < EMBEDDED_DATA.runs.length) {
+        saveCurrentFeedback();
+        showRun(newIndex);
+      }
+    }
+
+    function updateNavButtons() {
+      document.getElementById("prev-btn").disabled = currentIndex === 0;
+      document.getElementById("next-btn").disabled =
+        currentIndex === EMBEDDED_DATA.runs.length - 1;
+    }
+
+    // ---- Show a run ----
+    function showRun(index) {
+      currentIndex = index;
+      const run = EMBEDDED_DATA.runs[index];
+
+      // Progress
+      document.getElementById("progress").textContent =
+        `${index + 1} of ${EMBEDDED_DATA.runs.length}`;
+
+      // Prompt
+      document.getElementById("prompt-text").textContent = run.prompt;
+
+      // Config badge
+      const badge = document.getElementById("config-badge");
+      const configMatch = run.id.match(/(with_skill|without_skill|new_skill|old_skill)/);
+      if (configMatch) {
+        const config = configMatch[1];
+        const isBaseline = config === "without_skill" || config === "old_skill";
+        badge.textContent = config.replace(/_/g, " ");
+        badge.className = "config-badge " + (isBaseline ? "config-baseline" : "config-primary");
+        badge.style.display = "inline-block";
+      } else {
+        badge.style.display = "none";
+      }
+
+      // Outputs
+      renderOutputs(run);
+
+      // Previous outputs
+      renderPrevOutputs(run);
+
+      // Grades
+      renderGrades(run);
+
+      // Previous feedback
+      const prevFb = (EMBEDDED_DATA.previous_feedback || {})[run.id];
+      const prevEl = document.getElementById("prev-feedback");
+      if (prevFb) {
+        document.getElementById("prev-feedback-text").textContent = prevFb;
+        prevEl.style.display = "block";
+      } else {
+        prevEl.style.display = "none";
+      }
+
+      // Feedback
+      document.getElementById("feedback").value = feedbackMap[run.id] || "";
+      document.getElementById("feedback-status").textContent = "";
+
+      updateNavButtons();
+
+      // Track visited runs and promote done button when all visited
+      visitedRuns.add(index);
+      const doneBtn = document.getElementById("done-btn");
+      if (visitedRuns.size >= EMBEDDED_DATA.runs.length) {
+        doneBtn.classList.add("ready");
+      }
+
+      // Scroll main content to top
+      document.querySelector(".main").scrollTop = 0;
+    }
+
+    // ---- Render outputs ----
+    function renderOutputs(run) {
+      const container = document.getElementById("outputs-body");
+      container.innerHTML = "";
+
+      const outputs = run.outputs || [];
+      if (outputs.length === 0) {
+        container.innerHTML = '<div class="empty-state">No output files</div>';
+        return;
+      }
+
+      for (const file of outputs) {
+        const fileDiv = document.createElement("div");
+        fileDiv.className = "output-file";
+
+        // Always show file header with download link
+        const header = document.createElement("div");
+        header.className = "output-file-header";
+        const nameSpan = document.createElement("span");
+        nameSpan.textContent = file.name;
+        header.appendChild(nameSpan);
+        const dlBtn = document.createElement("a");
+        dlBtn.className = "dl-btn";
+        dlBtn.textContent = "Download";
+        dlBtn.download = file.name;
+        dlBtn.href = getDownloadUri(file);
+        header.appendChild(dlBtn);
+        fileDiv.appendChild(header);
+
+        const content = document.createElement("div");
+        content.className = "output-file-content";
+
+        if (file.type === "text") {
+          const pre = document.createElement("pre");
+          pre.textContent = file.content;
+          content.appendChild(pre);
+        } else if (file.type === "image") {
+          const img = document.createElement("img");
+          img.src = file.data_uri;
+          img.alt = file.name;
+          content.appendChild(img);
+        } else if (file.type === "pdf") {
+          const iframe = document.createElement("iframe");
+          iframe.src = file.data_uri;
+          content.appendChild(iframe);
+        } else if (file.type === "xlsx") {
+          renderXlsx(content, file.data_b64);
+        } else if (file.type === "binary") {
+          const a = document.createElement("a");
+          a.className = "download-link";
+          a.href = file.data_uri;
+          a.download = file.name;
+          a.textContent = "Download " + file.name;
+          content.appendChild(a);
+        } else if (file.type === "error") {
+          const pre = document.createElement("pre");
+          pre.textContent = file.content;
+          pre.style.color = "var(--red)";
+          content.appendChild(pre);
+        }
+
+        fileDiv.appendChild(content);
+        container.appendChild(fileDiv);
+      }
+    }
+
+    // ---- XLSX rendering via SheetJS ----
+    function renderXlsx(container, b64Data) {
+      try {
+        const raw = Uint8Array.from(atob(b64Data), c => c.charCodeAt(0));
+        const wb = XLSX.read(raw, { type: "array" });
+
+        for (let i = 0; i < wb.SheetNames.length; i++) {
+          const sheetName = wb.SheetNames[i];
+          const ws = wb.Sheets[sheetName];
+
+          if (wb.SheetNames.length > 1) {
+            const sheetLabel = document.createElement("div");
+            sheetLabel.style.cssText =
+              "font-weight:600; font-size:0.8rem; color:#b0aea5; margin-top:0.5rem; margin-bottom:0.25rem;";
+            sheetLabel.textContent = "Sheet: " + sheetName;
+            container.appendChild(sheetLabel);
+          }
+
+          const htmlStr = XLSX.utils.sheet_to_html(ws, { editable: false });
+          const wrapper = document.createElement("div");
+          wrapper.innerHTML = htmlStr;
+          container.appendChild(wrapper);
+        }
+      } catch (err) {
+        container.textContent = "Error rendering spreadsheet: " + err.message;
+      }
+    }
+
+    // ---- Grades ----
+    function renderGrades(run) {
+      const section = document.getElementById("grades-section");
+      const content = document.getElementById("grades-content");
+
+      if (!run.grading) {
+        section.style.display = "none";
+        return;
+      }
+
+      const grading = run.grading;
+      section.style.display = "block";
+      // Reset to collapsed
+      content.classList.remove("open");
+      document.getElementById("grades-arrow").classList.remove("open");
+
+      const summary = grading.summary || {};
+      const expectations = grading.expectations || [];
+
+      let html = '<div style="padding: 1rem;">';
+
+      // Summary line
+      const passRate = summary.pass_rate != null
+        ? Math.round(summary.pass_rate * 100) + "%"
+        : "?";
+      const badgeClass = summary.pass_rate >= 0.8 ? "grade-pass" : summary.pass_rate >= 0.5 ? "" : "grade-fail";
+      html += '<div class="grades-summary">';
+      html += '<span class="grade-badge ' + badgeClass + '">' + passRate + '</span>';
+      html += '<span>' + (summary.passed || 0) + ' passed, ' + (summary.failed || 0) + ' failed of ' + (summary.total || 0) + '</span>';
+      html += '</div>';
+
+      // Assertions list
+      html += '<ul class="assertion-list">';
+      for (const exp of expectations) {
+        const statusClass = exp.passed ? "pass" : "fail";
+        const statusIcon = exp.passed ? "\u2713" : "\u2717";
+        html += '<li class="assertion-item">';
+        html += '<span class="assertion-status ' + statusClass + '">' + statusIcon + '</span>';
+        html += '<span>' + escapeHtml(exp.text) + '</span>';
+        if (exp.evidence) {
+          html += '<div class="assertion-evidence">' + escapeHtml(exp.evidence) + '</div>';
+        }
+        html += '</li>';
+      }
+      html += '</ul>';
+
+      html += '</div>';
+      content.innerHTML = html;
+    }
+
+    function toggleGrades() {
+      const content = document.getElementById("grades-content");
+      const arrow = document.getElementById("grades-arrow");
+      content.classList.toggle("open");
+      arrow.classList.toggle("open");
+    }
+
+    // ---- Previous outputs (collapsible) ----
+    function renderPrevOutputs(run) {
+      const section = document.getElementById("prev-outputs-section");
+      const content = document.getElementById("prev-outputs-content");
+      const prevOutputs = (EMBEDDED_DATA.previous_outputs || {})[run.id];
+
+      if (!prevOutputs || prevOutputs.length === 0) {
+        section.style.display = "none";
+        return;
+      }
+
+      section.style.display = "block";
+      // Reset to collapsed
+      content.classList.remove("open");
+      document.getElementById("prev-outputs-arrow").classList.remove("open");
+
+      // Render the files into the content area
+      content.innerHTML = "";
+      const wrapper = document.createElement("div");
+      wrapper.style.padding = "1rem";
+
+      for (const file of prevOutputs) {
+        const fileDiv = document.createElement("div");
+        fileDiv.className = "output-file";
+
+        const header = document.createElement("div");
+        header.className = "output-file-header";
+        const nameSpan = document.createElement("span");
+        nameSpan.textContent = file.name;
+        header.appendChild(nameSpan);
+        const dlBtn = document.createElement("a");
+        dlBtn.className = "dl-btn";
+        dlBtn.textContent = "Download";
+        dlBtn.download = file.name;
+        dlBtn.href = getDownloadUri(file);
+        header.appendChild(dlBtn);
+        fileDiv.appendChild(header);
+
+        const fc = document.createElement("div");
+        fc.className = "output-file-content";
+
+        if (file.type === "text") {
+          const pre = document.createElement("pre");
+          pre.textContent = file.content;
+          fc.appendChild(pre);
+        } else if (file.type === "image") {
+          const img = document.createElement("img");
+          img.src = file.data_uri;
+          img.alt = file.name;
+          fc.appendChild(img);
+        } else if (file.type === "pdf") {
+          const iframe = document.createElement("iframe");
+          iframe.src = file.data_uri;
+          fc.appendChild(iframe);
+        } else if (file.type === "xlsx") {
+          renderXlsx(fc, file.data_b64);
+        } else if (file.type === "binary") {
+          const a = document.createElement("a");
+          a.className = "download-link";
+          a.href = file.data_uri;
+          a.download = file.name;
+          a.textContent = "Download " + file.name;
+          fc.appendChild(a);
+        }
+
+        fileDiv.appendChild(fc);
+        wrapper.appendChild(fileDiv);
+      }
+
+      content.appendChild(wrapper);
+    }
+
+    function togglePrevOutputs() {
+      const content = document.getElementById("prev-outputs-content");
+      const arrow = document.getElementById("prev-outputs-arrow");
+      content.classList.toggle("open");
+      arrow.classList.toggle("open");
+    }
+
+    // ---- Feedback (saved to server -> feedback.json) ----
+    function saveCurrentFeedback() {
+      const run = EMBEDDED_DATA.runs[currentIndex];
+      const text = document.getElementById("feedback").value;
+
+      if (text.trim() === "") {
+        delete feedbackMap[run.id];
+      } else {
+        feedbackMap[run.id] = text;
+      }
+
+      // Build reviews array from map
+      const reviews = [];
+      for (const [run_id, feedback] of Object.entries(feedbackMap)) {
+        if (feedback.trim()) {
+          reviews.push({ run_id, feedback, timestamp: new Date().toISOString() });
+        }
+      }
+
+      fetch("/api/feedback", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ reviews, status: "in_progress" }),
+      }).then(() => {
+        document.getElementById("feedback-status").textContent = "Saved";
+      }).catch(() => {
+        // Static mode or server unavailable — no-op on auto-save,
+        // feedback will be downloaded on final submit
+        document.getElementById("feedback-status").textContent = "Will download on submit";
+      });
+    }
+
+    // ---- Done ----
+    function showDoneDialog() {
+      // Save current textarea to feedbackMap (but don't POST yet)
+      const run = EMBEDDED_DATA.runs[currentIndex];
+      const text = document.getElementById("feedback").value;
+      if (text.trim() === "") {
+        delete feedbackMap[run.id];
+      } else {
+        feedbackMap[run.id] = text;
+      }
+
+      // POST once with status: complete — include ALL runs so the model
+      // can distinguish "no feedback" (looks good) from "not reviewed"
+      const reviews = [];
+      const ts = new Date().toISOString();
+      for (const r of EMBEDDED_DATA.runs) {
+        reviews.push({ run_id: r.id, feedback: feedbackMap[r.id] || "", timestamp: ts });
+      }
+      const payload = JSON.stringify({ reviews, status: "complete" }, null, 2);
+      fetch("/api/feedback", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: payload,
+      }).then(() => {
+        document.getElementById("done-overlay").classList.add("visible");
+      }).catch(() => {
+        // Server not available (static mode) — download as file
+        const blob = new Blob([payload], { type: "application/json" });
+        const url = URL.createObjectURL(blob);
+        const a = document.createElement("a");
+        a.href = url;
+        a.download = "feedback.json";
+        a.click();
+        URL.revokeObjectURL(url);
+        document.getElementById("done-overlay").classList.add("visible");
+      });
+    }
+
+    function closeDoneDialog() {
+      // Reset status back to in_progress
+      saveCurrentFeedback();
+      document.getElementById("done-overlay").classList.remove("visible");
+    }
+
+    // ---- Toast ----
+    function showToast(message) {
+      const toast = document.getElementById("toast");
+      toast.textContent = message;
+      toast.classList.add("visible");
+      setTimeout(() => toast.classList.remove("visible"), 2000);
+    }
+
+    // ---- Keyboard nav ----
+    document.addEventListener("keydown", (e) => {
+      // Don't capture when typing in textarea
+      if (e.target.tagName === "TEXTAREA") return;
+
+      if (e.key === "ArrowLeft" || e.key === "ArrowUp") {
+        e.preventDefault();
+        navigate(-1);
+      } else if (e.key === "ArrowRight" || e.key === "ArrowDown") {
+        e.preventDefault();
+        navigate(1);
+      }
+    });
+
+    // ---- Util ----
+    function getDownloadUri(file) {
+      if (file.data_uri) return file.data_uri;
+      if (file.data_b64) return "data:application/octet-stream;base64," + file.data_b64;
+      if (file.type === "text") return "data:text/plain;charset=utf-8," + encodeURIComponent(file.content);
+      return "#";
+    }
+
+    function escapeHtml(text) {
+      const div = document.createElement("div");
+      div.textContent = text;
+      return div.innerHTML;
+    }
+
+    // ---- View switching ----
+    function switchView(view) {
+      document.querySelectorAll(".view-tab").forEach(t => t.classList.remove("active"));
+      document.querySelectorAll(".view-panel").forEach(p => p.classList.remove("active"));
+      document.querySelector(`[onclick="switchView('${view}')"]`).classList.add("active");
+      document.getElementById("panel-" + view).classList.add("active");
+    }
+
+    // ---- Benchmark rendering ----
+    function renderBenchmark() {
+      const data = EMBEDDED_DATA.benchmark;
+      if (!data) return;
+
+      // Show the tabs
+      document.getElementById("view-tabs").style.display = "flex";
+
+      const container = document.getElementById("benchmark-content");
+      const summary = data.run_summary || {};
+      const metadata = data.metadata || {};
+      const notes = data.notes || [];
+
+      let html = "";
+
+      // Header
+      html += "<h2 style='font-family: Poppins, sans-serif; margin-bottom: 0.5rem;'>Benchmark Results</h2>";
+      html += "<p style='color: var(--text-muted); font-size: 0.875rem; margin-bottom: 1.25rem;'>";
+      if (metadata.skill_name) html += "<strong>" + escapeHtml(metadata.skill_name) + "</strong> &mdash; ";
+      if (metadata.timestamp) html += metadata.timestamp + " &mdash; ";
+      if (metadata.evals_run) html += "Evals: " + metadata.evals_run.join(", ") + " &mdash; ";
+      html += (metadata.runs_per_configuration || "?") + " runs per configuration";
+      html += "</p>";
+
+      // Summary table
+      html += '<table class="benchmark-table">';
+
+      function fmtStat(stat, pct) {
+        if (!stat) return "—";
+        const suffix = pct ? "%" : "";
+        const m = pct ? (stat.mean * 100).toFixed(0) : stat.mean.toFixed(1);
+        const s = pct ? (stat.stddev * 100).toFixed(0) : stat.stddev.toFixed(1);
+        return m + suffix + " ± " + s + suffix;
+      }
+
+      function deltaClass(val) {
+        if (!val) return "";
+        const n = parseFloat(val);
+        if (n > 0) return "benchmark-delta-positive";
+        if (n < 0) return "benchmark-delta-negative";
+        return "";
+      }
+
+      // Discover config names dynamically (everything except "delta")
+      const configs = Object.keys(summary).filter(k => k !== "delta");
+      const configA = configs[0] || "config_a";
+      const configB = configs[1] || "config_b";
+      const labelA = configA.replace(/_/g, " ").replace(/\b\w/g, c => c.toUpperCase());
+      const labelB = configB.replace(/_/g, " ").replace(/\b\w/g, c => c.toUpperCase());
+      const a = summary[configA] || {};
+      const b = summary[configB] || {};
+      const delta = summary.delta || {};
+
+      html += "<thead><tr><th>Metric</th><th>" + escapeHtml(labelA) + "</th><th>" + escapeHtml(labelB) + "</th><th>Delta</th></tr></thead>";
+      html += "<tbody>";
+
+      html += "<tr><td><strong>Pass Rate</strong></td>";
+      html += "<td>" + fmtStat(a.pass_rate, true) + "</td>";
+      html += "<td>" + fmtStat(b.pass_rate, true) + "</td>";
+      html += '<td class="' + deltaClass(delta.pass_rate) + '">' + (delta.pass_rate || "—") + "</td></tr>";
+
+      // Time (only show row if data exists)
+      if (a.time_seconds || b.time_seconds) {
+        html += "<tr><td><strong>Time (s)</strong></td>";
+        html += "<td>" + fmtStat(a.time_seconds, false) + "</td>";
+        html += "<td>" + fmtStat(b.time_seconds, false) + "</td>";
+        html += '<td class="' + deltaClass(delta.time_seconds) + '">' + (delta.time_seconds ? delta.time_seconds + "s" : "—") + "</td></tr>";
+      }
+
+      // Tokens (only show row if data exists)
+      if (a.tokens || b.tokens) {
+        html += "<tr><td><strong>Tokens</strong></td>";
+        html += "<td>" + fmtStat(a.tokens, false) + "</td>";
+        html += "<td>" + fmtStat(b.tokens, false) + "</td>";
+        html += '<td class="' + deltaClass(delta.tokens) + '">' + (delta.tokens || "—") + "</td></tr>";
+      }
+
+      html += "</tbody></table>";
+
+      // Per-eval breakdown (if runs data available)
+      const runs = data.runs || [];
+      if (runs.length > 0) {
+        const evalIds = [...new Set(runs.map(r => r.eval_id))].sort((a, b) => a - b);
+
+        html += "<h3 style='font-family: Poppins, sans-serif; margin-bottom: 0.75rem;'>Per-Eval Breakdown</h3>";
+
+        const hasTime = runs.some(r => r.result && r.result.time_seconds != null);
+        const hasErrors = runs.some(r => r.result && r.result.errors > 0);
+
+        for (const evalId of evalIds) {
+          const evalRuns = runs.filter(r => r.eval_id === evalId);
+          const evalName = evalRuns[0] && evalRuns[0].eval_name ? evalRuns[0].eval_name : "Eval " + evalId;
+
+          html += "<h4 style='font-family: Poppins, sans-serif; margin: 1rem 0 0.5rem; color: var(--text);'>" + escapeHtml(evalName) + "</h4>";
+          html += '<table class="benchmark-table">';
+          html += "<thead><tr><th>Config</th><th>Run</th><th>Pass Rate</th>";
+          if (hasTime) html += "<th>Time (s)</th>";
+          if (hasErrors) html += "<th>Crashes During Execution</th>";
+          html += "</tr></thead>";
+          html += "<tbody>";
+
+          // Group by config and render with average rows
+          const configGroups = [...new Set(evalRuns.map(r => r.configuration))];
+          for (let ci = 0; ci < configGroups.length; ci++) {
+            const config = configGroups[ci];
+            const configRuns = evalRuns.filter(r => r.configuration === config);
+            if (configRuns.length === 0) continue;
+
+            const rowClass = ci === 0 ? "benchmark-row-with" : "benchmark-row-without";
+            const configLabel = config.replace(/_/g, " ").replace(/\b\w/g, c => c.toUpperCase());
+
+            for (const run of configRuns) {
+              const r = run.result || {};
+              const prClass = r.pass_rate >= 0.8 ? "benchmark-delta-positive" : r.pass_rate < 0.5 ? "benchmark-delta-negative" : "";
+              html += '<tr class="' + rowClass + '">';
+              html += "<td>" + configLabel + "</td>";
+              html += "<td>" + run.run_number + "</td>";
+              html += '<td class="' + prClass + '">' + ((r.pass_rate || 0) * 100).toFixed(0) + "% (" + (r.passed || 0) + "/" + (r.total || 0) + ")</td>";
+              if (hasTime) html += "<td>" + (r.time_seconds != null ? r.time_seconds.toFixed(1) : "—") + "</td>";
+              if (hasErrors) html += "<td>" + (r.errors || 0) + "</td>";
+              html += "</tr>";
+            }
+
+            // Average row
+            const rates = configRuns.map(r => (r.result || {}).pass_rate || 0);
+            const avgRate = rates.reduce((a, b) => a + b, 0) / rates.length;
+            const avgPrClass = avgRate >= 0.8 ? "benchmark-delta-positive" : avgRate < 0.5 ? "benchmark-delta-negative" : "";
+            html += '<tr class="benchmark-row-avg ' + rowClass + '">';
+            html += "<td>" + configLabel + "</td>";
+            html += "<td>Avg</td>";
+            html += '<td class="' + avgPrClass + '">' + (avgRate * 100).toFixed(0) + "%</td>";
+            if (hasTime) {
+              const times = configRuns.map(r => (r.result || {}).time_seconds).filter(t => t != null);
+              html += "<td>" + (times.length ? (times.reduce((a, b) => a + b, 0) / times.length).toFixed(1) : "—") + "</td>";
+            }
+            if (hasErrors) html += "<td></td>";
+            html += "</tr>";
+          }
+          html += "</tbody></table>";
+
+          // Per-assertion detail for this eval
+          const runsWithExpectations = {};
+          for (const config of configGroups) {
+            runsWithExpectations[config] = evalRuns.filter(r => r.configuration === config && r.expectations && r.expectations.length > 0);
+          }
+          const hasAnyExpectations = Object.values(runsWithExpectations).some(runs => runs.length > 0);
+          if (hasAnyExpectations) {
+            // Collect all unique assertion texts across all configs
+            const allAssertions = [];
+            const seen = new Set();
+            for (const config of configGroups) {
+              for (const run of runsWithExpectations[config]) {
+                for (const exp of (run.expectations || [])) {
+                  if (!seen.has(exp.text)) {
+                    seen.add(exp.text);
+                    allAssertions.push(exp.text);
+                  }
+                }
+              }
+            }
+
+            html += '<table class="benchmark-table" style="margin-top: 0.5rem;">';
+            html += "<thead><tr><th>Assertion</th>";
+            for (const config of configGroups) {
+              const label = config.replace(/_/g, " ").replace(/\b\w/g, c => c.toUpperCase());
+              html += "<th>" + escapeHtml(label) + "</th>";
+            }
+            html += "</tr></thead><tbody>";
+
+            for (const assertionText of allAssertions) {
+              html += "<tr><td>" + escapeHtml(assertionText) + "</td>";
+
+              for (const config of configGroups) {
+                html += "<td>";
+                for (const run of runsWithExpectations[config]) {
+                  const exp = (run.expectations || []).find(e => e.text === assertionText);
+                  if (exp) {
+                    const cls = exp.passed ? "benchmark-delta-positive" : "benchmark-delta-negative";
+                    const icon = exp.passed ? "\u2713" : "\u2717";
+                    html += '<span class="' + cls + '" title="Run ' + run.run_number + ': ' + escapeHtml(exp.evidence || "") + '">' + icon + "</span> ";
+                  } else {
+                    html += "— ";
+                  }
+                }
+                html += "</td>";
+              }
+              html += "</tr>";
+            }
+            html += "</tbody></table>";
+          }
+        }
+      }
+
+      // Notes
+      if (notes.length > 0) {
+        html += '<div class="benchmark-notes">';
+        html += "<h3>Analysis Notes</h3>";
+        html += "<ul>";
+        for (const note of notes) {
+          html += "<li>" + escapeHtml(note) + "</li>";
+        }
+        html += "</ul></div>";
+      }
+
+      container.innerHTML = html;
+    }
+
+    // ---- Start ----
+    init();
+    renderBenchmark();
+  </script>
+</body>
+</html>

--- a/.claude/skills/skill-creator/references/schemas.md
+++ b/.claude/skills/skill-creator/references/schemas.md
@@ -1,0 +1,430 @@
+# JSON Schemas
+
+This document defines the JSON schemas used by skill-creator.
+
+---
+
+## evals.json
+
+Defines the evals for a skill. Located at `evals/evals.json` within the skill directory.
+
+```json
+{
+  "skill_name": "example-skill",
+  "evals": [
+    {
+      "id": 1,
+      "prompt": "User's example prompt",
+      "expected_output": "Description of expected result",
+      "files": ["evals/files/sample1.pdf"],
+      "expectations": [
+        "The output includes X",
+        "The skill used script Y"
+      ]
+    }
+  ]
+}
+```
+
+**Fields:**
+- `skill_name`: Name matching the skill's frontmatter
+- `evals[].id`: Unique integer identifier
+- `evals[].prompt`: The task to execute
+- `evals[].expected_output`: Human-readable description of success
+- `evals[].files`: Optional list of input file paths (relative to skill root)
+- `evals[].expectations`: List of verifiable statements
+
+---
+
+## history.json
+
+Tracks version progression in Improve mode. Located at workspace root.
+
+```json
+{
+  "started_at": "2026-01-15T10:30:00Z",
+  "skill_name": "pdf",
+  "current_best": "v2",
+  "iterations": [
+    {
+      "version": "v0",
+      "parent": null,
+      "expectation_pass_rate": 0.65,
+      "grading_result": "baseline",
+      "is_current_best": false
+    },
+    {
+      "version": "v1",
+      "parent": "v0",
+      "expectation_pass_rate": 0.75,
+      "grading_result": "won",
+      "is_current_best": false
+    },
+    {
+      "version": "v2",
+      "parent": "v1",
+      "expectation_pass_rate": 0.85,
+      "grading_result": "won",
+      "is_current_best": true
+    }
+  ]
+}
+```
+
+**Fields:**
+- `started_at`: ISO timestamp of when improvement started
+- `skill_name`: Name of the skill being improved
+- `current_best`: Version identifier of the best performer
+- `iterations[].version`: Version identifier (v0, v1, ...)
+- `iterations[].parent`: Parent version this was derived from
+- `iterations[].expectation_pass_rate`: Pass rate from grading
+- `iterations[].grading_result`: "baseline", "won", "lost", or "tie"
+- `iterations[].is_current_best`: Whether this is the current best version
+
+---
+
+## grading.json
+
+Output from the grader agent. Located at `<run-dir>/grading.json`.
+
+```json
+{
+  "expectations": [
+    {
+      "text": "The output includes the name 'John Smith'",
+      "passed": true,
+      "evidence": "Found in transcript Step 3: 'Extracted names: John Smith, Sarah Johnson'"
+    },
+    {
+      "text": "The spreadsheet has a SUM formula in cell B10",
+      "passed": false,
+      "evidence": "No spreadsheet was created. The output was a text file."
+    }
+  ],
+  "summary": {
+    "passed": 2,
+    "failed": 1,
+    "total": 3,
+    "pass_rate": 0.67
+  },
+  "execution_metrics": {
+    "tool_calls": {
+      "Read": 5,
+      "Write": 2,
+      "Bash": 8
+    },
+    "total_tool_calls": 15,
+    "total_steps": 6,
+    "errors_encountered": 0,
+    "output_chars": 12450,
+    "transcript_chars": 3200
+  },
+  "timing": {
+    "executor_duration_seconds": 165.0,
+    "grader_duration_seconds": 26.0,
+    "total_duration_seconds": 191.0
+  },
+  "claims": [
+    {
+      "claim": "The form has 12 fillable fields",
+      "type": "factual",
+      "verified": true,
+      "evidence": "Counted 12 fields in field_info.json"
+    }
+  ],
+  "user_notes_summary": {
+    "uncertainties": ["Used 2023 data, may be stale"],
+    "needs_review": [],
+    "workarounds": ["Fell back to text overlay for non-fillable fields"]
+  },
+  "eval_feedback": {
+    "suggestions": [
+      {
+        "assertion": "The output includes the name 'John Smith'",
+        "reason": "A hallucinated document that mentions the name would also pass"
+      }
+    ],
+    "overall": "Assertions check presence but not correctness."
+  }
+}
+```
+
+**Fields:**
+- `expectations[]`: Graded expectations with evidence
+- `summary`: Aggregate pass/fail counts
+- `execution_metrics`: Tool usage and output size (from executor's metrics.json)
+- `timing`: Wall clock timing (from timing.json)
+- `claims`: Extracted and verified claims from the output
+- `user_notes_summary`: Issues flagged by the executor
+- `eval_feedback`: (optional) Improvement suggestions for the evals, only present when the grader identifies issues worth raising
+
+---
+
+## metrics.json
+
+Output from the executor agent. Located at `<run-dir>/outputs/metrics.json`.
+
+```json
+{
+  "tool_calls": {
+    "Read": 5,
+    "Write": 2,
+    "Bash": 8,
+    "Edit": 1,
+    "Glob": 2,
+    "Grep": 0
+  },
+  "total_tool_calls": 18,
+  "total_steps": 6,
+  "files_created": ["filled_form.pdf", "field_values.json"],
+  "errors_encountered": 0,
+  "output_chars": 12450,
+  "transcript_chars": 3200
+}
+```
+
+**Fields:**
+- `tool_calls`: Count per tool type
+- `total_tool_calls`: Sum of all tool calls
+- `total_steps`: Number of major execution steps
+- `files_created`: List of output files created
+- `errors_encountered`: Number of errors during execution
+- `output_chars`: Total character count of output files
+- `transcript_chars`: Character count of transcript
+
+---
+
+## timing.json
+
+Wall clock timing for a run. Located at `<run-dir>/timing.json`.
+
+**How to capture:** When a subagent task completes, the task notification includes `total_tokens` and `duration_ms`. Save these immediately — they are not persisted anywhere else and cannot be recovered after the fact.
+
+```json
+{
+  "total_tokens": 84852,
+  "duration_ms": 23332,
+  "total_duration_seconds": 23.3,
+  "executor_start": "2026-01-15T10:30:00Z",
+  "executor_end": "2026-01-15T10:32:45Z",
+  "executor_duration_seconds": 165.0,
+  "grader_start": "2026-01-15T10:32:46Z",
+  "grader_end": "2026-01-15T10:33:12Z",
+  "grader_duration_seconds": 26.0
+}
+```
+
+---
+
+## benchmark.json
+
+Output from Benchmark mode. Located at `benchmarks/<timestamp>/benchmark.json`.
+
+```json
+{
+  "metadata": {
+    "skill_name": "pdf",
+    "skill_path": "/path/to/pdf",
+    "executor_model": "claude-sonnet-4-20250514",
+    "analyzer_model": "most-capable-model",
+    "timestamp": "2026-01-15T10:30:00Z",
+    "evals_run": [1, 2, 3],
+    "runs_per_configuration": 3
+  },
+
+  "runs": [
+    {
+      "eval_id": 1,
+      "eval_name": "Ocean",
+      "configuration": "with_skill",
+      "run_number": 1,
+      "result": {
+        "pass_rate": 0.85,
+        "passed": 6,
+        "failed": 1,
+        "total": 7,
+        "time_seconds": 42.5,
+        "tokens": 3800,
+        "tool_calls": 18,
+        "errors": 0
+      },
+      "expectations": [
+        {"text": "...", "passed": true, "evidence": "..."}
+      ],
+      "notes": [
+        "Used 2023 data, may be stale",
+        "Fell back to text overlay for non-fillable fields"
+      ]
+    }
+  ],
+
+  "run_summary": {
+    "with_skill": {
+      "pass_rate": {"mean": 0.85, "stddev": 0.05, "min": 0.80, "max": 0.90},
+      "time_seconds": {"mean": 45.0, "stddev": 12.0, "min": 32.0, "max": 58.0},
+      "tokens": {"mean": 3800, "stddev": 400, "min": 3200, "max": 4100}
+    },
+    "without_skill": {
+      "pass_rate": {"mean": 0.35, "stddev": 0.08, "min": 0.28, "max": 0.45},
+      "time_seconds": {"mean": 32.0, "stddev": 8.0, "min": 24.0, "max": 42.0},
+      "tokens": {"mean": 2100, "stddev": 300, "min": 1800, "max": 2500}
+    },
+    "delta": {
+      "pass_rate": "+0.50",
+      "time_seconds": "+13.0",
+      "tokens": "+1700"
+    }
+  },
+
+  "notes": [
+    "Assertion 'Output is a PDF file' passes 100% in both configurations - may not differentiate skill value",
+    "Eval 3 shows high variance (50% ± 40%) - may be flaky or model-dependent",
+    "Without-skill runs consistently fail on table extraction expectations",
+    "Skill adds 13s average execution time but improves pass rate by 50%"
+  ]
+}
+```
+
+**Fields:**
+- `metadata`: Information about the benchmark run
+  - `skill_name`: Name of the skill
+  - `timestamp`: When the benchmark was run
+  - `evals_run`: List of eval names or IDs
+  - `runs_per_configuration`: Number of runs per config (e.g. 3)
+- `runs[]`: Individual run results
+  - `eval_id`: Numeric eval identifier
+  - `eval_name`: Human-readable eval name (used as section header in the viewer)
+  - `configuration`: Must be `"with_skill"` or `"without_skill"` (the viewer uses this exact string for grouping and color coding)
+  - `run_number`: Integer run number (1, 2, 3...)
+  - `result`: Nested object with `pass_rate`, `passed`, `total`, `time_seconds`, `tokens`, `errors`
+- `run_summary`: Statistical aggregates per configuration
+  - `with_skill` / `without_skill`: Each contains `pass_rate`, `time_seconds`, `tokens` objects with `mean` and `stddev` fields
+  - `delta`: Difference strings like `"+0.50"`, `"+13.0"`, `"+1700"`
+- `notes`: Freeform observations from the analyzer
+
+**Important:** The viewer reads these field names exactly. Using `config` instead of `configuration`, or putting `pass_rate` at the top level of a run instead of nested under `result`, will cause the viewer to show empty/zero values. Always reference this schema when generating benchmark.json manually.
+
+---
+
+## comparison.json
+
+Output from blind comparator. Located at `<grading-dir>/comparison-N.json`.
+
+```json
+{
+  "winner": "A",
+  "reasoning": "Output A provides a complete solution with proper formatting and all required fields. Output B is missing the date field and has formatting inconsistencies.",
+  "rubric": {
+    "A": {
+      "content": {
+        "correctness": 5,
+        "completeness": 5,
+        "accuracy": 4
+      },
+      "structure": {
+        "organization": 4,
+        "formatting": 5,
+        "usability": 4
+      },
+      "content_score": 4.7,
+      "structure_score": 4.3,
+      "overall_score": 9.0
+    },
+    "B": {
+      "content": {
+        "correctness": 3,
+        "completeness": 2,
+        "accuracy": 3
+      },
+      "structure": {
+        "organization": 3,
+        "formatting": 2,
+        "usability": 3
+      },
+      "content_score": 2.7,
+      "structure_score": 2.7,
+      "overall_score": 5.4
+    }
+  },
+  "output_quality": {
+    "A": {
+      "score": 9,
+      "strengths": ["Complete solution", "Well-formatted", "All fields present"],
+      "weaknesses": ["Minor style inconsistency in header"]
+    },
+    "B": {
+      "score": 5,
+      "strengths": ["Readable output", "Correct basic structure"],
+      "weaknesses": ["Missing date field", "Formatting inconsistencies", "Partial data extraction"]
+    }
+  },
+  "expectation_results": {
+    "A": {
+      "passed": 4,
+      "total": 5,
+      "pass_rate": 0.80,
+      "details": [
+        {"text": "Output includes name", "passed": true}
+      ]
+    },
+    "B": {
+      "passed": 3,
+      "total": 5,
+      "pass_rate": 0.60,
+      "details": [
+        {"text": "Output includes name", "passed": true}
+      ]
+    }
+  }
+}
+```
+
+---
+
+## analysis.json
+
+Output from post-hoc analyzer. Located at `<grading-dir>/analysis.json`.
+
+```json
+{
+  "comparison_summary": {
+    "winner": "A",
+    "winner_skill": "path/to/winner/skill",
+    "loser_skill": "path/to/loser/skill",
+    "comparator_reasoning": "Brief summary of why comparator chose winner"
+  },
+  "winner_strengths": [
+    "Clear step-by-step instructions for handling multi-page documents",
+    "Included validation script that caught formatting errors"
+  ],
+  "loser_weaknesses": [
+    "Vague instruction 'process the document appropriately' led to inconsistent behavior",
+    "No script for validation, agent had to improvise"
+  ],
+  "instruction_following": {
+    "winner": {
+      "score": 9,
+      "issues": ["Minor: skipped optional logging step"]
+    },
+    "loser": {
+      "score": 6,
+      "issues": [
+        "Did not use the skill's formatting template",
+        "Invented own approach instead of following step 3"
+      ]
+    }
+  },
+  "improvement_suggestions": [
+    {
+      "priority": "high",
+      "category": "instructions",
+      "suggestion": "Replace 'process the document appropriately' with explicit steps",
+      "expected_impact": "Would eliminate ambiguity that caused inconsistent behavior"
+    }
+  ],
+  "transcript_insights": {
+    "winner_execution_pattern": "Read skill -> Followed 5-step process -> Used validation script",
+    "loser_execution_pattern": "Read skill -> Unclear on approach -> Tried 3 different methods"
+  }
+}
+```

--- a/.claude/skills/skill-creator/scripts/aggregate_benchmark.py
+++ b/.claude/skills/skill-creator/scripts/aggregate_benchmark.py
@@ -1,0 +1,401 @@
+#!/usr/bin/env python3
+"""
+Aggregate individual run results into benchmark summary statistics.
+
+Reads grading.json files from run directories and produces:
+- run_summary with mean, stddev, min, max for each metric
+- delta between with_skill and without_skill configurations
+
+Usage:
+    python aggregate_benchmark.py <benchmark_dir>
+
+Example:
+    python aggregate_benchmark.py benchmarks/2026-01-15T10-30-00/
+
+The script supports two directory layouts:
+
+    Workspace layout (from skill-creator iterations):
+    <benchmark_dir>/
+    └── eval-N/
+        ├── with_skill/
+        │   ├── run-1/grading.json
+        │   └── run-2/grading.json
+        └── without_skill/
+            ├── run-1/grading.json
+            └── run-2/grading.json
+
+    Legacy layout (with runs/ subdirectory):
+    <benchmark_dir>/
+    └── runs/
+        └── eval-N/
+            ├── with_skill/
+            │   └── run-1/grading.json
+            └── without_skill/
+                └── run-1/grading.json
+"""
+
+import argparse
+import json
+import math
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+
+def calculate_stats(values: list[float]) -> dict:
+    """Calculate mean, stddev, min, max for a list of values."""
+    if not values:
+        return {"mean": 0.0, "stddev": 0.0, "min": 0.0, "max": 0.0}
+
+    n = len(values)
+    mean = sum(values) / n
+
+    if n > 1:
+        variance = sum((x - mean) ** 2 for x in values) / (n - 1)
+        stddev = math.sqrt(variance)
+    else:
+        stddev = 0.0
+
+    return {
+        "mean": round(mean, 4),
+        "stddev": round(stddev, 4),
+        "min": round(min(values), 4),
+        "max": round(max(values), 4)
+    }
+
+
+def load_run_results(benchmark_dir: Path) -> dict:
+    """
+    Load all run results from a benchmark directory.
+
+    Returns dict keyed by config name (e.g. "with_skill"/"without_skill",
+    or "new_skill"/"old_skill"), each containing a list of run results.
+    """
+    # Support both layouts: eval dirs directly under benchmark_dir, or under runs/
+    runs_dir = benchmark_dir / "runs"
+    if runs_dir.exists():
+        search_dir = runs_dir
+    elif list(benchmark_dir.glob("eval-*")):
+        search_dir = benchmark_dir
+    else:
+        print(f"No eval directories found in {benchmark_dir} or {benchmark_dir / 'runs'}")
+        return {}
+
+    results: dict[str, list] = {}
+
+    for eval_idx, eval_dir in enumerate(sorted(search_dir.glob("eval-*"))):
+        metadata_path = eval_dir / "eval_metadata.json"
+        if metadata_path.exists():
+            try:
+                with open(metadata_path) as mf:
+                    eval_id = json.load(mf).get("eval_id", eval_idx)
+            except (json.JSONDecodeError, OSError):
+                eval_id = eval_idx
+        else:
+            try:
+                eval_id = int(eval_dir.name.split("-")[1])
+            except ValueError:
+                eval_id = eval_idx
+
+        # Discover config directories dynamically rather than hardcoding names
+        for config_dir in sorted(eval_dir.iterdir()):
+            if not config_dir.is_dir():
+                continue
+            # Skip non-config directories (inputs, outputs, etc.)
+            if not list(config_dir.glob("run-*")):
+                continue
+            config = config_dir.name
+            if config not in results:
+                results[config] = []
+
+            for run_dir in sorted(config_dir.glob("run-*")):
+                run_number = int(run_dir.name.split("-")[1])
+                grading_file = run_dir / "grading.json"
+
+                if not grading_file.exists():
+                    print(f"Warning: grading.json not found in {run_dir}")
+                    continue
+
+                try:
+                    with open(grading_file) as f:
+                        grading = json.load(f)
+                except json.JSONDecodeError as e:
+                    print(f"Warning: Invalid JSON in {grading_file}: {e}")
+                    continue
+
+                # Extract metrics
+                result = {
+                    "eval_id": eval_id,
+                    "run_number": run_number,
+                    "pass_rate": grading.get("summary", {}).get("pass_rate", 0.0),
+                    "passed": grading.get("summary", {}).get("passed", 0),
+                    "failed": grading.get("summary", {}).get("failed", 0),
+                    "total": grading.get("summary", {}).get("total", 0),
+                }
+
+                # Extract timing — check grading.json first, then sibling timing.json
+                timing = grading.get("timing", {})
+                result["time_seconds"] = timing.get("total_duration_seconds", 0.0)
+                timing_file = run_dir / "timing.json"
+                if result["time_seconds"] == 0.0 and timing_file.exists():
+                    try:
+                        with open(timing_file) as tf:
+                            timing_data = json.load(tf)
+                        result["time_seconds"] = timing_data.get("total_duration_seconds", 0.0)
+                        result["tokens"] = timing_data.get("total_tokens", 0)
+                    except json.JSONDecodeError:
+                        pass
+
+                # Extract metrics if available
+                metrics = grading.get("execution_metrics", {})
+                result["tool_calls"] = metrics.get("total_tool_calls", 0)
+                if not result.get("tokens"):
+                    result["tokens"] = metrics.get("output_chars", 0)
+                result["errors"] = metrics.get("errors_encountered", 0)
+
+                # Extract expectations — viewer requires fields: text, passed, evidence
+                raw_expectations = grading.get("expectations", [])
+                for exp in raw_expectations:
+                    if "text" not in exp or "passed" not in exp:
+                        print(f"Warning: expectation in {grading_file} missing required fields (text, passed, evidence): {exp}")
+                result["expectations"] = raw_expectations
+
+                # Extract notes from user_notes_summary
+                notes_summary = grading.get("user_notes_summary", {})
+                notes = []
+                notes.extend(notes_summary.get("uncertainties", []))
+                notes.extend(notes_summary.get("needs_review", []))
+                notes.extend(notes_summary.get("workarounds", []))
+                result["notes"] = notes
+
+                results[config].append(result)
+
+    return results
+
+
+def aggregate_results(results: dict) -> dict:
+    """
+    Aggregate run results into summary statistics.
+
+    Returns run_summary with stats for each configuration and delta.
+    """
+    run_summary = {}
+    configs = list(results.keys())
+
+    for config in configs:
+        runs = results.get(config, [])
+
+        if not runs:
+            run_summary[config] = {
+                "pass_rate": {"mean": 0.0, "stddev": 0.0, "min": 0.0, "max": 0.0},
+                "time_seconds": {"mean": 0.0, "stddev": 0.0, "min": 0.0, "max": 0.0},
+                "tokens": {"mean": 0, "stddev": 0, "min": 0, "max": 0}
+            }
+            continue
+
+        pass_rates = [r["pass_rate"] for r in runs]
+        times = [r["time_seconds"] for r in runs]
+        tokens = [r.get("tokens", 0) for r in runs]
+
+        run_summary[config] = {
+            "pass_rate": calculate_stats(pass_rates),
+            "time_seconds": calculate_stats(times),
+            "tokens": calculate_stats(tokens)
+        }
+
+    # Calculate delta between the first two configs (if two exist)
+    if len(configs) >= 2:
+        primary = run_summary.get(configs[0], {})
+        baseline = run_summary.get(configs[1], {})
+    else:
+        primary = run_summary.get(configs[0], {}) if configs else {}
+        baseline = {}
+
+    delta_pass_rate = primary.get("pass_rate", {}).get("mean", 0) - baseline.get("pass_rate", {}).get("mean", 0)
+    delta_time = primary.get("time_seconds", {}).get("mean", 0) - baseline.get("time_seconds", {}).get("mean", 0)
+    delta_tokens = primary.get("tokens", {}).get("mean", 0) - baseline.get("tokens", {}).get("mean", 0)
+
+    run_summary["delta"] = {
+        "pass_rate": f"{delta_pass_rate:+.2f}",
+        "time_seconds": f"{delta_time:+.1f}",
+        "tokens": f"{delta_tokens:+.0f}"
+    }
+
+    return run_summary
+
+
+def generate_benchmark(benchmark_dir: Path, skill_name: str = "", skill_path: str = "") -> dict:
+    """
+    Generate complete benchmark.json from run results.
+    """
+    results = load_run_results(benchmark_dir)
+    run_summary = aggregate_results(results)
+
+    # Build runs array for benchmark.json
+    runs = []
+    for config in results:
+        for result in results[config]:
+            runs.append({
+                "eval_id": result["eval_id"],
+                "configuration": config,
+                "run_number": result["run_number"],
+                "result": {
+                    "pass_rate": result["pass_rate"],
+                    "passed": result["passed"],
+                    "failed": result["failed"],
+                    "total": result["total"],
+                    "time_seconds": result["time_seconds"],
+                    "tokens": result.get("tokens", 0),
+                    "tool_calls": result.get("tool_calls", 0),
+                    "errors": result.get("errors", 0)
+                },
+                "expectations": result["expectations"],
+                "notes": result["notes"]
+            })
+
+    # Determine eval IDs from results
+    eval_ids = sorted(set(
+        r["eval_id"]
+        for config in results.values()
+        for r in config
+    ))
+
+    benchmark = {
+        "metadata": {
+            "skill_name": skill_name or "<skill-name>",
+            "skill_path": skill_path or "<path/to/skill>",
+            "executor_model": "<model-name>",
+            "analyzer_model": "<model-name>",
+            "timestamp": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+            "evals_run": eval_ids,
+            "runs_per_configuration": 3
+        },
+        "runs": runs,
+        "run_summary": run_summary,
+        "notes": []  # To be filled by analyzer
+    }
+
+    return benchmark
+
+
+def generate_markdown(benchmark: dict) -> str:
+    """Generate human-readable benchmark.md from benchmark data."""
+    metadata = benchmark["metadata"]
+    run_summary = benchmark["run_summary"]
+
+    # Determine config names (excluding "delta")
+    configs = [k for k in run_summary if k != "delta"]
+    config_a = configs[0] if len(configs) >= 1 else "config_a"
+    config_b = configs[1] if len(configs) >= 2 else "config_b"
+    label_a = config_a.replace("_", " ").title()
+    label_b = config_b.replace("_", " ").title()
+
+    lines = [
+        f"# Skill Benchmark: {metadata['skill_name']}",
+        "",
+        f"**Model**: {metadata['executor_model']}",
+        f"**Date**: {metadata['timestamp']}",
+        f"**Evals**: {', '.join(map(str, metadata['evals_run']))} ({metadata['runs_per_configuration']} runs each per configuration)",
+        "",
+        "## Summary",
+        "",
+        f"| Metric | {label_a} | {label_b} | Delta |",
+        "|--------|------------|---------------|-------|",
+    ]
+
+    a_summary = run_summary.get(config_a, {})
+    b_summary = run_summary.get(config_b, {})
+    delta = run_summary.get("delta", {})
+
+    # Format pass rate
+    a_pr = a_summary.get("pass_rate", {})
+    b_pr = b_summary.get("pass_rate", {})
+    lines.append(f"| Pass Rate | {a_pr.get('mean', 0)*100:.0f}% ± {a_pr.get('stddev', 0)*100:.0f}% | {b_pr.get('mean', 0)*100:.0f}% ± {b_pr.get('stddev', 0)*100:.0f}% | {delta.get('pass_rate', '—')} |")
+
+    # Format time
+    a_time = a_summary.get("time_seconds", {})
+    b_time = b_summary.get("time_seconds", {})
+    lines.append(f"| Time | {a_time.get('mean', 0):.1f}s ± {a_time.get('stddev', 0):.1f}s | {b_time.get('mean', 0):.1f}s ± {b_time.get('stddev', 0):.1f}s | {delta.get('time_seconds', '—')}s |")
+
+    # Format tokens
+    a_tokens = a_summary.get("tokens", {})
+    b_tokens = b_summary.get("tokens", {})
+    lines.append(f"| Tokens | {a_tokens.get('mean', 0):.0f} ± {a_tokens.get('stddev', 0):.0f} | {b_tokens.get('mean', 0):.0f} ± {b_tokens.get('stddev', 0):.0f} | {delta.get('tokens', '—')} |")
+
+    # Notes section
+    if benchmark.get("notes"):
+        lines.extend([
+            "",
+            "## Notes",
+            ""
+        ])
+        for note in benchmark["notes"]:
+            lines.append(f"- {note}")
+
+    return "\n".join(lines)
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Aggregate benchmark run results into summary statistics"
+    )
+    parser.add_argument(
+        "benchmark_dir",
+        type=Path,
+        help="Path to the benchmark directory"
+    )
+    parser.add_argument(
+        "--skill-name",
+        default="",
+        help="Name of the skill being benchmarked"
+    )
+    parser.add_argument(
+        "--skill-path",
+        default="",
+        help="Path to the skill being benchmarked"
+    )
+    parser.add_argument(
+        "--output", "-o",
+        type=Path,
+        help="Output path for benchmark.json (default: <benchmark_dir>/benchmark.json)"
+    )
+
+    args = parser.parse_args()
+
+    if not args.benchmark_dir.exists():
+        print(f"Directory not found: {args.benchmark_dir}")
+        sys.exit(1)
+
+    # Generate benchmark
+    benchmark = generate_benchmark(args.benchmark_dir, args.skill_name, args.skill_path)
+
+    # Determine output paths
+    output_json = args.output or (args.benchmark_dir / "benchmark.json")
+    output_md = output_json.with_suffix(".md")
+
+    # Write benchmark.json
+    with open(output_json, "w") as f:
+        json.dump(benchmark, f, indent=2)
+    print(f"Generated: {output_json}")
+
+    # Write benchmark.md
+    markdown = generate_markdown(benchmark)
+    with open(output_md, "w") as f:
+        f.write(markdown)
+    print(f"Generated: {output_md}")
+
+    # Print summary
+    run_summary = benchmark["run_summary"]
+    configs = [k for k in run_summary if k != "delta"]
+    delta = run_summary.get("delta", {})
+
+    print(f"\nSummary:")
+    for config in configs:
+        pr = run_summary[config]["pass_rate"]["mean"]
+        label = config.replace("_", " ").title()
+        print(f"  {label}: {pr*100:.1f}% pass rate")
+    print(f"  Delta:         {delta.get('pass_rate', '—')}")
+
+
+if __name__ == "__main__":
+    main()

--- a/.claude/skills/skill-creator/scripts/generate_report.py
+++ b/.claude/skills/skill-creator/scripts/generate_report.py
@@ -1,0 +1,326 @@
+#!/usr/bin/env python3
+"""Generate an HTML report from run_loop.py output.
+
+Takes the JSON output from run_loop.py and generates a visual HTML report
+showing each description attempt with check/x for each test case.
+Distinguishes between train and test queries.
+"""
+
+import argparse
+import html
+import json
+import sys
+from pathlib import Path
+
+
+def generate_html(data: dict, auto_refresh: bool = False, skill_name: str = "") -> str:
+    """Generate HTML report from loop output data. If auto_refresh is True, adds a meta refresh tag."""
+    history = data.get("history", [])
+    holdout = data.get("holdout", 0)
+    title_prefix = html.escape(skill_name + " \u2014 ") if skill_name else ""
+
+    # Get all unique queries from train and test sets, with should_trigger info
+    train_queries: list[dict] = []
+    test_queries: list[dict] = []
+    if history:
+        for r in history[0].get("train_results", history[0].get("results", [])):
+            train_queries.append({"query": r["query"], "should_trigger": r.get("should_trigger", True)})
+        if history[0].get("test_results"):
+            for r in history[0].get("test_results", []):
+                test_queries.append({"query": r["query"], "should_trigger": r.get("should_trigger", True)})
+
+    refresh_tag = '    <meta http-equiv="refresh" content="5">\n' if auto_refresh else ""
+
+    html_parts = ["""<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
+""" + refresh_tag + """    <title>""" + title_prefix + """Skill Description Optimization</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@500;600&family=Lora:wght@400;500&display=swap" rel="stylesheet">
+    <style>
+        body {
+            font-family: 'Lora', Georgia, serif;
+            max-width: 100%;
+            margin: 0 auto;
+            padding: 20px;
+            background: #faf9f5;
+            color: #141413;
+        }
+        h1 { font-family: 'Poppins', sans-serif; color: #141413; }
+        .explainer {
+            background: white;
+            padding: 15px;
+            border-radius: 6px;
+            margin-bottom: 20px;
+            border: 1px solid #e8e6dc;
+            color: #b0aea5;
+            font-size: 0.875rem;
+            line-height: 1.6;
+        }
+        .summary {
+            background: white;
+            padding: 15px;
+            border-radius: 6px;
+            margin-bottom: 20px;
+            border: 1px solid #e8e6dc;
+        }
+        .summary p { margin: 5px 0; }
+        .best { color: #788c5d; font-weight: bold; }
+        .table-container {
+            overflow-x: auto;
+            width: 100%;
+        }
+        table {
+            border-collapse: collapse;
+            background: white;
+            border: 1px solid #e8e6dc;
+            border-radius: 6px;
+            font-size: 12px;
+            min-width: 100%;
+        }
+        th, td {
+            padding: 8px;
+            text-align: left;
+            border: 1px solid #e8e6dc;
+            white-space: normal;
+            word-wrap: break-word;
+        }
+        th {
+            font-family: 'Poppins', sans-serif;
+            background: #141413;
+            color: #faf9f5;
+            font-weight: 500;
+        }
+        th.test-col {
+            background: #6a9bcc;
+        }
+        th.query-col { min-width: 200px; }
+        td.description {
+            font-family: monospace;
+            font-size: 11px;
+            word-wrap: break-word;
+            max-width: 400px;
+        }
+        td.result {
+            text-align: center;
+            font-size: 16px;
+            min-width: 40px;
+        }
+        td.test-result {
+            background: #f0f6fc;
+        }
+        .pass { color: #788c5d; }
+        .fail { color: #c44; }
+        .rate {
+            font-size: 9px;
+            color: #b0aea5;
+            display: block;
+        }
+        tr:hover { background: #faf9f5; }
+        .score {
+            display: inline-block;
+            padding: 2px 6px;
+            border-radius: 4px;
+            font-weight: bold;
+            font-size: 11px;
+        }
+        .score-good { background: #eef2e8; color: #788c5d; }
+        .score-ok { background: #fef3c7; color: #d97706; }
+        .score-bad { background: #fceaea; color: #c44; }
+        .train-label { color: #b0aea5; font-size: 10px; }
+        .test-label { color: #6a9bcc; font-size: 10px; font-weight: bold; }
+        .best-row { background: #f5f8f2; }
+        th.positive-col { border-bottom: 3px solid #788c5d; }
+        th.negative-col { border-bottom: 3px solid #c44; }
+        th.test-col.positive-col { border-bottom: 3px solid #788c5d; }
+        th.test-col.negative-col { border-bottom: 3px solid #c44; }
+        .legend { font-family: 'Poppins', sans-serif; display: flex; gap: 20px; margin-bottom: 10px; font-size: 13px; align-items: center; }
+        .legend-item { display: flex; align-items: center; gap: 6px; }
+        .legend-swatch { width: 16px; height: 16px; border-radius: 3px; display: inline-block; }
+        .swatch-positive { background: #141413; border-bottom: 3px solid #788c5d; }
+        .swatch-negative { background: #141413; border-bottom: 3px solid #c44; }
+        .swatch-test { background: #6a9bcc; }
+        .swatch-train { background: #141413; }
+    </style>
+</head>
+<body>
+    <h1>""" + title_prefix + """Skill Description Optimization</h1>
+    <div class="explainer">
+        <strong>Optimizing your skill's description.</strong> This page updates automatically as Claude tests different versions of your skill's description. Each row is an iteration — a new description attempt. The columns show test queries: green checkmarks mean the skill triggered correctly (or correctly didn't trigger), red crosses mean it got it wrong. The "Train" score shows performance on queries used to improve the description; the "Test" score shows performance on held-out queries the optimizer hasn't seen. When it's done, Claude will apply the best-performing description to your skill.
+    </div>
+"""]
+
+    # Summary section
+    best_test_score = data.get('best_test_score')
+    best_train_score = data.get('best_train_score')
+    html_parts.append(f"""
+    <div class="summary">
+        <p><strong>Original:</strong> {html.escape(data.get('original_description', 'N/A'))}</p>
+        <p class="best"><strong>Best:</strong> {html.escape(data.get('best_description', 'N/A'))}</p>
+        <p><strong>Best Score:</strong> {data.get('best_score', 'N/A')} {'(test)' if best_test_score else '(train)'}</p>
+        <p><strong>Iterations:</strong> {data.get('iterations_run', 0)} | <strong>Train:</strong> {data.get('train_size', '?')} | <strong>Test:</strong> {data.get('test_size', '?')}</p>
+    </div>
+""")
+
+    # Legend
+    html_parts.append("""
+    <div class="legend">
+        <span style="font-weight:600">Query columns:</span>
+        <span class="legend-item"><span class="legend-swatch swatch-positive"></span> Should trigger</span>
+        <span class="legend-item"><span class="legend-swatch swatch-negative"></span> Should NOT trigger</span>
+        <span class="legend-item"><span class="legend-swatch swatch-train"></span> Train</span>
+        <span class="legend-item"><span class="legend-swatch swatch-test"></span> Test</span>
+    </div>
+""")
+
+    # Table header
+    html_parts.append("""
+    <div class="table-container">
+    <table>
+        <thead>
+            <tr>
+                <th>Iter</th>
+                <th>Train</th>
+                <th>Test</th>
+                <th class="query-col">Description</th>
+""")
+
+    # Add column headers for train queries
+    for qinfo in train_queries:
+        polarity = "positive-col" if qinfo["should_trigger"] else "negative-col"
+        html_parts.append(f'                <th class="{polarity}">{html.escape(qinfo["query"])}</th>\n')
+
+    # Add column headers for test queries (different color)
+    for qinfo in test_queries:
+        polarity = "positive-col" if qinfo["should_trigger"] else "negative-col"
+        html_parts.append(f'                <th class="test-col {polarity}">{html.escape(qinfo["query"])}</th>\n')
+
+    html_parts.append("""            </tr>
+        </thead>
+        <tbody>
+""")
+
+    # Find best iteration for highlighting
+    if test_queries:
+        best_iter = max(history, key=lambda h: h.get("test_passed") or 0).get("iteration")
+    else:
+        best_iter = max(history, key=lambda h: h.get("train_passed", h.get("passed", 0))).get("iteration")
+
+    # Add rows for each iteration
+    for h in history:
+        iteration = h.get("iteration", "?")
+        train_passed = h.get("train_passed", h.get("passed", 0))
+        train_total = h.get("train_total", h.get("total", 0))
+        test_passed = h.get("test_passed")
+        test_total = h.get("test_total")
+        description = h.get("description", "")
+        train_results = h.get("train_results", h.get("results", []))
+        test_results = h.get("test_results", [])
+
+        # Create lookups for results by query
+        train_by_query = {r["query"]: r for r in train_results}
+        test_by_query = {r["query"]: r for r in test_results} if test_results else {}
+
+        # Compute aggregate correct/total runs across all retries
+        def aggregate_runs(results: list[dict]) -> tuple[int, int]:
+            correct = 0
+            total = 0
+            for r in results:
+                runs = r.get("runs", 0)
+                triggers = r.get("triggers", 0)
+                total += runs
+                if r.get("should_trigger", True):
+                    correct += triggers
+                else:
+                    correct += runs - triggers
+            return correct, total
+
+        train_correct, train_runs = aggregate_runs(train_results)
+        test_correct, test_runs = aggregate_runs(test_results)
+
+        # Determine score classes
+        def score_class(correct: int, total: int) -> str:
+            if total > 0:
+                ratio = correct / total
+                if ratio >= 0.8:
+                    return "score-good"
+                elif ratio >= 0.5:
+                    return "score-ok"
+            return "score-bad"
+
+        train_class = score_class(train_correct, train_runs)
+        test_class = score_class(test_correct, test_runs)
+
+        row_class = "best-row" if iteration == best_iter else ""
+
+        html_parts.append(f"""            <tr class="{row_class}">
+                <td>{iteration}</td>
+                <td><span class="score {train_class}">{train_correct}/{train_runs}</span></td>
+                <td><span class="score {test_class}">{test_correct}/{test_runs}</span></td>
+                <td class="description">{html.escape(description)}</td>
+""")
+
+        # Add result for each train query
+        for qinfo in train_queries:
+            r = train_by_query.get(qinfo["query"], {})
+            did_pass = r.get("pass", False)
+            triggers = r.get("triggers", 0)
+            runs = r.get("runs", 0)
+
+            icon = "✓" if did_pass else "✗"
+            css_class = "pass" if did_pass else "fail"
+
+            html_parts.append(f'                <td class="result {css_class}">{icon}<span class="rate">{triggers}/{runs}</span></td>\n')
+
+        # Add result for each test query (with different background)
+        for qinfo in test_queries:
+            r = test_by_query.get(qinfo["query"], {})
+            did_pass = r.get("pass", False)
+            triggers = r.get("triggers", 0)
+            runs = r.get("runs", 0)
+
+            icon = "✓" if did_pass else "✗"
+            css_class = "pass" if did_pass else "fail"
+
+            html_parts.append(f'                <td class="result test-result {css_class}">{icon}<span class="rate">{triggers}/{runs}</span></td>\n')
+
+        html_parts.append("            </tr>\n")
+
+    html_parts.append("""        </tbody>
+    </table>
+    </div>
+""")
+
+    html_parts.append("""
+</body>
+</html>
+""")
+
+    return "".join(html_parts)
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Generate HTML report from run_loop output")
+    parser.add_argument("input", help="Path to JSON output from run_loop.py (or - for stdin)")
+    parser.add_argument("-o", "--output", default=None, help="Output HTML file (default: stdout)")
+    parser.add_argument("--skill-name", default="", help="Skill name to include in the report title")
+    args = parser.parse_args()
+
+    if args.input == "-":
+        data = json.load(sys.stdin)
+    else:
+        data = json.loads(Path(args.input).read_text())
+
+    html_output = generate_html(data, skill_name=args.skill_name)
+
+    if args.output:
+        Path(args.output).write_text(html_output)
+        print(f"Report written to {args.output}", file=sys.stderr)
+    else:
+        print(html_output)
+
+
+if __name__ == "__main__":
+    main()

--- a/.claude/skills/skill-creator/scripts/improve_description.py
+++ b/.claude/skills/skill-creator/scripts/improve_description.py
@@ -1,0 +1,248 @@
+#!/usr/bin/env python3
+"""Improve a skill description based on eval results.
+
+Takes eval results (from run_eval.py) and generates an improved description
+using Claude with extended thinking.
+"""
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+
+import anthropic
+
+from scripts.utils import parse_skill_md
+
+
+def improve_description(
+    client: anthropic.Anthropic,
+    skill_name: str,
+    skill_content: str,
+    current_description: str,
+    eval_results: dict,
+    history: list[dict],
+    model: str,
+    test_results: dict | None = None,
+    log_dir: Path | None = None,
+    iteration: int | None = None,
+) -> str:
+    """Call Claude to improve the description based on eval results."""
+    failed_triggers = [
+        r for r in eval_results["results"]
+        if r["should_trigger"] and not r["pass"]
+    ]
+    false_triggers = [
+        r for r in eval_results["results"]
+        if not r["should_trigger"] and not r["pass"]
+    ]
+
+    # Build scores summary
+    train_score = f"{eval_results['summary']['passed']}/{eval_results['summary']['total']}"
+    if test_results:
+        test_score = f"{test_results['summary']['passed']}/{test_results['summary']['total']}"
+        scores_summary = f"Train: {train_score}, Test: {test_score}"
+    else:
+        scores_summary = f"Train: {train_score}"
+
+    prompt = f"""You are optimizing a skill description for a Claude Code skill called "{skill_name}". A "skill" is sort of like a prompt, but with progressive disclosure -- there's a title and description that Claude sees when deciding whether to use the skill, and then if it does use the skill, it reads the .md file which has lots more details and potentially links to other resources in the skill folder like helper files and scripts and additional documentation or examples.
+
+The description appears in Claude's "available_skills" list. When a user sends a query, Claude decides whether to invoke the skill based solely on the title and on this description. Your goal is to write a description that triggers for relevant queries, and doesn't trigger for irrelevant ones.
+
+Here's the current description:
+<current_description>
+"{current_description}"
+</current_description>
+
+Current scores ({scores_summary}):
+<scores_summary>
+"""
+    if failed_triggers:
+        prompt += "FAILED TO TRIGGER (should have triggered but didn't):\n"
+        for r in failed_triggers:
+            prompt += f'  - "{r["query"]}" (triggered {r["triggers"]}/{r["runs"]} times)\n'
+        prompt += "\n"
+
+    if false_triggers:
+        prompt += "FALSE TRIGGERS (triggered but shouldn't have):\n"
+        for r in false_triggers:
+            prompt += f'  - "{r["query"]}" (triggered {r["triggers"]}/{r["runs"]} times)\n'
+        prompt += "\n"
+
+    if history:
+        prompt += "PREVIOUS ATTEMPTS (do NOT repeat these — try something structurally different):\n\n"
+        for h in history:
+            train_s = f"{h.get('train_passed', h.get('passed', 0))}/{h.get('train_total', h.get('total', 0))}"
+            test_s = f"{h.get('test_passed', '?')}/{h.get('test_total', '?')}" if h.get('test_passed') is not None else None
+            score_str = f"train={train_s}" + (f", test={test_s}" if test_s else "")
+            prompt += f'<attempt {score_str}>\n'
+            prompt += f'Description: "{h["description"]}"\n'
+            if "results" in h:
+                prompt += "Train results:\n"
+                for r in h["results"]:
+                    status = "PASS" if r["pass"] else "FAIL"
+                    prompt += f'  [{status}] "{r["query"][:80]}" (triggered {r["triggers"]}/{r["runs"]})\n'
+            if h.get("note"):
+                prompt += f'Note: {h["note"]}\n'
+            prompt += "</attempt>\n\n"
+
+    prompt += f"""</scores_summary>
+
+Skill content (for context on what the skill does):
+<skill_content>
+{skill_content}
+</skill_content>
+
+Based on the failures, write a new and improved description that is more likely to trigger correctly. When I say "based on the failures", it's a bit of a tricky line to walk because we don't want to overfit to the specific cases you're seeing. So what I DON'T want you to do is produce an ever-expanding list of specific queries that this skill should or shouldn't trigger for. Instead, try to generalize from the failures to broader categories of user intent and situations where this skill would be useful or not useful. The reason for this is twofold:
+
+1. Avoid overfitting
+2. The list might get loooong and it's injected into ALL queries and there might be a lot of skills, so we don't want to blow too much space on any given description.
+
+Concretely, your description should not be more than about 100-200 words, even if that comes at the cost of accuracy.
+
+Here are some tips that we've found to work well in writing these descriptions:
+- The skill should be phrased in the imperative -- "Use this skill for" rather than "this skill does"
+- The skill description should focus on the user's intent, what they are trying to achieve, vs. the implementation details of how the skill works.
+- The description competes with other skills for Claude's attention — make it distinctive and immediately recognizable.
+- If you're getting lots of failures after repeated attempts, change things up. Try different sentence structures or wordings.
+
+I'd encourage you to be creative and mix up the style in different iterations since you'll have multiple opportunities to try different approaches and we'll just grab the highest-scoring one at the end. 
+
+Please respond with only the new description text in <new_description> tags, nothing else."""
+
+    response = client.messages.create(
+        model=model,
+        max_tokens=16000,
+        thinking={
+            "type": "enabled",
+            "budget_tokens": 10000,
+        },
+        messages=[{"role": "user", "content": prompt}],
+    )
+
+    # Extract thinking and text from response
+    thinking_text = ""
+    text = ""
+    for block in response.content:
+        if block.type == "thinking":
+            thinking_text = block.thinking
+        elif block.type == "text":
+            text = block.text
+
+    # Parse out the <new_description> tags
+    match = re.search(r"<new_description>(.*?)</new_description>", text, re.DOTALL)
+    description = match.group(1).strip().strip('"') if match else text.strip().strip('"')
+
+    # Log the transcript
+    transcript: dict = {
+        "iteration": iteration,
+        "prompt": prompt,
+        "thinking": thinking_text,
+        "response": text,
+        "parsed_description": description,
+        "char_count": len(description),
+        "over_limit": len(description) > 1024,
+    }
+
+    # If over 1024 chars, ask the model to shorten it
+    if len(description) > 1024:
+        shorten_prompt = f"Your description is {len(description)} characters, which exceeds the hard 1024 character limit. Please rewrite it to be under 1024 characters while preserving the most important trigger words and intent coverage. Respond with only the new description in <new_description> tags."
+        shorten_response = client.messages.create(
+            model=model,
+            max_tokens=16000,
+            thinking={
+                "type": "enabled",
+                "budget_tokens": 10000,
+            },
+            messages=[
+                {"role": "user", "content": prompt},
+                {"role": "assistant", "content": text},
+                {"role": "user", "content": shorten_prompt},
+            ],
+        )
+
+        shorten_thinking = ""
+        shorten_text = ""
+        for block in shorten_response.content:
+            if block.type == "thinking":
+                shorten_thinking = block.thinking
+            elif block.type == "text":
+                shorten_text = block.text
+
+        match = re.search(r"<new_description>(.*?)</new_description>", shorten_text, re.DOTALL)
+        shortened = match.group(1).strip().strip('"') if match else shorten_text.strip().strip('"')
+
+        transcript["rewrite_prompt"] = shorten_prompt
+        transcript["rewrite_thinking"] = shorten_thinking
+        transcript["rewrite_response"] = shorten_text
+        transcript["rewrite_description"] = shortened
+        transcript["rewrite_char_count"] = len(shortened)
+        description = shortened
+
+    transcript["final_description"] = description
+
+    if log_dir:
+        log_dir.mkdir(parents=True, exist_ok=True)
+        log_file = log_dir / f"improve_iter_{iteration or 'unknown'}.json"
+        log_file.write_text(json.dumps(transcript, indent=2))
+
+    return description
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Improve a skill description based on eval results")
+    parser.add_argument("--eval-results", required=True, help="Path to eval results JSON (from run_eval.py)")
+    parser.add_argument("--skill-path", required=True, help="Path to skill directory")
+    parser.add_argument("--history", default=None, help="Path to history JSON (previous attempts)")
+    parser.add_argument("--model", required=True, help="Model for improvement")
+    parser.add_argument("--verbose", action="store_true", help="Print thinking to stderr")
+    args = parser.parse_args()
+
+    skill_path = Path(args.skill_path)
+    if not (skill_path / "SKILL.md").exists():
+        print(f"Error: No SKILL.md found at {skill_path}", file=sys.stderr)
+        sys.exit(1)
+
+    eval_results = json.loads(Path(args.eval_results).read_text())
+    history = []
+    if args.history:
+        history = json.loads(Path(args.history).read_text())
+
+    name, _, content = parse_skill_md(skill_path)
+    current_description = eval_results["description"]
+
+    if args.verbose:
+        print(f"Current: {current_description}", file=sys.stderr)
+        print(f"Score: {eval_results['summary']['passed']}/{eval_results['summary']['total']}", file=sys.stderr)
+
+    client = anthropic.Anthropic()
+    new_description = improve_description(
+        client=client,
+        skill_name=name,
+        skill_content=content,
+        current_description=current_description,
+        eval_results=eval_results,
+        history=history,
+        model=args.model,
+    )
+
+    if args.verbose:
+        print(f"Improved: {new_description}", file=sys.stderr)
+
+    # Output as JSON with both the new description and updated history
+    output = {
+        "description": new_description,
+        "history": history + [{
+            "description": current_description,
+            "passed": eval_results["summary"]["passed"],
+            "failed": eval_results["summary"]["failed"],
+            "total": eval_results["summary"]["total"],
+            "results": eval_results["results"],
+        }],
+    }
+    print(json.dumps(output, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/.claude/skills/skill-creator/scripts/package_skill.py
+++ b/.claude/skills/skill-creator/scripts/package_skill.py
@@ -1,0 +1,136 @@
+#!/usr/bin/env python3
+"""
+Skill Packager - Creates a distributable .skill file of a skill folder
+
+Usage:
+    python utils/package_skill.py <path/to/skill-folder> [output-directory]
+
+Example:
+    python utils/package_skill.py skills/public/my-skill
+    python utils/package_skill.py skills/public/my-skill ./dist
+"""
+
+import fnmatch
+import sys
+import zipfile
+from pathlib import Path
+from scripts.quick_validate import validate_skill
+
+# Patterns to exclude when packaging skills.
+EXCLUDE_DIRS = {"__pycache__", "node_modules"}
+EXCLUDE_GLOBS = {"*.pyc"}
+EXCLUDE_FILES = {".DS_Store"}
+# Directories excluded only at the skill root (not when nested deeper).
+ROOT_EXCLUDE_DIRS = {"evals"}
+
+
+def should_exclude(rel_path: Path) -> bool:
+    """Check if a path should be excluded from packaging."""
+    parts = rel_path.parts
+    if any(part in EXCLUDE_DIRS for part in parts):
+        return True
+    # rel_path is relative to skill_path.parent, so parts[0] is the skill
+    # folder name and parts[1] (if present) is the first subdir.
+    if len(parts) > 1 and parts[1] in ROOT_EXCLUDE_DIRS:
+        return True
+    name = rel_path.name
+    if name in EXCLUDE_FILES:
+        return True
+    return any(fnmatch.fnmatch(name, pat) for pat in EXCLUDE_GLOBS)
+
+
+def package_skill(skill_path, output_dir=None):
+    """
+    Package a skill folder into a .skill file.
+
+    Args:
+        skill_path: Path to the skill folder
+        output_dir: Optional output directory for the .skill file (defaults to current directory)
+
+    Returns:
+        Path to the created .skill file, or None if error
+    """
+    skill_path = Path(skill_path).resolve()
+
+    # Validate skill folder exists
+    if not skill_path.exists():
+        print(f"❌ Error: Skill folder not found: {skill_path}")
+        return None
+
+    if not skill_path.is_dir():
+        print(f"❌ Error: Path is not a directory: {skill_path}")
+        return None
+
+    # Validate SKILL.md exists
+    skill_md = skill_path / "SKILL.md"
+    if not skill_md.exists():
+        print(f"❌ Error: SKILL.md not found in {skill_path}")
+        return None
+
+    # Run validation before packaging
+    print("🔍 Validating skill...")
+    valid, message = validate_skill(skill_path)
+    if not valid:
+        print(f"❌ Validation failed: {message}")
+        print("   Please fix the validation errors before packaging.")
+        return None
+    print(f"✅ {message}\n")
+
+    # Determine output location
+    skill_name = skill_path.name
+    if output_dir:
+        output_path = Path(output_dir).resolve()
+        output_path.mkdir(parents=True, exist_ok=True)
+    else:
+        output_path = Path.cwd()
+
+    skill_filename = output_path / f"{skill_name}.skill"
+
+    # Create the .skill file (zip format)
+    try:
+        with zipfile.ZipFile(skill_filename, 'w', zipfile.ZIP_DEFLATED) as zipf:
+            # Walk through the skill directory, excluding build artifacts
+            for file_path in skill_path.rglob('*'):
+                if not file_path.is_file():
+                    continue
+                arcname = file_path.relative_to(skill_path.parent)
+                if should_exclude(arcname):
+                    print(f"  Skipped: {arcname}")
+                    continue
+                zipf.write(file_path, arcname)
+                print(f"  Added: {arcname}")
+
+        print(f"\n✅ Successfully packaged skill to: {skill_filename}")
+        return skill_filename
+
+    except Exception as e:
+        print(f"❌ Error creating .skill file: {e}")
+        return None
+
+
+def main():
+    if len(sys.argv) < 2:
+        print("Usage: python utils/package_skill.py <path/to/skill-folder> [output-directory]")
+        print("\nExample:")
+        print("  python utils/package_skill.py skills/public/my-skill")
+        print("  python utils/package_skill.py skills/public/my-skill ./dist")
+        sys.exit(1)
+
+    skill_path = sys.argv[1]
+    output_dir = sys.argv[2] if len(sys.argv) > 2 else None
+
+    print(f"📦 Packaging skill: {skill_path}")
+    if output_dir:
+        print(f"   Output directory: {output_dir}")
+    print()
+
+    result = package_skill(skill_path, output_dir)
+
+    if result:
+        sys.exit(0)
+    else:
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/.claude/skills/skill-creator/scripts/quick_validate.py
+++ b/.claude/skills/skill-creator/scripts/quick_validate.py
@@ -1,0 +1,103 @@
+#!/usr/bin/env python3
+"""
+Quick validation script for skills - minimal version
+"""
+
+import sys
+import os
+import re
+import yaml
+from pathlib import Path
+
+def validate_skill(skill_path):
+    """Basic validation of a skill"""
+    skill_path = Path(skill_path)
+
+    # Check SKILL.md exists
+    skill_md = skill_path / 'SKILL.md'
+    if not skill_md.exists():
+        return False, "SKILL.md not found"
+
+    # Read and validate frontmatter
+    content = skill_md.read_text()
+    if not content.startswith('---'):
+        return False, "No YAML frontmatter found"
+
+    # Extract frontmatter
+    match = re.match(r'^---\n(.*?)\n---', content, re.DOTALL)
+    if not match:
+        return False, "Invalid frontmatter format"
+
+    frontmatter_text = match.group(1)
+
+    # Parse YAML frontmatter
+    try:
+        frontmatter = yaml.safe_load(frontmatter_text)
+        if not isinstance(frontmatter, dict):
+            return False, "Frontmatter must be a YAML dictionary"
+    except yaml.YAMLError as e:
+        return False, f"Invalid YAML in frontmatter: {e}"
+
+    # Define allowed properties
+    ALLOWED_PROPERTIES = {'name', 'description', 'license', 'allowed-tools', 'metadata', 'compatibility'}
+
+    # Check for unexpected properties (excluding nested keys under metadata)
+    unexpected_keys = set(frontmatter.keys()) - ALLOWED_PROPERTIES
+    if unexpected_keys:
+        return False, (
+            f"Unexpected key(s) in SKILL.md frontmatter: {', '.join(sorted(unexpected_keys))}. "
+            f"Allowed properties are: {', '.join(sorted(ALLOWED_PROPERTIES))}"
+        )
+
+    # Check required fields
+    if 'name' not in frontmatter:
+        return False, "Missing 'name' in frontmatter"
+    if 'description' not in frontmatter:
+        return False, "Missing 'description' in frontmatter"
+
+    # Extract name for validation
+    name = frontmatter.get('name', '')
+    if not isinstance(name, str):
+        return False, f"Name must be a string, got {type(name).__name__}"
+    name = name.strip()
+    if name:
+        # Check naming convention (kebab-case: lowercase with hyphens)
+        if not re.match(r'^[a-z0-9-]+$', name):
+            return False, f"Name '{name}' should be kebab-case (lowercase letters, digits, and hyphens only)"
+        if name.startswith('-') or name.endswith('-') or '--' in name:
+            return False, f"Name '{name}' cannot start/end with hyphen or contain consecutive hyphens"
+        # Check name length (max 64 characters per spec)
+        if len(name) > 64:
+            return False, f"Name is too long ({len(name)} characters). Maximum is 64 characters."
+
+    # Extract and validate description
+    description = frontmatter.get('description', '')
+    if not isinstance(description, str):
+        return False, f"Description must be a string, got {type(description).__name__}"
+    description = description.strip()
+    if description:
+        # Check for angle brackets
+        if '<' in description or '>' in description:
+            return False, "Description cannot contain angle brackets (< or >)"
+        # Check description length (max 1024 characters per spec)
+        if len(description) > 1024:
+            return False, f"Description is too long ({len(description)} characters). Maximum is 1024 characters."
+
+    # Validate compatibility field if present (optional)
+    compatibility = frontmatter.get('compatibility', '')
+    if compatibility:
+        if not isinstance(compatibility, str):
+            return False, f"Compatibility must be a string, got {type(compatibility).__name__}"
+        if len(compatibility) > 500:
+            return False, f"Compatibility is too long ({len(compatibility)} characters). Maximum is 500 characters."
+
+    return True, "Skill is valid!"
+
+if __name__ == "__main__":
+    if len(sys.argv) != 2:
+        print("Usage: python quick_validate.py <skill_directory>")
+        sys.exit(1)
+    
+    valid, message = validate_skill(sys.argv[1])
+    print(message)
+    sys.exit(0 if valid else 1)

--- a/.claude/skills/skill-creator/scripts/run_eval.py
+++ b/.claude/skills/skill-creator/scripts/run_eval.py
@@ -1,0 +1,310 @@
+#!/usr/bin/env python3
+"""Run trigger evaluation for a skill description.
+
+Tests whether a skill's description causes Claude to trigger (read the skill)
+for a set of queries. Outputs results as JSON.
+"""
+
+import argparse
+import json
+import os
+import select
+import subprocess
+import sys
+import time
+import uuid
+from concurrent.futures import ProcessPoolExecutor, as_completed
+from pathlib import Path
+
+from scripts.utils import parse_skill_md
+
+
+def find_project_root() -> Path:
+    """Find the project root by walking up from cwd looking for .claude/.
+
+    Mimics how Claude Code discovers its project root, so the command file
+    we create ends up where claude -p will look for it.
+    """
+    current = Path.cwd()
+    for parent in [current, *current.parents]:
+        if (parent / ".claude").is_dir():
+            return parent
+    return current
+
+
+def run_single_query(
+    query: str,
+    skill_name: str,
+    skill_description: str,
+    timeout: int,
+    project_root: str,
+    model: str | None = None,
+) -> bool:
+    """Run a single query and return whether the skill was triggered.
+
+    Creates a command file in .claude/commands/ so it appears in Claude's
+    available_skills list, then runs `claude -p` with the raw query.
+    Uses --include-partial-messages to detect triggering early from
+    stream events (content_block_start) rather than waiting for the
+    full assistant message, which only arrives after tool execution.
+    """
+    unique_id = uuid.uuid4().hex[:8]
+    clean_name = f"{skill_name}-skill-{unique_id}"
+    project_commands_dir = Path(project_root) / ".claude" / "commands"
+    command_file = project_commands_dir / f"{clean_name}.md"
+
+    try:
+        project_commands_dir.mkdir(parents=True, exist_ok=True)
+        # Use YAML block scalar to avoid breaking on quotes in description
+        indented_desc = "\n  ".join(skill_description.split("\n"))
+        command_content = (
+            f"---\n"
+            f"description: |\n"
+            f"  {indented_desc}\n"
+            f"---\n\n"
+            f"# {skill_name}\n\n"
+            f"This skill handles: {skill_description}\n"
+        )
+        command_file.write_text(command_content)
+
+        cmd = [
+            "claude",
+            "-p", query,
+            "--output-format", "stream-json",
+            "--verbose",
+            "--include-partial-messages",
+        ]
+        if model:
+            cmd.extend(["--model", model])
+
+        # Remove CLAUDECODE env var to allow nesting claude -p inside a
+        # Claude Code session. The guard is for interactive terminal conflicts;
+        # programmatic subprocess usage is safe.
+        env = {k: v for k, v in os.environ.items() if k != "CLAUDECODE"}
+
+        process = subprocess.Popen(
+            cmd,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.DEVNULL,
+            cwd=project_root,
+            env=env,
+        )
+
+        triggered = False
+        start_time = time.time()
+        buffer = ""
+        # Track state for stream event detection
+        pending_tool_name = None
+        accumulated_json = ""
+
+        try:
+            while time.time() - start_time < timeout:
+                if process.poll() is not None:
+                    remaining = process.stdout.read()
+                    if remaining:
+                        buffer += remaining.decode("utf-8", errors="replace")
+                    break
+
+                ready, _, _ = select.select([process.stdout], [], [], 1.0)
+                if not ready:
+                    continue
+
+                chunk = os.read(process.stdout.fileno(), 8192)
+                if not chunk:
+                    break
+                buffer += chunk.decode("utf-8", errors="replace")
+
+                while "\n" in buffer:
+                    line, buffer = buffer.split("\n", 1)
+                    line = line.strip()
+                    if not line:
+                        continue
+
+                    try:
+                        event = json.loads(line)
+                    except json.JSONDecodeError:
+                        continue
+
+                    # Early detection via stream events
+                    if event.get("type") == "stream_event":
+                        se = event.get("event", {})
+                        se_type = se.get("type", "")
+
+                        if se_type == "content_block_start":
+                            cb = se.get("content_block", {})
+                            if cb.get("type") == "tool_use":
+                                tool_name = cb.get("name", "")
+                                if tool_name in ("Skill", "Read"):
+                                    pending_tool_name = tool_name
+                                    accumulated_json = ""
+                                else:
+                                    return False
+
+                        elif se_type == "content_block_delta" and pending_tool_name:
+                            delta = se.get("delta", {})
+                            if delta.get("type") == "input_json_delta":
+                                accumulated_json += delta.get("partial_json", "")
+                                if clean_name in accumulated_json:
+                                    return True
+
+                        elif se_type in ("content_block_stop", "message_stop"):
+                            if pending_tool_name:
+                                return clean_name in accumulated_json
+                            if se_type == "message_stop":
+                                return False
+
+                    # Fallback: full assistant message
+                    elif event.get("type") == "assistant":
+                        message = event.get("message", {})
+                        for content_item in message.get("content", []):
+                            if content_item.get("type") != "tool_use":
+                                continue
+                            tool_name = content_item.get("name", "")
+                            tool_input = content_item.get("input", {})
+                            if tool_name == "Skill" and clean_name in tool_input.get("skill", ""):
+                                triggered = True
+                            elif tool_name == "Read" and clean_name in tool_input.get("file_path", ""):
+                                triggered = True
+                            return triggered
+
+                    elif event.get("type") == "result":
+                        return triggered
+        finally:
+            # Clean up process on any exit path (return, exception, timeout)
+            if process.poll() is None:
+                process.kill()
+                process.wait()
+
+        return triggered
+    finally:
+        if command_file.exists():
+            command_file.unlink()
+
+
+def run_eval(
+    eval_set: list[dict],
+    skill_name: str,
+    description: str,
+    num_workers: int,
+    timeout: int,
+    project_root: Path,
+    runs_per_query: int = 1,
+    trigger_threshold: float = 0.5,
+    model: str | None = None,
+) -> dict:
+    """Run the full eval set and return results."""
+    results = []
+
+    with ProcessPoolExecutor(max_workers=num_workers) as executor:
+        future_to_info = {}
+        for item in eval_set:
+            for run_idx in range(runs_per_query):
+                future = executor.submit(
+                    run_single_query,
+                    item["query"],
+                    skill_name,
+                    description,
+                    timeout,
+                    str(project_root),
+                    model,
+                )
+                future_to_info[future] = (item, run_idx)
+
+        query_triggers: dict[str, list[bool]] = {}
+        query_items: dict[str, dict] = {}
+        for future in as_completed(future_to_info):
+            item, _ = future_to_info[future]
+            query = item["query"]
+            query_items[query] = item
+            if query not in query_triggers:
+                query_triggers[query] = []
+            try:
+                query_triggers[query].append(future.result())
+            except Exception as e:
+                print(f"Warning: query failed: {e}", file=sys.stderr)
+                query_triggers[query].append(False)
+
+    for query, triggers in query_triggers.items():
+        item = query_items[query]
+        trigger_rate = sum(triggers) / len(triggers)
+        should_trigger = item["should_trigger"]
+        if should_trigger:
+            did_pass = trigger_rate >= trigger_threshold
+        else:
+            did_pass = trigger_rate < trigger_threshold
+        results.append({
+            "query": query,
+            "should_trigger": should_trigger,
+            "trigger_rate": trigger_rate,
+            "triggers": sum(triggers),
+            "runs": len(triggers),
+            "pass": did_pass,
+        })
+
+    passed = sum(1 for r in results if r["pass"])
+    total = len(results)
+
+    return {
+        "skill_name": skill_name,
+        "description": description,
+        "results": results,
+        "summary": {
+            "total": total,
+            "passed": passed,
+            "failed": total - passed,
+        },
+    }
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Run trigger evaluation for a skill description")
+    parser.add_argument("--eval-set", required=True, help="Path to eval set JSON file")
+    parser.add_argument("--skill-path", required=True, help="Path to skill directory")
+    parser.add_argument("--description", default=None, help="Override description to test")
+    parser.add_argument("--num-workers", type=int, default=10, help="Number of parallel workers")
+    parser.add_argument("--timeout", type=int, default=30, help="Timeout per query in seconds")
+    parser.add_argument("--runs-per-query", type=int, default=3, help="Number of runs per query")
+    parser.add_argument("--trigger-threshold", type=float, default=0.5, help="Trigger rate threshold")
+    parser.add_argument("--model", default=None, help="Model to use for claude -p (default: user's configured model)")
+    parser.add_argument("--verbose", action="store_true", help="Print progress to stderr")
+    args = parser.parse_args()
+
+    eval_set = json.loads(Path(args.eval_set).read_text())
+    skill_path = Path(args.skill_path)
+
+    if not (skill_path / "SKILL.md").exists():
+        print(f"Error: No SKILL.md found at {skill_path}", file=sys.stderr)
+        sys.exit(1)
+
+    name, original_description, content = parse_skill_md(skill_path)
+    description = args.description or original_description
+    project_root = find_project_root()
+
+    if args.verbose:
+        print(f"Evaluating: {description}", file=sys.stderr)
+
+    output = run_eval(
+        eval_set=eval_set,
+        skill_name=name,
+        description=description,
+        num_workers=args.num_workers,
+        timeout=args.timeout,
+        project_root=project_root,
+        runs_per_query=args.runs_per_query,
+        trigger_threshold=args.trigger_threshold,
+        model=args.model,
+    )
+
+    if args.verbose:
+        summary = output["summary"]
+        print(f"Results: {summary['passed']}/{summary['total']} passed", file=sys.stderr)
+        for r in output["results"]:
+            status = "PASS" if r["pass"] else "FAIL"
+            rate_str = f"{r['triggers']}/{r['runs']}"
+            print(f"  [{status}] rate={rate_str} expected={r['should_trigger']}: {r['query'][:70]}", file=sys.stderr)
+
+    print(json.dumps(output, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/.claude/skills/skill-creator/scripts/run_loop.py
+++ b/.claude/skills/skill-creator/scripts/run_loop.py
@@ -1,0 +1,332 @@
+#!/usr/bin/env python3
+"""Run the eval + improve loop until all pass or max iterations reached.
+
+Combines run_eval.py and improve_description.py in a loop, tracking history
+and returning the best description found. Supports train/test split to prevent
+overfitting.
+"""
+
+import argparse
+import json
+import random
+import sys
+import tempfile
+import time
+import webbrowser
+from pathlib import Path
+
+import anthropic
+
+from scripts.generate_report import generate_html
+from scripts.improve_description import improve_description
+from scripts.run_eval import find_project_root, run_eval
+from scripts.utils import parse_skill_md
+
+
+def split_eval_set(eval_set: list[dict], holdout: float, seed: int = 42) -> tuple[list[dict], list[dict]]:
+    """Split eval set into train and test sets, stratified by should_trigger."""
+    random.seed(seed)
+
+    # Separate by should_trigger
+    trigger = [e for e in eval_set if e["should_trigger"]]
+    no_trigger = [e for e in eval_set if not e["should_trigger"]]
+
+    # Shuffle each group
+    random.shuffle(trigger)
+    random.shuffle(no_trigger)
+
+    # Calculate split points
+    n_trigger_test = max(1, int(len(trigger) * holdout))
+    n_no_trigger_test = max(1, int(len(no_trigger) * holdout))
+
+    # Split
+    test_set = trigger[:n_trigger_test] + no_trigger[:n_no_trigger_test]
+    train_set = trigger[n_trigger_test:] + no_trigger[n_no_trigger_test:]
+
+    return train_set, test_set
+
+
+def run_loop(
+    eval_set: list[dict],
+    skill_path: Path,
+    description_override: str | None,
+    num_workers: int,
+    timeout: int,
+    max_iterations: int,
+    runs_per_query: int,
+    trigger_threshold: float,
+    holdout: float,
+    model: str,
+    verbose: bool,
+    live_report_path: Path | None = None,
+    log_dir: Path | None = None,
+) -> dict:
+    """Run the eval + improvement loop."""
+    project_root = find_project_root()
+    name, original_description, content = parse_skill_md(skill_path)
+    current_description = description_override or original_description
+
+    # Split into train/test if holdout > 0
+    if holdout > 0:
+        train_set, test_set = split_eval_set(eval_set, holdout)
+        if verbose:
+            print(f"Split: {len(train_set)} train, {len(test_set)} test (holdout={holdout})", file=sys.stderr)
+    else:
+        train_set = eval_set
+        test_set = []
+
+    client = anthropic.Anthropic()
+    history = []
+    exit_reason = "unknown"
+
+    for iteration in range(1, max_iterations + 1):
+        if verbose:
+            print(f"\n{'='*60}", file=sys.stderr)
+            print(f"Iteration {iteration}/{max_iterations}", file=sys.stderr)
+            print(f"Description: {current_description}", file=sys.stderr)
+            print(f"{'='*60}", file=sys.stderr)
+
+        # Evaluate train + test together in one batch for parallelism
+        all_queries = train_set + test_set
+        t0 = time.time()
+        all_results = run_eval(
+            eval_set=all_queries,
+            skill_name=name,
+            description=current_description,
+            num_workers=num_workers,
+            timeout=timeout,
+            project_root=project_root,
+            runs_per_query=runs_per_query,
+            trigger_threshold=trigger_threshold,
+            model=model,
+        )
+        eval_elapsed = time.time() - t0
+
+        # Split results back into train/test by matching queries
+        train_queries_set = {q["query"] for q in train_set}
+        train_result_list = [r for r in all_results["results"] if r["query"] in train_queries_set]
+        test_result_list = [r for r in all_results["results"] if r["query"] not in train_queries_set]
+
+        train_passed = sum(1 for r in train_result_list if r["pass"])
+        train_total = len(train_result_list)
+        train_summary = {"passed": train_passed, "failed": train_total - train_passed, "total": train_total}
+        train_results = {"results": train_result_list, "summary": train_summary}
+
+        if test_set:
+            test_passed = sum(1 for r in test_result_list if r["pass"])
+            test_total = len(test_result_list)
+            test_summary = {"passed": test_passed, "failed": test_total - test_passed, "total": test_total}
+            test_results = {"results": test_result_list, "summary": test_summary}
+        else:
+            test_results = None
+            test_summary = None
+
+        history.append({
+            "iteration": iteration,
+            "description": current_description,
+            "train_passed": train_summary["passed"],
+            "train_failed": train_summary["failed"],
+            "train_total": train_summary["total"],
+            "train_results": train_results["results"],
+            "test_passed": test_summary["passed"] if test_summary else None,
+            "test_failed": test_summary["failed"] if test_summary else None,
+            "test_total": test_summary["total"] if test_summary else None,
+            "test_results": test_results["results"] if test_results else None,
+            # For backward compat with report generator
+            "passed": train_summary["passed"],
+            "failed": train_summary["failed"],
+            "total": train_summary["total"],
+            "results": train_results["results"],
+        })
+
+        # Write live report if path provided
+        if live_report_path:
+            partial_output = {
+                "original_description": original_description,
+                "best_description": current_description,
+                "best_score": "in progress",
+                "iterations_run": len(history),
+                "holdout": holdout,
+                "train_size": len(train_set),
+                "test_size": len(test_set),
+                "history": history,
+            }
+            live_report_path.write_text(generate_html(partial_output, auto_refresh=True, skill_name=name))
+
+        if verbose:
+            def print_eval_stats(label, results, elapsed):
+                pos = [r for r in results if r["should_trigger"]]
+                neg = [r for r in results if not r["should_trigger"]]
+                tp = sum(r["triggers"] for r in pos)
+                pos_runs = sum(r["runs"] for r in pos)
+                fn = pos_runs - tp
+                fp = sum(r["triggers"] for r in neg)
+                neg_runs = sum(r["runs"] for r in neg)
+                tn = neg_runs - fp
+                total = tp + tn + fp + fn
+                precision = tp / (tp + fp) if (tp + fp) > 0 else 1.0
+                recall = tp / (tp + fn) if (tp + fn) > 0 else 1.0
+                accuracy = (tp + tn) / total if total > 0 else 0.0
+                print(f"{label}: {tp+tn}/{total} correct, precision={precision:.0%} recall={recall:.0%} accuracy={accuracy:.0%} ({elapsed:.1f}s)", file=sys.stderr)
+                for r in results:
+                    status = "PASS" if r["pass"] else "FAIL"
+                    rate_str = f"{r['triggers']}/{r['runs']}"
+                    print(f"  [{status}] rate={rate_str} expected={r['should_trigger']}: {r['query'][:60]}", file=sys.stderr)
+
+            print_eval_stats("Train", train_results["results"], eval_elapsed)
+            if test_summary:
+                print_eval_stats("Test ", test_results["results"], 0)
+
+        if train_summary["failed"] == 0:
+            exit_reason = f"all_passed (iteration {iteration})"
+            if verbose:
+                print(f"\nAll train queries passed on iteration {iteration}!", file=sys.stderr)
+            break
+
+        if iteration == max_iterations:
+            exit_reason = f"max_iterations ({max_iterations})"
+            if verbose:
+                print(f"\nMax iterations reached ({max_iterations}).", file=sys.stderr)
+            break
+
+        # Improve the description based on train results
+        if verbose:
+            print(f"\nImproving description...", file=sys.stderr)
+
+        t0 = time.time()
+        # Strip test scores from history so improvement model can't see them
+        blinded_history = [
+            {k: v for k, v in h.items() if not k.startswith("test_")}
+            for h in history
+        ]
+        new_description = improve_description(
+            client=client,
+            skill_name=name,
+            skill_content=content,
+            current_description=current_description,
+            eval_results=train_results,
+            history=blinded_history,
+            model=model,
+            log_dir=log_dir,
+            iteration=iteration,
+        )
+        improve_elapsed = time.time() - t0
+
+        if verbose:
+            print(f"Proposed ({improve_elapsed:.1f}s): {new_description}", file=sys.stderr)
+
+        current_description = new_description
+
+    # Find the best iteration by TEST score (or train if no test set)
+    if test_set:
+        best = max(history, key=lambda h: h["test_passed"] or 0)
+        best_score = f"{best['test_passed']}/{best['test_total']}"
+    else:
+        best = max(history, key=lambda h: h["train_passed"])
+        best_score = f"{best['train_passed']}/{best['train_total']}"
+
+    if verbose:
+        print(f"\nExit reason: {exit_reason}", file=sys.stderr)
+        print(f"Best score: {best_score} (iteration {best['iteration']})", file=sys.stderr)
+
+    return {
+        "exit_reason": exit_reason,
+        "original_description": original_description,
+        "best_description": best["description"],
+        "best_score": best_score,
+        "best_train_score": f"{best['train_passed']}/{best['train_total']}",
+        "best_test_score": f"{best['test_passed']}/{best['test_total']}" if test_set else None,
+        "final_description": current_description,
+        "iterations_run": len(history),
+        "holdout": holdout,
+        "train_size": len(train_set),
+        "test_size": len(test_set),
+        "history": history,
+    }
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Run eval + improve loop")
+    parser.add_argument("--eval-set", required=True, help="Path to eval set JSON file")
+    parser.add_argument("--skill-path", required=True, help="Path to skill directory")
+    parser.add_argument("--description", default=None, help="Override starting description")
+    parser.add_argument("--num-workers", type=int, default=10, help="Number of parallel workers")
+    parser.add_argument("--timeout", type=int, default=30, help="Timeout per query in seconds")
+    parser.add_argument("--max-iterations", type=int, default=5, help="Max improvement iterations")
+    parser.add_argument("--runs-per-query", type=int, default=3, help="Number of runs per query")
+    parser.add_argument("--trigger-threshold", type=float, default=0.5, help="Trigger rate threshold")
+    parser.add_argument("--holdout", type=float, default=0.4, help="Fraction of eval set to hold out for testing (0 to disable)")
+    parser.add_argument("--model", required=True, help="Model for improvement")
+    parser.add_argument("--verbose", action="store_true", help="Print progress to stderr")
+    parser.add_argument("--report", default="auto", help="Generate HTML report at this path (default: 'auto' for temp file, 'none' to disable)")
+    parser.add_argument("--results-dir", default=None, help="Save all outputs (results.json, report.html, log.txt) to a timestamped subdirectory here")
+    args = parser.parse_args()
+
+    eval_set = json.loads(Path(args.eval_set).read_text())
+    skill_path = Path(args.skill_path)
+
+    if not (skill_path / "SKILL.md").exists():
+        print(f"Error: No SKILL.md found at {skill_path}", file=sys.stderr)
+        sys.exit(1)
+
+    name, _, _ = parse_skill_md(skill_path)
+
+    # Set up live report path
+    if args.report != "none":
+        if args.report == "auto":
+            timestamp = time.strftime("%Y%m%d_%H%M%S")
+            live_report_path = Path(tempfile.gettempdir()) / f"skill_description_report_{skill_path.name}_{timestamp}.html"
+        else:
+            live_report_path = Path(args.report)
+        # Open the report immediately so the user can watch
+        live_report_path.write_text("<html><body><h1>Starting optimization loop...</h1><meta http-equiv='refresh' content='5'></body></html>")
+        webbrowser.open(str(live_report_path))
+    else:
+        live_report_path = None
+
+    # Determine output directory (create before run_loop so logs can be written)
+    if args.results_dir:
+        timestamp = time.strftime("%Y-%m-%d_%H%M%S")
+        results_dir = Path(args.results_dir) / timestamp
+        results_dir.mkdir(parents=True, exist_ok=True)
+    else:
+        results_dir = None
+
+    log_dir = results_dir / "logs" if results_dir else None
+
+    output = run_loop(
+        eval_set=eval_set,
+        skill_path=skill_path,
+        description_override=args.description,
+        num_workers=args.num_workers,
+        timeout=args.timeout,
+        max_iterations=args.max_iterations,
+        runs_per_query=args.runs_per_query,
+        trigger_threshold=args.trigger_threshold,
+        holdout=args.holdout,
+        model=args.model,
+        verbose=args.verbose,
+        live_report_path=live_report_path,
+        log_dir=log_dir,
+    )
+
+    # Save JSON output
+    json_output = json.dumps(output, indent=2)
+    print(json_output)
+    if results_dir:
+        (results_dir / "results.json").write_text(json_output)
+
+    # Write final HTML report (without auto-refresh)
+    if live_report_path:
+        live_report_path.write_text(generate_html(output, auto_refresh=False, skill_name=name))
+        print(f"\nReport: {live_report_path}", file=sys.stderr)
+
+    if results_dir and live_report_path:
+        (results_dir / "report.html").write_text(generate_html(output, auto_refresh=False, skill_name=name))
+
+    if results_dir:
+        print(f"Results saved to: {results_dir}", file=sys.stderr)
+
+
+if __name__ == "__main__":
+    main()

--- a/.claude/skills/skill-creator/scripts/utils.py
+++ b/.claude/skills/skill-creator/scripts/utils.py
@@ -1,0 +1,47 @@
+"""Shared utilities for skill-creator scripts."""
+
+from pathlib import Path
+
+
+
+def parse_skill_md(skill_path: Path) -> tuple[str, str, str]:
+    """Parse a SKILL.md file, returning (name, description, full_content)."""
+    content = (skill_path / "SKILL.md").read_text()
+    lines = content.split("\n")
+
+    if lines[0].strip() != "---":
+        raise ValueError("SKILL.md missing frontmatter (no opening ---)")
+
+    end_idx = None
+    for i, line in enumerate(lines[1:], start=1):
+        if line.strip() == "---":
+            end_idx = i
+            break
+
+    if end_idx is None:
+        raise ValueError("SKILL.md missing frontmatter (no closing ---)")
+
+    name = ""
+    description = ""
+    frontmatter_lines = lines[1:end_idx]
+    i = 0
+    while i < len(frontmatter_lines):
+        line = frontmatter_lines[i]
+        if line.startswith("name:"):
+            name = line[len("name:"):].strip().strip('"').strip("'")
+        elif line.startswith("description:"):
+            value = line[len("description:"):].strip()
+            # Handle YAML multiline indicators (>, |, >-, |-)
+            if value in (">", "|", ">-", "|-"):
+                continuation_lines: list[str] = []
+                i += 1
+                while i < len(frontmatter_lines) and (frontmatter_lines[i].startswith("  ") or frontmatter_lines[i].startswith("\t")):
+                    continuation_lines.append(frontmatter_lines[i].strip())
+                    i += 1
+                description = " ".join(continuation_lines)
+                continue
+            else:
+                description = value.strip('"').strip("'")
+        i += 1
+
+    return name, description, content

--- a/.claude/skills/task/SKILL.md
+++ b/.claude/skills/task/SKILL.md
@@ -1,0 +1,128 @@
+---
+name: task
+description: Log and tick individual work items (TSK-NNN) inside a phase of the Sick Rabbit theme roadmap. Use this skill whenever the user says "add a task", "new task", "log a task", "that's a task", "make it a task", "what tasks are open", "task list", "mark TSK-NNN done", "tick that task", "TSK-", or describes something to build or add ("we need a newsletter block", "add a filter for size"). Also trigger when the user wants to sequence concrete sub-steps inside an active phase before starting work. For fixing broken behaviour use the issue skill; for adding, reordering, or shipping whole phases use the plan skill; this skill is the item-level tool that sits between them.
+---
+
+# Task
+
+Track individual buildable work items inside a phase in `planning/roadmap.md`. Tasks are **things to build** — features, components, enhancements. They are NOT fixes for broken behaviour (that's the `issue` skill) and NOT phase-level structure (that's the `plan` skill).
+
+## Task vs. issue vs. roadmap item
+
+- **Task** — "we need a newsletter signup block on the footer" → something to build → `TSK-NNN` in `planning/roadmap.md`
+- **Issue** — "the newsletter signup submits twice on double-click" → something broken → `ISS-NNN` in `planning/issues.md`
+- **Roadmap item** (phase) — "Phase 3 — Restyle sections" → the overall chunk of work → managed by the `plan` skill
+
+If the user describes something broken, redirect to the `issue` skill. If they're adding or reorganising a whole phase, redirect to `plan`.
+
+## How this splits with `plan`
+
+- **`plan`** owns phase-level structure: the Shipped table, the In Progress section, the Next queue, audit checkpoints, phase transitions (Next → In Progress → Shipped), and reconciliation with the Kiro Shopify Build Plan.
+- **`task`** owns item-level work within a phase: adding `TSK-NNN` bullets, ticking them done, listing what's open.
+
+When a phase's tasks are all ticked and the phase should move to Shipped, that's a `plan` operation — this skill confirms and hands off.
+
+## Task ID format
+
+`TSK-NNN`, zero-padded to 3 digits. Increment from the highest existing ID in `planning/roadmap.md`. Read the file first to find it — don't guess, because some phases have their own TSK ranges and a collision is ugly.
+
+## Where tasks live
+
+Tasks are checklist bullets inside a phase section in `planning/roadmap.md`. One line each:
+
+```markdown
+### Phase 3 — Restyle sections
+- [ ] **TSK-001**: Restyle header (logo, nav, cart icon, announcement bar)
+- [ ] **TSK-002**: Restyle homepage (hero, featured collections, content modules)
+- [x] **TSK-003**: Restyle collection page
+```
+
+`[ ]` = open. `[x]` = done. Tasks can live in **In Progress** (active phase) or in **Next** sections (planned phases not yet started — optional, for sequencing work ahead of time).
+
+## Operations
+
+### Add a task
+
+When the user describes something to build:
+
+1. **Confirm it's a task, not an issue.** If the description implies broken behaviour, redirect to the `issue` skill.
+2. **Read `planning/roadmap.md`.** Find the highest existing `TSK-NNN` and identify the phase sections.
+3. **Decide which phase it belongs to.**
+   - If one phase is In Progress and the work belongs there, use it.
+   - If the work belongs to a future Next phase, put it there — good for sequencing.
+   - If no phase fits (it's a parallel sub-stream, or a pre-Phase-1 prep), ask the user.
+4. **Add the bullet** with the next `TSK-NNN` ID, under the right phase section.
+5. **Confirm in chat:** *"Added TSK-017 to Phase 3: Restyle product page / PDP gallery."*
+
+Keep the description to one line — enough to recognise at a glance. If the user's explanation is longer, distill it. Longer context belongs in the commit message or a decisions-log entry, not the roadmap.
+
+### List open tasks
+
+When the user asks what's open:
+
+1. Read `planning/roadmap.md`.
+2. Show open (`[ ]`) tasks grouped by phase, phase name as header, TSK-NNN IDs and descriptions under each.
+3. Skip completed tasks unless the user asks for them.
+
+Format:
+
+```
+Open tasks:
+
+Phase 3 — Restyle sections
+  TSK-001: Restyle header
+  TSK-002: Restyle homepage
+  TSK-004: Restyle product page / PDP
+
+Phase 4 — Content + products
+  TSK-010: Tapstitch integration
+  TSK-011: Product tagging conventions
+```
+
+### Mark a task done
+
+When the user says a task is done ("TSK-002 is done", "mark that task complete", "tick off the cart drawer restyle"):
+
+1. Read `planning/roadmap.md`.
+2. Find the task — by TSK number if given, otherwise by description (ask if ambiguous).
+3. Change `- [ ]` to `- [x]`.
+4. Confirm: *"Marked TSK-002 as done."*
+
+If marking this task finishes every task in the current In Progress phase, say so and suggest the `plan` skill to move the phase to Shipped:
+
+> That was the last task in Phase 3. Want me to hand off to the `plan` skill to move Phase 3 to Shipped?
+
+### Mark multiple tasks at once
+
+If the user says "mark TSK-001 and TSK-003 as done", handle them in one pass, then confirm both.
+
+### Reopen a task
+
+If a task was ticked but actually isn't done (regression, missed scope), change `[x]` back to `[ ]` and note why in chat so the user has context. Don't silently re-open — the checkbox is a social signal to the rest of the project.
+
+## Commit integration
+
+When a commit closes out a task, reference the TSK ID in the subject so `git log | grep TSK-` stays useful and the `pr-commit` skill's auto-detection can pick it up:
+
+```
+restyle: header to match brand type scale (TSK-001)
+feat: announcement bar with admin-editable message (TSK-009)
+```
+
+The `pr-commit` skill parses `TSK-\d+` from commit messages in the branch and ticks the matching tasks as part of its doc-update step — so disciplined TSK references mean the roadmap stays current without extra effort at PR time.
+
+## Edge cases
+
+- **"Add a task" without details** — ask: *"What's the task?"* Don't invent a placeholder.
+- **Task straddles phases** — ask the user to pick the primary phase, or split into two smaller tasks.
+- **Task that's actually a whole phase** — redirect to `plan`. If it needs 6+ sub-items and a deliverable statement, it's not a task.
+- **User describes something broken, not something to build** — redirect to the `issue` skill.
+- **Task duplicates an existing one** — flag it and ask whether to consolidate or keep both.
+- **TSK-NNN collision** (two tasks claiming the same ID) — should never happen, but if it does, renumber the later one and tell the user.
+
+## Principles
+
+- **IDs are cheap, ambiguity is expensive.** Always use TSK-NNN even for small tasks — the commit/PR traceability is worth the small friction.
+- **One-line descriptions.** If a task needs a paragraph, it's either scope that needs splitting or context that belongs in a commit message.
+- **Don't let the list bloat.** If the same user keeps adding tasks to a phase that's already underway, pause and ask whether the phase's scope has genuinely grown or whether the new items should go to Next.
+- **Tick promptly.** The list stops being useful the moment it drifts from reality. Mark done when done; don't batch up 10 ticks at the end of a session.

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,30 @@
+#!/bin/sh
+# Refuse direct commits to main. main auto-deploys to the live Shopify theme
+# via the GitHub integration — anything that lands here goes live. Feature work
+# belongs on a branch that gets reviewed and merged via PR.
+#
+# To bypass in a genuine emergency: git commit --no-verify
+# (Then ask yourself twice whether it was actually an emergency.)
+
+branch=$(git rev-parse --abbrev-ref HEAD)
+
+if [ "$branch" = "main" ]; then
+  echo ""
+  echo "  ✗ Direct commits to main are blocked on this repo."
+  echo ""
+  echo "  main auto-deploys to the live Shopify theme. All work goes"
+  echo "  through a branch + PR + Greptile review."
+  echo ""
+  echo "  Create a branch:"
+  echo "    git checkout -b <type>/<short-description>"
+  echo ""
+  echo "  Types: fix, feat, restyle, tokens, refactor, docs, chore, content"
+  echo "  (see .claude/skills/commit/SKILL.md)"
+  echo ""
+  echo "  Emergency override (not recommended):"
+  echo "    git commit --no-verify"
+  echo ""
+  exit 1
+fi
+
+exit 0

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,10 @@
 ehthumbs.db
 Thumbs.db
 .shopify
+
+# Greptile MCP (contains API key)
+.greptile/mcp-proxy.mjs
+
+# Python bytecode (from .claude/skills/* scripts)
+__pycache__/
+*.pyc

--- a/.greptile/config.json
+++ b/.greptile/config.json
@@ -1,0 +1,114 @@
+{
+  "strictness": 2,
+  "commentTypes": ["logic", "syntax", "style"],
+  "triggerOnUpdates": false,
+  "ignorePatterns": "node_modules/**\n.shopify/**\nassets/*.js.map\n*.lock\n**/*.generated.*\nlocales/*.json",
+  "rules": [
+    {
+      "id": "design-tokens-only",
+      "rule": "Never hardcode colours, font-sizes, spacing, or radii in section/snippet CSS. Use Dawn's CSS custom properties or Sick Rabbit tokens defined in assets/base.css and config/settings_data.json. If a value isn't in the token system, add it to docs/design/system.md and assets/base.css first.",
+      "scope": ["assets/**/*.css", "sections/**/*.liquid", "snippets/**/*.liquid", "layout/**/*.liquid"],
+      "severity": "high"
+    },
+    {
+      "id": "no-hex-in-liquid-inline-styles",
+      "rule": "Never write hex or rgb() colour values in inline style='' attributes inside Liquid templates. Pull from settings or use a CSS class backed by tokens.",
+      "scope": ["sections/**/*.liquid", "snippets/**/*.liquid", "layout/**/*.liquid", "templates/**/*.liquid"],
+      "severity": "high"
+    },
+    {
+      "id": "section-schema-required",
+      "rule": "Any .liquid file in sections/ must keep a {% schema %} block with valid settings, blocks, and presets so merchants can still add and edit it from the theme editor. Do not inline a section's markup without its schema.",
+      "scope": ["sections/**/*.liquid"],
+      "severity": "high"
+    },
+    {
+      "id": "use-render-not-include",
+      "rule": "Always use {% render 'snippet-name' %} to render snippets. Never use the deprecated {% include %} tag.",
+      "scope": ["sections/**/*.liquid", "snippets/**/*.liquid", "layout/**/*.liquid", "templates/**/*.liquid"],
+      "severity": "medium"
+    },
+    {
+      "id": "shopify-money-filter",
+      "rule": "Format prices with the money, money_with_currency, or money_without_trailing_zeros filters. Never format currency client-side or concatenate a currency symbol manually.",
+      "scope": ["sections/**/*.liquid", "snippets/**/*.liquid", "assets/**/*.js"],
+      "severity": "high"
+    },
+    {
+      "id": "translate-user-facing-strings",
+      "rule": "Every user-facing string in Liquid must go through the t filter with a key from locales/en.default.json. Don't hardcode English copy in templates.",
+      "scope": ["sections/**/*.liquid", "snippets/**/*.liquid", "layout/**/*.liquid"],
+      "severity": "medium"
+    },
+    {
+      "id": "no-client-side-business-logic",
+      "rule": "Don't reimplement cart, variant selection, or money formatting in client-side JS. Use Shopify's Cart AJAX API and Liquid objects. Dawn is HTML-first, JS-only-as-needed.",
+      "scope": ["assets/**/*.js"],
+      "severity": "high"
+    },
+    {
+      "id": "check-components-registry",
+      "rule": "Before creating a new snippet or section, check docs/components.md for existing shared components that cover the need. If a Liquid pattern shows up in 2+ places, extract it into snippets/ instead of copying.",
+      "scope": ["sections/**/*.liquid", "snippets/**/*.liquid"],
+      "severity": "medium"
+    },
+    {
+      "id": "update-components-registry",
+      "rule": "When adding or renaming a snippet or section, update docs/components.md in the same PR.",
+      "scope": ["sections/**", "snippets/**"],
+      "severity": "medium"
+    },
+    {
+      "id": "naming-conventions",
+      "rule": "Snippets and sections: kebab-case filenames. JSON templates: kebab-case. CSS: kebab-case (prefix with section-<name>.css). Liquid variables: snake_case. Locale keys: dot-separated snake_case.",
+      "scope": ["assets/**", "sections/**", "snippets/**", "templates/**", "locales/**"],
+      "severity": "low"
+    },
+    {
+      "id": "preserve-dawn-files",
+      "rule": "Don't rename, delete, or restructure Dawn's existing files. Prefer additive changes (new sections, new snippets, CSS overrides) so git merge upstream/main stays tractable.",
+      "scope": ["assets/**", "sections/**", "snippets/**", "templates/**", "layout/**", "config/**"],
+      "severity": "high"
+    },
+    {
+      "id": "theme-check-clean",
+      "rule": "Any change must pass `shopify theme check`. Don't suppress check rules without a justification in docs/decisions.md.",
+      "scope": [".theme-check.yml", "sections/**", "snippets/**", "assets/**", "layout/**", "templates/**"],
+      "severity": "medium"
+    }
+  ],
+  "files": [
+    {
+      "path": "CLAUDE.md",
+      "description": "Project coding standards — the authoritative source for all conventions"
+    },
+    {
+      "path": "docs/architecture.md",
+      "description": "Theme structure, OS 2.0 templating model, deploy path"
+    },
+    {
+      "path": "docs/components.md",
+      "description": "Shared snippet/section registry — check before creating any new section or snippet",
+      "scope": ["sections/**", "snippets/**"]
+    },
+    {
+      "path": "docs/design/system.md",
+      "description": "Design tokens — colours, typography, spacing, radii, shadows",
+      "scope": ["assets/**/*.css", "sections/**/*.liquid", "snippets/**/*.liquid", "config/settings_data.json"]
+    },
+    {
+      "path": "docs/design/vision.md",
+      "description": "Brand direction and design personality",
+      "scope": ["sections/**", "snippets/**", "assets/**/*.css"]
+    },
+    {
+      "path": "docs/decisions.md",
+      "description": "Architectural decisions log — check before proposing alternative approaches"
+    }
+  ],
+  "other": [
+    "This is a Shopify Online Store 2.0 theme, forked from Dawn. Liquid + JSON templates + CSS + vanilla JS only. No bundler, no TypeScript, no framework.",
+    "Deploy is via Shopify's GitHub integration: pushing to `main` syncs to the live theme. Merchant edits in Shopify admin auto-commit back to the connected branch.",
+    "Dawn is tracked as `upstream`. Prefer additive changes over restructuring so upstream merges stay tractable."
+  ]
+}

--- a/.greptile/files.json
+++ b/.greptile/files.json
@@ -1,0 +1,29 @@
+[
+  {
+    "path": "CLAUDE.md",
+    "description": "Project coding standards — the authoritative source for all conventions"
+  },
+  {
+    "path": "docs/architecture.md",
+    "description": "Theme structure, OS 2.0 templating model, deploy path"
+  },
+  {
+    "path": "docs/components.md",
+    "description": "Shared snippet/section registry — check before creating any new section or snippet",
+    "scope": ["sections/**", "snippets/**"]
+  },
+  {
+    "path": "docs/design/system.md",
+    "description": "Design tokens — colours, typography, spacing, radii, shadows",
+    "scope": ["assets/**/*.css", "sections/**/*.liquid", "snippets/**/*.liquid", "config/settings_data.json"]
+  },
+  {
+    "path": "docs/design/vision.md",
+    "description": "Brand direction and design personality",
+    "scope": ["sections/**", "snippets/**", "assets/**/*.css"]
+  },
+  {
+    "path": "docs/decisions.md",
+    "description": "Architectural decisions log — check before proposing alternative approaches"
+  }
+]

--- a/.greptile/rules.md
+++ b/.greptile/rules.md
@@ -1,0 +1,117 @@
+# Sick Rabbit — Code Review Standards
+
+Prose version of the structured rules in `config.json`, with examples. Scoped to the Shopify theme tree at the repo root.
+
+## Design tokens
+
+Every colour, font-size, spacing value, and radius in the theme must come from a token — either Dawn's existing CSS custom properties or the Sick Rabbit tokens declared in `assets/base.css` / `config/settings_data.json`.
+
+```css
+/* Correct */
+.product-card__title {
+  color: var(--color-graphite);
+  font-family: var(--font-heading);
+  padding: var(--space-3);
+}
+
+/* Wrong — hardcoded */
+.product-card__title {
+  color: #2d2d2a;
+  font-family: 'Pirata One', cursive;
+  padding: 24px;
+}
+```
+
+If the value you need isn't in the token system, add it to `docs/design/system.md` and `assets/base.css` first, then use it.
+
+Inline `style=""` attributes in Liquid must never carry hex or rgb literals. Either use a class, a setting, or pass a token through:
+
+```liquid
+<!-- Correct -->
+<div class="banner banner--slate">...</div>
+
+<!-- Correct — setting-driven -->
+<div style="background: {{ section.settings.background_color }};">...</div>
+
+<!-- Wrong -->
+<div style="background: #1c4d4f;">...</div>
+```
+
+## OS 2.0 sections
+
+Every file in `sections/` is a section the merchant can place, reorder, and edit in the theme editor. That contract is protected by the `{% schema %}` block. Don't remove it. Don't hardcode copy that belongs in `settings`. Provide `presets` so the section is discoverable in the theme editor.
+
+```liquid
+{% schema %}
+{
+  "name": "Featured Collection",
+  "settings": [
+    { "type": "collection", "id": "collection", "label": "Collection" },
+    { "type": "text", "id": "heading", "label": "Heading", "default": "Featured" }
+  ],
+  "presets": [{ "name": "Featured Collection" }]
+}
+{% endschema %}
+```
+
+## Render vs. include
+
+Use `{% render %}` for every snippet. `{% include %}` is deprecated and leaks scope.
+
+```liquid
+{% render 'product-card', product: product %}
+```
+
+## Translations
+
+Every visible English string goes through `t:` and has an entry in `locales/en.default.json`. Don't hardcode copy.
+
+```liquid
+<!-- Correct -->
+<button>{{ 'products.product.add_to_cart' | t }}</button>
+
+<!-- Wrong -->
+<button>Add to cart</button>
+```
+
+## Money
+
+Prices always go through `money`, `money_with_currency`, or `money_without_trailing_zeros`. Never concatenate a currency symbol.
+
+```liquid
+<!-- Correct -->
+<span>{{ product.price | money }}</span>
+
+<!-- Wrong -->
+<span>£{{ product.price | divided_by: 100.0 }}</span>
+```
+
+## Client-side JS
+
+Dawn is HTML-first. Don't reimplement cart, variants, or money formatting on the client. Use Shopify's Cart AJAX API for dynamic updates, and progressive enhancement for interactivity. If you're reaching for a framework, stop and ask first.
+
+## Respect Dawn
+
+Every file rename or structural change creates permanent conflicts with `upstream/main`. Prefer additive changes:
+
+- New sections go in `sections/sick-rabbit-*.liquid` or similar distinct names
+- Override styling via CSS specificity and custom properties, not by editing Dawn's core CSS in place when it's avoidable
+- When a Dawn file must be modified, keep the change minimal and self-contained
+
+## Components registry
+
+Before creating a new snippet or section, grep `docs/components.md` and `snippets/` + `sections/` for what already exists. If a pattern shows up in 2+ places, extract it to a snippet. When you add or rename a snippet or section, update `docs/components.md` in the same PR.
+
+## Naming
+
+| Thing | Convention | Example |
+|---|---|---|
+| Snippet / section file | kebab-case `.liquid` | `product-card.liquid` |
+| JSON template | kebab-case `.json` | `collection.anachronism.json` |
+| Section-scoped CSS | `section-<name>.css` | `section-featured-collection.css` |
+| Liquid variable | snake_case | `product_card_image_ratio` |
+| Locale key | dot.snake_case | `products.product.add_to_cart` |
+
+## Theme check
+
+Every change must pass `shopify theme check`. Don't disable a check rule without logging it in `docs/decisions.md`.

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,9 @@
+{
+  "mcpServers": {
+    "greptile-api": {
+      "type": "stdio",
+      "command": "node",
+      "args": ["./.greptile/mcp-proxy.mjs"]
+    }
+  }
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,87 @@
+# Sick Rabbit Theme — Claude Instructions
+
+A forked-and-restyled Shopify Dawn theme for the Sick Rabbit apparel brand. Deployed at `sickrabbit.com` via Shopify's GitHub integration (push to `main` → live theme).
+
+## File Operations (CRITICAL)
+- Always Read a file before editing it
+- Use Edit for targeted changes, Write only when rewriting whole files
+- Never use Bash/Task agents for file writes — they don't reliably persist
+- Always verify with git status/diff before committing
+- Do **not** rename or delete Dawn's existing files wholesale. Prefer additive changes (extend, override via CSS vars, add new sections/snippets) so `git merge upstream/main` stays tractable
+
+## Before Writing Any Code
+1. Check `docs/components.md` for existing snippets/sections that cover the need
+2. Check `snippets/` and `sections/` for anything already written that does the job
+3. If a block of Liquid shows up in 2+ places, extract it to a snippet — don't copy it
+4. Read `docs/design/system.md` before making any visual decision
+5. Check `docs/decisions.md` before proposing architectural alternatives
+
+## Shopify / OS 2.0 Rules
+- Templates are JSON (`templates/*.json`) — they reference sections, they don't contain layout. Don't replace a JSON template with a `.liquid` template without an explicit decision log entry
+- Every section intended for admin reuse must keep its `{% schema %}` block with valid `presets`, `settings`, and `blocks` so merchants can still edit it in the theme editor
+- Never inline business logic that Shopify already provides (money formatting, translations, cart, variants) — use filters (`money`, `t:`) and Liquid objects, not JS shims
+- Client-side JS is a last resort. Dawn's principle is HTML-first, JS-only-as-needed — follow it
+- Any new setting that needs merchant control goes in the section's schema or `config/settings_schema.json`, never hardcoded
+- Two-way sync with Shopify admin: merchant edits auto-commit to the connected branch. Assume `config/settings_data.json` and `templates/*.json` may be changed outside of code and rebase-friendly
+
+## Component Rules (Liquid edition)
+- Reusable markup → `snippets/` (render with `{% render 'name' %}`)
+- Reusable content blocks → `sections/` (with schema, so merchants can edit)
+- Page templates → `templates/*.json` (compose sections)
+- Screens/templates contain composition only — no primitive markup that belongs in a snippet
+- Update `docs/components.md` when adding a new snippet or section
+
+## Design Token Standard (NO EXCEPTIONS)
+- Never hardcode colours, font sizes, spacing, or radii in section/snippet CSS
+- Always use Dawn's CSS custom properties or Sick Rabbit tokens (defined in `assets/base.css` / `config/settings_data.json`)
+- Colours go through Dawn's colour scheme system — don't bypass it to hardcode a brand hex
+- If a value isn't in the design system, add it to `docs/design/system.md` and `assets/base.css` first, then use it
+
+## Naming Conventions
+- Snippets: kebab-case (`product-card.liquid`, `icon-cart.liquid`)
+- Sections: kebab-case (`featured-collection.liquid`, `announcement-bar.liquid`)
+- JSON templates: kebab-case (`product.json`, `collection.anachronism.json`)
+- CSS files: kebab-case (`section-featured-collection.css`)
+- Liquid variables: snake_case (`product_card_image_ratio`)
+- Locale keys: dot-separated snake_case (`products.product.add_to_cart`)
+
+## Commits & branches (CRITICAL — main is live)
+
+`main` is connected to the live Shopify theme. Every merge to `main` deploys within seconds. There is no staging. Discipline:
+
+- **Never commit directly to `main`.** Always on a branch. Always via PR. The pre-commit hook (`.githooks/pre-commit`, enabled via `git config core.hooksPath .githooks`) enforces this locally.
+- **Never push directly to `origin/main`.** PRs only. GitHub branch protection enforces this remotely (see `docs/setup/branching.md`).
+- **Small fixes still get branches.** A typo fix on a branch takes 30 seconds; a typo on `main` is live to customers in 15. The asymmetry is the whole rule.
+- **Exception**: the Shopify GitHub bot commits merchant admin edits directly to `main`. That's expected — don't revert those casually.
+- **Branch types**: `fix/`, `feat/`, `restyle/`, `tokens/`, `refactor/`, `docs/`, `chore/`, `content/`. See the `commit` skill and `docs/setup/branching.md`.
+- **Keep commits focused.** One logical change per commit — so Shopify admin auto-commits don't collide with code changes and `git revert` stays useful.
+- **Use the skills.** `commit` for local commits; `pr-commit` to open a PR (auto-schedules review checks); `pr-comments` for the Greptile review loop. They enforce the above rules and the project conventions.
+
+## Upstream Dawn merges
+- `upstream` remote → `https://github.com/Shopify/dawn.git`
+- Periodically `git fetch upstream && git merge upstream/main`; expect conflicts in anything we've restyled
+- After merging, run `shopify theme check` and smoke-test at `127.0.0.1:9292`
+
+## Project Info
+- Stack: Shopify Dawn theme (Liquid + OS 2.0 JSON templates + CSS + vanilla JS)
+- Local dev: `shopify theme dev --store=sick-rabbit-store.myshopify.com` → `127.0.0.1:9292`
+- Current branch: main
+- Main branch: main
+- Store: `sick-rabbit-store.myshopify.com`
+- Live domain (Phase 5): `sickrabbit.com`
+- Key docs: `docs/architecture.md`, `docs/components.md`, `docs/design/system.md`, `docs/decisions.md`, `planning/roadmap.md`
+
+## Kiro Vault (Companion Knowledge Base)
+
+This project has a companion folder in the Kiro Obsidian vault.
+The vault path is defined in the user's global `~/.claude/CLAUDE.md`. Read it from there, then find project docs at `Projects/Sick Rabbit/`. Website-specific docs are under `Projects/Sick Rabbit/Documentation/Website/` — start with `CONTEXT.md` and `Development/Shopify Build Plan.md`.
+
+When the user says "reference Kiro", "check Kiro", or mentions project docs,
+strategy, planning, or research context — read files from that folder. Start with:
+- `Projects/Sick Rabbit/Documentation/Website/CONTEXT.md` — website tech context and folder map
+- `Projects/Sick Rabbit/Sick Rabbit.md` — the brand's substance: what it is, its goals, its current state
+- `Projects/Sick Rabbit/Documentation/Website/Development/Shopify Build Plan.md` — the phased build plan
+
+Kiro is NOT a code project. It is a personal knowledge vault containing strategy docs,
+task files, research, competitive analysis, and planning for all of the user's projects.
+Do not search or modify files outside this project's folder in the vault.

--- a/README.md
+++ b/README.md
@@ -1,99 +1,56 @@
-# Dawn
+# Sick Rabbit Theme
 
-[![Build status](https://github.com/shopify/dawn/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/Shopify/dawn/actions/workflows/ci.yml?query=branch%3Amain)
-[![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg?color=informational)](/.github/CONTRIBUTING.md)
+Custom Shopify theme for the [Sick Rabbit](https://sickrabbit.com) apparel brand. Forked from Shopify's [Dawn](https://github.com/Shopify/dawn) reference theme and restyled to the brand.
 
-[Getting started](#getting-started) |
-[Staying up to date with Dawn changes](#staying-up-to-date-with-dawn-changes) |
-[Developer tools](#developer-tools) |
-[Contributing](#contributing) |
-[Code of conduct](#code-of-conduct) |
-[Theme Store submission](#theme-store-submission) |
-[License](#license)
+- **Store**: `sick-rabbit-store.myshopify.com`
+- **Live domain (Phase 5)**: `sickrabbit.com`
+- **Deploy**: GitHub integration — push to `main` auto-syncs to the live theme.
 
-Dawn represents a HTML-first, JavaScript-only-as-needed approach to theme development. It's Shopify's first source available theme with performance, flexibility, and [Online Store 2.0 features](https://www.shopify.com/partners/blog/shopify-online-store) built-in and acts as a reference for building Shopify themes.
+## Tech stack
 
-* **Web-native in its purest form:** Themes run on the [evergreen web](https://www.w3.org/2001/tag/doc/evergreen-web/). We leverage the latest web browsers to their fullest, while maintaining support for the older ones through progressive enhancement—not polyfills.
-* **Lean, fast, and reliable:** Functionality and design defaults to “no” until it meets this requirement. Code ships on quality. Themes must be built with purpose. They shouldn’t support each and every feature in Shopify.
-* **Server-rendered:** HTML must be rendered by Shopify servers using Liquid. Business logic and platform primitives such as translations and money formatting don’t belong on the client. Async and on-demand rendering of parts of the page is OK, but we do it sparingly as a progressive enhancement.
-* **Functional, not pixel-perfect:** The Web doesn’t require each page to be rendered pixel-perfect by each browser engine. Using semantic markup, progressive enhancement, and clever design, we ensure that themes remain functional regardless of the browser.
-
-You can find a more detailed version of our theme code principles in the [contribution guide](https://github.com/Shopify/dawn/blob/main/.github/CONTRIBUTING.md#theme-code-principles).
+| Layer | Choice |
+|---|---|
+| Platform | Shopify (Basic, GBP) |
+| Theme base | Dawn (OS 2.0, performance-tuned) |
+| Templating | Liquid + OS 2.0 JSON templates |
+| Styling | CSS custom properties on top of Dawn's token system |
+| Local dev | [Shopify CLI](https://shopify.dev/docs/api/shopify-cli/theme) |
+| Version control | Git + GitHub |
+| Fulfillment | [Tapstitch](https://www.tapstitch.com/) (print-on-demand) |
+| Review | [Greptile](https://greptile.com) via MCP |
 
 ## Getting started
-We recommend using Dawn as a starting point for theme development. [Learn more on Shopify.dev](https://shopify.dev/themes/getting-started/create).
 
-> If you're building a theme for the Shopify Theme Store, then you can use Dawn as a starting point. However, the theme that you submit needs to be [substantively different from Dawn](https://shopify.dev/themes/store/requirements#uniqueness) so that it provides added value for merchants. Learn about the [ways that you can use Dawn](https://shopify.dev/themes/tools/dawn#ways-to-use-dawn).
+Prerequisites: Node.js, [Shopify CLI](https://shopify.dev/docs/themes/tools/cli/install).
 
-Please note that the main branch may include code for features not yet released. The "stable" version of Dawn is available in the theme store.
-
-## Staying up to date with Dawn changes
-
-Say you're building a new theme off Dawn but you still want to be able to pull in the latest changes, you can add a remote `upstream` pointing to this Dawn repository.
-
-1. Navigate to your local theme folder.
-2. Verify the list of remotes and validate that you have both an `origin` and `upstream`:
 ```sh
-git remote -v
+# clone, then from the repo root
+shopify theme dev --store=sick-rabbit-store.myshopify.com
 ```
-3. If you don't see an `upstream`, you can add one that points to Shopify's Dawn repository:
-```sh
-git remote add upstream https://github.com/Shopify/dawn.git
-```
-4. Pull in the latest Dawn changes into your repository:
+
+Hot reload runs at `http://127.0.0.1:9292`. See [`docs/setup/build.md`](docs/setup/build.md) for the full command list and [`docs/setup/environment.md`](docs/setup/environment.md) for auth and env setup.
+
+## Key docs
+
+- [`CLAUDE.md`](CLAUDE.md) — coding rules and conventions
+- [`docs/architecture.md`](docs/architecture.md) — theme structure
+- [`docs/design/vision.md`](docs/design/vision.md) — brand direction
+- [`docs/design/system.md`](docs/design/system.md) — tokens (colours, type, spacing)
+- [`docs/components.md`](docs/components.md) — snippet/section registry
+- [`docs/decisions.md`](docs/decisions.md) — architectural decisions log
+- [`planning/roadmap.md`](planning/roadmap.md) — what's shipped, in progress, next
+
+## Staying up to date with Dawn
+
+Dawn is tracked as `upstream`:
+
 ```sh
 git fetch upstream
-git pull upstream main
+git merge upstream/main
 ```
 
-## Developer tools
-
-There are a number of really useful tools that the Shopify Themes team uses during development. Dawn is already set up to work with these tools.
-
-### Shopify CLI
-
-[Shopify CLI](https://github.com/Shopify/shopify-cli) helps you build Shopify themes faster and is used to automate and enhance your local development workflow. It comes bundled with a suite of commands for developing Shopify themes—everything from working with themes on a Shopify store (e.g. creating, publishing, deleting themes) or launching a development server for local theme development.
-
-You can follow this [quick start guide for theme developers](https://shopify.dev/docs/themes/tools/cli) to get started.
-
-### Theme Check
-
-We recommend using [Theme Check](https://github.com/shopify/theme-check) as a way to validate and lint your Shopify themes.
-
-We've added Theme Check to Dawn's [list of VS Code extensions](/.vscode/extensions.json) so if you're using Visual Studio Code as your code editor of choice, you'll be prompted to install the [Theme Check VS Code](https://marketplace.visualstudio.com/items?itemName=Shopify.theme-check-vscode) extension upon opening VS Code after you've forked and cloned Dawn.
-
-You can also run it from a terminal with the following Shopify CLI command:
-
-```bash
-shopify theme check
-```
-
-### Continuous Integration
-
-Dawn uses [GitHub Actions](https://github.com/features/actions) to maintain the quality of the theme. [This is a starting point](https://github.com/Shopify/dawn/blob/main/.github/workflows/ci.yml) and what we suggest to use in order to ensure you're building better themes. Feel free to build off of it!
-
-#### Shopify/lighthouse-ci-action
-
-We love fast websites! Which is why we created [Shopify/lighthouse-ci-action](https://github.com/Shopify/lighthouse-ci-action). This runs a series of [Google Lighthouse](https://developers.google.com/web/tools/lighthouse) audits for the home, product and collections pages on a store to ensure code that gets added doesn't degrade storefront performance over time.
-
-#### Shopify/theme-check-action
-
-Dawn runs [Theme Check](#Theme-Check) on every commit via [Shopify/theme-check-action](https://github.com/Shopify/theme-check-action).
-
-## Contributing
-
-Want to make commerce better for everyone by contributing to Dawn? We'd love your help! Please read our [contributing guide](https://github.com/Shopify/dawn/blob/main/.github/CONTRIBUTING.md) to learn about our development process, how to propose bug fixes and improvements, and how to build for Dawn.
-
-## Code of conduct
-
-All developers who wish to contribute through code or issues, please first read our [Code of Conduct](https://github.com/Shopify/dawn/blob/main/.github/CODE_OF_CONDUCT.md).
-
-## Theme Store submission
-
-The [Shopify Theme Store](https://themes.shopify.com/) is the place where Shopify merchants find the themes that they'll use to showcase and support their business. As a theme partner, you can create themes for the Shopify Theme Store and reach an international audience of an ever-growing number of entrepreneurs.
-
-Ensure that you follow the list of [theme store requirements](https://shopify.dev/themes/store/requirements) if you're interested in becoming a [Shopify Theme Partner](https://themes.shopify.com/services/themes/guidelines) and building themes for the Shopify platform.
+Resolve conflicts in our restyled areas; run `shopify theme check` afterwards.
 
 ## License
 
-Copyright (c) 2021-present Shopify Inc. See [LICENSE](/LICENSE.md) for further details.
+Dawn is MIT licensed — see [`LICENSE.md`](LICENSE.md). Sick Rabbit customisations on top are proprietary.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,67 @@
+# Architecture
+
+Sick Rabbit theme is a Shopify Online Store 2.0 theme, forked from Dawn. This doc maps the Dawn-provided structure and our layered-on additions.
+
+## Folder structure
+
+```
+sickrabbit-theme/
+├── assets/             # CSS, JS, theme images, static files served by Shopify's CDN
+├── config/             # settings_schema.json (schema), settings_data.json (values)
+├── layout/             # theme.liquid — master template wrapping every page
+├── locales/            # Translations; en.default.json is primary
+├── sections/           # Reusable content sections with {% schema %} blocks
+├── snippets/           # Small reusable Liquid fragments (no schema)
+├── templates/          # OS 2.0 JSON templates + /customers account pages
+├── docs/               # Repo documentation (this folder)
+├── planning/           # Roadmap, ideas, issues
+├── .greptile/          # Greptile review config
+└── .claude/skills/     # Project-specific Claude skills
+```
+
+## Templating model (OS 2.0)
+
+- **Layout** (`layout/theme.liquid`) wraps every page. Global head tags, header/footer include points, JSON-LD scaffolding.
+- **Templates** (`templates/*.json`) are thin JSON files listing sections and their order for a given page type (`product.json`, `collection.json`, `index.json`, etc.).
+- **Sections** (`sections/*.liquid`) are self-contained blocks of markup, CSS, and schema. Merchants rearrange them in the theme editor.
+- **Snippets** (`snippets/*.liquid`) are small reusable fragments rendered from sections and other snippets via `{% render %}`.
+
+```
+Request → theme.liquid (layout) → template.json → section A → snippet
+                                               → section B → snippet
+                                               → section C
+```
+
+## State and data
+
+There is no app-side state. All data comes from:
+
+- **Liquid objects** (`product`, `collection`, `cart`, `customer`, `shop`, `settings`) — server-rendered by Shopify
+- **Section settings / block settings** — merchant-editable, read via `section.settings.*` and `block.settings.*`
+- **Theme settings** (`settings.*`) — defined in `config/settings_schema.json`, values live in `config/settings_data.json`
+- **Translations** — `locales/*.json`, accessed via the `t` filter
+
+Any client-side state is per-page and scoped to the component's JS file in `assets/`.
+
+## Styling
+
+Dawn uses CSS custom properties set from `config/settings_data.json` and theme colour schemes. We layer Sick Rabbit tokens on top in `assets/base.css`. Per-section styles live in `assets/section-<name>.css`, loaded in the section's Liquid.
+
+See [`docs/design/system.md`](design/system.md) for the full token list.
+
+## Deploy path
+
+- `main` branch → Shopify live theme, via [Shopify GitHub integration](https://shopify.dev/docs/storefronts/themes/tools/github)
+- Merchant edits in admin auto-commit back to the connected branch (two-way sync)
+- Local dev uses `shopify theme dev` against `sick-rabbit-store.myshopify.com`
+
+## Upstream
+
+Dawn remains `upstream`. Pull periodically to inherit Shopify's fixes and new OS 2.0 features.
+
+```sh
+git fetch upstream
+git merge upstream/main
+```
+
+Expect conflicts in any section/snippet we've restyled.

--- a/docs/components.md
+++ b/docs/components.md
@@ -1,0 +1,26 @@
+# Components
+
+Shared snippet and section registry. Check this before creating anything new. Update every time a shared snippet or section is added or changed.
+
+Dawn ships with many snippets and sections out of the box — this registry is **Sick Rabbit's custom additions and significant overrides**, not a catalogue of everything Dawn provides. For Dawn's originals, read `snippets/` and `sections/` directly.
+
+## Sections (custom / significantly modified)
+
+| Name | File | Purpose | Used on |
+|---|---|---|---|
+| _(none yet)_ | — | — | — |
+
+## Snippets (custom / significantly modified)
+
+| Name | File | Purpose | Rendered in |
+|---|---|---|---|
+| _(none yet)_ | — | — | — |
+
+## Conventions
+
+- New Liquid sections go in `sections/` with a `{% schema %}` block. Give it `presets` so merchants can add it in the theme editor.
+- Reusable markup fragments (no schema, no merchant editing) go in `snippets/` — render with `{% render 'name' %}`, never with the deprecated `{% include %}`.
+- Co-locate CSS in `assets/section-<name>.css` and load it from the section via `{{ 'section-<name>.css' | asset_url | stylesheet_tag }}`.
+- Add a row to this file when you ship a new snippet or section.
+
+Components are added here as they're created.

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -1,0 +1,105 @@
+# Decisions
+
+Architectural and design decisions. What was decided, why, what was rejected.
+
+## 2026-04-19: Fork Dawn, restyle — don't build from scratch or go headless
+
+**Decision:** Use Shopify's Dawn as the base theme, fork it, restyle it. Deploy via Shopify's GitHub integration.
+
+**Why:** Dawn is the reference OS 2.0 theme — performance-tuned, actively maintained by Shopify, free, well-understood. All standard e-commerce plumbing (cart, checkout, PDP, variants, search) comes for free. The only problem left to solve is styling.
+
+**Rejected:**
+- Headless / Hydrogen — explicitly moving away from the prior Astro direction. Adds complexity for no benefit at this scale.
+- Build from scratch — 4–8 weeks of reinventing cart logic nobody asked for.
+- Paid theme — pay to then fight its opinions. Dawn is freer, cleaner, updates from Shopify.
+
+## 2026-04-19: Retrofit the Dev Project Playbook structure onto Dawn (don't overwrite)
+
+**Decision:** Layer `CLAUDE.md`, `docs/`, `planning/`, `.greptile/`, `.claude/skills/` alongside Dawn's existing `assets/`, `sections/`, `snippets/`, `templates/` etc. Do not rename, delete, or restructure Dawn's files.
+
+**Why:** Dawn is tracked as `upstream`. Every rename or structural change we make becomes a merge conflict forever. Keep changes additive.
+
+**Rejected:** Restructuring Dawn into a "tidier" layout. Not worth the perpetual merge cost.
+
+## 2026-04-19: Invert the Build Order — visual first, functional already done
+
+**Decision:** Skip the playbook's "functional-first, visual later" phase. Go straight to brand-token extraction and section restyling.
+
+**Why:** The Build Order principle assumes you're building features from scratch. Here, Dawn ships a fully-functional storefront on day one. Functional work is maintenance only (upstream merges, occasional bug fixes). The whole point of forking Dawn is that we skip that phase.
+
+**Rejected:** Running functional audits or feature-building passes before visual work. There's nothing to audit — it works.
+
+## 2026-04-19: Products-first, collections-later
+
+**Decision:** Populate the catalogue by creating products and tagging them as we go. Build collections — likely rule-based / automatic — once there's enough product data to organise.
+
+**Why:** Tapstitch is the fulfillment source and the catalogue is being built from scratch. Designing collections against zero products is speculative. Tags are cheap; collections can be recomputed any time.
+
+**Rejected:** Designing collection structure up front.
+
+## 2026-04-20: Use Shopify AI Toolkit instead of benjaminsehl/liquid-skills
+
+**Decision:** Install the official [Shopify AI Toolkit](https://github.com/Shopify/Shopify-AI-Toolkit) as the Liquid / Shopify Agent Skill source, not `benjaminsehl/liquid-skills` as originally planned in Kiro's `CONTEXT.md`.
+
+**Why:** The liquid-skills repo's own README now redirects people to Shopify's official toolkit ("No longer needed — go check out the official Shopify AI Toolkit"). The official toolkit adds doc search, GraphQL/Liquid validation, and store management via the CLI's execute capability, with auto-updates.
+
+**Rejected:** Cloning the deprecated `benjaminsehl/liquid-skills`. Would work for the three skill files, but we'd miss the validator, doc search, and ongoing updates, and we'd own a dead dependency.
+
+**Install:** Inside Claude Code, run `/plugin marketplace add Shopify/shopify-ai-toolkit` then `/plugin install shopify-plugin@shopify-ai-toolkit`.
+
+## 2026-04-20: Fonts — hybrid Shopify font_picker + Google Fonts link
+
+**Decision:** Load Sick Rabbit fonts through a hybrid system based on what Shopify's font library actually carries.
+
+**Shopify `font_picker` (4 fonts)** — auto-subsetted, edge-cached, merchant-editable:
+- `type_body_font` → `anonymous_pro_n4` (body, UI)
+- `type_display_special_font` → `unifraktur_maguntia_n4` (H1, buttons)
+- `type_logo_font` → `unifraktur_cook_n7` (logo, bold only)
+- `type_hero_title_font` → `outfit_n4` (hero)
+
+**Google Fonts `<link>` (2 fonts)** — hardcoded in `layout/theme.liquid`:
+- `Pirata One` → `--font-heading-family` (H2)
+- `Cinzel` → `--font-display-family` (collection names — stand-in for Nordica Plus)
+
+**Why hybrid:** Pirata One and Cinzel are not in Shopify's curated font library. They're both on Google Fonts, so a single `<link>` in `<head>` (with preconnect) gets both with `font-display: swap`. Everything else goes through Shopify's native pipeline for best performance. `type_header_font` picker is kept with Dawn's default `assistant_n4` but its effect on `--font-heading-family` is overridden in `theme.liquid` — the setting is retained so upstream Dawn merges stay clean.
+
+**Nordica Plus gap:** The original brand display font for collection names is not in Shopify's library OR Google Fonts (paid foundry font). Cinzel is the stand-in — medieval-leaning display serif, sits in the same gothic band as Pirata One and UnifrakturCook. Licensing + self-hosting Nordica Plus is a **post-launch decision** — logged in `planning/ideas.md`.
+
+**Initial attempt that failed:** Tried to put all 6 fonts through `font_picker` on the assumption that Shopify's library = full Google Fonts catalogue. It isn't. Shopify's library is curated. Check the [available fonts](https://shopify.dev/docs/storefronts/themes/architecture/settings/fonts) before defaulting any `font_picker` to a non-standard family.
+
+**Rejected:**
+- Self-hosting all six fonts via `@font-face` — slower first paint, bigger repo, font files to license/manage.
+- Finding in-library substitutes for Pirata One and Cinzel — the brand tokens call these out specifically; substitution is last-resort, not a convenience.
+- Licensing Nordica Plus now — blocks Phase 2 on an external purchase; Cinzel is a strong-enough stand-in to move forward.
+
+## 2026-04-20: Dawn colour scheme mapping — Sick Rabbit palette
+
+**Decision:** Map the five Sick Rabbit brand tokens onto Dawn's five built-in colour schemes, keeping Dawn's scheme conventions (cards default to scheme-2, sold-out badges to scheme-3, sale badges to scheme-5).
+
+| Scheme | Role | Background | Text | Button |
+|---|---|---|---|---|
+| 1 | Sand Dune — primary / default | `#e5dcc5` | `#2d2d2a` | `#903636` burnt rose |
+| 2 | Graphite — cards | `#2d2d2a` | `#e5dcc5` | `#903636` burnt rose |
+| 3 | Slate — sold-out badge | `#1c4d4f` | `#e5dcc5` | `#903636` burnt rose |
+| 4 | Rose — featured / hero accent | `#903636` | `#e5dcc5` | `#2d2d2a` graphite |
+| 5 | Copper — sale badge | `#a77b5f` | `#2d2d2a` | `#2d2d2a` graphite |
+
+**Why:**
+- Scheme-1 = Sand Dune (light) matches the old Astro site's default page background — most of the storefront renders on this.
+- Dark graphite cards (scheme-2) on sand backgrounds give strong contrast — core Sick Rabbit feel.
+- Burnt rose is the button colour across light schemes so CTAs pop without per-section overrides.
+- Slate → sold-out and Copper → sale leans on Dawn's existing `sale_badge_color_scheme` / `sold_out_badge_color_scheme` conventions so merchants and upstream Dawn merges keep working.
+- `--color-faded-copper` was flagged as "reserved / special uses" — sale badges are rare enough to qualify as a special use.
+
+**Rejected:**
+- Fewer schemes (e.g. 3) — would break Dawn's admin picker UX and break presets.
+- Burnt rose as scheme-1 background — too aggressive for the default surface; reserved for featured moments instead.
+- Keeping Copper entirely out of the scheme system — would leave scheme-5 doing nothing useful.
+
+## 2026-04-19: Copy source is the old Astro repo
+
+**Decision:** Reuse homepage copy, about page, collection descriptions from `C:\Users\redpo\repos\sickrabbit-website` (`src/pages/`, `src/content/`). Only rewrite when the old copy doesn't fit the new context.
+
+**Why:** The voice is already right. Don't redo the voice work just because the stack changed.
+
+**Rejected:** Writing copy from scratch for the Shopify version.

--- a/docs/design/system.md
+++ b/docs/design/system.md
@@ -1,0 +1,160 @@
+# Design System
+
+Source tokens extracted from the old Astro repo at `C:\Users\redpo\repos\sickrabbit-website\src\styles\variables.css`. These are the target values — Phase 2 of the build plan applies them to Dawn's CSS custom properties and colour schemes.
+
+> Status: **placeholder — not yet wired into the theme.** See `planning/roadmap.md` → Phase 2.
+
+## Colour
+
+### Core palette
+
+| Token | Hex | Usage |
+|---|---|---|
+| `--color-graphite` | `#2d2d2a` | Primary dark — body text on light, surface-dark background |
+| `--color-sand-dune` | `#e5dcc5` | Default background, header, footer |
+| `--color-dark-slate-grey` | `#1c4d4f` | Secondary accent, elevated surfaces, tag badges |
+| `--color-burnt-rose` | `#903636` | Primary CTA, accent |
+| `--color-faded-copper` | `#a77b5f` | Reserved — special uses only |
+
+### Semantic
+
+| Token | Maps to |
+|---|---|
+| `--color-cta-primary` | `--color-burnt-rose` |
+| `--color-cta-secondary` | `--color-dark-slate-grey` |
+| `--color-surface-dark` | `--color-graphite` |
+| `--color-surface-elevated` | `--color-dark-slate-grey` |
+| `--color-surface-light` | `--color-sand-dune` |
+| `--color-background-default` | `--color-sand-dune` |
+| `--color-tag-badge` | `--color-dark-slate-grey` |
+
+### States
+
+| Token | Hex |
+|---|---|
+| `--color-success` | `#7FA099` |
+| `--color-error` | `#D47A7A` |
+| `--color-warning` | `#D4A574` |
+
+> `--color-info` was present in the old Astro repo but referenced a non-existent `--color-interface-lavender` (dangling leftover from a deleted audio-interface palette). Dropped for Sick Rabbit — add back later if a Phase 3 component genuinely needs an info state.
+
+**Shopify mapping**: these tokens will be mapped onto Dawn's colour scheme settings (background, text, button, button-label, etc.) in `config/settings_data.json` during Phase 2, and also set as CSS custom properties in `assets/base.css` for ad-hoc use.
+
+## Typography
+
+### Families
+
+Set in `layout/theme.liquid`. Four fonts come from Shopify's `font_picker` + `font_face` pipeline (see `config/settings_schema.json` → typography). Two (Pirata One, Cinzel) aren't in Shopify's font library, so they're loaded from Google Fonts and hardcoded into their CSS custom properties.
+
+| Token | Default font | Role | Source |
+|---|---|---|---|
+| `--font-display-special-family` | `UnifrakturMaguntia` | H1, buttons | Shopify `font_picker` (`type_display_special_font`) |
+| `--font-heading-family` | `Pirata One` | H2 | Google Fonts `<link>`, hardcoded in `theme.liquid` |
+| `--font-body-family` | `Anonymous Pro` (monospace) | Body text, UI | Shopify `font_picker` (`type_body_font`) |
+| `--font-display-family` | `Cinzel` ⚠️ | Collection names | Google Fonts `<link>`, hardcoded in `theme.liquid` |
+| `--font-logo-family` | `UnifrakturCook` | Logo | Shopify `font_picker` (`type_logo_font`) |
+| `--font-hero-title-family` | `Outfit` | Hero title ("Sick Rabbit" wordmark) | Shopify `font_picker` (`type_hero_title_font`) |
+
+> ⚠️ **Nordica Plus substitute**: Nordica Plus (the original brand display font) is not in Shopify's font library OR Google's. `Cinzel` is serving as a stand-in until Nordica Plus is licensed and self-hosted — see `docs/decisions.md` (2026-04-20 Fonts decision).
+
+### Scale
+
+| Token | Size | Pixels |
+|---|---|---|
+| `--text-display` | `4rem` | 64 |
+| `--text-h1` | `3rem` | 48 |
+| `--text-h3` | `2rem` | 32 |
+| `--text-h2` / `--text-h4` | `1.5rem` | 24 |
+| `--text-h5` | `1.25rem` | 20 |
+| `--text-h6` / `--text-body` | `1rem` | 16 |
+| `--text-body-lg` | `1.125rem` | 18 |
+| `--text-body-sm` | `0.875rem` | 14 |
+| `--text-body-xs` | `0.75rem` | 12 |
+| `--text-display-collection` | `2.3125rem` | 37 |
+| `--text-logo` | `5.25rem` | 84 |
+
+### Weights / line heights
+
+- Weights: `--weight-regular: 400`, `--weight-bold: 700`
+- Line heights: `--leading-tight: 1` (gothic display), `--leading-normal: 1.5` (body), `--leading-relaxed: 1.8` (long-form)
+
+## Spacing
+
+8px base grid.
+
+| Token | Value |
+|---|---|
+| `--space-1` | `0.5rem` (8px) |
+| `--space-2` | `1rem` (16px) |
+| `--space-3` | `1.5rem` (24px) |
+| `--space-4` | `2rem` (32px) |
+| `--space-5` | `2.5rem` (40px) |
+| `--space-6` | `3rem` (48px) |
+| `--space-8` | `4rem` (64px) |
+| `--space-10` | `5rem` (80px) |
+| `--space-12` | `6rem` (96px) |
+| `--space-16` | `8rem` (128px) |
+
+## Containers / breakpoints
+
+| Token | Value |
+|---|---|
+| `--container-sm` / `--breakpoint-sm` | `640px` |
+| `--container-md` / `--breakpoint-md` | `768px` |
+| `--container-lg` / `--breakpoint-lg` | `1024px` |
+| `--container-xl` / `--breakpoint-xl` | `1280px` |
+| `--container-2xl` / `--breakpoint-2xl` | `1536px` |
+
+## Border radius
+
+| Token | Value |
+|---|---|
+| `--radius-sm` | `4px` |
+| `--radius-md` | `8px` |
+| `--radius-lg` | `12px` |
+| `--radius-full` | `9999px` |
+
+## Shadows
+
+| Token | Value |
+|---|---|
+| `--shadow-sm` | `0 2px 4px rgba(0, 0, 0, 0.1)` |
+| `--shadow-md` | `0 4px 8px rgba(0, 0, 0, 0.2)` |
+| `--shadow-lg` | `0 8px 16px rgba(0, 0, 0, 0.3)` |
+| `--shadow-xl` | `0 16px 32px rgba(0, 0, 0, 0.4)` |
+
+### 3D bevel effects
+
+Used sparingly, for interface elements that want an analogue / physical-device feel (buttons, toggles, cart-bar). Three states:
+
+```css
+--shadow-bevel-raised:
+  inset -2px -2px 4px rgba(0, 0, 0, 0.4),
+  inset 2px 2px 4px rgba(255, 255, 255, 0.1),
+  0 4px 8px rgba(0, 0, 0, 0.3);
+
+--shadow-bevel-pressed:
+  inset 2px 2px 6px rgba(0, 0, 0, 0.5),
+  inset -2px -2px 4px rgba(255, 255, 255, 0.05);
+
+--shadow-bevel-hover:
+  inset -3px -3px 6px rgba(0, 0, 0, 0.5),
+  inset 3px 3px 6px rgba(255, 255, 255, 0.15),
+  0 6px 12px rgba(0, 0, 0, 0.4);
+```
+
+## Transitions
+
+| Token | Value |
+|---|---|
+| `--transition-fast` | `0.2s ease` |
+| `--transition-normal` | `0.3s ease` |
+| `--transition-slow` | `0.5s ease` |
+
+## Buttons
+
+TODO (Phase 3 — header/hero pass). Dawn ships a button system; decide whether to extend it (`.button`, `.button--primary`, `.button--secondary`) or replace. Log decision in `docs/decisions.md` when made.
+
+## Inputs
+
+TODO (Phase 3). Dawn's `.field` pattern is the starting point. Any deviation gets logged.

--- a/docs/design/vision.md
+++ b/docs/design/vision.md
@@ -1,0 +1,37 @@
+# Design Vision
+
+## What Sick Rabbit is
+
+A streetwear-adjacent apparel brand with a slightly occult, literary, tech-myth aesthetic. Collection themes include Anachronism, Norse Poets Society, Digital Occult, Major Arcana — creative, irreverent, unafraid to be strange.
+
+## Site personality
+
+A peculiar combination — archaic/literary-occult typography sitting next to analogue music-gear physicality (pedal boards, mixing desks, hardware synths), held together by a playful irreverence. The three ingredients matter in combination:
+
+- The archaic blackletter + monospace is the "text-as-artefact" side
+- Knobs, bevels, dials, meters is the "object-you-touch" side
+- Playful irreverence is what keeps it from being cosplay-goth or tech-bro
+
+Principles:
+
+- **Deliberate, not corporate.** The storefront should feel like a small label run by someone with weird taste, not a generic Shopify fit-any-brand template.
+- **Warm-dark, not goth-dark.** Earthy darks (graphite, burnt rose, dark slate) with a sand-dune cream as the default light tone. Black-on-grey is lazy; this brand uses colour.
+- **Typography-led.** Blackletter display faces carry the identity. UI text is a monospace for contrast and a techy feel.
+- **Analogue-physical vocabulary for interactive controls.** CTAs, variant pickers, quantity adjusters, filters — these can feel like hardware (bevelled buttons that depress, knobs, toggles, meters). The `--shadow-bevel-raised/-pressed/-hover` tokens exist for exactly this. Editorial surfaces stay flat. The goal is *one leg in the physical world* as a brand signal, not full skeuomorphism cosplay.
+- **Product-first.** Once we're on the PDP, photography and the variant picker are the centre of gravity. Minimal chrome.
+- **Playful, not precious.** Slightly strange, irreverent, doesn't take itself too seriously. Microcopy can be funny. Empty states can have personality. A 404 can be on-brand and dumb in a good way.
+
+## What to avoid
+
+- Generic SaaS gradients, pastel "friendly" palettes, rounded-everything.
+- Bright primary CTAs that fight the warm-dark palette.
+- Overuse of animation — occasional, purposeful transitions only.
+- Any UI pattern that screams "default Shopify theme."
+
+## North star
+
+A visitor should land on the homepage and feel they've arrived at *a brand*, not a store template. Without reading any copy, the typography and colour choices should already be saying something.
+
+## Build order exception
+
+The [[Build Order]] playbook says "functional first, visual later." For this project it's inverted: Dawn ships functional, so we skip directly to the visual layer. See [`docs/decisions.md`](../decisions.md).

--- a/docs/setup/branching.md
+++ b/docs/setup/branching.md
@@ -1,0 +1,106 @@
+# Branching discipline
+
+`main` on this repo is connected to the **live Shopify theme** via the GitHub integration. Every commit that lands on `main` deploys to `sick-rabbit-store.myshopify.com` (and, post-launch, `sickrabbit.com`) within seconds. There is no staging, no CI gate, no build step — `main` is production.
+
+That reality drives every workflow rule below.
+
+## The rule
+
+**All code work happens on a branch. Branches merge to `main` via a PR that has passed Greptile review. No exceptions for "small fixes".**
+
+A typo takes 30 seconds on a branch and merges in 2 minutes. A typo committed directly to `main` deploys to customers in 15 seconds. The asymmetry is the whole reason for the rule.
+
+## The layered gate
+
+Three layers, weakest to strongest:
+
+### 1. Skill-level (Claude Code)
+
+Every skill that writes git state (`commit`, `pr-commit`, `pr-comments`, `debug-session`, `refactor`) checks the current branch first and refuses to proceed on `main`. This catches most cases because most work is routed through a skill.
+
+### 2. Git hook (client-side)
+
+The `.githooks/pre-commit` script refuses commits to `main` at the git level. This catches the cases where someone uses raw `git` commands outside a skill. Configured once per machine:
+
+```bash
+git config core.hooksPath .githooks
+```
+
+Verify by checking out `main`, trying to commit, and seeing the refusal.
+
+The hook is committed to the repo (under `.githooks/`, not `.git/hooks/`), so every clone gets the same protection — but each machine still has to enable it once.
+
+**Emergency override**: `git commit --no-verify`. Use only when there's a genuine reason (e.g. a hook itself is broken). Ask yourself twice whether it's truly an emergency.
+
+### 3. GitHub branch protection (remote-side)
+
+The strongest gate. Configured once in GitHub → Settings → Branches → Branch protection rules → `main`.
+
+Required settings:
+
+- **Require a pull request before merging** — on
+  - **Require approvals** — at least 1 (Greptile's approval counts once configured, or yours on self-review)
+  - **Dismiss stale pull request approvals when new commits are pushed** — on (so approvals don't carry forward after unreviewed changes)
+- **Require status checks to pass before merging** — on (once CI exists — the GitHub Actions workflow from Dawn's upstream runs theme-check)
+- **Require linear history** — on (keeps `main` clean; pairs with squash-merge in the pr-comments skill)
+- **Do not allow bypassing the above settings** — on for everyone except the Shopify GitHub bot (see next section)
+
+### Important: the Shopify GitHub bot exemption
+
+Shopify's GitHub integration commits merchant admin edits (section settings, theme customiser changes) directly to the connected branch — which is `main`. That's how two-way sync works. Branch protection will block the Shopify bot's pushes by default.
+
+**Add the Shopify GitHub app as a bypass actor** under "Who can bypass these restrictions". Otherwise merchant admin edits will fail silently and the admin ↔ repo sync will break.
+
+If you can't figure out the exact bot identity in GitHub's UI, the simplest alternative is:
+
+1. Temporarily let the Shopify integration push → note which user/app appears as the commit author
+2. Add that actor to the bypass list
+3. Test: edit a section in Shopify admin → confirm it lands on `main`
+
+## What goes where
+
+| Work type | Where it happens | How it reaches `main` |
+|---|---|---|
+| Feature, fix, restyle, refactor, docs | feature branch | PR → Greptile review → squash-merge |
+| Token changes | `tokens/*` branch | PR → review → merge |
+| Content / locale tweaks | `content/*` branch | PR → review → merge |
+| Dawn upstream merge | `chore/upstream-merge-YYYY-MM-DD` branch | PR → review → merge (expect conflicts in styled areas) |
+| Merchant admin edit | Shopify admin → bot commits directly to `main` | Bypass (legit, intentional) |
+| Hot-fix genuine production emergency | `fix/urgent-description` branch | PR → fast review → merge (same flow; the branch cost is negligible) |
+
+There is no case where a human types `git commit` on `main` and means it.
+
+## Branch naming
+
+From the `commit` skill:
+
+- `fix/<desc>` — bug fixes
+- `feat/<desc>` — new features
+- `restyle/<section>` — Phase 3 visual restyle
+- `tokens/<desc>` — design token / theme settings changes
+- `refactor/<desc>` — additive structural changes
+- `docs/<desc>` — documentation only
+- `chore/<desc>` — tooling, config, deps, upstream merges
+- `content/<desc>` — locale / translation / copy-only changes
+
+## Recovery: "I accidentally committed to main locally"
+
+The pre-commit hook should have caught it, but if it didn't (disabled hooks, `--no-verify`, whatever):
+
+1. **Don't push.** If you haven't pushed, nothing is live.
+2. Rewind local main to origin:
+   ```bash
+   git log --oneline -n 5            # confirm the accidental commit is on top
+   git reset --soft origin/main      # unstage the commit but keep the changes
+   git checkout -b <type>/<desc>     # move onto a branch
+   git commit -m "<proper message>"  # commit on the branch instead
+   ```
+3. Continue as normal — `pr-commit` skill from here.
+
+If you already pushed to `main`, Shopify has already deployed it. At that point you have two options: revert the commit (`git revert <sha>` on a new branch, PR, merge → deploys the revert) or roll forward with a fix on a new branch. Don't force-push to undo — it breaks history for everyone and Shopify's sync can get confused.
+
+## When can I touch `main` directly?
+
+Never, with one exception: `git pull` after a merge, to sync your local checkout. That's not a commit, it's a fast-forward.
+
+If you think you have a reason to commit to `main` directly, you don't.

--- a/docs/setup/build.md
+++ b/docs/setup/build.md
@@ -1,0 +1,67 @@
+# Build & Dev Commands
+
+Shopify CLI is the primary tool. Install it once globally:
+
+```sh
+npm install -g @shopify/cli
+```
+
+Theme commands are bundled — since CLI `3.59.0` the separate `@shopify/theme` package is deprecated and redundant. Docs: [shopify.dev/docs/themes/tools/cli/install](https://shopify.dev/docs/themes/tools/cli/install).
+
+## Local dev
+
+```sh
+shopify theme dev --store=sick-rabbit-store.myshopify.com
+```
+
+Opens a local server at `http://127.0.0.1:9292` with hot reload for Liquid/CSS/JS changes. First run prompts for auth — logs you into the Shopify Partner / store account.
+
+Useful flags:
+
+| Flag | Purpose |
+|---|---|
+| `--theme <id-or-name>` | Develop against a specific unpublished theme instead of the default dev theme |
+| `--live-reload <mode>` | `hot-reload` (default), `full-page`, or `off` |
+| `--host 0.0.0.0` | Expose on LAN (for phone testing) |
+
+## Lint
+
+```sh
+shopify theme check
+```
+
+Runs theme-check against the repo. Rules live in `.theme-check.yml` (Dawn default). Expect this to run in CI via Dawn's existing GitHub Actions workflow.
+
+## Push / pull
+
+```sh
+# Push the current directory as an unpublished theme for review
+shopify theme push --unpublished --theme "Sick Rabbit dev $(date +%Y-%m-%d)"
+
+# Push to the live theme (DO NOT use once GitHub integration is live — let it auto-deploy)
+shopify theme push --live
+
+# Pull the published theme's current state (useful for syncing merchant admin edits locally)
+shopify theme pull --live
+```
+
+**Once the GitHub integration is connected at Phase 5**, prefer `git push` over `shopify theme push`. Shopify will sync `main` to the live theme automatically and commit admin edits back.
+
+## Deploy (Phase 5 onwards)
+
+1. Push to `main` on GitHub
+2. Shopify GitHub integration picks it up, syncs to the connected theme
+3. Theme goes live at `sickrabbit.com`
+
+Nothing to run locally for deploy.
+
+## Upstream merges
+
+```sh
+git fetch upstream
+git merge upstream/main
+# resolve conflicts
+shopify theme check
+shopify theme dev --store=sick-rabbit-store.myshopify.com   # smoke test
+git push origin main
+```

--- a/docs/setup/environment.md
+++ b/docs/setup/environment.md
@@ -1,0 +1,59 @@
+# Environment
+
+Shopify themes don't use a `.env` file for theme code — there are no runtime env vars baked into Liquid. Authentication is handled per-machine by the Shopify CLI.
+
+## Prerequisites
+
+- **Node.js** — 18 LTS or newer
+- **Shopify CLI** — `npm install -g @shopify/cli` (theme commands are bundled since CLI 3.59.0)
+- **[Shopify Liquid VS Code extension](https://shopify.dev/docs/storefronts/themes/tools/shopify-liquid-vscode)** — live theme-check diagnostics, autocomplete for tags/filters/objects/settings, hover docs, Liquid Prettier formatting. Catches most issues at save-time before they ever reach a commit.
+- **Git** — standard
+- **Access to the Sick Rabbit store** — owner or staff account on `sick-rabbit-store.myshopify.com`
+
+## Enable the git pre-commit hook (per-machine, do this once)
+
+The repo ships a pre-commit hook at `.githooks/pre-commit` that refuses direct commits to `main` (which would auto-deploy to the live theme). Enable it:
+
+```sh
+git config core.hooksPath .githooks
+```
+
+Verify: `git checkout main && git commit --allow-empty -m "test"` should fail with a clear error message. Then `git checkout -` to return to wherever you were. See `docs/setup/branching.md` for the full branch-discipline context.
+
+## First-time auth
+
+```sh
+shopify theme dev --store=sick-rabbit-store.myshopify.com
+```
+
+The first run opens a browser for login and stores credentials in the CLI's config directory (`~/.config/shopify/` on macOS/Linux, `%APPDATA%\shopify\` on Windows). After that the CLI re-auths silently.
+
+To switch accounts: `shopify auth logout` then re-run `shopify theme dev`.
+
+## Greptile MCP
+
+The Greptile code review agent needs an API key to connect. See `.greptile/` setup and [the Greptile section of the Kiro vault](https://app.greptile.com/settings/api) for the key.
+
+1. Get the API key from [app.greptile.com/settings/api](https://app.greptile.com/settings/api)
+2. Open `.greptile/mcp-proxy.mjs` and replace `"your-key-here"` with the real key
+3. Restart Claude Code — `/mcp` should show `greptile-api` as connected
+
+`.greptile/mcp-proxy.mjs` is gitignored so the key never ends up in Git. Each machine sets its own copy.
+
+## GitHub integration (Phase 5)
+
+When ready to connect the live theme:
+
+1. In Shopify admin → Online Store → Themes → Add theme → "Connect from GitHub"
+2. Authorise Shopify's GitHub app on `redpotatoe07/sickrabbit-theme`
+3. Pick the `main` branch
+4. Merchant edits from admin will auto-commit back to `main`
+
+## Troubleshooting
+
+| Symptom | Fix |
+|---|---|
+| `shopify theme dev` says "store not found" | Check the `--store` flag spelling, re-auth with `shopify auth logout` |
+| Hot reload stops working | Kill the process and restart. CSS changes occasionally need a hard refresh |
+| `shopify theme check` complains about schema | Validate JSON in `templates/*.json` and any `{% schema %}` blocks |
+| Merchant admin edits don't appear locally | `shopify theme pull --live` to sync them down |

--- a/planning/ideas.md
+++ b/planning/ideas.md
@@ -1,0 +1,20 @@
+# Ideas
+
+Features being considered but not committed to the roadmap. Promote to `roadmap.md` when agreed.
+
+## Post-launch
+
+- **Bespoke PDP layout** — after the clean-Dawn-restyle launch. Large-format imagery, experimental typography, narrative-style product descriptions.
+- **Custom cart drawer animations** — small moments of personality (rabbit icon, blackletter loading state).
+- **Editorial content pages** — lookbooks / collection stories using OS 2.0 page templates, referencing themes from the old Astro repo (Anachronism, Norse Poets Society, etc.).
+- **Lookbook / mood-board sections** — reusable section merchants can drop into any page.
+- **Loyalty / referral** — Shopify apps (Smile.io, ReferralCandy, etc.) if volume warrants.
+- **Wishlist / favourites** — evaluate app vs. custom. Probably app.
+- **Custom 404** — something on-brand and strange.
+- **Email capture with a story** — newsletter form that isn't "sign up for 10% off."
+
+## Deferred decisions
+
+- **License and self-host Nordica Plus** — the original brand display font for collection names. Not in Shopify's font library, so Phase 2 shipped with `Cinzel` as a stand-in (see `docs/decisions.md` 2026-04-20 Fonts). Post-launch: source the foundry file, drop in `assets/`, wire `@font-face`, update `--font-display-family` to prefer Nordica Plus with Cinzel as fallback.
+- **Dark mode**: the brand palette is already dark-leaning; a true dark mode might be gratuitous. Revisit if a user asks.
+- **Multi-currency**: GBP only at launch. Shopify Markets available if needed later.

--- a/planning/issues.md
+++ b/planning/issues.md
@@ -1,0 +1,22 @@
+# Issues
+
+Issue tracker. Log every known issue; when fixed, update the entry with the fix summary and commit hash.
+
+Format:
+
+```
+### ISS-NNN: Description
+**Found:** YYYY-MM-DD
+**Steps:** How to reproduce
+**Severity:** High / Medium / Low
+```
+
+Fixed entries add `**Fixed:** YYYY-MM-DD`, `**Fix:**` one-line summary, `**Commit:** <hash>`.
+
+## Open
+
+_(none yet)_
+
+## Fixed
+
+_(none yet)_

--- a/planning/roadmap.md
+++ b/planning/roadmap.md
@@ -1,0 +1,52 @@
+# Roadmap
+
+Mirrors the [Shopify Build Plan](../../Kiro) in the Kiro vault at `Projects/Sick Rabbit/Documentation/Website/Development/Shopify Build Plan.md`. That doc is the source of truth; this file is the repo-side summary.
+
+Item-level tasks use `TSK-NNN` IDs so commits can reference them (`restyle: header nav (TSK-005)`). Managed by the `task` skill. Phase-level structure (this file's sections, transitions, audit checkpoints) is managed by the `plan` skill.
+
+## Shipped
+
+| Version | What | Date |
+|---|---|---|
+| — | Dawn forked as base theme | 2026-04-19 |
+| — | Repo setup retrofit (CLAUDE.md, docs/, planning/, .greptile/, .claude/skills/) | 2026-04-19 |
+| Phase 1 | Setup complete — Shopify CLI, Greptile + MCP, AI Toolkit, project skills, GitHub ruleset on `main` | 2026-04-20 |
+
+## In Progress
+
+### Phase 2 — Extract brand tokens (1 session)
+- [ ] **TSK-001**: Pull colours, fonts, type scale, spacing from `C:\Users\redpo\repos\sickrabbit-website\src\styles\variables.css`
+- [ ] **TSK-002**: Map onto Dawn's colour schemes in `config/settings_data.json`
+- [ ] **TSK-003**: Add CSS custom properties (including `--shadow-bevel-*`) to `assets/base.css`
+- [ ] **TSK-004**: Wire webfonts (UnifrakturMaguntia, Pirata One, Anonymous Pro, Nordica Plus, UnifrakturCook, Outfit) — `font_picker` settings or explicit `@font-face`
+
+## Next
+
+### Audit Checkpoint (post-Phase 2)
+Token-coverage audit before Phase 3 restyle begins. Run the `audit` skill with the token-coverage + font-loading extras.
+
+### Phase 3 — Restyle sections (iterative, ~4–6 sessions)
+- [ ] **TSK-005**: Restyle header (logo, nav, cart icon, announcement bar)
+- [ ] **TSK-006**: Restyle homepage (hero, featured collections, content modules)
+- [ ] **TSK-007**: Restyle collection page (grid, filters, sort)
+- [ ] **TSK-008**: Restyle product page / PDP (gallery, variants, add-to-cart, description)
+- [ ] **TSK-009**: Restyle cart drawer (quantity, line items, checkout button)
+- [ ] **TSK-010**: Restyle footer (links, newsletter, socials)
+
+### Phase 4 — Content + products (parallel with Phase 3)
+- [ ] **TSK-011**: Tapstitch integration — app install or CSV sync
+- [ ] **TSK-012**: Product creation + tagging conventions
+- [ ] **TSK-013**: Rule-based collections (Anachronism, Norse Poets Society, Digital Occult, Major Arcana)
+- [ ] **TSK-014**: Paste/write homepage, about, policies (copy from old Astro repo)
+- [ ] **TSK-015**: Shipping zones, payment gateways, taxes (GBP)
+
+### Audit Checkpoint (pre-launch, mandatory)
+Full audit including the pre-launch checklist before Phase 5. Non-negotiable — enforced by the `audit` skill.
+
+### Phase 5 — Launch
+- [ ] **TSK-016**: Connect GitHub integration — `main` → live theme
+- [ ] **TSK-016a**: Add Shopify GitHub app to the `main` ruleset bypass list (only appears in the picker after TSK-016 installs it). Without this, merchant admin edits will fail to commit.
+- [ ] **TSK-017**: Point `sickrabbit.com` DNS at Shopify (DNS-only cutover from Vercel)
+- [ ] **TSK-018**: SSL auto-provision
+- [ ] **TSK-019**: Password-protect for final QA
+- [ ] **TSK-020**: Remove password → live


### PR DESCRIPTION
## Summary

Lays the Sick Rabbit development infrastructure on top of the forked Dawn theme. Retrofit mode means additive only — no Dawn files renamed or deleted — so `git merge upstream/main` stays tractable going forward.

This is the first PR into the repo beyond Dawn. Nothing here changes how the storefront renders; it's the scaffolding the rest of the project is built on.

- **CLAUDE.md** — Liquid / OS 2.0 conventions, branch discipline (`main` is live, PR-only), design token rules, naming conventions, upstream-merge workflow
- **`.claude/skills/`** — 10 project skills (`commit`, `issue`, `task`, `plan`, `audit`, `debug-session`, `frontend-design`, `refactor`, `pr-commit`, `pr-comments`) plus `skill-creator`
- **`.githooks/pre-commit`** — client-side gate refusing commits on `main`; enabled per-machine with `git config core.hooksPath .githooks`
- **`.greptile/`** — review rules (design-token enforcement, no hex in inline styles, Dawn-file destruction flag), config, and file tags. `mcp-proxy.mjs` is gitignored because it carries a local API-key fallback
- **`.mcp.json`** — MCP server configuration
- **`docs/`** — architecture, components registry, design (vision + token system), decisions log (6 entries already captured), setup guides (branching, build, environment)
- **`planning/`** — roadmap (phased Shopify build plan), ideas backlog, issue tracker
- **`.gitignore`** — adds `.greptile/mcp-proxy.mjs` and `__pycache__/` exclusions
- **README.md** — replaces Dawn's public README with a Sick Rabbit project doc

## What changed in the theme

Nothing that affects the storefront. Dawn's `sections/`, `snippets/`, `templates/`, `layout/`, `assets/`, `locales/`, `config/` are untouched — this PR is purely repository scaffolding.

## Test plan

- [ ] Clone on a fresh machine, run `git config core.hooksPath .githooks`, try to commit on `main` — expect the hook to refuse
- [ ] Load `127.0.0.1:9292` via `shopify theme dev` — confirm storefront still renders identically (no visual regressions; this PR doesn't touch Liquid or CSS)
- [ ] `shopify theme check` — existing Dawn errors in `sections/main-search.liquid` are pre-existing; no new errors introduced by this PR

## Upstream / Dawn notes

Additive changes only — no Dawn files renamed or removed. The only existing files modified are `.gitignore` (additions) and `README.md` (replaced Dawn's public README with a project doc; Dawn's original content lives in upstream). `docs/decisions.md` records the retrofit approach as a logged decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)