### PR TITLE
fix(price): render only contextually correct badge in HTML source

### DIFF
--- a/snippets/price.liquid
+++ b/snippets/price.liquid
@@ -113,13 +113,15 @@
       {%- endif -%}
     </div>
     {%- if show_badges -%}
-      <span class="badge price__badge-sale color-{{ settings.sale_badge_color_scheme }}">
-        {{ 'products.product.on_sale' | t }}
-      </span>
-
-      <span class="badge price__badge-sold-out color-{{ settings.sold_out_badge_color_scheme }}">
-        {{ 'products.product.sold_out' | t }}
-      </span>
+      {%- if available == false -%}
+        <span class="badge price__badge-sold-out color-{{ settings.sold_out_badge_color_scheme }}">
+          {{ 'products.product.sold_out' | t }}
+        </span>
+      {%- elsif compare_at_price > price and product.quantity_price_breaks_configured? != true -%}
+        <span class="badge price__badge-sale color-{{ settings.sale_badge_color_scheme }}">
+          {{ 'products.product.on_sale' | t }}
+        </span>
+      {%- endif -%}
     {%- endif -%}
   </div>
 {% endunless %}


### PR DESCRIPTION
## Summary

Replace unconditional badge rendering in `snippets/price.liquid` with conditional logic that mirrors the parent div's CSS class behavior. Only the contextually correct badge is rendered into HTML source.

## Problem

Both `sale` and `sold-out` badge strings were always rendered into HTML whenever `show_badges` was true, regardless of product state. The theme relied solely on CSS to hide the wrong badge visually — but non-visual consumers (SEO crawlers, screen readers, AI shopping assistants) read the raw HTML and saw both strings.

## Solution

Wrap each badge in a condition matching the CSS logic already applied to the parent `div`:
- `available == false` → sold-out badge only
- `compare_at_price > price and product.quantity_price_breaks_configured? != true` → sale badge only
- otherwise → no badge

## Testing

- Sold-out badge text no longer appears in raw HTML for in-stock discounted products
- Sale badge renders correctly for discounted products
- Sold-out badge renders correctly for unavailable products
- No badge renders for regular-priced available products
- CSS visual display unchanged for human visitors

Fixes #3924