### PR TITLE
Fix cart drawer desync on partial inventory 422

### DIFF
--- a/assets/product-form.js
+++ b/assets/product-form.js
@@ -59,6 +59,7 @@ if (!customElements.get('product-form')) {
               this.handleErrorMessage(response.description);
               this.dispatchCartErrorEvent(response.description || response.message, 'INVALID');
               linesUpdateDeferred?.reject(new Error(response.description || response.message));
+              if (response.status == 422) this.refreshCartUIAfterAvailabilityError(response);
 
               const soldOutMessage = this.submitButton.querySelector('.sold-out-message');
               if (!soldOutMessage) return;
@@ -182,6 +183,74 @@ if (!customElements.get('product-form')) {
         const { CartErrorEvent } = window.StandardEvents || {};
         if (!CartErrorEvent) return;
         this.dispatchEvent(new CartErrorEvent({ error: message, code }));
+      }
+
+      // 422 inventory responses can partially mutate the cart without returning section
+      // HTML. Bundled sections are only returned from cart/add|change|update|clear POST
+      // bodies, not GET /cart.js?sections=, so fetch section HTML via section_id when needed.
+      refreshCartUIAfterAvailabilityError(response = null) {
+        const cartDrawer = this.cart?.tagName === 'CART-DRAWER' ? this.cart : null;
+        if (!cartDrawer?.renderContents) return;
+
+        const revealDrawer = () => {
+          CartPerformance.measure('add:paint-updated-sections', () => {
+            if (!cartDrawer.classList.contains('active')) cartDrawer.open();
+          });
+        };
+
+        const quickAddModal = this.closest('quick-add-modal');
+        const afterRefresh = (callback) => {
+          if (quickAddModal) {
+            document.body.addEventListener(
+              'modalClosed',
+              () => {
+                setTimeout(callback);
+              },
+              { once: true }
+            );
+            quickAddModal.hide(true);
+          } else {
+            callback();
+          }
+        };
+
+        if (response?.sections && response.item_count > 0) {
+          cartDrawer.classList.remove('is-empty');
+          afterRefresh(() => {
+            CartPerformance.measure('add:paint-updated-sections', () => {
+              cartDrawer.renderContents(response);
+            });
+          });
+          return;
+        }
+
+        fetch(`${routes.cart_url}.js`)
+          .then((res) => res.json())
+          .then((cartData) => {
+            if (!cartData?.item_count) return;
+
+            cartDrawer.classList.remove('is-empty');
+
+            const sectionsUrl = window.location.pathname;
+
+            return Promise.all([
+              fetch(`${sectionsUrl}?section_id=cart-drawer`).then((res) => res.text()),
+              fetch(`${sectionsUrl}?section_id=cart-icon-bubble`).then((res) => res.text()),
+            ]).then(([drawerText, bubbleText]) => {
+              const drawerDoc = new DOMParser().parseFromString(drawerText, 'text/html');
+              const sourceInner = drawerDoc.querySelector('cart-drawer .drawer__inner');
+              const targetInner = cartDrawer.querySelector('.drawer__inner');
+              if (sourceInner && targetInner) targetInner.replaceWith(sourceInner);
+
+              const bubbleDoc = new DOMParser().parseFromString(bubbleText, 'text/html');
+              const bubbleSource = bubbleDoc.querySelector('.shopify-section');
+              const bubbleTarget = document.getElementById('cart-icon-bubble');
+              if (bubbleSource && bubbleTarget) bubbleTarget.innerHTML = bubbleSource.innerHTML;
+
+              afterRefresh(revealDrawer);
+            });
+          })
+          .catch((e) => console.error(e));
       }
 
       get variantIdInput() {


### PR DESCRIPTION
### PR Summary

When a customer tries to add more of a product than is available, the cart drawer now shows what was actually added to the cart instead of staying empty, while the product page still displays the availability warning.

### Why are these changes introduced?

Fixes #3921

When `/cart/add` returns 422 after partially adding available quantity, the server cart updates but Dawn's error branch did not refresh cart drawer UI. The drawer could open empty or stay stale even though `/cart.js` had items and the product form showed the availability error.

### What approach did you take?

In `assets/product-form.js`, when `response.status == 422`, keep existing error handling (`handleErrorMessage`, pubsub `cartError`, `CartErrorEvent`) unchanged, then call a new `refreshCartUIAfterAvailabilityError()` method for cart drawer mode.

1. **Fast path:** If the 422 `/cart/add` response already includes `sections` and `item_count > 0`, call existing `cart-drawer.renderContents(response)` (same as successful add).
2. **Fallback:** Otherwise fetch `/cart.js` to confirm `item_count > 0`, then use the Section Rendering API:
   - `?section_id=cart-drawer` to replace `.drawer__inner` (removes stale empty-cart markup)
   - `?section_id=cart-icon-bubble` to refresh the header bubble
   - Open the drawer if it is not already open

Cart notification mode is unchanged. Its `renderContents` depends on add-response line item `key`, so this helper is scoped to `CART-DRAWER` only.

### Other considerations

- Shopify Cart AJAX 422 can represent partial success: the cart may gain available quantity even when the response is an error.
- Bundled `sections` HTML is returned on cart **POST** endpoints (`/cart/add`, `/cart/change`, etc.), not on `GET /cart.js?sections=`. The initial fix attempt using that GET pattern did not work.
- Related issue #3906 (invalid quantity update via `/cart/change`) is a separate code path in `assets/cart.js` and is out of scope for this PR.
- No Liquid, CSS, or theme settings changes.

### Decision log

| # | Decision | Alternatives | Rationale | Downsides |
|---|---|---|---|---|
| 1 | Refresh via `?section_id=cart-drawer` and `?section_id=cart-icon-bubble` | `GET /cart.js?sections=...`; `cart-drawer-items.onCartUpdate()` only | Section Rendering API returns server-rendered HTML with current cart state. `onCartUpdate` does not remove empty-drawer markup or refresh the bubble. `GET /cart.js?sections=` does not return bundled section HTML. | Two extra requests on 422 when add response lacks `sections` |
| 2 | Gate refresh on `response.status == 422` and `item_count > 0` | Refresh on all `response.status` errors | Matches partial inventory partial-success scope; avoids unnecessary fetches on sold-out errors with an unchanged empty cart | Requires `item_count` check via add response or `/cart.js` |
| 3 | Scope to cart drawer only | Shared helper for cart notification | `cart-notification.renderContents` requires add-response `key`; applying same logic there needs separate validation | Cart notification mode not fixed by this PR |

### Visual impact on existing themes

Merchants using **cart drawer** mode will see the drawer populate correctly when a customer over-requests quantity and Shopify partially adds available stock. The inline availability error on the product form remains visible. No change for merchants using cart page or cart notification modes. Normal successful add-to-cart behavior is unchanged.

### Testing steps/scenarios

- [x] Clear cart. Product with tracked inventory, qty 1 available, continue selling off. Set qty 2, click Add to cart.
- [x] Confirm `/cart/add` returns 422 with availability description.
- [x] Confirm product form shows error (e.g. "Only 1 item was added to your cart due to availability.").
- [x] Confirm `/cart.js` reports `item_count: 1`.
- [x] Confirm cart drawer opens and shows the product at quantity 1.
- [x] Confirm cart bubble shows count 1.
- [x] Confirm normal add (qty 1, sufficient stock) still succeeds with unchanged drawer behavior.
- [x] Sold-out add (qty 1, stock 0): sold-out UI unchanged, drawer stays empty if cart unchanged.
- [ ] Tested on mobile
- [x] Tested on multiple browsers
- [ ] Tested for accessibility (focus trap when drawer opens after error)

### Demo links

- [Store](https://yogivision-te9k3ruq.myshopify.com/?preview_theme_id=YOUR_PREVIEW_THEME_ID)
- [Editor](https://yogivision-te9k3ruq.myshopify.com/admin/themes/YOUR_THEME_ID/editor)

Replace theme IDs with your development theme if sharing with reviewers.

### Checklist

- [x] Added PR summary for [release notes](https://themes.shopify.com/themes/dawn/styles/default#ReleaseNotes)
- [x] Requested review from UX (Only for changes that are affecting the experience or perceivable visual details)
- [ ] Created a ticket for the [help.shopify.com](https://help.shopify.com) documentation team about updates to theme settings. (Internal-only task; N/A, no settings changes)
- [x] Followed [theme code principles](https://github.com/Shopify/dawn/blob/main/.github/CONTRIBUTING.md#theme-code-principles)
- [ ] Linted with [Theme Check](https://github.com/Shopify/theme-check) (CI on PR; not run locally)
- [ ] Tested on [mobile](https://shopify.dev/themes/store/requirements#mobile-browser-requirements)
- [x] Tested on [multiple browsers](https://shopify.dev/themes/store/requirements#desktop-browser-requirements)
- [ ] Tested for [accessibility](https://shopify.dev/themes/best-practices/accessibility)
