### PR TITLE
Add custom features section

### DIFF
--- a/sections/custom-features.liquid
+++ b/sections/custom-features.liquid
@@ -26,6 +26,15 @@
     <div class="custom-features__grid">
       {%- for block in section.blocks -%}
         <div class="custom-features__item scroll-trigger animate--slide-in" data-cascade style="--animation-order: {{ forloop.index }};" {{ block.shopify_attributes }}>
+          {%- if block.settings.icon != blank -%}
+            <img 
+                src="{{ block.settings.icon | image_url: width: 96 }}"
+                alt="{{ block.settings.icon.alt | escape }}"
+                width="48"
+                height="48"
+                loading="lazy"
+            >
+          {%- endif -%}  
           {%- if block.settings.title != blank -%}
             <h3 class="custom-features__title">{{ block.settings.title }}</h3>
           {%- endif -%}
@@ -79,6 +88,11 @@
       "name": "Перевага",
       "limit": 6,
       "settings": [
+        {
+          "type": "image_picker",
+          "id": "icon",
+          "label": "Іконка"
+        },
         {
           "type": "text",
           "id": "title",

--- a/sections/custom-features.liquid
+++ b/sections/custom-features.liquid
@@ -24,25 +24,19 @@
 
   {%- if section.blocks.size > 0 -%}
     <div class="custom-features__grid">
-      {%- for block in section.blocks -%}
-        <div class="custom-features__item scroll-trigger animate--slide-in" data-cascade style="--animation-order: {{ forloop.index }};" {{ block.shopify_attributes }}>
-          {%- if block.settings.icon != blank -%}
-            <img 
-                src="{{ block.settings.icon | image_url: width: 96 }}"
-                alt="{{ block.settings.icon.alt | escape }}"
-                width="48"
-                height="48"
-                loading="lazy"
+        {%- for block in section.blocks -%}
+            <div 
+                class="custom-features__item scroll-trigger animate--slide-in"
+                {{ block.shopify_attributes }}
+                data-cascade
+                style="--animation-order: {{ forloop.index }};"
             >
-          {%- endif -%}  
-          {%- if block.settings.title != blank -%}
-            <h3 class="custom-features__title">{{ block.settings.title }}</h3>
-          {%- endif -%}
-          {%- if block.settings.text != blank -%}
-            <p class="custom-features__text">{{ block.settings.text }}</p>
-          {%- endif -%}
-        </div>
-      {%- endfor -%}
+                {% render 'feature-card',
+                icon: block.settings.icon,
+                title: block.settings.title,
+                text: block.settings.text %}
+             </div>
+        {%- endfor -%}
     </div>
   {%- endif -%}
 

--- a/sections/custom-features.liquid
+++ b/sections/custom-features.liquid
@@ -12,7 +12,7 @@
   }
 {%- endstyle -%}
 
-<div id="CustomFeatures-{{ section.id }}" class="page-width section-{{ section.id }}-padding">
+<div id="CustomFeatures-{{ section.id }}" class="page-width section-{{ section.id }}-padding" data-cascade>
 
   {%- if section.settings.heading != blank -%}
     <h2 class="title">{{ section.settings.heading }}</h2>
@@ -25,7 +25,7 @@
   {%- if section.blocks.size > 0 -%}
     <div class="custom-features__grid">
       {%- for block in section.blocks -%}
-        <div class="custom-features__item" {{ block.shopify_attributes }}>
+        <div class="custom-features__item scroll-trigger animate--slide-in" data-cascade style="--animation-order: {{ forloop.index }};" {{ block.shopify_attributes }}>
           {%- if block.settings.title != blank -%}
             <h3 class="custom-features__title">{{ block.settings.title }}</h3>
           {%- endif -%}

--- a/sections/custom-features.liquid
+++ b/sections/custom-features.liquid
@@ -1,0 +1,108 @@
+{%- style -%}
+  #CustomFeatures-{{ section.id }} .custom-features__grid {
+    display: grid;
+    gap: 2rem;
+    grid-template-columns: repeat({{ section.settings.columns | default: 3 }}, 1fr);
+  }
+
+  @media screen and (max-width: 749px) {
+    #CustomFeatures-{{ section.id }} .custom-features__grid {
+      grid-template-columns: 1fr;
+    }
+  }
+{%- endstyle -%}
+
+<div id="CustomFeatures-{{ section.id }}" class="page-width section-{{ section.id }}-padding">
+
+  {%- if section.settings.heading != blank -%}
+    <h2 class="title">{{ section.settings.heading }}</h2>
+  {%- endif -%}
+
+  {%- if section.settings.show_subheading and section.settings.subheading != blank -%}
+    <p class="subtitle">{{ section.settings.subheading }}</p>
+  {%- endif -%}
+
+  {%- if section.blocks.size > 0 -%}
+    <div class="custom-features__grid">
+      {%- for block in section.blocks -%}
+        <div class="custom-features__item" {{ block.shopify_attributes }}>
+          {%- if block.settings.title != blank -%}
+            <h3 class="custom-features__title">{{ block.settings.title }}</h3>
+          {%- endif -%}
+          {%- if block.settings.text != blank -%}
+            <p class="custom-features__text">{{ block.settings.text }}</p>
+          {%- endif -%}
+        </div>
+      {%- endfor -%}
+    </div>
+  {%- endif -%}
+
+</div>
+
+{% schema %}
+{
+  "name": "Переваги",
+  "tag": "section",
+  "class": "section",
+  "settings": [
+    {
+      "type": "text",
+      "id": "heading",
+      "default": "Чому саме ми",
+      "label": "Заголовок"
+    },
+    {
+      "type": "checkbox",
+      "id": "show_subheading",
+      "default": false,
+      "label": "Показати підзаголовок"
+    },
+    {
+      "type":"textarea",
+      "id": "subheading",
+      "label": "Підзаголовок",
+      "visible_if": "{{ section.settings.show_subheading }}"
+    },
+    {
+      "type": "range",
+      "id": "columns",
+      "min": 2,
+      "max": 4,
+      "step": 1,
+      "default": 3,
+      "label": "Колонок на десктопі"
+    }
+  ],
+  "blocks": [
+    {
+      "type": "feature",
+      "name": "Перевага",
+      "limit": 6,
+      "settings": [
+        {
+          "type": "text",
+          "id": "title",
+          "default": "Назва переваги",
+          "label": "Назва"
+        },
+        {
+          "type": "textarea",
+          "id": "text",
+          "default": "Короткий опис переваги.",
+          "label": "Опис"
+        }
+      ]
+    }
+  ],
+  "presets": [
+    {
+      "name": "Переваги",
+      "blocks": [
+        { "type": "feature" },
+        { "type": "feature" },
+        { "type": "feature" }
+      ]
+    }
+  ]
+}
+{% endschema %}

--- a/sections/footer.liquid
+++ b/sections/footer.liquid
@@ -170,6 +170,11 @@
               {%- if section.settings.newsletter_heading != blank -%}
                 <h2 class="footer-block__heading inline-richtext">{{ section.settings.newsletter_heading }}</h2>
               {%- endif -%}
+              {%- if section.settings.newsletter_subheading != blank -%}
+                <div class="footer-block__newsletter-subheading rte">
+                  {{ section.settings.newsletter_subheading }}
+                </div>
+              {%- endif -%}
               {%- form 'customer', id: 'ContactFooter', class: 'footer__newsletter newsletter-form' -%}
                 <input type="hidden" name="contact[tags]" value="newsletter">
                 <div class="newsletter-form__field-wrapper">
@@ -446,6 +451,12 @@
       "id": "newsletter_heading",
       "default": "t:sections.footer.settings.newsletter_heading.default",
       "label": "t:sections.footer.settings.newsletter_heading.label"
+    },
+    {
+      "type": "richtext",
+      "id": "newsletter_subheading",
+      "default": "<p>Отримуйте новини першими</p>",
+      "label": "Підзаголовок розсилки"
     },
     {
       "type": "header",

--- a/snippets/feature-card.liquid
+++ b/snippets/feature-card.liquid
@@ -1,0 +1,26 @@
+{%- comment -%}
+  Картка переваги.
+
+  Параметри:
+  - icon  {Image}  іконка (опційно)
+  - title {String} заголовок
+  - text  {String} опис
+{%- endcomment -%}
+
+{%- if icon != blank -%}
+  <img
+    src="{{ icon | image_url: width: 96 }}"
+    alt="{{ icon.alt | escape }}"
+    width="48"
+    height="48"
+    loading="lazy"
+  >
+{%- endif -%}
+
+{%- if title != blank -%}
+  <h3 class="custom-features__title">{{ title }}</h3>
+{%- endif -%}
+
+{%- if text != blank -%}
+  <p class="custom-features__text">{{ text }}</p>
+{%- endif -%}


### PR DESCRIPTION
**## What's done**
New "Features" section with blocks the merchant can add and reorder.

**##Details:**

- Section settings: heading, optional subheading (visible_if), column count (range 2–4)
- feature block type: icon, title, description. Limit of 6
- Responsive grid: configured columns on desktop, single column on mobile
- Reveal animation using Dawn's built-in mechanism (scroll-trigger + cascade)
- Card markup extracted into snippets/feature-card.liquid
 

**##Tested:**

- Shopify theme check - no errors
- Two sections on the same page don't conflict in styles