### PR TITLE
Add custom heading and body font settings

### DIFF
--- a/config/settings_schema.json
+++ b/config/settings_schema.json
@@ -112,7 +112,8 @@
         "type": "font_picker",
         "id": "type_header_font",
         "default": "assistant_n4",
-        "label": "t:settings_schema.typography.settings.type_header_font.label"
+        "label": "t:settings_schema.typography.settings.type_header_font.label",
+        "visible_if": "{{ settings.custom_heading_font_enabled == false }}"
       },
       {
         "type": "range",
@@ -126,13 +127,65 @@
       },
       {
         "type": "header",
+        "content": "t:settings_schema.typography.settings.custom_heading.content"
+      },
+      {
+        "type": "checkbox",
+        "id": "custom_heading_font_enabled",
+        "label": "t:settings_schema.typography.settings.custom_font_enabled.label",
+        "default": false
+      },
+      {
+        "type": "text",
+        "id": "custom_heading_font_family",
+        "label": "t:settings_schema.typography.settings.custom_font_family.label",
+        "default": "Custom Heading",
+        "visible_if": "{{ settings.custom_heading_font_enabled }}"
+      },
+      {
+        "type": "url",
+        "id": "custom_heading_font_url",
+        "label": "t:settings_schema.typography.settings.custom_font_url.label",
+        "info": "t:settings_schema.typography.settings.custom_font_url.info",
+        "visible_if": "{{ settings.custom_heading_font_enabled }}"
+      },
+      {
+        "type": "range",
+        "id": "custom_heading_font_weight",
+        "min": 100,
+        "max": 1000,
+        "step": 100,
+        "label": "t:settings_schema.typography.settings.custom_font_weight.label",
+        "default": 400,
+        "visible_if": "{{ settings.custom_heading_font_enabled }}"
+      },
+      {
+        "type": "select",
+        "id": "custom_heading_font_style",
+        "label": "t:settings_schema.typography.settings.custom_font_style.label",
+        "options": [
+          {
+            "value": "normal",
+            "label": "t:settings_schema.typography.settings.custom_font_style.options__1.label"
+          },
+          {
+            "value": "italic",
+            "label": "t:settings_schema.typography.settings.custom_font_style.options__2.label"
+          }
+        ],
+        "default": "normal",
+        "visible_if": "{{ settings.custom_heading_font_enabled }}"
+      },
+      {
+        "type": "header",
         "content": "t:settings_schema.typography.settings.header__2.content"
       },
       {
         "type": "font_picker",
         "id": "type_body_font",
         "default": "assistant_n4",
-        "label": "t:settings_schema.typography.settings.type_body_font.label"
+        "label": "t:settings_schema.typography.settings.type_body_font.label",
+        "visible_if": "{{ settings.custom_body_font_enabled == false }}"
       },
       {
         "type": "range",
@@ -143,6 +196,57 @@
         "unit": "%",
         "label": "t:settings_schema.typography.settings.body_scale.label",
         "default": 100
+      },
+      {
+        "type": "header",
+        "content": "t:settings_schema.typography.settings.custom_body.content"
+      },
+      {
+        "type": "checkbox",
+        "id": "custom_body_font_enabled",
+        "label": "t:settings_schema.typography.settings.custom_font_enabled.label",
+        "default": false
+      },
+      {
+        "type": "text",
+        "id": "custom_body_font_family",
+        "label": "t:settings_schema.typography.settings.custom_font_family.label",
+        "default": "Custom Body",
+        "visible_if": "{{ settings.custom_body_font_enabled }}"
+      },
+      {
+        "type": "url",
+        "id": "custom_body_font_url",
+        "label": "t:settings_schema.typography.settings.custom_font_url.label",
+        "info": "t:settings_schema.typography.settings.custom_font_url.info",
+        "visible_if": "{{ settings.custom_body_font_enabled }}"
+      },
+      {
+        "type": "range",
+        "id": "custom_body_font_weight",
+        "min": 100,
+        "max": 1000,
+        "step": 100,
+        "label": "t:settings_schema.typography.settings.custom_font_weight.label",
+        "default": 400,
+        "visible_if": "{{ settings.custom_body_font_enabled }}"
+      },
+      {
+        "type": "select",
+        "id": "custom_body_font_style",
+        "label": "t:settings_schema.typography.settings.custom_font_style.label",
+        "options": [
+          {
+            "value": "normal",
+            "label": "t:settings_schema.typography.settings.custom_font_style.options__1.label"
+          },
+          {
+            "value": "italic",
+            "label": "t:settings_schema.typography.settings.custom_font_style.options__2.label"
+          }
+        ],
+        "default": "normal",
+        "visible_if": "{{ settings.custom_body_font_enabled }}"
       }
     ]
   },

--- a/layout/password.liquid
+++ b/layout/password.liquid
@@ -23,18 +23,25 @@
 
     {{ content_for_header }}
 
+    {% render 'custom-fonts' %}
+
     {%- liquid
       assign body_font_bold = settings.type_body_font | font_modify: 'weight', 'bold'
       assign body_font_italic = settings.type_body_font | font_modify: 'style', 'italic'
       assign body_font_bold_italic = body_font_bold | font_modify: 'style', 'italic'
+      assign scheme_classes = ''
     %}
 
     {% style %}
+      {% unless settings.custom_body_font_enabled %}
       {{ settings.type_body_font | font_face: font_display: 'swap' }}
       {{ body_font_bold | font_face: font_display: 'swap' }}
       {{ body_font_italic | font_face: font_display: 'swap' }}
       {{ body_font_bold_italic | font_face: font_display: 'swap' }}
+      {% endunless %}
+      {% unless settings.custom_heading_font_enabled %}
       {{ settings.type_header_font | font_face: font_display: 'swap' }}
+      {% endunless %}
 
       {% for scheme in settings.color_schemes -%}
         {% assign scheme_classes = scheme_classes | append: ', .color-' | append: scheme.id %}
@@ -68,13 +75,25 @@
       }
 
       :root {
-        --font-body-family: {{ settings.type_body_font.family }}, {{ settings.type_body_font.fallback_families }};
-        --font-body-style: {{ settings.type_body_font.style }};
-        --font-body-weight: {{ settings.type_body_font.weight }};
+        {% if settings.custom_body_font_enabled %}
+          --font-body-family: {{ settings.custom_body_font_family | json }}, sans-serif;
+          --font-body-style: {{ settings.custom_body_font_style }};
+          --font-body-weight: {{ settings.custom_body_font_weight }};
+        {% else %}
+          --font-body-family: {{ settings.type_body_font.family }}, {{ settings.type_body_font.fallback_families }};
+          --font-body-style: {{ settings.type_body_font.style }};
+          --font-body-weight: {{ settings.type_body_font.weight }};
+        {% endif %}
 
-        --font-heading-family: {{ settings.type_header_font.family }}, {{ settings.type_header_font.fallback_families }};
-        --font-heading-style: {{ settings.type_header_font.style }};
-        --font-heading-weight: {{ settings.type_header_font.weight }};
+        {% if settings.custom_heading_font_enabled %}
+          --font-heading-family: {{ settings.custom_heading_font_family | json }}, sans-serif;
+          --font-heading-style: {{ settings.custom_heading_font_style }};
+          --font-heading-weight: {{ settings.custom_heading_font_weight }};
+        {% else %}
+          --font-heading-family: {{ settings.type_header_font.family }}, {{ settings.type_header_font.fallback_families }};
+          --font-heading-style: {{ settings.type_header_font.style }};
+          --font-heading-weight: {{ settings.type_header_font.weight }};
+        {% endif %}
 
         --font-body-scale: {{ settings.body_scale | divided_by: 100.0 }};
         --font-heading-scale: {{ settings.heading_scale | times: 1.0 | divided_by: settings.body_scale }};
@@ -174,12 +193,12 @@
       }
     {% endstyle %}
 
-    {%- unless settings.type_body_font.system? -%}
+    {%- unless settings.custom_body_font_enabled or settings.type_body_font.system? -%}
       {% comment %}theme-check-disable AssetPreload{% endcomment %}
       <link rel="preload" as="font" href="{{ settings.type_body_font | font_url }}" type="font/woff2" crossorigin>
       {% comment %}theme-check-enable AssetPreload{% endcomment %}
     {%- endunless -%}
-    {%- unless settings.type_header_font.system? -%}
+    {%- unless settings.custom_heading_font_enabled or settings.type_header_font.system? -%}
       {% comment %}theme-check-disable AssetPreload{% endcomment %}
       <link rel="preload" as="font" href="{{ settings.type_header_font | font_url }}" type="font/woff2" crossorigin>
       {% comment %}theme-check-enable AssetPreload{% endcomment %}

--- a/layout/theme.liquid
+++ b/layout/theme.liquid
@@ -65,18 +65,25 @@
 
     {{ content_for_header }}
 
+    {% render 'custom-fonts' %}
+
     {%- liquid
       assign body_font_bold = settings.type_body_font | font_modify: 'weight', 'bold'
       assign body_font_italic = settings.type_body_font | font_modify: 'style', 'italic'
       assign body_font_bold_italic = body_font_bold | font_modify: 'style', 'italic'
+      assign scheme_classes = ''
     %}
 
     {% style %}
+      {% unless settings.custom_body_font_enabled %}
       {{ settings.type_body_font | font_face: font_display: 'swap' }}
       {{ body_font_bold | font_face: font_display: 'swap' }}
       {{ body_font_italic | font_face: font_display: 'swap' }}
       {{ body_font_bold_italic | font_face: font_display: 'swap' }}
+      {% endunless %}
+      {% unless settings.custom_heading_font_enabled %}
       {{ settings.type_header_font | font_face: font_display: 'swap' }}
+      {% endunless %}
 
       {% for scheme in settings.color_schemes -%}
         {% assign scheme_classes = scheme_classes | append: ', .color-' | append: scheme.id %}
@@ -124,14 +131,27 @@
       }
 
       :root {
-        --font-body-family: {{ settings.type_body_font.family }}, {{ settings.type_body_font.fallback_families }};
-        --font-body-style: {{ settings.type_body_font.style }};
-        --font-body-weight: {{ settings.type_body_font.weight }};
-        --font-body-weight-bold: {{ settings.type_body_font.weight | plus: 300 | at_most: 1000 }};
+        {% if settings.custom_body_font_enabled %}
+          --font-body-family: {{ settings.custom_body_font_family | json }}, sans-serif;
+          --font-body-style: {{ settings.custom_body_font_style }};
+          --font-body-weight: {{ settings.custom_body_font_weight }};
+          --font-body-weight-bold: {{ settings.custom_body_font_weight | plus: 300 | at_most: 1000 }};
+        {% else %}
+          --font-body-family: {{ settings.type_body_font.family }}, {{ settings.type_body_font.fallback_families }};
+          --font-body-style: {{ settings.type_body_font.style }};
+          --font-body-weight: {{ settings.type_body_font.weight }};
+          --font-body-weight-bold: {{ settings.type_body_font.weight | plus: 300 | at_most: 1000 }};
+        {% endif %}
 
-        --font-heading-family: {{ settings.type_header_font.family }}, {{ settings.type_header_font.fallback_families }};
-        --font-heading-style: {{ settings.type_header_font.style }};
-        --font-heading-weight: {{ settings.type_header_font.weight }};
+        {% if settings.custom_heading_font_enabled %}
+          --font-heading-family: {{ settings.custom_heading_font_family | json }}, sans-serif;
+          --font-heading-style: {{ settings.custom_heading_font_style }};
+          --font-heading-weight: {{ settings.custom_heading_font_weight }};
+        {% else %}
+          --font-heading-family: {{ settings.type_header_font.family }}, {{ settings.type_header_font.fallback_families }};
+          --font-heading-style: {{ settings.type_header_font.style }};
+          --font-heading-weight: {{ settings.type_header_font.weight }};
+        {% endif %}
 
         --font-body-scale: {{ settings.body_scale | divided_by: 100.0 }};
         --font-heading-scale: {{ settings.heading_scale | times: 1.0 | divided_by: settings.body_scale }};
@@ -289,12 +309,12 @@
       {{ 'component-discounts.css' | asset_url | stylesheet_tag }}
     {%- endif -%}
 
-    {%- unless settings.type_body_font.system? -%}
+    {%- unless settings.custom_body_font_enabled or settings.type_body_font.system? -%}
       {% comment %}theme-check-disable AssetPreload{% endcomment %}
       <link rel="preload" as="font" href="{{ settings.type_body_font | font_url }}" type="font/woff2" crossorigin>
       {% comment %}theme-check-enable AssetPreload{% endcomment %}
     {%- endunless -%}
-    {%- unless settings.type_header_font.system? -%}
+    {%- unless settings.custom_heading_font_enabled or settings.type_header_font.system? -%}
       {% comment %}theme-check-disable AssetPreload{% endcomment %}
       <link rel="preload" as="font" href="{{ settings.type_header_font | font_url }}" type="font/woff2" crossorigin>
       {% comment %}theme-check-enable AssetPreload{% endcomment %}

--- a/locales/cs.schema.json
+++ b/locales/cs.schema.json
@@ -47,6 +47,34 @@
         },
         "body_scale": {
           "label": "Škálování"
+        },
+        "custom_heading": {
+          "content": "Vlastní písmo nadpisu"
+        },
+        "custom_body": {
+          "content": "Vlastní písmo textu"
+        },
+        "custom_font_enabled": {
+          "label": "Použít vlastní písmo"
+        },
+        "custom_font_family": {
+          "label": "Rodina písma"
+        },
+        "custom_font_url": {
+          "label": "Adresa URL písma",
+          "info": "Zadejte adresu URL šablony stylů Google Fonts nebo přímou adresu URL písma WOFF2."
+        },
+        "custom_font_weight": {
+          "label": "Tloušťka písma"
+        },
+        "custom_font_style": {
+          "label": "Styl písma",
+          "options__1": {
+            "label": "Normální"
+          },
+          "options__2": {
+            "label": "Kurzíva"
+          }
         }
       }
     },

--- a/locales/da.schema.json
+++ b/locales/da.schema.json
@@ -47,6 +47,34 @@
         },
         "body_scale": {
           "label": "Skalering"
+        },
+        "custom_heading": {
+          "content": "Brugerdefineret overskriftsfont"
+        },
+        "custom_body": {
+          "content": "Brugerdefineret brødtekstfont"
+        },
+        "custom_font_enabled": {
+          "label": "Brug brugerdefineret skrifttype"
+        },
+        "custom_font_family": {
+          "label": "Skrifttypefamilie"
+        },
+        "custom_font_url": {
+          "label": "Skrifttype-URL",
+          "info": "Angiv en Google Fonts-stilark-URL eller en direkte WOFF2-skrifttype-URL."
+        },
+        "custom_font_weight": {
+          "label": "Skrifttypevægt"
+        },
+        "custom_font_style": {
+          "label": "Skrifttypestil",
+          "options__1": {
+            "label": "Normal"
+          },
+          "options__2": {
+            "label": "Kursiv"
+          }
         }
       }
     },

--- a/locales/de.schema.json
+++ b/locales/de.schema.json
@@ -47,6 +47,34 @@
         },
         "body_scale": {
           "label": "Maßstab"
+        },
+        "custom_heading": {
+          "content": "Benutzerdefinierte Überschriftenschriftart"
+        },
+        "custom_body": {
+          "content": "Benutzerdefinierte Textschriftart"
+        },
+        "custom_font_enabled": {
+          "label": "Benutzerdefinierte Schriftart verwenden"
+        },
+        "custom_font_family": {
+          "label": "Schriftfamilie"
+        },
+        "custom_font_url": {
+          "label": "Schriftart-URL",
+          "info": "Gib eine Google Fonts-Stylesheet-URL oder eine direkte WOFF2-Schriftart-URL ein."
+        },
+        "custom_font_weight": {
+          "label": "Schriftstärke"
+        },
+        "custom_font_style": {
+          "label": "Schriftstil",
+          "options__1": {
+            "label": "Normal"
+          },
+          "options__2": {
+            "label": "Kursiv"
+          }
         }
       }
     },

--- a/locales/en.default.schema.json
+++ b/locales/en.default.schema.json
@@ -204,6 +204,34 @@
         },
         "body_scale": {
           "label": "Scale"
+        },
+        "custom_heading": {
+          "content": "Custom heading font"
+        },
+        "custom_body": {
+          "content": "Custom body font"
+        },
+        "custom_font_enabled": {
+          "label": "Use custom font"
+        },
+        "custom_font_family": {
+          "label": "Font family"
+        },
+        "custom_font_url": {
+          "label": "Font URL",
+          "info": "Enter a Google Fonts stylesheet URL or a direct WOFF2 font URL."
+        },
+        "custom_font_weight": {
+          "label": "Font weight"
+        },
+        "custom_font_style": {
+          "label": "Font style",
+          "options__1": {
+            "label": "Normal"
+          },
+          "options__2": {
+            "label": "Italic"
+          }
         }
       }
     },

--- a/locales/es.schema.json
+++ b/locales/es.schema.json
@@ -47,6 +47,34 @@
         },
         "body_scale": {
           "label": "Escala"
+        },
+        "custom_heading": {
+          "content": "Fuente de encabezado personalizada"
+        },
+        "custom_body": {
+          "content": "Fuente de texto personalizada"
+        },
+        "custom_font_enabled": {
+          "label": "Usar fuente personalizada"
+        },
+        "custom_font_family": {
+          "label": "Familia tipográfica"
+        },
+        "custom_font_url": {
+          "label": "URL de la fuente",
+          "info": "Introduce una URL de hoja de estilos de Google Fonts o una URL directa de fuente WOFF2."
+        },
+        "custom_font_weight": {
+          "label": "Grosor de fuente"
+        },
+        "custom_font_style": {
+          "label": "Estilo de fuente",
+          "options__1": {
+            "label": "Normal"
+          },
+          "options__2": {
+            "label": "Cursiva"
+          }
         }
       }
     },

--- a/locales/fi.schema.json
+++ b/locales/fi.schema.json
@@ -47,6 +47,34 @@
         },
         "body_scale": {
           "label": "Skaalaa"
+        },
+        "custom_heading": {
+          "content": "Mukautettu otsikkofontti"
+        },
+        "custom_body": {
+          "content": "Mukautettu leipätekstifontti"
+        },
+        "custom_font_enabled": {
+          "label": "Käytä mukautettua fonttia"
+        },
+        "custom_font_family": {
+          "label": "Fonttiperhe"
+        },
+        "custom_font_url": {
+          "label": "Fontin URL-osoite",
+          "info": "Anna Google Fonts -tyylisivun URL-osoite tai suora WOFF2-fontin URL-osoite."
+        },
+        "custom_font_weight": {
+          "label": "Fontin paksuus"
+        },
+        "custom_font_style": {
+          "label": "Fontin tyyli",
+          "options__1": {
+            "label": "Normaali"
+          },
+          "options__2": {
+            "label": "Kursiivi"
+          }
         }
       }
     },

--- a/locales/fr.schema.json
+++ b/locales/fr.schema.json
@@ -47,6 +47,34 @@
         },
         "body_scale": {
           "label": "Échelle"
+        },
+        "custom_heading": {
+          "content": "Police de titre personnalisée"
+        },
+        "custom_body": {
+          "content": "Police de corps personnalisée"
+        },
+        "custom_font_enabled": {
+          "label": "Utiliser une police personnalisée"
+        },
+        "custom_font_family": {
+          "label": "Famille de polices"
+        },
+        "custom_font_url": {
+          "label": "URL de la police",
+          "info": "Saisissez une URL de feuille de style Google Fonts ou une URL directe de police WOFF2."
+        },
+        "custom_font_weight": {
+          "label": "Graisse de la police"
+        },
+        "custom_font_style": {
+          "label": "Style de police",
+          "options__1": {
+            "label": "Normal"
+          },
+          "options__2": {
+            "label": "Italique"
+          }
         }
       }
     },

--- a/locales/it.schema.json
+++ b/locales/it.schema.json
@@ -47,6 +47,34 @@
         },
         "body_scale": {
           "label": "Ridimensionamento"
+        },
+        "custom_heading": {
+          "content": "Carattere del titolo personalizzato"
+        },
+        "custom_body": {
+          "content": "Carattere del testo personalizzato"
+        },
+        "custom_font_enabled": {
+          "label": "Usa carattere personalizzato"
+        },
+        "custom_font_family": {
+          "label": "Famiglia di caratteri"
+        },
+        "custom_font_url": {
+          "label": "URL del carattere",
+          "info": "Inserisci un URL del foglio di stile di Google Fonts o un URL diretto del carattere WOFF2."
+        },
+        "custom_font_weight": {
+          "label": "Peso del carattere"
+        },
+        "custom_font_style": {
+          "label": "Stile del carattere",
+          "options__1": {
+            "label": "Normale"
+          },
+          "options__2": {
+            "label": "Corsivo"
+          }
         }
       }
     },

--- a/locales/ja.schema.json
+++ b/locales/ja.schema.json
@@ -47,6 +47,34 @@
         },
         "body_scale": {
           "label": "拡大"
+        },
+        "custom_heading": {
+          "content": "カスタム見出しフォント"
+        },
+        "custom_body": {
+          "content": "カスタム本文フォント"
+        },
+        "custom_font_enabled": {
+          "label": "カスタムフォントを使用"
+        },
+        "custom_font_family": {
+          "label": "フォントファミリー"
+        },
+        "custom_font_url": {
+          "label": "フォントURL",
+          "info": "Google Fonts スタイルシートの URL または WOFF2 フォントの直接 URL を入力してください。"
+        },
+        "custom_font_weight": {
+          "label": "フォントの太さ"
+        },
+        "custom_font_style": {
+          "label": "フォントスタイル",
+          "options__1": {
+            "label": "標準"
+          },
+          "options__2": {
+            "label": "イタリック"
+          }
         }
       }
     },

--- a/locales/ko.schema.json
+++ b/locales/ko.schema.json
@@ -47,6 +47,34 @@
         },
         "body_scale": {
           "label": "크기 조정"
+        },
+        "custom_heading": {
+          "content": "사용자 지정 제목 글꼴"
+        },
+        "custom_body": {
+          "content": "사용자 지정 본문 글꼴"
+        },
+        "custom_font_enabled": {
+          "label": "사용자 지정 글꼴 사용"
+        },
+        "custom_font_family": {
+          "label": "글꼴 모음"
+        },
+        "custom_font_url": {
+          "label": "글꼴 URL",
+          "info": "Google Fonts 스타일시트 URL 또는 직접 WOFF2 글꼴 URL을 입력하세요."
+        },
+        "custom_font_weight": {
+          "label": "글꼴 굵기"
+        },
+        "custom_font_style": {
+          "label": "글꼴 스타일",
+          "options__1": {
+            "label": "보통"
+          },
+          "options__2": {
+            "label": "기울임꼴"
+          }
         }
       }
     },

--- a/locales/nb.schema.json
+++ b/locales/nb.schema.json
@@ -47,6 +47,34 @@
         },
         "body_scale": {
           "label": "Skala"
+        },
+        "custom_heading": {
+          "content": "Egendefinert overskriftsfont"
+        },
+        "custom_body": {
+          "content": "Egendefinert brødtekstfont"
+        },
+        "custom_font_enabled": {
+          "label": "Bruk egendefinert skrifttype"
+        },
+        "custom_font_family": {
+          "label": "Skriftfamilie"
+        },
+        "custom_font_url": {
+          "label": "Skrift-URL",
+          "info": "Angi en Google Fonts-stilark-URL eller en direkte WOFF2-skrifttype-URL."
+        },
+        "custom_font_weight": {
+          "label": "Skrifttykkelse"
+        },
+        "custom_font_style": {
+          "label": "Skriftstil",
+          "options__1": {
+            "label": "Normal"
+          },
+          "options__2": {
+            "label": "Kursiv"
+          }
         }
       }
     },

--- a/locales/nl.schema.json
+++ b/locales/nl.schema.json
@@ -47,6 +47,34 @@
         },
         "body_scale": {
           "label": "Schaal"
+        },
+        "custom_heading": {
+          "content": "Aangepast koplettertype"
+        },
+        "custom_body": {
+          "content": "Aangepast hoofdtekstlettertype"
+        },
+        "custom_font_enabled": {
+          "label": "Aangepast lettertype gebruiken"
+        },
+        "custom_font_family": {
+          "label": "Lettertypefamilie"
+        },
+        "custom_font_url": {
+          "label": "Lettertype-URL",
+          "info": "Voer een Google Fonts-stylesheet-URL of een directe WOFF2-lettertype-URL in."
+        },
+        "custom_font_weight": {
+          "label": "Lettertypedikte"
+        },
+        "custom_font_style": {
+          "label": "Lettertypestijl",
+          "options__1": {
+            "label": "Normaal"
+          },
+          "options__2": {
+            "label": "Cursief"
+          }
         }
       }
     },

--- a/locales/pl.schema.json
+++ b/locales/pl.schema.json
@@ -47,6 +47,34 @@
         },
         "body_scale": {
           "label": "Skala"
+        },
+        "custom_heading": {
+          "content": "Niestandardowa czcionka nagłówków"
+        },
+        "custom_body": {
+          "content": "Niestandardowa czcionka tekstu"
+        },
+        "custom_font_enabled": {
+          "label": "Użyj niestandardowej czcionki"
+        },
+        "custom_font_family": {
+          "label": "Rodzina czcionek"
+        },
+        "custom_font_url": {
+          "label": "Adres URL czcionki",
+          "info": "Wprowadź adres URL arkusza stylów Google Fonts lub bezpośredni adres URL czcionki WOFF2."
+        },
+        "custom_font_weight": {
+          "label": "Grubość czcionki"
+        },
+        "custom_font_style": {
+          "label": "Styl czcionki",
+          "options__1": {
+            "label": "Normalny"
+          },
+          "options__2": {
+            "label": "Kursywa"
+          }
         }
       }
     },

--- a/locales/pt-BR.schema.json
+++ b/locales/pt-BR.schema.json
@@ -47,6 +47,34 @@
         },
         "body_scale": {
           "label": "Escala"
+        },
+        "custom_heading": {
+          "content": "Fonte personalizada de cabeçalho"
+        },
+        "custom_body": {
+          "content": "Fonte personalizada do corpo"
+        },
+        "custom_font_enabled": {
+          "label": "Usar fonte personalizada"
+        },
+        "custom_font_family": {
+          "label": "Família da fonte"
+        },
+        "custom_font_url": {
+          "label": "URL da fonte",
+          "info": "Insira uma URL de folha de estilo do Google Fonts ou uma URL direta de fonte WOFF2."
+        },
+        "custom_font_weight": {
+          "label": "Peso da fonte"
+        },
+        "custom_font_style": {
+          "label": "Estilo da fonte",
+          "options__1": {
+            "label": "Normal"
+          },
+          "options__2": {
+            "label": "Itálico"
+          }
         }
       }
     },

--- a/locales/pt-PT.schema.json
+++ b/locales/pt-PT.schema.json
@@ -47,6 +47,34 @@
         },
         "body_scale": {
           "label": "Expansão"
+        },
+        "custom_heading": {
+          "content": "Tipo de letra personalizado do cabeçalho"
+        },
+        "custom_body": {
+          "content": "Tipo de letra personalizado do corpo"
+        },
+        "custom_font_enabled": {
+          "label": "Utilizar tipo de letra personalizado"
+        },
+        "custom_font_family": {
+          "label": "Família do tipo de letra"
+        },
+        "custom_font_url": {
+          "label": "URL do tipo de letra",
+          "info": "Introduza um URL de folha de estilo do Google Fonts ou um URL direto de tipo de letra WOFF2."
+        },
+        "custom_font_weight": {
+          "label": "Peso do tipo de letra"
+        },
+        "custom_font_style": {
+          "label": "Estilo do tipo de letra",
+          "options__1": {
+            "label": "Normal"
+          },
+          "options__2": {
+            "label": "Itálico"
+          }
         }
       }
     },

--- a/locales/sv.schema.json
+++ b/locales/sv.schema.json
@@ -47,6 +47,34 @@
         },
         "body_scale": {
           "label": "Skala"
+        },
+        "custom_heading": {
+          "content": "Anpassat rubriktypsnitt"
+        },
+        "custom_body": {
+          "content": "Anpassat brödtexttypsnitt"
+        },
+        "custom_font_enabled": {
+          "label": "Använd anpassat typsnitt"
+        },
+        "custom_font_family": {
+          "label": "Teckensnittsfamilj"
+        },
+        "custom_font_url": {
+          "label": "Teckensnitts-URL",
+          "info": "Ange en Google Fonts-formatmall-URL eller en direkt WOFF2-teckensnitts-URL."
+        },
+        "custom_font_weight": {
+          "label": "Teckensnittsvikt"
+        },
+        "custom_font_style": {
+          "label": "Teckensnittsstil",
+          "options__1": {
+            "label": "Normal"
+          },
+          "options__2": {
+            "label": "Kursiv"
+          }
         }
       }
     },

--- a/locales/th.schema.json
+++ b/locales/th.schema.json
@@ -47,6 +47,34 @@
         },
         "body_scale": {
           "label": "ขนาด"
+        },
+        "custom_heading": {
+          "content": "แบบอักษรหัวเรื่องแบบกำหนดเอง"
+        },
+        "custom_body": {
+          "content": "แบบอักษรเนื้อหาแบบกำหนดเอง"
+        },
+        "custom_font_enabled": {
+          "label": "ใช้แบบอักษรแบบกำหนดเอง"
+        },
+        "custom_font_family": {
+          "label": "ตระกูลแบบอักษร"
+        },
+        "custom_font_url": {
+          "label": "URL แบบอักษร",
+          "info": "ป้อน URL สไตล์ชีตของ Google Fonts หรือ URL แบบอักษร WOFF2 โดยตรง"
+        },
+        "custom_font_weight": {
+          "label": "น้ำหนักแบบอักษร"
+        },
+        "custom_font_style": {
+          "label": "รูปแบบแบบอักษร",
+          "options__1": {
+            "label": "ปกติ"
+          },
+          "options__2": {
+            "label": "ตัวเอียง"
+          }
         }
       }
     },

--- a/locales/tr.schema.json
+++ b/locales/tr.schema.json
@@ -47,6 +47,34 @@
         },
         "body_scale": {
           "label": "Ölçek"
+        },
+        "custom_heading": {
+          "content": "Özel başlık yazı tipi"
+        },
+        "custom_body": {
+          "content": "Özel gövde yazı tipi"
+        },
+        "custom_font_enabled": {
+          "label": "Özel yazı tipi kullan"
+        },
+        "custom_font_family": {
+          "label": "Yazı tipi ailesi"
+        },
+        "custom_font_url": {
+          "label": "Yazı tipi URL",
+          "info": "Bir Google Fonts stil sayfası URL veya doğrudan bir WOFF2 yazı tipi URL girin."
+        },
+        "custom_font_weight": {
+          "label": "Yazı tipi kalınlığı"
+        },
+        "custom_font_style": {
+          "label": "Yazı tipi stili",
+          "options__1": {
+            "label": "Normal"
+          },
+          "options__2": {
+            "label": "İtalik"
+          }
         }
       }
     },

--- a/locales/zh-CN.schema.json
+++ b/locales/zh-CN.schema.json
@@ -47,6 +47,34 @@
         },
         "body_scale": {
           "label": "缩放"
+        },
+        "custom_heading": {
+          "content": "自定义标题字体"
+        },
+        "custom_body": {
+          "content": "自定义正文字体"
+        },
+        "custom_font_enabled": {
+          "label": "使用自定义字体"
+        },
+        "custom_font_family": {
+          "label": "字体系列"
+        },
+        "custom_font_url": {
+          "label": "字体 URL",
+          "info": "输入 Google Fonts 样式表 URL 或直接 WOFF2 字体 URL。"
+        },
+        "custom_font_weight": {
+          "label": "字体粗细"
+        },
+        "custom_font_style": {
+          "label": "字体样式",
+          "options__1": {
+            "label": "正常"
+          },
+          "options__2": {
+            "label": "斜体"
+          }
         }
       }
     },

--- a/locales/zh-TW.schema.json
+++ b/locales/zh-TW.schema.json
@@ -47,6 +47,34 @@
         },
         "body_scale": {
           "label": "縮放比例"
+        },
+        "custom_heading": {
+          "content": "自訂標題字體"
+        },
+        "custom_body": {
+          "content": "自訂內文字體"
+        },
+        "custom_font_enabled": {
+          "label": "使用自訂字體"
+        },
+        "custom_font_family": {
+          "label": "字體系列"
+        },
+        "custom_font_url": {
+          "label": "字體 URL",
+          "info": "輸入 Google Fonts 樣式表 URL 或直接 WOFF2 字體 URL。"
+        },
+        "custom_font_weight": {
+          "label": "字體粗細"
+        },
+        "custom_font_style": {
+          "label": "字體樣式",
+          "options__1": {
+            "label": "一般"
+          },
+          "options__2": {
+            "label": "斜體"
+          }
         }
       }
     },

--- a/release-notes.md
+++ b/release-notes.md
@@ -11,6 +11,7 @@ Updates the header to use Shopify's customer account experience, adds a Customer
 ### Changed
 
 - [Customer accounts] The header account icon now opens Shopify's customer account popover instead of a separate login page.
+- [Typography] Added support for custom heading and body fonts using Google Fonts or direct WOFF2 font URLs.
 
 ### Fixes and improvements
 

--- a/snippets/custom-fonts.liquid
+++ b/snippets/custom-fonts.liquid
@@ -1,0 +1,37 @@
+{% doc %}
+  Loads custom heading and body fonts from a Google Fonts stylesheet or direct WOFF2 file URL.
+{% enddoc %}
+
+{%- if settings.custom_heading_font_enabled and settings.custom_heading_font_url contains 'fonts.googleapis.com' -%}
+  <link rel="stylesheet" href="{{ settings.custom_heading_font_url | escape }}">
+{%- endif -%}
+
+{%- if settings.custom_body_font_enabled and settings.custom_body_font_url contains 'fonts.googleapis.com' -%}
+  <link rel="stylesheet" href="{{ settings.custom_body_font_url | escape }}">
+{%- endif -%}
+
+{% style %}
+  {%- if settings.custom_heading_font_enabled and settings.custom_heading_font_url != blank -%}
+    {%- unless settings.custom_heading_font_url contains 'fonts.googleapis.com' -%}
+      @font-face {
+        font-family: {{ settings.custom_heading_font_family | json }};
+        src: url({{ settings.custom_heading_font_url | json }}) format('woff2');
+        font-style: {{ settings.custom_heading_font_style }};
+        font-weight: {{ settings.custom_heading_font_weight }};
+        font-display: swap;
+      }
+    {%- endunless -%}
+  {%- endif -%}
+
+  {%- if settings.custom_body_font_enabled and settings.custom_body_font_url != blank -%}
+    {%- unless settings.custom_body_font_url contains 'fonts.googleapis.com' -%}
+      @font-face {
+        font-family: {{ settings.custom_body_font_family | json }};
+        src: url({{ settings.custom_body_font_url | json }}) format('woff2');
+        font-style: {{ settings.custom_body_font_style }};
+        font-weight: {{ settings.custom_body_font_weight }};
+        font-display: swap;
+      }
+    {%- endunless -%}
+  {%- endif -%}
+{% endstyle %}


### PR DESCRIPTION
### PR Summary

Adds optional custom heading and body font settings. Merchants can use either a Google Fonts stylesheet URL or a direct WOFF2 font URL without editing theme code.

### Why are these changes introduced?

Dawn currently supports Shopify's font picker for typography. This change gives merchants an opt-in way to use custom brand fonts while preserving the existing font picker as the default experience.

### What approach did you take?

- Added separate opt-in settings for custom heading and body fonts.
- Added fields for font family, font URL, weight, and style.
- Created a reusable `custom-fonts` snippet that:
  - Loads Google Fonts stylesheet URLs.
  - Defines `@font-face` for direct WOFF2 URLs.
  - Uses `font-display: swap`.
- Updated both `theme.liquid` and `password.liquid` so custom fonts apply consistently across the storefront and password page.
- Preserved the existing Dawn font-picker behavior whenever custom fonts are disabled.
- Added schema translations for all supported Dawn schema locales.

### Other considerations

- This is fully opt-in and does not change the appearance of existing themes after upgrade.
- A Google Fonts URL requires the configured font-family value to match the family provided by the stylesheet.
- Direct font URLs are expected to point to WOFF2 files.

### Decision log

| # | Decision | Alternatives | Rationale | Downsides |
|---|---|---|---|---|
| 1 | Keep Shopify font picker as the default | Replace the existing font picker | Prevents visual changes for existing merchants | Adds additional typography settings |
| 2 | Support Google Fonts stylesheet and direct WOFF2 URLs | Support only one source type | Supports common merchant font workflows | Merchants must provide a valid URL |
| 3 | Use `font-display: swap` | Default font-loading behavior | Avoids invisible text while custom fonts load | A brief fallback-font render can occur |

### Visual impact on existing themes

None by default. Existing themes retain their current selected heading and body fonts. Custom fonts are applied only after a merchant enables the relevant setting.

### Testing steps/scenarios

- [x] Ran `shopify theme check --path .`
- [x] Validated updated Liquid, schema, locale, and snippet files.
- [ ] Enable a custom heading Google Fonts stylesheet and verify headings use the configured font.
- [ ] Enable a custom body Google Fonts stylesheet and verify body text uses the configured font.
- [ ] Configure direct WOFF2 URLs for heading and body fonts and verify each loads correctly.
- [ ] Disable custom fonts and verify the existing Dawn font-picker selection is restored.
- [ ] Verify the password page uses the same custom font settings.
- [ ] Test on mobile and supported desktop browsers.
- [ ] Test accessibility and fallback rendering with a failed font URL.

### Checklist

- [x] Added PR summary for release notes
- [ ] Requested review from UX
- [ ] Created a ticket for the help.shopify.com documentation team about updates to theme settings. (Internal-only task)
- [x] Followed theme code principles
- [x] Linted with Theme Check
- [ ] Tested on mobile
- [ ] Tested on multiple browsers
- [ ] Tested for accessibility