### PR TITLE
Fix quantity input +/- buttons decrementing under screen readers

### DIFF
--- a/assets/global.js
+++ b/assets/global.js
@@ -246,7 +246,7 @@ class QuantityInput extends HTMLElement {
     event.preventDefault();
     const previousValue = this.input.value;
 
-    if (event.target.name === 'plus') {
+    if (event.currentTarget.name === 'plus') {
       if (parseInt(this.input.dataset.min) > parseInt(this.input.step) && this.input.value == 0) {
         this.input.value = this.input.dataset.min;
       } else {
@@ -258,7 +258,7 @@ class QuantityInput extends HTMLElement {
 
     if (previousValue !== this.input.value) this.input.dispatchEvent(this.changeEvent);
 
-    if (this.input.dataset.min === previousValue && event.target.name === 'minus') {
+    if (this.input.dataset.min === previousValue && event.currentTarget.name === 'minus') {
       this.input.value = parseInt(this.input.min);
     }
   }


### PR DESCRIPTION
 Fixes #3972 line
 
QuantityInput.onButtonClick` (`assets/global.js`) used `event.target.name` to determine which button was pressed. When the button is activated via a screen reader or keyboard, `event.target` resolves to the visually-hidden accessible-name span inside the button (which has no `name` attribute) rather than the button itself — since that span has `pointer-events: auto` while the icon has `pointer-events: none`. Lacking a `name`, the check falls through to `stepDown()`, so the "+" button decrements the quantity instead of incrementing it. Mouse clicks are unaffected since they hit-test to the button directly.

Fix: use `event.currentTarget` instead, which always refers to the element the listener is bound to (the button). This matches the pattern already used in the slider's `onButtonClick` in the same file.

## Before / after
Before (bug — `event.target.name`, two occurrences):
https://prnt.sc/spD1BXBgWfL4

After (fixed — `event.currentTarget.name`, no remaining occurrences):
https://prnt.sc/I0n3jufAMiJe

## Test plan
- [x] Verified both `event.target.name` occurrences (lines 249, 261) replaced with `event.currentTarget.name`
- [x] Confirmed the pattern matches the existing slider `onButtonClick` handler in the same file
- [x] Manual test: activate +/- buttons via screen reader/keyboard on a product page with a quantity selector
