### PR TITLE
Base pickup preview on the closest in-stock location

### DIFF
--- a/sections/pickup-availability.liquid
+++ b/sections/pickup-availability.liquid
@@ -3,7 +3,20 @@
 
 {%- if pick_up_availabilities.size > 0 -%}
   <pickup-availability-preview class="pickup-availability-preview">
-    {% assign closest_location = pick_up_availabilities.first %}
+    {%- comment -%}
+      Prefer the closest location that actually has stock. `pick_up_availabilities` is ordered by
+      distance from the buyer, or by city then name when the buyer location is unknown -- never by
+      stock. So `first` is regularly out of stock while a farther store has the variant, and leading
+      with `first` announced "currently unavailable" while the drawer below listed an available
+      store. Falling back to `first` keeps the unavailable copy naming the nearest location when no
+      store has stock.
+    {%- endcomment -%}
+    {%- assign closest_available_location = pick_up_availabilities | where: 'available', true | first -%}
+    {%- if closest_available_location -%}
+      {%- assign closest_location = closest_available_location -%}
+    {%- else -%}
+      {%- assign closest_location = pick_up_availabilities.first -%}
+    {%- endif -%}
 
     {% if closest_location.available %}
       <span class="svg-wrapper">{{ 'icon-tick.svg' | inline_asset_content }}</span>


### PR DESCRIPTION
### Why

`sections/pickup-availability.liquid` leads the preview with:

```liquid
{% assign closest_location = pick_up_availabilities.first %}
```

`pick_up_availabilities` is ordered by distance from the buyer — or by city then name when the buyer's location is unknown — and never by stock. `available` is a pure stock check.

So whenever the nearest pickup location is out of stock and a further one has the variant, the preview announces **"Pickup currently unavailable at \<nearest\>"** while the drawer immediately below lists the further store as available. The page contradicts itself, and the buyer is told to go and check other stores to discover something the page already knew.

### What this changes

Prefer the closest location that actually has stock, falling back to the nearest location so the unavailable copy still names a store when nothing is in stock.

Both downstream branches are untouched: with an in-stock location selected, `closest_location.available` is true and the existing available-at copy runs; with none, it is false and the existing unavailable-at copy runs.

The drawer is deliberately left alone — it should keep listing every location with its own stock state. Only the summary line changes.

### Notes

- **No new locale strings.** This reuses `pick_up_available_at_html` and `pick_up_unavailable_at_html`, so it lands correctly translated in every locale immediately.
- `shopify theme check` reports the same 10 offenses across 7 files before and after, none of them in this file.
- The filter pattern (`| where:` then `| first`, with a `nil` check) matches what the file already does elsewhere.

### Follow-up, split out

While tracing this I noticed a second, separate issue a few lines down in the same file: the drawer's availability line is wrapped in `{% if availability.available %}` with no `{% else %}`, so an out-of-stock store renders an empty `<p>` between its name and its street address — which reads as a store you can collect from.

That is now **#3980**, deliberately kept separate. It turned out not to need a new locale string after all: `products.product.inventory_out_of_stock` already exists and is translated in all 31 locales, so it lands translated immediately.

The two are independent and either can merge first — same file, different regions, and I verified the merge is clean in both orders. This PR fixes the summary line above the drawer; #3980 fixes the rows inside it.
