### PR TITLE
Label out-of-stock stores in the pickup drawer

### DIFF
--- a/sections/pickup-availability.liquid
+++ b/sections/pickup-availability.liquid
@@ -90,6 +90,8 @@
               </span>
               {{ 'products.product.pickup_availability.pick_up_available' | t }},
               {{ availability.pick_up_time | downcase }}
+            {%- else -%}
+              {{ 'products.product.inventory_out_of_stock' | t }}
             {%- endif -%}
           </p>
 


### PR DESCRIPTION
### Why

Each store in the pickup drawer renders its name, an availability line, then its address. That line is only filled in when the variant is in stock:

```liquid
<p class="pickup-availability-preview caption-large">
  {%- if availability.available -%}
    ✓ {{ 'products.product.pickup_availability.pick_up_available' | t }}, {{ availability.pick_up_time | downcase }}
  {%- endif -%}
</p>
```

There is no `{% else %}`, so a store that doesn't have the variant renders as **store name → empty paragraph → street address**. Visually that reads as a store you can go and collect from, and the shopper only finds out otherwise by travelling there or calling.

### What this changes

Fills the blank with the existing `products.product.inventory_out_of_stock` string.

### Why that string rather than a "pickup unavailable" one

Every location in this list is already pickup-enabled — the drawer only ever lists pickup locations. So the sole reason the line was empty is that this store has no stock.

"Out of stock" states exactly that. A "Pickup unavailable" phrasing, while it would mirror the "Pickup available" line above it more neatly, can be misread as *this store doesn't offer collection at all*, which is not true of anything in this list.

It also means **no new locale strings**: `products.product.inventory_out_of_stock` is already present and translated in all 31 locale files, so this lands correct in every language on merge instead of shipping English into 30 translated locales and waiting.

### No icon

The in-stock line carries a tick. This branch deliberately adds no ✗ — the absence of a tick already reads as negative, and it avoids introducing another asset and its alignment behaviour for a one-line label.

### Checks

`shopify theme check` reports the same 10 warnings across the same 7 files before and after; none are in this file.

### Relation to #3979

Independent, and either can merge first. #3979 fixes the *summary line above the drawer* picking the nearest location instead of the nearest in-stock one. This one fixes the *drawer rows themselves*. Same file, different regions, no conflict.
